### PR TITLE
Home: view more toggle on compact rows, broaden view-all parsing

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -87,6 +87,14 @@ class Settings:
     # developer.spotify.com and paste the id here. PKCE OAuth so we
     # don't need a secret. Empty string = import feature hidden in UI.
     spotify_client_id: str = ""
+    # When Tidal returns both an explicit and a clean edit of the same
+    # album / track, the UI would otherwise show both side by side
+    # (e.g. "Rodeo" and "Rodeo" by Travis Scott). Match Tidal's own
+    # client behaviour and collapse the pair.
+    #  - "explicit": keep the explicit edit when both exist (default).
+    #  - "clean":    keep the clean edit when both exist.
+    #  - "both":     show both, as the raw API returned them.
+    explicit_content_preference: str = "explicit"
 
 
 def load_settings() -> Settings:

--- a/app/tidal_client.py
+++ b/app/tidal_client.py
@@ -742,8 +742,18 @@ class TidalClient:
             return None
 
     def favorite(self, kind: str, obj_id: str, add: bool) -> None:
-        """Add or remove a favorite. `kind` in {track, album, artist, playlist}."""
+        """Add or remove a favorite. `kind` in {track, album, artist, playlist, mix}."""
         favs = self.session.user.favorites
+        # tidalapi's mix helpers are plural (add_mixes / remove_mixes) and
+        # accept a list of string ids, while the other kinds are singular
+        # and expect an int (or a uuid string for playlist).
+        if kind == "mix":
+            method_name = ("add_" if add else "remove_") + "mixes"
+            method = getattr(favs, method_name, None)
+            if method is None:
+                raise ValueError("Unsupported favorite kind: mix")
+            method([str(obj_id)])
+            return
         method_name = ("add_" if add else "remove_") + kind
         method = getattr(favs, method_name, None)
         if method is None:
@@ -754,7 +764,7 @@ class TidalClient:
 
     def favorites_snapshot(self) -> dict:
         """Return sets of favorite IDs the UI needs to render heart states."""
-        result = {"tracks": [], "albums": [], "artists": [], "playlists": []}
+        result = {"tracks": [], "albums": [], "artists": [], "playlists": [], "mixes": []}
         for kind, attr in (
             ("tracks", "get_favorite_tracks"),
             ("albums", "get_favorite_albums"),
@@ -768,6 +778,13 @@ class TidalClient:
                 ]
             except Exception:
                 continue
+        # Mixes live under session.user.mixes() in tidalapi rather than
+        # self.get_favorite_* like the other kinds.
+        try:
+            mixes = self.session.user.mixes(limit=200)
+            result["mixes"] = [str(getattr(m, "id", "") or "") for m in mixes if getattr(m, "id", "")]
+        except Exception:
+            pass
         return result
 
     def create_playlist(self, title: str, description: str = ""):

--- a/server.py
+++ b/server.py
@@ -6305,7 +6305,7 @@ def resolve_page(req: PagePathRequest) -> dict:
 # ---------------------------------------------------------------------------
 
 
-FAVORITE_KINDS = {"track", "album", "artist", "playlist"}
+FAVORITE_KINDS = {"track", "album", "artist", "playlist", "mix"}
 
 
 @app.get("/api/favorites")

--- a/server.py
+++ b/server.py
@@ -110,6 +110,43 @@ def _patched_parse_base(self, list_item):
 _tidal_page.PageCategoryV2._parse_base = _patched_parse_base
 
 
+# tidalapi's SimpleList.get_item silently returns None for any item type
+# it doesn't recognize, and only logs at WARNING level on its own
+# "tidalapi.page" logger which we don't forward. Wrap it so both the
+# "type not implemented" case and the "parse raised an exception" case
+# surface to stderr with the raw shape, so a row that suddenly renders
+# short tells us which item types got dropped.
+_orig_get_item = _tidal_page.SimpleList.get_item
+
+
+def _patched_get_item(self, json_obj):
+    try:
+        result = _orig_get_item(self, json_obj)
+    except Exception as exc:
+        try:
+            data_preview = json.dumps(json_obj)[:400]
+        except Exception:
+            data_preview = repr(json_obj)[:400]
+        print(
+            f"[page] SimpleList.get_item raised on "
+            f"type={json_obj.get('type')!r}: {exc} | data={data_preview}",
+            file=sys.stderr,
+            flush=True,
+        )
+        return None
+    if result is None:
+        print(
+            f"[page] SimpleList.get_item dropped item type="
+            f"{json_obj.get('type')!r} (not in item_types map)",
+            file=sys.stderr,
+            flush=True,
+        )
+    return result
+
+
+_tidal_page.SimpleList.get_item = _patched_get_item
+
+
 tidal = TidalClient()
 lastfm = LastFmClient()
 play_reporter = PlayReporter(tidal)
@@ -5893,7 +5930,23 @@ def _serialize_page(page) -> dict:
                 subtitle = candidate
                 break
         raw_items = list(getattr(cat, "items", []) or [])
-        items = [d for d in (_serialize_page_item(i) for i in raw_items) if d]
+        serialized_pairs = [(i, _serialize_page_item(i)) for i in raw_items]
+        items = [d for _, d in serialized_pairs if d]
+        if len(items) < len(raw_items):
+            # Log which tidalapi classes we dropped so a short row like
+            # "Recently played shows 13 instead of 15" surfaces the
+            # concrete types we still need to handle.
+            dropped = sorted({
+                "None" if raw is None else type(raw).__name__
+                for raw, d in serialized_pairs if d is None
+            })
+            if dropped:
+                print(
+                    f"[page] {cat_type} {title!r} served "
+                    f"{len(items)}/{len(raw_items)} items; dropped classes={dropped}",
+                    file=sys.stderr,
+                    flush=True,
+                )
         if not items:
             continue
         entry: dict = {"type": cat_type, "title": title, "items": items}

--- a/server.py
+++ b/server.py
@@ -5791,22 +5791,43 @@ def _fetch_v2_view_all(path: str) -> dict:
     title = body.get("title") or ""
     raw_items = _collect_v2_items(body)
     out: list[dict] = []
+    dropped_types: list[str] = []
     for entry in raw_items:
+        serialized: Optional[dict] = None
+        # First try tidalapi's parsers + our existing serializer. They
+        # cover the common shape where Tidal includes every field the
+        # parser expects.
         obj = _parse_v2_item(session, entry)
-        if obj is None:
-            continue
-        serialized = _serialize_page_item(obj)
+        if obj is not None:
+            serialized = _serialize_page_item(obj)
+        # Fallback: map the raw JSON straight to our wire shape. tidalapi's
+        # parse methods insist on fields like numberOfVideos /
+        # promotedArtists that Tidal drops from V2 view-all payloads,
+        # so a playlist that renders fine on Home disappears here unless
+        # we can bypass the strict parser.
+        if serialized is None:
+            serialized = _raw_entry_to_item(entry)
         if serialized:
             out.append(serialized)
+        else:
+            dropped_types.append(
+                (entry.get("type") if isinstance(entry, dict) else None) or "?"
+            )
+
+    if dropped_types:
+        print(
+            f"[page/resolve] view-all dropped {len(dropped_types)} item(s) for "
+            f"path={path!r}; types={sorted(set(dropped_types))}",
+            file=sys.stderr,
+            flush=True,
+        )
 
     if not out:
-        # Log the body when parsing produced nothing so we can diagnose
-        # new Tidal response shapes without having to add tracing each
-        # time a row silently disappears from the UI.
         preview = json.dumps(body)[:800] if isinstance(body, (dict, list)) else str(body)[:800]
         print(
             f"[page/resolve] view-all produced zero items for path={path!r}; "
             f"body preview: {preview}",
+            file=sys.stderr,
             flush=True,
         )
 
@@ -5816,6 +5837,116 @@ def _fetch_v2_view_all(path: str) -> dict:
             {"type": "HorizontalList", "title": "", "items": out},
         ],
     }
+
+
+def _raw_entry_to_item(entry: Any) -> Optional[dict]:
+    """Map a raw Tidal V2 item entry straight onto our PageItem shape.
+
+    This is the fallback for when tidalapi's strict parsers reject a
+    payload that is missing a field. The UI only needs id, name, a cover
+    image, and enough metadata to render the card, so we can build that
+    from whichever fields Tidal did include without demanding the full
+    set tidalapi wants."""
+    if not isinstance(entry, dict):
+        return None
+    item_type = (entry.get("type") or "").upper()
+    data = entry.get("data") if isinstance(entry.get("data"), dict) else entry
+
+    def _cover(uuid: Optional[str]) -> Optional[str]:
+        return _cover_url_from_uuid(uuid, size=640) if uuid else None
+
+    def _artist_names(xs) -> list[dict]:
+        out: list[dict] = []
+        if not isinstance(xs, list):
+            return out
+        for a in xs:
+            if not isinstance(a, dict):
+                continue
+            name = a.get("name") or ""
+            aid = a.get("id")
+            if name or aid is not None:
+                out.append({"id": str(aid or ""), "name": name, "picture": a.get("picture")})
+        return out
+
+    try:
+        if item_type == "PLAYLIST":
+            return {
+                "kind": "playlist",
+                "id": str(data.get("uuid") or data.get("id") or ""),
+                "name": data.get("title") or "",
+                "description": data.get("description") or "",
+                "num_tracks": int(data.get("numberOfTracks") or 0),
+                "duration": int(data.get("duration") or 0),
+                "cover": _cover(data.get("squareImage") or data.get("image")),
+                "creator": (data.get("creator") or {}).get("name"),
+                "creator_id": str((data.get("creator") or {}).get("id") or "") or None,
+                "owned": False,
+                "share_url": None,
+            }
+        if item_type == "ALBUM":
+            return {
+                "kind": "album",
+                "id": str(data.get("id") or ""),
+                "name": data.get("title") or "",
+                "num_tracks": int(data.get("numberOfTracks") or 0),
+                "year": _release_year(data.get("releaseDate") or data.get("streamStartDate")),
+                "duration": int(data.get("duration") or 0),
+                "cover": _cover(data.get("cover")),
+                "artists": _artist_names(data.get("artists")),
+                "explicit": bool(data.get("explicit")),
+                "share_url": None,
+                "release_date": data.get("releaseDate"),
+                "copyright": data.get("copyright"),
+                "media_tags": data.get("mediaMetadata", {}).get("tags") or [],
+            }
+        if item_type == "ARTIST":
+            return {
+                "kind": "artist",
+                "id": str(data.get("id") or ""),
+                "name": data.get("name") or "",
+                "picture": _cover(data.get("picture")),
+            }
+        if item_type == "TRACK":
+            album = data.get("album") or {}
+            return {
+                "kind": "track",
+                "id": str(data.get("id") or ""),
+                "name": data.get("title") or "",
+                "duration": int(data.get("duration") or 0),
+                "track_num": int(data.get("trackNumber") or 0),
+                "explicit": bool(data.get("explicit")),
+                "artists": _artist_names(data.get("artists")),
+                "album": {
+                    "id": str(album.get("id") or ""),
+                    "name": album.get("title") or "",
+                    "cover": _cover(album.get("cover")),
+                } if album.get("id") else None,
+                "share_url": None,
+                "media_tags": data.get("mediaMetadata", {}).get("tags") or [],
+                "isrc": data.get("isrc"),
+            }
+        if item_type == "MIX":
+            images = data.get("images") or {}
+            sq = images.get("SQUARE") or images.get("MEDIUM") or {}
+            return {
+                "kind": "mix",
+                "id": str(data.get("id") or ""),
+                "name": data.get("title") or "",
+                "subtitle": data.get("subTitle") or data.get("subtitle") or "",
+                "cover": sq.get("url"),
+            }
+    except Exception:
+        return None
+    return None
+
+
+def _release_year(date_str: Optional[str]) -> Optional[int]:
+    if not date_str:
+        return None
+    try:
+        return int(str(date_str)[:4])
+    except Exception:
+        return None
 
 
 def _collect_v2_items(body: Any) -> list:

--- a/server.py
+++ b/server.py
@@ -5652,9 +5652,11 @@ def _serialize_page_item(item) -> Optional[dict]:
         return artist_to_dict(item)
     if isinstance(item, tidalapi.Playlist):
         return playlist_to_dict(item)
-    # Mix — lives in tidalapi.mix.Mix (or MixV2)
+    # Mix — tidalapi ships these under several class names
+    # (Mix, MixV2, MixV2Full, …). Any class whose name starts with
+    # "Mix" is a mix record from our perspective.
     name = type(item).__name__
-    if name in ("Mix", "MixV2"):
+    if name.startswith("Mix"):
         try:
             return {
                 "kind": "mix",
@@ -5717,9 +5719,11 @@ def _fetch_v2_view_all(path: str) -> dict:
     ``home/pages/NEW_ALBUM_SUGGESTIONS/view-all``) and serialize it as
     a single-category Page so the frontend can render it with PageView.
 
-    The view-all response shape is different from a regular Page — it's
-    a flat {"items": [...]} where each item has a ``type`` like
-    "ALBUM"/"TRACK"/"ARTIST"/"PLAYLIST"/"MIX" and a ``data`` payload.
+    Tidal emits several response shapes for view-alls:
+      1. Flat items with type wrappers: {"items": [{"type": "MIX", "data": {...}}, ...]}
+      2. Flat items as bare objects: {"items": [{...mix fields...}, ...]}
+      3. Module-nested: {"modules": [{"pagedList": {"items": [...]}}]} or
+         {"rows": [{"modules": [...]}]}
     tidalapi's Page parser expects category-typed rows, so we map items
     ourselves using session.parse_* helpers and emit one synthetic
     "HorizontalList" row.
@@ -5747,30 +5751,27 @@ def _fetch_v2_view_all(path: str) -> dict:
     resp.raise_for_status()
     body = resp.json()
 
-    raw_items = body.get("items") or []
     title = body.get("title") or ""
+    raw_items = _collect_v2_items(body)
     out: list[dict] = []
     for entry in raw_items:
-        item_type = (entry.get("type") or "").upper()
-        data = entry.get("data") or entry
-        try:
-            if item_type == "TRACK":
-                obj = session.parse_track(data)
-            elif item_type == "ALBUM":
-                obj = session.parse_album(data)
-            elif item_type == "ARTIST":
-                obj = session.parse_artist(data)
-            elif item_type == "PLAYLIST":
-                obj = session.parse_playlist(data)
-            elif item_type == "MIX":
-                obj = session.parse_mix(data)
-            else:
-                continue
-        except Exception:
+        obj = _parse_v2_item(session, entry)
+        if obj is None:
             continue
         serialized = _serialize_page_item(obj)
         if serialized:
             out.append(serialized)
+
+    if not out:
+        # Log the body when parsing produced nothing so we can diagnose
+        # new Tidal response shapes without having to add tracing each
+        # time a row silently disappears from the UI.
+        preview = json.dumps(body)[:800] if isinstance(body, (dict, list)) else str(body)[:800]
+        print(
+            f"[page/resolve] view-all produced zero items for path={path!r}; "
+            f"body preview: {preview}",
+            flush=True,
+        )
 
     return {
         "title": title,
@@ -5778,6 +5779,79 @@ def _fetch_v2_view_all(path: str) -> dict:
             {"type": "HorizontalList", "title": "", "items": out},
         ],
     }
+
+
+def _collect_v2_items(body: Any) -> list:
+    """Walk a Tidal V2 view-all response and collect everything that
+    looks like an item. Handles a few shapes Tidal uses for different
+    content types without requiring per-row special-casing."""
+    if not isinstance(body, dict):
+        return []
+    # Shape 1 / 2: top-level items array.
+    items = body.get("items")
+    if isinstance(items, list) and items:
+        return items
+    # Shape 3: modules / rows wrapper — flatten one level.
+    out: list = []
+    for container_key in ("modules", "rows"):
+        container = body.get(container_key)
+        if not isinstance(container, list):
+            continue
+        for module in container:
+            if not isinstance(module, dict):
+                continue
+            for inner_key in ("items", "pagedList"):
+                inner = module.get(inner_key)
+                if isinstance(inner, dict):
+                    inner = inner.get("items")
+                if isinstance(inner, list):
+                    out.extend(inner)
+    return out
+
+
+def _parse_v2_item(session, entry: Any):
+    """Turn a single V2 item dict into a tidalapi object, tolerating
+    both the {type, data} wrapper and bare-object shapes. Returns None
+    when the entry is something we don't render."""
+    if not isinstance(entry, dict):
+        return None
+    item_type = (entry.get("type") or "").upper()
+    data = entry.get("data") if isinstance(entry.get("data"), dict) else entry
+
+    # Type wrapper present — dispatch by the declared type.
+    if item_type:
+        try:
+            if item_type == "TRACK":
+                return session.parse_track(data)
+            if item_type == "ALBUM":
+                return session.parse_album(data)
+            if item_type == "ARTIST":
+                return session.parse_artist(data)
+            if item_type == "PLAYLIST":
+                return session.parse_playlist(data)
+            if item_type == "MIX":
+                return session.parse_mix(data)
+        except Exception:
+            return None
+        return None
+
+    # No type wrapper — sniff the shape. Mixes carry a `mixType` or a
+    # string id that starts with a known prefix; albums/tracks/playlists
+    # carry numeric / uuid ids with distinguishing fields.
+    try:
+        if "mixType" in data or "mixNumber" in data:
+            return session.parse_mix(data)
+        if "numberOfTracks" in data and "artists" in data:
+            return session.parse_album(data)
+        if "numberOfTracks" in data and "creator" in data:
+            return session.parse_playlist(data)
+        if "album" in data and "duration" in data:
+            return session.parse_track(data)
+        if "picture" in data and "name" in data and "popularity" in data:
+            return session.parse_artist(data)
+    except Exception:
+        return None
+    return None
 
 
 def _category_view_all_path(cat) -> Optional[str]:
@@ -5893,11 +5967,7 @@ def resolve_page(req: PagePathRequest) -> dict:
             # V2 view-all path — returns a JSON dict directly, no Page
             # object to serialize.
             return _fetch_v2_view_all(path)
-    except Exception as exc:
-        # Tidal's 400/404 bodies usually contain a JSON error that tells
-        # us exactly which parameter it's rejecting — the HTTPError
-        # itself only says "400 Bad Request". Grab the latest response
-        # tidalapi cached and log both.
+    except Exception as exc:  # noqa: BLE001 — need a catch-all to log body
         body = ""
         try:
             resp = tidal.session.request.latest_err_response
@@ -5910,7 +5980,27 @@ def resolve_page(req: PagePathRequest) -> dict:
             flush=True,
         )
         raise HTTPException(status_code=502, detail=f"{path}: {exc} | {body}")
-    return _serialize_page(page)
+    result = _serialize_page(page)
+    if not result.get("categories"):
+        # V1 page returned but every row was filtered out during
+        # serialization — usually because tidalapi handed back a class
+        # name _serialize_page_item doesn't recognise. Log a preview so
+        # we can see which types went missing.
+        preview = []
+        for cat in getattr(page, "categories", []) or []:
+            raw_items = list(getattr(cat, "items", []) or [])
+            preview.append({
+                "category": type(cat).__name__,
+                "title": getattr(cat, "title", "") or "",
+                "item_types": sorted({type(x).__name__ for x in raw_items}),
+                "count": len(raw_items),
+            })
+        print(
+            f"[page/resolve] V1 page had zero renderable categories "
+            f"for path={path!r}; raw rows: {preview}",
+            flush=True,
+        )
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/server.py
+++ b/server.py
@@ -9,6 +9,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 import subprocess
 import tempfile
 import webbrowser
@@ -688,6 +689,85 @@ def album_to_dict(a) -> dict:
         # download-dropdown Max/Lossless annotation.
         "media_tags": [m for m in media_tags if m] if media_tags else [],
     }
+
+
+def _norm_title(s: Optional[str]) -> str:
+    """Normalise an album / track name for explicit-dupe matching. Drop
+    anything after a final '(Clean)' / '(Explicit)' marker so we treat
+    'Rodeo' and 'Rodeo (Clean)' as the same record."""
+    if not s:
+        return ""
+    base = s.strip().lower()
+    base = re.sub(r"\s*\((clean|explicit)\)\s*$", "", base)
+    return base
+
+
+def filter_explicit_dupes(items: list, preference: str, *, kind: str) -> list:
+    """Collapse explicit / clean pairs of the same album or track.
+
+    `preference` is whatever is stored in settings.explicit_content_preference:
+    'explicit' (default), 'clean', or 'both'. 'both' returns the list
+    unchanged; the other two drop the unwanted edition when a matching
+    pair exists, and leave solo entries alone.
+
+    Items are matched on (normalised_name, version, primary_artist_id)
+    for albums and (normalised_name, normalised_album, primary_artist_id)
+    for tracks, so a Deluxe re-release never merges into its original
+    and the same song on two different albums stays distinct."""
+    if preference not in ("explicit", "clean"):
+        return list(items)
+
+    def _primary_artist_id(item) -> str:
+        try:
+            artists = getattr(item, "artists", None) or []
+            if artists:
+                aid = getattr(artists[0], "id", None)
+                if aid is not None:
+                    return str(aid)
+        except Exception:
+            pass
+        try:
+            aid = getattr(getattr(item, "artist", None), "id", None)
+            return str(aid) if aid is not None else ""
+        except Exception:
+            return ""
+
+    def _key(item):
+        primary = _primary_artist_id(item)
+        name = _norm_title(getattr(item, "name", None))
+        if kind == "album":
+            version = (getattr(item, "version", "") or "").strip().lower()
+            return ("album", name, version, primary)
+        album_obj = getattr(item, "album", None)
+        album_name = _norm_title(getattr(album_obj, "name", None)) if album_obj else ""
+        return ("track", name, album_name, primary)
+
+    # Group items by key preserving first-seen order. If more than one
+    # edition exists under the same key, pick the preferred one.
+    buckets: dict[tuple, list] = {}
+    order: list[tuple] = []
+    for it in items:
+        key = _key(it)
+        if key not in buckets:
+            order.append(key)
+            buckets[key] = []
+        buckets[key].append(it)
+
+    out: list = []
+    want_explicit = preference == "explicit"
+    for key in order:
+        bucket = buckets[key]
+        if len(bucket) == 1:
+            out.append(bucket[0])
+            continue
+        # Prefer the requested edition; fall back to the first-seen when
+        # the preferred one isn't present.
+        preferred = next(
+            (x for x in bucket if bool(getattr(x, "explicit", False)) == want_explicit),
+            bucket[0],
+        )
+        out.append(preferred)
+    return out
 
 
 def artist_to_dict(a) -> dict:
@@ -3364,9 +3444,12 @@ def search(q: str, limit: int = 25) -> dict:
         results = tidal.search(q, limit=limit)
     except Exception as exc:
         raise HTTPException(status_code=502, detail=f"Search failed: {exc}")
+    pref = (settings.explicit_content_preference or "explicit").lower()
+    tracks = filter_explicit_dupes(results.get("tracks", []), pref, kind="track")
+    albums = filter_explicit_dupes(results.get("albums", []), pref, kind="album")
     return {
-        "tracks": [track_to_dict(t) for t in results.get("tracks", [])],
-        "albums": [album_to_dict(a) for a in results.get("albums", [])],
+        "tracks": [track_to_dict(t) for t in tracks],
+        "albums": [album_to_dict(a) for a in albums],
         "artists": [artist_to_dict(a) for a in results.get("artists", [])],
         "playlists": [playlist_to_dict(p) for p in results.get("playlists", [])],
     }
@@ -3972,6 +4055,14 @@ def artist_detail(artist_id: int) -> dict:
     albums_objs = _dedupe(raw_albums)
     ep_singles_objs = _dedupe(raw_eps)
     appears_on_objs = _dedupe(raw_appears)
+
+    # Collapse explicit / clean editions of the same album per the
+    # user's content-filter setting. Keeps the discography looking like
+    # Tidal's own client where duplicates rarely sit side by side.
+    pref = (settings.explicit_content_preference or "explicit").lower()
+    albums_objs = filter_explicit_dupes(albums_objs, pref, kind="album")
+    ep_singles_objs = filter_explicit_dupes(ep_singles_objs, pref, kind="album")
+    appears_on_objs = filter_explicit_dupes(appears_on_objs, pref, kind="album")
 
     return {
         **artist_to_dict(artist),

--- a/server.py
+++ b/server.py
@@ -5805,14 +5805,26 @@ def _fetch_v2_view_all(path: str) -> dict:
         # promotedArtists that Tidal drops from V2 view-all payloads,
         # so a playlist that renders fine on Home disappears here unless
         # we can bypass the strict parser.
-        if serialized is None:
-            serialized = _raw_entry_to_item(entry)
-        if serialized:
+        if serialized is None or _is_empty_shell(serialized):
+            serialized = _raw_entry_to_item(entry) or serialized
+        if serialized and not _is_empty_shell(serialized):
             out.append(serialized)
         else:
             dropped_types.append(
                 (entry.get("type") if isinstance(entry, dict) else None) or "?"
             )
+            if isinstance(entry, dict):
+                try:
+                    preview = json.dumps(entry)[:600]
+                except Exception:
+                    preview = repr(entry)[:600]
+                print(
+                    f"[page/resolve] could not build an item for "
+                    f"type={entry.get('type')!r}; entry keys={list(entry.keys())}; "
+                    f"sample={preview}",
+                    file=sys.stderr,
+                    flush=True,
+                )
 
     if dropped_types:
         print(
@@ -5850,7 +5862,7 @@ def _raw_entry_to_item(entry: Any) -> Optional[dict]:
     if not isinstance(entry, dict):
         return None
     item_type = (entry.get("type") or "").upper()
-    data = entry.get("data") if isinstance(entry.get("data"), dict) else entry
+    data = _resolve_entry_payload(entry, item_type)
 
     def _cover(uuid: Optional[str]) -> Optional[str]:
         return _cover_url_from_uuid(uuid, size=640) if uuid else None
@@ -5947,6 +5959,35 @@ def _release_year(date_str: Optional[str]) -> Optional[int]:
         return int(str(date_str)[:4])
     except Exception:
         return None
+
+
+def _is_empty_shell(item: dict) -> bool:
+    """True when an item dict has no id and no name — the card would
+    render as a blank placeholder with a music icon. Better to drop it
+    than to paint emptiness on the page."""
+    if not isinstance(item, dict):
+        return True
+    has_id = bool(str(item.get("id") or "").strip())
+    has_name = bool((item.get("name") or "").strip())
+    return not (has_id and has_name)
+
+
+def _resolve_entry_payload(entry: dict, item_type: str) -> dict:
+    """Find the inner object inside a V2 view-all entry. Tidal puts the
+    real payload in different slots depending on endpoint: some ship
+    `data`, others ship `item`, others stash a type-specific key like
+    `playlist`/`album`, and a few dump the fields straight onto the
+    entry. Try each candidate in turn."""
+    type_key = item_type.lower() if item_type else ""
+    candidate_keys = ("data", "item", type_key) if type_key else ("data", "item")
+    for key in candidate_keys:
+        if not key:
+            continue
+        candidate = entry.get(key)
+        if isinstance(candidate, dict) and candidate:
+            return candidate
+    # Fall through: treat the entry itself as the payload.
+    return entry
 
 
 def _collect_v2_items(body: Any) -> list:

--- a/server.py
+++ b/server.py
@@ -5938,18 +5938,86 @@ def _raw_entry_to_item(entry: Any) -> Optional[dict]:
                 "isrc": data.get("isrc"),
             }
         if item_type == "MIX":
-            images = data.get("images") or {}
-            sq = images.get("SQUARE") or images.get("MEDIUM") or {}
-            return {
-                "kind": "mix",
-                "id": str(data.get("id") or ""),
-                "name": data.get("title") or "",
-                "subtitle": data.get("subTitle") or data.get("subtitle") or "",
-                "cover": sq.get("url"),
-            }
+            return _raw_mix_to_item(data)
     except Exception:
         return None
     return None
+
+
+_MIX_TYPE_LABELS = {
+    "DAILY_MIX": "Daily Mix",
+    "DISCOVERY_MIX": "Discovery Mix",
+    "NEW_ARRIVALS_MIX": "New Arrivals",
+    "HISTORY_ALLTIME_MIX": "My All-Time Mix",
+    "HISTORY_RECENT_MIX": "Recent History",
+    "ARTIST_MIX": "Artist Mix",
+    "TRACK_MIX": "Track Radio",
+    "ALBUM_MIX": "Album Radio",
+    "GENRE_MIX": "Genre Mix",
+    "DECADE_MIX": "Decade Mix",
+}
+
+
+def _raw_mix_to_item(data: dict) -> Optional[dict]:
+    """Map a raw V2 mix payload to our wire shape.
+
+    Tidal's V2 mix payloads come in two flavors depending on endpoint.
+    Some ship the full home-feed shape with `title` / `subTitle` and an
+    `images` dict keyed by SQUARE/MEDIUM/LARGE, others ship a stripped
+    pages shape with `titleTextInfo.text` / `subtitleTextInfo.text` and
+    a flat `mixImages` array of {size, url} objects. Handle both."""
+    if not isinstance(data, dict):
+        return None
+    mix_id = str(data.get("id") or "").strip()
+    if not mix_id:
+        return None
+    # Title: home-feed shipping uses `title`, pages shipping uses
+    # `titleTextInfo.text`. Fall back to a human label derived from the
+    # inner mix type constant so a missing text info never leaves the
+    # card blank.
+    title_info = data.get("titleTextInfo") if isinstance(data.get("titleTextInfo"), dict) else {}
+    subtitle_info = data.get("subtitleTextInfo") if isinstance(data.get("subtitleTextInfo"), dict) else {}
+    inner_type = (data.get("type") or "").upper()
+    name = (
+        data.get("title")
+        or title_info.get("text")
+        or _MIX_TYPE_LABELS.get(inner_type)
+        or "Mix"
+    )
+    subtitle = (
+        data.get("subTitle")
+        or data.get("subtitle")
+        or subtitle_info.get("text")
+        or ""
+    )
+    # Cover: home-feed shape first, then the pages-shape array.
+    images = data.get("images") if isinstance(data.get("images"), dict) else {}
+    cover = None
+    for bucket in ("SQUARE", "MEDIUM", "LARGE", "SMALL"):
+        img = images.get(bucket) if isinstance(images, dict) else None
+        if isinstance(img, dict) and img.get("url"):
+            cover = img["url"]
+            break
+    if not cover:
+        mix_images = data.get("mixImages")
+        if isinstance(mix_images, list) and mix_images:
+            # Prefer MEDIUM; fall back to whichever we have.
+            best = next(
+                (m for m in mix_images if isinstance(m, dict) and m.get("size") == "MEDIUM"),
+                None,
+            ) or next(
+                (m for m in mix_images if isinstance(m, dict) and m.get("url")),
+                None,
+            )
+            if best:
+                cover = best.get("url")
+    return {
+        "kind": "mix",
+        "id": mix_id,
+        "name": name,
+        "subtitle": subtitle,
+        "cover": cover,
+    }
 
 
 def _release_year(date_str: Optional[str]) -> Optional[int]:
@@ -6039,7 +6107,11 @@ def _parse_v2_item(session, entry: Any):
             if item_type == "PLAYLIST":
                 return session.parse_playlist(data)
             if item_type == "MIX":
-                return session.parse_mix(data)
+                # parse_v2_mix covers the V2 home/pages mix shape
+                # (mixImages / titleTextInfo); parse_mix is the V1
+                # legacy parser that expects a flat title field.
+                parser = getattr(session, "parse_v2_mix", None) or session.parse_mix
+                return parser(data)
         except Exception:
             return None
         return None

--- a/web/public/app-icon.svg
+++ b/web/public/app-icon.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
-  <g fill="hsl(266, 85%, 62%)">
+  <g fill="hsl(195, 90%, 52%)">
     <rect x="11" y="24" width="6" height="16" rx="3"/>
     <rect x="23" y="16" width="6" height="32" rx="3"/>
     <rect x="35" y="20" width="6" height="24" rx="3"/>

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -388,13 +388,14 @@ export interface QualityOption {
   description: string;
 }
 
-export type FavoriteKind = "track" | "album" | "artist" | "playlist";
+export type FavoriteKind = "track" | "album" | "artist" | "playlist" | "mix";
 
 export interface FavoritesSnapshot {
   tracks: string[];
   albums: string[];
   artists: string[];
   playlists: string[];
+  mixes: string[];
 }
 
 export interface MixItem {

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -246,6 +246,12 @@ export interface Settings {
   offline_mode: boolean;
   notify_on_complete: boolean;
   notify_on_track_change: boolean;
+  /** How to handle Tidal returning both an explicit and a clean edit
+   *  of the same album / track. "explicit" keeps the explicit copy
+   *  (default), "clean" keeps the clean copy, "both" shows them both
+   *  as Tidal returned. Mirrors the toggle Tidal's own client has
+   *  under its "Explicit content" setting. */
+  explicit_content_preference: "explicit" | "clean" | "both";
 }
 
 export interface AuthStatus {

--- a/web/src/components/MediaCard.tsx
+++ b/web/src/components/MediaCard.tsx
@@ -1,10 +1,10 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { Music } from "lucide-react";
-import type { Album, Artist, Playlist } from "@/api/types";
+import { Heart, Music } from "lucide-react";
+import type { Album, Artist, Playlist, FavoriteKind } from "@/api/types";
 import type { OnDownload } from "@/api/download";
+import { useFavorites } from "@/hooks/useFavorites";
 import { imageProxy } from "@/lib/utils";
-import { HeartButton } from "@/components/HeartButton";
 import { PlayMediaButton } from "@/components/PlayMediaButton";
 
 type Item = Album | Artist | Playlist;
@@ -71,17 +71,11 @@ export function MediaCard({
                 onOpenChange={setMenuOpen}
               />
             </div>
-            <div
-              className={`absolute bottom-2 right-2 flex h-10 w-10 items-center justify-center rounded-full bg-black/60 shadow-lg transition-all ${hoverGroup}`}
-            >
-              <HeartButton
-                kind={item.kind}
-                id={item.id}
-                size="md"
-                tone="foreground"
-                className="bg-transparent hover:bg-transparent"
-              />
-            </div>
+            <InlineHeart
+              kind={item.kind as FavoriteKind}
+              id={item.id}
+              className={`absolute bottom-2 right-2 transition-all ${hoverGroup}`}
+            />
           </>
         )}
       </div>
@@ -92,6 +86,45 @@ export function MediaCard({
         </div>
       </div>
     </Link>
+  );
+}
+
+/**
+ * Self-contained heart button for the hover overlay. Built in-place
+ * rather than going through HeartButton+Button+cva so there's no
+ * chance of an opacity or size class getting stripped by the merge
+ * chain. Dark circle, white outline when un-liked, primary fill when
+ * liked. Stops propagation so clicking it never follows the parent
+ * Link.
+ */
+function InlineHeart({
+  kind,
+  id,
+  className,
+}: {
+  kind: FavoriteKind;
+  id: string;
+  className?: string;
+}) {
+  const favs = useFavorites();
+  const liked = favs.has(kind, id);
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        void favs.toggle(kind, id);
+      }}
+      aria-pressed={liked}
+      aria-label={liked ? `Unlike ${kind}` : `Like ${kind}`}
+      title={liked ? `Unlike ${kind}` : `Like ${kind}`}
+      className={`flex h-10 w-10 items-center justify-center rounded-full bg-black/70 text-white shadow-lg transition-colors hover:bg-black/90 ${className ?? ""}`}
+    >
+      <Heart
+        className={`h-5 w-5 ${liked ? "fill-primary stroke-primary" : ""}`}
+      />
+    </button>
   );
 }
 

--- a/web/src/components/MediaCard.tsx
+++ b/web/src/components/MediaCard.tsx
@@ -72,13 +72,14 @@ export function MediaCard({
               />
             </div>
             <div
-              className={`absolute bottom-2 right-2 transition-all ${hoverGroup}`}
+              className={`absolute bottom-2 right-2 flex h-10 w-10 items-center justify-center rounded-full bg-black/60 shadow-lg transition-all ${hoverGroup}`}
             >
               <HeartButton
                 kind={item.kind}
                 id={item.id}
                 size="md"
-                className="h-10 w-10 bg-background/80 backdrop-blur hover:bg-background"
+                tone="foreground"
+                className="bg-transparent hover:bg-transparent"
               />
             </div>
           </>

--- a/web/src/components/MediaCard.tsx
+++ b/web/src/components/MediaCard.tsx
@@ -4,16 +4,19 @@ import { Music } from "lucide-react";
 import type { Album, Artist, Playlist } from "@/api/types";
 import type { OnDownload } from "@/api/download";
 import { imageProxy } from "@/lib/utils";
-import { DownloadButton } from "@/components/DownloadButton";
+import { HeartButton } from "@/components/HeartButton";
 import { PlayMediaButton } from "@/components/PlayMediaButton";
 
 type Item = Album | Artist | Playlist;
 
 export function MediaCard({
   item,
-  onDownload,
 }: {
   item: Item;
+  /** Download triggering was part of the old card overlay. Callers still
+   *  pass it through but the affordance now lives on the detail page so
+   *  we no longer render it in the hover area. Prop kept so the call
+   *  sites stay stable. */
   onDownload?: OnDownload;
 }) {
   const [menuOpen, setMenuOpen] = useState(false);
@@ -28,6 +31,15 @@ export function MediaCard({
 
   const cover = imageProxy(item.kind === "artist" ? item.picture : item.cover);
   const rounded = item.kind === "artist" ? "rounded-full" : "rounded-md";
+  const showHoverActions = item.kind !== "artist";
+  // Hide-on-leave is suppressed while the play request is in flight, so
+  // the button doesn't flicker back to opacity-0 if the cursor drifts
+  // off before the fetch resolves.
+  const hoverGroup = showHoverActions
+    ? menuOpen
+      ? "opacity-100"
+      : "opacity-0 group-hover:opacity-100 focus-within:opacity-100"
+    : "";
 
   return (
     <Link
@@ -47,31 +59,29 @@ export function MediaCard({
             <Music className="h-10 w-10" />
           </div>
         )}
-        {item.kind !== "artist" && (
-          <div
-            className={`absolute bottom-2 right-2 flex items-center gap-2 transition-all ${
-              menuOpen
-                ? "translate-y-0 opacity-100"
-                : "translate-y-2 opacity-0 group-hover:translate-y-0 group-hover:opacity-100"
-            }`}
-          >
-            <PlayMediaButton
-              kind={item.kind}
-              id={item.id}
-              className="h-10 w-10"
-              onOpenChange={setMenuOpen}
-            />
-            {onDownload && (
-              <DownloadButton
-                kind={item.kind}
+        {showHoverActions && (
+          <>
+            <div
+              className={`absolute bottom-2 left-2 transition-all ${hoverGroup}`}
+            >
+              <PlayMediaButton
+                kind={item.kind as "album" | "playlist"}
                 id={item.id}
-                onPick={onDownload}
-                iconOnly
-                className="h-10 w-10 shadow-lg"
+                className="h-10 w-10"
                 onOpenChange={setMenuOpen}
               />
-            )}
-          </div>
+            </div>
+            <div
+              className={`absolute bottom-2 right-2 transition-all ${hoverGroup}`}
+            >
+              <HeartButton
+                kind={item.kind}
+                id={item.id}
+                size="md"
+                className="h-10 w-10 bg-background/80 backdrop-blur hover:bg-background"
+              />
+            </div>
+          </>
         )}
       </div>
       <div className="min-w-0">

--- a/web/src/components/NowPlaying.tsx
+++ b/web/src/components/NowPlaying.tsx
@@ -344,7 +344,7 @@ const QUALITY_OPTIONS: {
 
 // Per-tier color for the Now Playing quality pill. Pinned Tailwind
 // palette entries read on both dark and light backgrounds without
-// needing a mode-specific override; `primary` is the brand purple,
+// needing a mode-specific override. `primary` is the brand accent,
 // reserved for Max so the top tier is visually distinct.
 const QUALITY_BADGE_CLASS: Record<StreamingQuality, string> = {
   low_96k: "bg-neutral-500/15 text-neutral-400 hover:bg-neutral-500/25",

--- a/web/src/components/PageView.tsx
+++ b/web/src/components/PageView.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import { ChevronRight, Home, Music, Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
@@ -17,6 +18,7 @@ import type {
 import type { OnDownload } from "@/api/download";
 import { HeartButton } from "@/components/HeartButton";
 import { MediaCard } from "@/components/MediaCard";
+import { PlayMediaButton } from "@/components/PlayMediaButton";
 import { TrackList } from "@/components/TrackList";
 import { useColumnCount } from "@/hooks/useColumnCount";
 import { usePlayerActions, usePlayerMeta } from "@/hooks/PlayerContext";
@@ -387,12 +389,20 @@ function TrackCard({ track, rowTracks }: { track: Track; rowTracks: Track[] }) {
 }
 
 function MixCard({ mix }: { mix: MixItem }) {
+  // Same bottom-left hover-play treatment as MediaCard. Mixes don't
+  // have a backend favorite endpoint so the bottom-right heart slot is
+  // intentionally omitted — Tidal's own homepage renders mix cards the
+  // same way.
+  const [menuOpen, setMenuOpen] = useState(false);
+  const hoverGroup = menuOpen
+    ? "opacity-100"
+    : "opacity-0 group-hover:opacity-100 focus-within:opacity-100";
   return (
     <Link
       to={`/mix/${encodeURIComponent(mix.id)}`}
-      className="group flex flex-col gap-3 rounded-lg bg-card p-4 transition-colors hover:bg-accent"
+      className="group relative flex flex-col gap-3 rounded-lg bg-card p-4 transition-colors hover:bg-accent"
     >
-      <div className="aspect-square overflow-hidden rounded-md bg-secondary">
+      <div className="relative aspect-square overflow-hidden rounded-md bg-secondary">
         {mix.cover ? (
           <img
             src={imageProxy(mix.cover)}
@@ -402,6 +412,14 @@ function MixCard({ mix }: { mix: MixItem }) {
         ) : (
           <Music className="m-auto h-10 w-10 text-muted-foreground" />
         )}
+        <div className={`absolute bottom-2 left-2 transition-all ${hoverGroup}`}>
+          <PlayMediaButton
+            kind="mix"
+            id={mix.id}
+            className="h-10 w-10"
+            onOpenChange={setMenuOpen}
+          />
+        </div>
       </div>
       <div className="min-w-0">
         <div className="truncate font-semibold">{mix.name}</div>

--- a/web/src/components/PageView.tsx
+++ b/web/src/components/PageView.tsx
@@ -413,11 +413,42 @@ function TrackHeart({
   );
 }
 
+function MixHeart({
+  mixId,
+  className,
+}: {
+  mixId: string;
+  className?: string;
+}) {
+  const favs = useFavorites();
+  const liked = favs.has("mix", mixId);
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        void favs.toggle("mix", mixId);
+      }}
+      aria-pressed={liked}
+      aria-label={liked ? "Unlike mix" : "Like mix"}
+      title={liked ? "Unlike mix" : "Like mix"}
+      className={cn(
+        "flex h-10 w-10 items-center justify-center rounded-full bg-black/70 text-white shadow-lg transition-colors hover:bg-black/90",
+        className,
+      )}
+    >
+      <Heart
+        className={cn("h-5 w-5", liked && "fill-primary stroke-primary")}
+      />
+    </button>
+  );
+}
+
 function MixCard({ mix }: { mix: MixItem }) {
-  // Same bottom-left hover-play treatment as MediaCard. Mixes don't
-  // have a backend favorite endpoint so the bottom-right heart slot is
-  // intentionally omitted — Tidal's own homepage renders mix cards the
-  // same way.
+  // Same bottom-left hover-play + bottom-right hover-heart treatment as
+  // MediaCard. tidalapi exposes favorites/mixes/add|remove, so mixes
+  // get the full card interaction instead of play-only.
   const [menuOpen, setMenuOpen] = useState(false);
   const hoverGroup = menuOpen
     ? "opacity-100"
@@ -445,6 +476,10 @@ function MixCard({ mix }: { mix: MixItem }) {
             onOpenChange={setMenuOpen}
           />
         </div>
+        <MixHeart
+          mixId={mix.id}
+          className={`absolute bottom-2 right-2 transition-all ${hoverGroup}`}
+        />
       </div>
       <div className="min-w-0">
         <div className="truncate font-semibold">{mix.name}</div>

--- a/web/src/components/PageView.tsx
+++ b/web/src/components/PageView.tsx
@@ -294,11 +294,13 @@ function PageItemCard({
 }
 
 /**
- * Track card with three hit regions, matching Tidal's homepage: clicking
- * the art plays the song (with the row's other tracks as the playback
- * queue), clicking the title navigates to the album, clicking the
- * artist name navigates to the artist. A hover-revealed heart button
- * in the bottom-right lets the user favourite the track in place.
+ * Track card matching the MediaCard layout so tracks on a view-more
+ * page feel like first-class items. The whole card is a Link to the
+ * album; the hover overlay puts a play button in the bottom-left and
+ * a heart in the bottom-right, same slots the album / playlist cards
+ * use. Clicking play kicks off the track with the row's other tracks
+ * as the queue. Artist names in the subtitle are their own Links that
+ * stop propagation so the card's Link doesn't swallow the click.
  */
 function TrackCard({ track, rowTracks }: { track: Track; rowTracks: Track[] }) {
   const actions = usePlayerActions();
@@ -316,58 +318,49 @@ function TrackCard({ track, rowTracks }: { track: Track; rowTracks: Track[] }) {
       actions.play(track, rowTracks.length > 0 ? rowTracks : [track]);
     }
   };
-  return (
-    <div className="group flex flex-col gap-3 rounded-lg bg-card p-4 transition-colors hover:bg-accent">
+  const overlayClass =
+    "opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100";
+  const inner = (
+    <>
       <div className="relative aspect-square overflow-hidden rounded-md bg-secondary">
+        {cover ? (
+          <img
+            src={cover}
+            alt=""
+            loading="lazy"
+            className="h-full w-full object-cover transition-transform group-hover:scale-105"
+          />
+        ) : (
+          <Music className="m-auto h-10 w-10 text-muted-foreground" />
+        )}
         <button
           type="button"
           onClick={handlePlay}
           aria-label={isPlaying ? `Pause ${track.name}` : `Play ${track.name}`}
-          className="absolute inset-0 z-0"
-        >
-          {cover ? (
-            <img
-              src={cover}
-              alt=""
-              loading="lazy"
-              className="h-full w-full object-cover transition-transform group-hover:scale-105"
-            />
-          ) : (
-            <Music className="m-auto h-10 w-10 text-muted-foreground" />
+          className={cn(
+            "absolute bottom-2 left-2 flex h-10 w-10 items-center justify-center rounded-full bg-primary text-primary-foreground shadow-lg transition-transform hover:scale-105",
+            isPlaying ? "opacity-100" : overlayClass,
           )}
-          <span
-            className={cn(
-              "absolute inset-0 flex items-center justify-center bg-black/50 transition-opacity",
-              isPlaying
-                ? "opacity-100"
-                : "opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
-            )}
-          >
-            <Play className="h-10 w-10 text-foreground" fill="currentColor" />
-          </span>
+        >
+          <Play className="h-5 w-5" fill="currentColor" />
         </button>
         <TrackHeart
           trackId={track.id}
-          className="absolute bottom-2 right-2 z-10 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+          className={cn("absolute bottom-2 right-2", overlayClass)}
         />
       </div>
       <div className="min-w-0">
-        {albumPath ? (
-          <Link
-            to={albumPath}
-            className="block truncate font-semibold hover:underline"
-          >
-            {track.name}
-          </Link>
-        ) : (
-          <div className="truncate font-semibold">{track.name}</div>
-        )}
+        <div className="truncate font-semibold">{track.name}</div>
         <div className="truncate text-xs text-muted-foreground">
           {track.artists.map((a, i) => (
             <span key={a.id || i}>
               {i > 0 && ", "}
               {a.id ? (
-                <Link to={`/artist/${a.id}`} className="hover:text-foreground hover:underline">
+                <Link
+                  to={`/artist/${a.id}`}
+                  onClick={(e) => e.stopPropagation()}
+                  className="hover:text-foreground hover:underline"
+                >
                   {a.name}
                 </Link>
               ) : (
@@ -377,6 +370,21 @@ function TrackCard({ track, rowTracks }: { track: Track; rowTracks: Track[] }) {
           ))}
         </div>
       </div>
+    </>
+  );
+  if (albumPath) {
+    return (
+      <Link
+        to={albumPath}
+        className="group flex flex-col gap-3 rounded-lg bg-card p-4 transition-colors hover:bg-accent"
+      >
+        {inner}
+      </Link>
+    );
+  }
+  return (
+    <div className="group flex flex-col gap-3 rounded-lg bg-card p-4 transition-colors hover:bg-accent">
+      {inner}
     </div>
   );
 }

--- a/web/src/components/PageView.tsx
+++ b/web/src/components/PageView.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
-import { ChevronRight, Home, Music, Play } from "lucide-react";
+import { ChevronRight, Heart, Home, Music, Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/EmptyState";
 import type {
@@ -16,7 +16,7 @@ import type {
   Track,
 } from "@/api/types";
 import type { OnDownload } from "@/api/download";
-import { HeartButton } from "@/components/HeartButton";
+import { useFavorites } from "@/hooks/useFavorites";
 import { MediaCard } from "@/components/MediaCard";
 import { PlayMediaButton } from "@/components/PlayMediaButton";
 import { TrackList } from "@/components/TrackList";
@@ -346,18 +346,10 @@ function TrackCard({ track, rowTracks }: { track: Track; rowTracks: Track[] }) {
             <Play className="h-10 w-10 text-foreground" fill="currentColor" />
           </span>
         </button>
-        {/* Heart sits above the play button and stops propagation so
-            clicking it never triggers playback. z-10 raises it out of
-            the play button's flow without needing a portal. */}
-        <div className="absolute bottom-2 right-2 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-black/60 opacity-0 shadow-lg transition-opacity group-hover:opacity-100 focus-within:opacity-100">
-          <HeartButton
-            kind="track"
-            id={track.id}
-            size="md"
-            tone="foreground"
-            className="bg-transparent hover:bg-transparent"
-          />
-        </div>
+        <TrackHeart
+          trackId={track.id}
+          className="absolute bottom-2 right-2 z-10 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100"
+        />
       </div>
       <div className="min-w-0">
         {albumPath ? (
@@ -386,6 +378,38 @@ function TrackCard({ track, rowTracks }: { track: Track; rowTracks: Track[] }) {
         </div>
       </div>
     </div>
+  );
+}
+
+function TrackHeart({
+  trackId,
+  className,
+}: {
+  trackId: string;
+  className?: string;
+}) {
+  const favs = useFavorites();
+  const liked = favs.has("track", trackId);
+  return (
+    <button
+      type="button"
+      onClick={(e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        void favs.toggle("track", trackId);
+      }}
+      aria-pressed={liked}
+      aria-label={liked ? "Unlike track" : "Like track"}
+      title={liked ? "Unlike track" : "Like track"}
+      className={cn(
+        "flex h-10 w-10 items-center justify-center rounded-full bg-black/70 text-white shadow-lg transition-colors hover:bg-black/90",
+        className,
+      )}
+    >
+      <Heart
+        className={cn("h-5 w-5", liked && "fill-primary stroke-primary")}
+      />
+    </button>
   );
 }
 

--- a/web/src/components/PageView.tsx
+++ b/web/src/components/PageView.tsx
@@ -349,12 +349,13 @@ function TrackCard({ track, rowTracks }: { track: Track; rowTracks: Track[] }) {
         {/* Heart sits above the play button and stops propagation so
             clicking it never triggers playback. z-10 raises it out of
             the play button's flow without needing a portal. */}
-        <div className="absolute bottom-2 right-2 z-10 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+        <div className="absolute bottom-2 right-2 z-10 flex h-10 w-10 items-center justify-center rounded-full bg-black/60 opacity-0 shadow-lg transition-opacity group-hover:opacity-100 focus-within:opacity-100">
           <HeartButton
             kind="track"
             id={track.id}
             size="md"
-            className="h-10 w-10 bg-background/80 backdrop-blur hover:bg-background"
+            tone="foreground"
+            className="bg-transparent hover:bg-transparent"
           />
         </div>
       </div>

--- a/web/src/components/PageView.tsx
+++ b/web/src/components/PageView.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom";
-import { ChevronRight, Home, Music } from "lucide-react";
+import { ChevronRight, Home, Music, Play } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { EmptyState } from "@/components/EmptyState";
 import type {
@@ -15,9 +15,11 @@ import type {
   Track,
 } from "@/api/types";
 import type { OnDownload } from "@/api/download";
+import { HeartButton } from "@/components/HeartButton";
 import { MediaCard } from "@/components/MediaCard";
 import { TrackList } from "@/components/TrackList";
 import { useColumnCount } from "@/hooks/useColumnCount";
+import { usePlayerActions, usePlayerMeta } from "@/hooks/PlayerContext";
 import { cn, imageProxy } from "@/lib/utils";
 
 interface Props {
@@ -126,10 +128,15 @@ function Section({
   // sections is quick; the only cost is some rows lose their "view
   // more" affordance when Tidal didn't send a viewAllPath for them.
   const singleRow = forceSingleRow || Boolean(context || viewAllPath);
-  // Cap to actual visible column count so the row never wraps. Without
-  // this, at lg (5 cols) a 6-item cap leaves one card orphaned on a
-  // partial second row — the exact visual glitch we're trying to avoid.
-  const visible = singleRow ? items.slice(0, columnCount) : items;
+  // Cap single rows at whichever is smaller: five (matches Tidal's
+  // homepage density) or the actual visible column count. Without the
+  // second cap a narrower viewport renders 4 cards then an orphaned
+  // 5th on a partial second row.
+  const ROW_CAP = 5;
+  const visible = singleRow ? items.slice(0, Math.min(ROW_CAP, columnCount)) : items;
+  // Track rows need a shared playback context: clicking one track's
+  // cover should play it with the row's other tracks queued up.
+  const rowTracks = items.filter((i): i is Track => i.kind === "track");
   return (
     <div>
       {title && (
@@ -144,7 +151,7 @@ function Section({
         className={cn(
           "grid gap-4",
           singleRow
-            ? "grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 2xl:grid-cols-6"
+            ? "grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
             : "grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6",
         )}
       >
@@ -153,6 +160,7 @@ function Section({
             key={`${it.kind}-${itemKey(it)}-${idx}`}
             item={it}
             onDownload={onDownload}
+            rowTracks={rowTracks}
           />
         ))}
       </div>
@@ -262,7 +270,15 @@ function SectionHeader({
   );
 }
 
-function PageItemCard({ item, onDownload }: { item: PageItem; onDownload: OnDownload }) {
+function PageItemCard({
+  item,
+  onDownload,
+  rowTracks = [],
+}: {
+  item: PageItem;
+  onDownload: OnDownload;
+  rowTracks?: Track[];
+}) {
   if (item.kind === "album" || item.kind === "artist" || item.kind === "playlist") {
     return <MediaCard item={item as Album | Artist | Playlist} onDownload={onDownload} />;
   }
@@ -270,29 +286,104 @@ function PageItemCard({ item, onDownload }: { item: PageItem; onDownload: OnDown
     return <MixCard mix={item} />;
   }
   if (item.kind === "track") {
-    const t = item as Track;
-    return (
-      <Link
-        to={t.album ? `/album/${t.album.id}` : `/artist/${t.artists[0]?.id ?? ""}`}
-        className="flex flex-col gap-3 rounded-lg bg-card p-4 transition-colors hover:bg-accent"
-      >
-        <div className="aspect-square overflow-hidden rounded-md bg-secondary">
-          {t.album?.cover ? (
-            <img src={imageProxy(t.album.cover)} alt="" className="h-full w-full object-cover" />
+    return <TrackCard track={item} rowTracks={rowTracks} />;
+  }
+  return null;
+}
+
+/**
+ * Track card with three hit regions, matching Tidal's homepage: clicking
+ * the art plays the song (with the row's other tracks as the playback
+ * queue), clicking the title navigates to the album, clicking the
+ * artist name navigates to the artist. A hover-revealed heart button
+ * in the bottom-right lets the user favourite the track in place.
+ */
+function TrackCard({ track, rowTracks }: { track: Track; rowTracks: Track[] }) {
+  const actions = usePlayerActions();
+  const meta = usePlayerMeta();
+  const isCurrent = meta.track?.id === track.id;
+  const isPlaying = isCurrent && meta.playing;
+  const cover = track.album?.cover ? imageProxy(track.album.cover) : null;
+  const albumPath = track.album ? `/album/${track.album.id}` : null;
+  const handlePlay = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (isCurrent) {
+      actions.toggle();
+    } else {
+      actions.play(track, rowTracks.length > 0 ? rowTracks : [track]);
+    }
+  };
+  return (
+    <div className="group flex flex-col gap-3 rounded-lg bg-card p-4 transition-colors hover:bg-accent">
+      <div className="relative aspect-square overflow-hidden rounded-md bg-secondary">
+        <button
+          type="button"
+          onClick={handlePlay}
+          aria-label={isPlaying ? `Pause ${track.name}` : `Play ${track.name}`}
+          className="absolute inset-0 z-0"
+        >
+          {cover ? (
+            <img
+              src={cover}
+              alt=""
+              loading="lazy"
+              className="h-full w-full object-cover transition-transform group-hover:scale-105"
+            />
           ) : (
             <Music className="m-auto h-10 w-10 text-muted-foreground" />
           )}
+          <span
+            className={cn(
+              "absolute inset-0 flex items-center justify-center bg-black/50 transition-opacity",
+              isPlaying
+                ? "opacity-100"
+                : "opacity-0 group-hover:opacity-100 focus-visible:opacity-100",
+            )}
+          >
+            <Play className="h-10 w-10 text-foreground" fill="currentColor" />
+          </span>
+        </button>
+        {/* Heart sits above the play button and stops propagation so
+            clicking it never triggers playback. z-10 raises it out of
+            the play button's flow without needing a portal. */}
+        <div className="absolute bottom-2 right-2 z-10 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+          <HeartButton
+            kind="track"
+            id={track.id}
+            size="md"
+            className="h-10 w-10 bg-background/80 backdrop-blur hover:bg-background"
+          />
         </div>
-        <div className="min-w-0">
-          <div className="truncate font-semibold">{t.name}</div>
-          <div className="truncate text-xs text-muted-foreground">
-            {t.artists.map((a) => a.name).join(", ")}
-          </div>
+      </div>
+      <div className="min-w-0">
+        {albumPath ? (
+          <Link
+            to={albumPath}
+            className="block truncate font-semibold hover:underline"
+          >
+            {track.name}
+          </Link>
+        ) : (
+          <div className="truncate font-semibold">{track.name}</div>
+        )}
+        <div className="truncate text-xs text-muted-foreground">
+          {track.artists.map((a, i) => (
+            <span key={a.id || i}>
+              {i > 0 && ", "}
+              {a.id ? (
+                <Link to={`/artist/${a.id}`} className="hover:text-foreground hover:underline">
+                  {a.name}
+                </Link>
+              ) : (
+                a.name
+              )}
+            </span>
+          ))}
         </div>
-      </Link>
-    );
-  }
-  return null;
+      </div>
+    </div>
+  );
 }
 
 function MixCard({ mix }: { mix: MixItem }) {

--- a/web/src/components/PlayMediaButton.tsx
+++ b/web/src/components/PlayMediaButton.tsx
@@ -23,7 +23,7 @@ export function PlayMediaButton({
   className,
   onOpenChange,
 }: {
-  kind: "album" | "playlist";
+  kind: "album" | "playlist" | "mix";
   id: string;
   className?: string;
   /** Matches DownloadButton's prop so the hover-reveal CSS can latch
@@ -43,7 +43,11 @@ export function PlayMediaButton({
     onOpenChange?.(true);
     try {
       const detail =
-        kind === "album" ? await api.album(id) : await api.playlist(id);
+        kind === "album"
+          ? await api.album(id)
+          : kind === "playlist"
+            ? await api.playlist(id)
+            : await api.mix(id);
       const tracks = detail.tracks;
       if (!tracks?.length) {
         toast.show({

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -94,7 +94,7 @@ export function Sidebar({
           half of the 40 pixel glyph lands at 38, which is where the
           20 pixel nav icons have their centers.
 
-          On hover the background tints with a soft brand purple via
+          On hover the background tints with a soft brand accent via
           `bg-primary/10` and the glyph scales up to 1.05. That feels
           like an interactive logo rather than a nav row that happens
           to be at the top. */}

--- a/web/src/hooks/useFavorites.tsx
+++ b/web/src/hooks/useFavorites.tsx
@@ -24,6 +24,7 @@ const EMPTY: Sets = {
   album: new Set(),
   artist: new Set(),
   playlist: new Set(),
+  mix: new Set(),
 };
 
 const Ctx = createContext<FavoritesContextValue>({
@@ -69,6 +70,7 @@ export function FavoritesProvider({ children }: { children: ReactNode }) {
             album: mergeSets(new Set(snap.albums), prev.album),
             artist: mergeSets(new Set(snap.artists), prev.artist),
             playlist: mergeSets(new Set(snap.playlists), prev.playlist),
+            mix: mergeSets(new Set(snap.mixes), prev.mix),
           }));
           return;
         }
@@ -77,6 +79,7 @@ export function FavoritesProvider({ children }: { children: ReactNode }) {
           album: new Set(snap.albums),
           artist: new Set(snap.artists),
           playlist: new Set(snap.playlists),
+          mix: new Set(snap.mixes),
         });
       })
       .catch(() => {

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -27,7 +27,7 @@
     --card-foreground: 0 0% 98%;
     --popover: 0 0% 4%;
     --popover-foreground: 0 0% 98%;
-    --primary: 266 85% 62%;
+    --primary: 195 90% 52%;
     --primary-foreground: 0 0% 98%;
     --secondary: 0 0% 9%;
     --secondary-foreground: 0 0% 98%;
@@ -39,7 +39,7 @@
     --destructive-foreground: 0 0% 98%;
     --border: 0 0% 13%;
     --input: 0 0% 13%;
-    --ring: 266 85% 62%;
+    --ring: 195 90% 52%;
     --radius: 0.5rem;
     /* Theme-specific chrome colors (scrollbar track/thumb, hardcoded
      *  now-playing bar, hero gradient fallback). Defined here as
@@ -61,10 +61,10 @@
     --card-foreground: 220 20% 14%;
     --popover: 0 0% 100%;
     --popover-foreground: 220 20% 14%;
-    /* Purple tuned for contrast on white (≈4.6:1). Vibrant enough to
-     *  carry the brand against the cool-tinted light background, dim
-     *  enough that saturated chrome doesn't vibrate. */
-    --primary: 266 70% 48%;
+    /* Cyan-blue tuned for contrast on white (≈4.6:1). Vibrant enough
+     *  to carry the brand against the cool-tinted light background,
+     *  dim enough that saturated chrome doesn't vibrate. */
+    --primary: 200 90% 38%;
     --primary-foreground: 0 0% 100%;
     --secondary: 220 14% 92%;
     --secondary-foreground: 220 20% 14%;
@@ -76,7 +76,7 @@
     --destructive-foreground: 0 0% 100%;
     --border: 220 13% 86%;
     --input: 220 13% 86%;
-    --ring: 266 70% 48%;
+    --ring: 200 90% 38%;
     --now-playing-bg: 0 0% 100%;
     --scrollbar-thumb: 220 12% 78%;
     --scrollbar-thumb-hover: 220 12% 62%;

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,11 +1,15 @@
+import { Link } from "react-router-dom";
+import { ChevronRight, MoreHorizontal, Music, Play } from "lucide-react";
 import { api } from "@/api/client";
 import type { OnDownload } from "@/api/download";
 import { useApi } from "@/hooks/useApi";
+import { usePlayerActions, usePlayerMeta } from "@/hooks/PlayerContext";
 import { PageView } from "@/components/PageView";
 import { ErrorView } from "@/components/ErrorView";
 import { GridSkeleton } from "@/components/Skeletons";
 import { LastfmConnectNudge } from "@/components/LastfmConnectNudge";
-import type { PageCategory, PageItem, TidalPage } from "@/api/types";
+import { imageProxy } from "@/lib/utils";
+import type { PageCategory, PageItem, TidalPage, Track } from "@/api/types";
 
 // Titles of Tidal editorial rows we do not want on our home page.
 // Matched case insensitively as a substring against the row title,
@@ -37,11 +41,18 @@ const HIDDEN_HOME_ROW_TITLES = [
 const MERGE_SOURCE_TITLES = ["recommended new tracks", "uploads for you"];
 const MERGED_ROW_TITLE = "Suggested new songs for you";
 
-// Desired order for the card-style rows at the top of the feed.
-// Anything not listed here keeps whatever order Tidal sent.
-const PRIORITY_ROW_ORDER = [
+// Rows that read better as a compact pill shelf than as a grid of
+// big cards. Track-heavy rows belong here because the density lets
+// the user scan more recently-played / suggested tracks without
+// scrolling. Albums / playlists / mixes stay as big cards below.
+const COMPACT_ROW_TITLES = new Set([
   "recently played",
   normalizeTitle(MERGED_ROW_TITLE),
+]);
+
+// Desired order for the card-style rows that render through PageView.
+// Anything not listed here keeps whatever order Tidal sent.
+const PRIORITY_ROW_ORDER = [
   "suggested new albums for you",
   "custom mixes",
   "personal radio stations",
@@ -54,7 +65,10 @@ function normalizeTitle(s: string): string {
     .replace(/[“”‟″]/g, '"'); // curly / prime double quotes
 }
 
-function filterHomeRows(page: TidalPage): TidalPage {
+function filterHomeRows(page: TidalPage): {
+  compactRows: PageCategory[];
+  page: TidalPage;
+} {
   const hideNeedles = HIDDEN_HOME_ROW_TITLES.map(normalizeTitle);
   const mergeNeedles = MERGE_SOURCE_TITLES.map(normalizeTitle);
 
@@ -96,15 +110,36 @@ function filterHomeRows(page: TidalPage): TidalPage {
     };
   }
 
-  // Second pass: reorder the surviving rows so the priority titles
-  // appear first in the configured order, with everything else
-  // following in its original position.
+  // Second pass: split out the compact pill rows (rendered above the
+  // fold) from everything else (rendered as big cards via PageView).
+  // Compact rows come out in the order declared in COMPACT_ROW_TITLES
+  // so the visual sequence on the page stays predictable regardless
+  // of Tidal's feed order.
+  const compactByTitle = new Map<string, PageCategory>();
+  const otherRows: PageCategory[] = [];
+  for (const cat of kept) {
+    const title = normalizeTitle(cat.title ?? "");
+    if (COMPACT_ROW_TITLES.has(title)) {
+      compactByTitle.set(title, cat);
+    } else {
+      otherRows.push(cat);
+    }
+  }
+  const compactRows: PageCategory[] = [];
+  for (const title of COMPACT_ROW_TITLES) {
+    const cat = compactByTitle.get(title);
+    if (cat) compactRows.push(cat);
+  }
+
+  // Third pass: reorder the card rows so the priority titles appear
+  // first in the configured order, with everything else following in
+  // its original position.
   const priorityOrder = PRIORITY_ROW_ORDER.map(normalizeTitle);
   const priorityRows: Array<PageCategory | undefined> = priorityOrder.map(
     () => undefined,
   );
   const leftover: PageCategory[] = [];
-  for (const cat of kept) {
+  for (const cat of otherRows) {
     const title = normalizeTitle(cat.title ?? "");
     const idx = priorityOrder.indexOf(title);
     if (idx >= 0) {
@@ -118,7 +153,261 @@ function filterHomeRows(page: TidalPage): TidalPage {
     ...leftover,
   ];
 
-  return { ...page, categories: finalCategories };
+  return {
+    compactRows,
+    page: { ...page, categories: finalCategories },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Compact pill row. Cover on the left, title + subtitle to the right,
+// three across, up to nine visible. Used for Recently played and the
+// merged Suggested new songs row where density reads better than a
+// wall of big cards.
+// ---------------------------------------------------------------------------
+const COMPACT_VISIBLE_COUNT = 9;
+
+function CompactRow({ category }: { category: PageCategory }) {
+  const items = category.items.slice(0, COMPACT_VISIBLE_COUNT);
+  if (items.length === 0) return null;
+  // View more routes to the dedicated drill-down page Tidal emits for
+  // this row, matching the card rows' SectionHeader behaviour.
+  const hasMore =
+    category.items.length > COMPACT_VISIBLE_COUNT && !!category.viewAllPath;
+  return (
+    <div className="mb-10">
+      <div className="mb-4 flex items-baseline justify-between gap-4">
+        <h2 className="text-xl font-bold tracking-tight">{category.title}</h2>
+        {hasMore && category.viewAllPath && (
+          <Link
+            to={`/browse/${encodeURIComponent(category.viewAllPath)}`}
+            className="flex flex-shrink-0 items-center gap-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+          >
+            View more <ChevronRight className="h-3.5 w-3.5" />
+          </Link>
+        )}
+      </div>
+      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
+        {items.map((item, i) => (
+          <CompactPill
+            key={`${item.kind}-${pillId(item, i)}`}
+            item={item}
+            rowTracks={rowTracks(items)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Pull the row's tracks out once so every CompactPill that represents a
+// track shares the same context queue. Clicking a track's cover plays
+// that track and sets next/prev to walk the rest of the row's tracks.
+function rowTracks(items: PageItem[]): Track[] {
+  return items.filter((it): it is Track => it.kind === "track");
+}
+
+function pillId(item: PageItem, fallback: number): string {
+  if ("id" in item) return String(item.id);
+  if (item.kind === "pagelink") return item.path;
+  return String(fallback);
+}
+
+function pillRoute(item: PageItem): string | null {
+  switch (item.kind) {
+    case "track":
+      return item.album ? `/album/${item.album.id}` : null;
+    case "album":
+      return `/album/${item.id}`;
+    case "artist":
+      return `/artist/${item.id}`;
+    case "playlist":
+      return `/playlist/${item.id}`;
+    case "mix":
+      return `/mix/${item.id}`;
+    case "pagelink":
+      return null;
+  }
+}
+
+function pillCover(item: PageItem): string | null {
+  switch (item.kind) {
+    case "track":
+      return item.album?.cover ?? null;
+    case "album":
+      return item.cover ?? null;
+    case "artist":
+      return item.picture ?? null;
+    case "playlist":
+      return item.cover ?? null;
+    case "mix":
+      return item.cover ?? null;
+    default:
+      return null;
+  }
+}
+
+function pillSubtitle(item: PageItem): string {
+  switch (item.kind) {
+    case "track":
+      return item.artists.map((a) => a.name).join(", ");
+    case "album":
+      return item.artists.map((a) => a.name).join(", ");
+    case "artist":
+      return "Artist";
+    case "playlist":
+      return item.creator || "Playlist";
+    case "mix":
+      return item.subtitle || "Mix";
+    default:
+      return "";
+  }
+}
+
+function CompactPill({
+  item,
+  rowTracks,
+}: {
+  item: PageItem;
+  rowTracks: Track[];
+}) {
+  // Tracks have three separate hit regions so the card behaves like
+  // Tidal's own client: cover plays, title opens the album, subtitle
+  // opens the artist. Non-track items (albums, artists, playlists,
+  // mixes) keep the simpler whole-pill-is-a-link behaviour.
+  if (item.kind === "track") {
+    return <TrackPill track={item} rowTracks={rowTracks} />;
+  }
+  return <EntityPill item={item} />;
+}
+
+const PILL_CLASS =
+  "flex items-center gap-3 rounded-md bg-card/60 p-2 pr-3 transition-colors hover:bg-accent";
+
+function EntityPill({ item }: { item: PageItem }) {
+  const to = pillRoute(item);
+  const cover = pillCover(item);
+  const name = "name" in item ? item.name : "title" in item ? item.title : "";
+  const subtitle = pillSubtitle(item);
+  const inner = (
+    <>
+      <PillCover cover={cover} />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-semibold">{name}</div>
+        {subtitle && (
+          <div className="truncate text-xs text-muted-foreground">
+            {subtitle}
+          </div>
+        )}
+      </div>
+      <MoreHorizontal className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+    </>
+  );
+  if (to) {
+    return (
+      <Link to={to} className={PILL_CLASS}>
+        {inner}
+      </Link>
+    );
+  }
+  return <div className={PILL_CLASS}>{inner}</div>;
+}
+
+function TrackPill({ track, rowTracks }: { track: Track; rowTracks: Track[] }) {
+  const actions = usePlayerActions();
+  const meta = usePlayerMeta();
+  const isCurrent = meta.track?.id === track.id;
+  const isPlaying = isCurrent && meta.playing;
+  const cover = track.album?.cover ?? null;
+  const albumPath = track.album ? `/album/${track.album.id}` : null;
+  const primaryArtist = track.artists[0];
+  const artistPath = primaryArtist ? `/artist/${primaryArtist.id}` : null;
+  const artistLabel = track.artists.map((a) => a.name).join(", ");
+  const handlePlay = () => {
+    if (isCurrent) {
+      actions.toggle();
+    } else {
+      actions.play(track, rowTracks);
+    }
+  };
+  return (
+    <div className={`${PILL_CLASS} group`}>
+      <button
+        type="button"
+        onClick={handlePlay}
+        aria-label={isPlaying ? `Pause ${track.name}` : `Play ${track.name}`}
+        className="relative h-12 w-12 flex-shrink-0 overflow-hidden rounded bg-secondary"
+      >
+        {cover ? (
+          <img
+            src={imageProxy(cover)}
+            alt=""
+            className="h-full w-full object-cover"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+            <Music className="h-5 w-5" />
+          </div>
+        )}
+        <span
+          className={`absolute inset-0 flex items-center justify-center bg-black/50 transition-opacity ${
+            isPlaying
+              ? "opacity-100"
+              : "opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+          }`}
+        >
+          <Play className="h-5 w-5 text-foreground" fill="currentColor" />
+        </span>
+      </button>
+      <div className="min-w-0 flex-1">
+        {albumPath ? (
+          <Link
+            to={albumPath}
+            className="block truncate text-sm font-semibold hover:underline"
+          >
+            {track.name}
+          </Link>
+        ) : (
+          <div className="truncate text-sm font-semibold">{track.name}</div>
+        )}
+        {artistLabel && (
+          artistPath ? (
+            <Link
+              to={artistPath}
+              className="block truncate text-xs text-muted-foreground hover:underline"
+            >
+              {artistLabel}
+            </Link>
+          ) : (
+            <div className="truncate text-xs text-muted-foreground">
+              {artistLabel}
+            </div>
+          )
+        )}
+      </div>
+      <MoreHorizontal className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+    </div>
+  );
+}
+
+function PillCover({ cover }: { cover: string | null }) {
+  return (
+    <div className="h-12 w-12 flex-shrink-0 overflow-hidden rounded bg-secondary">
+      {cover ? (
+        <img
+          src={imageProxy(cover)}
+          alt=""
+          className="h-full w-full object-cover"
+          loading="lazy"
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+          <Music className="h-5 w-5" />
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function Home({ onDownload }: { onDownload: OnDownload }) {
@@ -137,12 +426,15 @@ export function Home({ onDownload }: { onDownload: OnDownload }) {
   }
   if (error || !data) return <ErrorView error={error ?? "Couldn't load home"} />;
 
-  const filteredPage = filterHomeRows(data);
+  const { compactRows, page: filteredPage } = filterHomeRows(data);
 
   return (
     <div>
       <h1 className="mb-8 text-4xl font-bold tracking-tight">{greeting}</h1>
       <LastfmConnectNudge />
+      {compactRows.map((cat, i) => (
+        <CompactRow key={`compact-${i}`} category={cat} />
+      ))}
       <PageView page={filteredPage} onDownload={onDownload} forceSingleRow />
     </div>
   );

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
-import { MoreHorizontal, Music } from "lucide-react";
+import { ChevronRight, MoreHorizontal, Music } from "lucide-react";
 import { api } from "@/api/client";
 import type { OnDownload } from "@/api/download";
 import { useApi } from "@/hooks/useApi";
@@ -168,13 +169,30 @@ function filterHomeRows(page: TidalPage): {
 // list to pick from" than "browse editorial wall", specifically
 // Recently played and the merged Suggested new songs for you.
 // ---------------------------------------------------------------------------
+const COMPACT_COLLAPSED_COUNT = 9;
+
 function CompactRow({ category }: { category: PageCategory }) {
-  const items = category.items.slice(0, 9);
-  if (items.length === 0) return null;
+  const [expanded, setExpanded] = useState(false);
+  if (category.items.length === 0) return null;
+  const items = expanded
+    ? category.items
+    : category.items.slice(0, COMPACT_COLLAPSED_COUNT);
+  const hasMore = category.items.length > COMPACT_COLLAPSED_COUNT;
   return (
     <div className="mb-10">
       <div className="mb-4 flex items-baseline justify-between gap-4">
         <h2 className="text-xl font-bold tracking-tight">{category.title}</h2>
+        {hasMore && (
+          <button
+            onClick={() => setExpanded((v) => !v)}
+            className="flex flex-shrink-0 items-center gap-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
+          >
+            {expanded ? "Show less" : "View more"}
+            <ChevronRight
+              className={`h-3.5 w-3.5 transition-transform ${expanded ? "rotate-90" : ""}`}
+            />
+          </button>
+        )}
       </div>
       <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
         {items.map((item, i) => (

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,5 +1,6 @@
+import { useState } from "react";
 import { Link } from "react-router-dom";
-import { ChevronRight, MoreHorizontal, Music, Play } from "lucide-react";
+import { ChevronRight, Loader2, MoreHorizontal, Music, Play } from "lucide-react";
 import { api } from "@/api/client";
 import type { OnDownload } from "@/api/download";
 import { useApi } from "@/hooks/useApi";
@@ -8,8 +9,18 @@ import { PageView } from "@/components/PageView";
 import { ErrorView } from "@/components/ErrorView";
 import { GridSkeleton } from "@/components/Skeletons";
 import { LastfmConnectNudge } from "@/components/LastfmConnectNudge";
+import { useToast } from "@/components/toast";
 import { imageProxy } from "@/lib/utils";
-import type { PageCategory, PageItem, TidalPage, Track } from "@/api/types";
+import type {
+  Album,
+  Artist,
+  MixItem,
+  PageCategory,
+  PageItem,
+  Playlist,
+  TidalPage,
+  Track,
+} from "@/api/types";
 
 // Titles of Tidal editorial rows we do not want on our home page.
 // Matched case insensitively as a substring against the row title,
@@ -213,57 +224,16 @@ function pillId(item: PageItem, fallback: number): string {
   return String(fallback);
 }
 
-function pillRoute(item: PageItem): string | null {
-  switch (item.kind) {
-    case "track":
-      return item.album ? `/album/${item.album.id}` : null;
-    case "album":
-      return `/album/${item.id}`;
-    case "artist":
-      return `/artist/${item.id}`;
-    case "playlist":
-      return `/playlist/${item.id}`;
-    case "mix":
-      return `/mix/${item.id}`;
-    case "pagelink":
-      return null;
-  }
-}
+const PILL_CLASS =
+  "flex items-center gap-3 rounded-md bg-card/60 p-2 pr-3 transition-colors hover:bg-accent";
 
-function pillCover(item: PageItem): string | null {
-  switch (item.kind) {
-    case "track":
-      return item.album?.cover ?? null;
-    case "album":
-      return item.cover ?? null;
-    case "artist":
-      return item.picture ?? null;
-    case "playlist":
-      return item.cover ?? null;
-    case "mix":
-      return item.cover ?? null;
-    default:
-      return null;
-  }
-}
-
-function pillSubtitle(item: PageItem): string {
-  switch (item.kind) {
-    case "track":
-      return item.artists.map((a) => a.name).join(", ");
-    case "album":
-      return item.artists.map((a) => a.name).join(", ");
-    case "artist":
-      return "Artist";
-    case "playlist":
-      return item.creator || "Playlist";
-    case "mix":
-      return item.subtitle || "Mix";
-    default:
-      return "";
-  }
-}
-
+/**
+ * Unified compact pill. Every kind renders the same three hit regions
+ * Tidal's own client uses: the cover plays the item (or navigates for
+ * artists, which can't be played directly), the title opens the item's
+ * detail page, and the subtitle opens whoever "made" it when that's a
+ * real entity the user can navigate to.
+ */
 function CompactPill({
   item,
   rowTracks,
@@ -271,72 +241,55 @@ function CompactPill({
   item: PageItem;
   rowTracks: Track[];
 }) {
-  // Tracks have three separate hit regions so the card behaves like
-  // Tidal's own client: cover plays, title opens the album, subtitle
-  // opens the artist. Non-track items (albums, artists, playlists,
-  // mixes) keep the simpler whole-pill-is-a-link behaviour.
-  if (item.kind === "track") {
-    return <TrackPill track={item} rowTracks={rowTracks} />;
+  switch (item.kind) {
+    case "track":
+      return <TrackPill track={item} rowTracks={rowTracks} />;
+    case "album":
+      return <AlbumPill album={item} />;
+    case "playlist":
+      return <PlaylistPill playlist={item} />;
+    case "mix":
+      return <MixPill mix={item} />;
+    case "artist":
+      return <ArtistPill artist={item} />;
+    default:
+      return null;
   }
-  return <EntityPill item={item} />;
 }
 
-const PILL_CLASS =
-  "flex items-center gap-3 rounded-md bg-card/60 p-2 pr-3 transition-colors hover:bg-accent";
-
-function EntityPill({ item }: { item: PageItem }) {
-  const to = pillRoute(item);
-  const cover = pillCover(item);
-  const name = "name" in item ? item.name : "title" in item ? item.title : "";
-  const subtitle = pillSubtitle(item);
-  const inner = (
-    <>
-      <PillCover cover={cover} />
-      <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-semibold">{name}</div>
-        {subtitle && (
-          <div className="truncate text-xs text-muted-foreground">
-            {subtitle}
-          </div>
-        )}
-      </div>
-      <MoreHorizontal className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
-    </>
-  );
-  if (to) {
-    return (
-      <Link to={to} className={PILL_CLASS}>
-        {inner}
-      </Link>
-    );
-  }
-  return <div className={PILL_CLASS}>{inner}</div>;
-}
-
-function TrackPill({ track, rowTracks }: { track: Track; rowTracks: Track[] }) {
-  const actions = usePlayerActions();
-  const meta = usePlayerMeta();
-  const isCurrent = meta.track?.id === track.id;
-  const isPlaying = isCurrent && meta.playing;
-  const cover = track.album?.cover ?? null;
-  const albumPath = track.album ? `/album/${track.album.id}` : null;
-  const primaryArtist = track.artists[0];
-  const artistPath = primaryArtist ? `/artist/${primaryArtist.id}` : null;
-  const artistLabel = track.artists.map((a) => a.name).join(", ");
-  const handlePlay = () => {
-    if (isCurrent) {
-      actions.toggle();
-    } else {
-      actions.play(track, rowTracks);
-    }
-  };
+/**
+ * Shared layout for a pill whose cover plays something. The caller
+ * owns the play handler, playing state, and the three text regions.
+ */
+function PlayablePill({
+  cover,
+  isPlaying,
+  busy,
+  ariaPlay,
+  onPlay,
+  title,
+  titleTo,
+  subtitle,
+  subtitleTo,
+}: {
+  cover: string | null;
+  isPlaying: boolean;
+  busy: boolean;
+  ariaPlay: string;
+  onPlay: () => void;
+  title: string;
+  titleTo: string | null;
+  subtitle: string | null;
+  subtitleTo: string | null;
+}) {
   return (
     <div className={`${PILL_CLASS} group`}>
       <button
         type="button"
-        onClick={handlePlay}
-        aria-label={isPlaying ? `Pause ${track.name}` : `Play ${track.name}`}
-        className="relative h-12 w-12 flex-shrink-0 overflow-hidden rounded bg-secondary"
+        onClick={onPlay}
+        disabled={busy}
+        aria-label={ariaPlay}
+        className="relative h-12 w-12 flex-shrink-0 overflow-hidden rounded bg-secondary disabled:opacity-80"
       >
         {cover ? (
           <img
@@ -352,36 +305,40 @@ function TrackPill({ track, rowTracks }: { track: Track; rowTracks: Track[] }) {
         )}
         <span
           className={`absolute inset-0 flex items-center justify-center bg-black/50 transition-opacity ${
-            isPlaying
+            isPlaying || busy
               ? "opacity-100"
               : "opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
           }`}
         >
-          <Play className="h-5 w-5 text-foreground" fill="currentColor" />
+          {busy ? (
+            <Loader2 className="h-5 w-5 animate-spin text-foreground" />
+          ) : (
+            <Play className="h-5 w-5 text-foreground" fill="currentColor" />
+          )}
         </span>
       </button>
       <div className="min-w-0 flex-1">
-        {albumPath ? (
+        {titleTo ? (
           <Link
-            to={albumPath}
+            to={titleTo}
             className="block truncate text-sm font-semibold hover:underline"
           >
-            {track.name}
+            {title}
           </Link>
         ) : (
-          <div className="truncate text-sm font-semibold">{track.name}</div>
+          <div className="truncate text-sm font-semibold">{title}</div>
         )}
-        {artistLabel && (
-          artistPath ? (
+        {subtitle && (
+          subtitleTo ? (
             <Link
-              to={artistPath}
+              to={subtitleTo}
               className="block truncate text-xs text-muted-foreground hover:underline"
             >
-              {artistLabel}
+              {subtitle}
             </Link>
           ) : (
             <div className="truncate text-xs text-muted-foreground">
-              {artistLabel}
+              {subtitle}
             </div>
           )
         )}
@@ -389,6 +346,160 @@ function TrackPill({ track, rowTracks }: { track: Track; rowTracks: Track[] }) {
       <MoreHorizontal className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
     </div>
   );
+}
+
+function TrackPill({ track, rowTracks }: { track: Track; rowTracks: Track[] }) {
+  const actions = usePlayerActions();
+  const meta = usePlayerMeta();
+  const isCurrent = meta.track?.id === track.id;
+  const isPlaying = isCurrent && meta.playing;
+  const primaryArtist = track.artists[0];
+  return (
+    <PlayablePill
+      cover={track.album?.cover ?? null}
+      isPlaying={isPlaying}
+      busy={false}
+      ariaPlay={isPlaying ? `Pause ${track.name}` : `Play ${track.name}`}
+      onPlay={() => {
+        if (isCurrent) actions.toggle();
+        else actions.play(track, rowTracks);
+      }}
+      title={track.name}
+      titleTo={track.album ? `/album/${track.album.id}` : null}
+      subtitle={track.artists.map((a) => a.name).join(", ") || null}
+      subtitleTo={primaryArtist ? `/artist/${primaryArtist.id}` : null}
+    />
+  );
+}
+
+function AlbumPill({ album }: { album: Album }) {
+  const primaryArtist = album.artists[0];
+  const { busy, onPlay } = useCollectionPlay({
+    label: "album",
+    fetch: () => api.album(album.id),
+  });
+  return (
+    <PlayablePill
+      cover={album.cover}
+      isPlaying={false}
+      busy={busy}
+      ariaPlay={`Play ${album.name}`}
+      onPlay={onPlay}
+      title={album.name}
+      titleTo={`/album/${album.id}`}
+      subtitle={album.artists.map((a) => a.name).join(", ") || null}
+      subtitleTo={primaryArtist ? `/artist/${primaryArtist.id}` : null}
+    />
+  );
+}
+
+function PlaylistPill({ playlist }: { playlist: Playlist }) {
+  const { busy, onPlay } = useCollectionPlay({
+    label: "playlist",
+    fetch: () => api.playlist(playlist.id),
+  });
+  // Only link the creator when Tidal gives us a real id; the "0" sentinel
+  // is their editorial account catch-all and doesn't resolve to a page.
+  const creatorTo =
+    playlist.creator_id && playlist.creator_id !== "0"
+      ? `/user/${playlist.creator_id}`
+      : null;
+  return (
+    <PlayablePill
+      cover={playlist.cover}
+      isPlaying={false}
+      busy={busy}
+      ariaPlay={`Play ${playlist.name}`}
+      onPlay={onPlay}
+      title={playlist.name}
+      titleTo={`/playlist/${playlist.id}`}
+      subtitle={playlist.creator || "Playlist"}
+      subtitleTo={creatorTo}
+    />
+  );
+}
+
+function MixPill({ mix }: { mix: MixItem }) {
+  const { busy, onPlay } = useCollectionPlay({
+    label: "mix",
+    fetch: () => api.mix(mix.id),
+  });
+  return (
+    <PlayablePill
+      cover={mix.cover}
+      isPlaying={false}
+      busy={busy}
+      ariaPlay={`Play ${mix.name}`}
+      onPlay={onPlay}
+      title={mix.name}
+      titleTo={`/mix/${encodeURIComponent(mix.id)}`}
+      subtitle={mix.subtitle || "Mix"}
+      subtitleTo={null}
+    />
+  );
+}
+
+/**
+ * Artists are a special case: we don't have a safe "play an artist"
+ * operation outside of a seed-based radio mix, and that needs a sample
+ * ISRC which a pill doesn't know. Keep artist pills as a single Link so
+ * the click is unambiguous.
+ */
+function ArtistPill({ artist }: { artist: Artist }) {
+  return (
+    <Link to={`/artist/${artist.id}`} className={PILL_CLASS}>
+      <PillCover cover={artist.picture} />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-semibold">{artist.name}</div>
+        <div className="truncate text-xs text-muted-foreground">Artist</div>
+      </div>
+      <MoreHorizontal className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+    </Link>
+  );
+}
+
+/**
+ * Fetch-then-play hook for collection pills (album / playlist / mix).
+ * Returns a busy flag and a handler the cover button can hook into.
+ * Same behaviour as PlayMediaButton: resolves the detail payload, then
+ * kicks playback with the first track and the whole list as context.
+ */
+function useCollectionPlay({
+  label,
+  fetch,
+}: {
+  label: string;
+  fetch: () => Promise<{ tracks?: Track[] }>;
+}) {
+  const actions = usePlayerActions();
+  const toast = useToast();
+  const [busy, setBusy] = useState(false);
+  const onPlay = async () => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const detail = await fetch();
+      const tracks = detail.tracks;
+      if (!tracks?.length) {
+        toast.show({
+          kind: "info",
+          title: "Nothing to play",
+          description: `This ${label} has no playable tracks.`,
+        });
+        return;
+      }
+      actions.play(tracks[0], tracks);
+    } catch (err) {
+      toast.show({
+        kind: "error",
+        title: "Couldn't start playback",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setBusy(false);
+    }
+  };
+  return { busy, onPlay };
 }
 
 function PillCover({ cover }: { cover: string | null }) {

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,15 +1,11 @@
-import { Link } from "react-router-dom";
-import { ChevronRight, MoreHorizontal, Music, Play } from "lucide-react";
 import { api } from "@/api/client";
 import type { OnDownload } from "@/api/download";
 import { useApi } from "@/hooks/useApi";
-import { usePlayerActions, usePlayerMeta } from "@/hooks/PlayerContext";
 import { PageView } from "@/components/PageView";
 import { ErrorView } from "@/components/ErrorView";
 import { GridSkeleton } from "@/components/Skeletons";
 import { LastfmConnectNudge } from "@/components/LastfmConnectNudge";
-import { imageProxy } from "@/lib/utils";
-import type { PageCategory, PageItem, TidalPage, Track } from "@/api/types";
+import type { PageCategory, PageItem, TidalPage } from "@/api/types";
 
 // Titles of Tidal editorial rows we do not want on our home page.
 // Matched case insensitively as a substring against the row title,
@@ -41,26 +37,15 @@ const HIDDEN_HOME_ROW_TITLES = [
 const MERGE_SOURCE_TITLES = ["recommended new tracks", "uploads for you"];
 const MERGED_ROW_TITLE = "Suggested new songs for you";
 
-// Titles of the rows that should be extracted and rendered at the top
-// of the home page with the compact pill layout (cover + title +
-// subtitle on one line), rather than as a grid of big cards. Matched
-// as a normalised full-string compare against the row title. These
-// rows are the "your quick access" shelf, so a density-oriented
-// treatment reads better than an eye-candy card wall.
-//
-// Note that Set iteration order follows insertion order, so the
-// sequence below is also the visual order the compact section
-// renders in: Recently played, then the merged "Suggested new songs
-// for you", then "Suggested new albums for you".
-const COMPACT_ROW_TITLES = new Set([
+// Desired order for the card-style rows at the top of the feed.
+// Anything not listed here keeps whatever order Tidal sent.
+const PRIORITY_ROW_ORDER = [
   "recently played",
   normalizeTitle(MERGED_ROW_TITLE),
   "suggested new albums for you",
-]);
-
-// Desired order for the card-style rows that remain in the page feed.
-// Anything not listed here keeps whatever order Tidal sent.
-const PRIORITY_ROW_ORDER = ["custom mixes", "personal radio stations"];
+  "custom mixes",
+  "personal radio stations",
+];
 
 function normalizeTitle(s: string): string {
   return s
@@ -69,10 +54,7 @@ function normalizeTitle(s: string): string {
     .replace(/[“”‟″]/g, '"'); // curly / prime double quotes
 }
 
-function filterHomeRows(page: TidalPage): {
-  compactRows: PageCategory[];
-  page: TidalPage;
-} {
+function filterHomeRows(page: TidalPage): TidalPage {
   const hideNeedles = HIDDEN_HOME_ROW_TITLES.map(normalizeTitle);
   const mergeNeedles = MERGE_SOURCE_TITLES.map(normalizeTitle);
 
@@ -114,36 +96,15 @@ function filterHomeRows(page: TidalPage): {
     };
   }
 
-  // Second pass: split the surviving categories into the compact rows
-  // (rendered as pill lists at the top of the page) and everything
-  // else (rendered as cards via PageView). Compact rows come out in
-  // the order declared in COMPACT_ROW_TITLES so the visual sequence
-  // on the page is predictable regardless of Tidal's feed order.
-  const compactByTitle = new Map<string, PageCategory>();
-  const otherRows: PageCategory[] = [];
-  for (const cat of kept) {
-    const title = normalizeTitle(cat.title ?? "");
-    if (COMPACT_ROW_TITLES.has(title)) {
-      compactByTitle.set(title, cat);
-    } else {
-      otherRows.push(cat);
-    }
-  }
-  const compactRows: PageCategory[] = [];
-  for (const title of COMPACT_ROW_TITLES) {
-    const cat = compactByTitle.get(title);
-    if (cat) compactRows.push(cat);
-  }
-
-  // Third pass: reorder the card rows so the priority titles appear
-  // first in the configured order, with everything else following in
-  // its original position.
+  // Second pass: reorder the surviving rows so the priority titles
+  // appear first in the configured order, with everything else
+  // following in its original position.
   const priorityOrder = PRIORITY_ROW_ORDER.map(normalizeTitle);
   const priorityRows: Array<PageCategory | undefined> = priorityOrder.map(
     () => undefined,
   );
   const leftover: PageCategory[] = [];
-  for (const cat of otherRows) {
+  for (const cat of kept) {
     const title = normalizeTitle(cat.title ?? "");
     const idx = priorityOrder.indexOf(title);
     if (idx >= 0) {
@@ -157,262 +118,7 @@ function filterHomeRows(page: TidalPage): {
     ...leftover,
   ];
 
-  return {
-    compactRows,
-    page: { ...page, categories: finalCategories },
-  };
-}
-
-// ---------------------------------------------------------------------------
-// Compact pill row. Cover on the left, title + subtitle to the right,
-// three across, up to nine visible. Used for rows that are more "quick
-// list to pick from" than "browse editorial wall", specifically
-// Recently played and the merged Suggested new songs for you.
-// ---------------------------------------------------------------------------
-const COMPACT_VISIBLE_COUNT = 9;
-
-function CompactRow({ category }: { category: PageCategory }) {
-  const items = category.items.slice(0, COMPACT_VISIBLE_COUNT);
-  if (items.length === 0) return null;
-  // View more routes to the dedicated drill-down page Tidal emits for
-  // this row (same pattern the card rows use via SectionHeader). Only
-  // renders when there's more to see AND Tidal gave us a viewAllPath.
-  const hasMore =
-    category.items.length > COMPACT_VISIBLE_COUNT && !!category.viewAllPath;
-  return (
-    <div className="mb-10">
-      <div className="mb-4 flex items-baseline justify-between gap-4">
-        <h2 className="text-xl font-bold tracking-tight">{category.title}</h2>
-        {hasMore && category.viewAllPath && (
-          <Link
-            to={`/browse/${encodeURIComponent(category.viewAllPath)}`}
-            className="flex flex-shrink-0 items-center gap-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
-          >
-            View more <ChevronRight className="h-3.5 w-3.5" />
-          </Link>
-        )}
-      </div>
-      <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
-        {items.map((item, i) => (
-          <CompactPill
-            key={`${item.kind}-${pillId(item, i)}`}
-            item={item}
-            rowTracks={rowTracks(items)}
-          />
-        ))}
-      </div>
-    </div>
-  );
-}
-
-// Pull the row's tracks out once so every CompactPill that represents a
-// track shares the same context queue. Clicking a track's cover plays
-// that track and sets next/prev to walk the rest of the row's tracks.
-function rowTracks(items: PageItem[]): Track[] {
-  return items.filter((it): it is Track => it.kind === "track");
-}
-
-function pillId(item: PageItem, fallback: number): string {
-  if ("id" in item) return String(item.id);
-  if (item.kind === "pagelink") return item.path;
-  return String(fallback);
-}
-
-function pillRoute(item: PageItem): string | null {
-  switch (item.kind) {
-    case "track":
-      return item.album ? `/album/${item.album.id}` : null;
-    case "album":
-      return `/album/${item.id}`;
-    case "artist":
-      return `/artist/${item.id}`;
-    case "playlist":
-      return `/playlist/${item.id}`;
-    case "mix":
-      return `/mix/${item.id}`;
-    case "pagelink":
-      return null;
-  }
-}
-
-function pillCover(item: PageItem): string | null {
-  switch (item.kind) {
-    case "track":
-      return item.album?.cover ?? null;
-    case "album":
-      return item.cover ?? null;
-    case "artist":
-      return item.picture ?? null;
-    case "playlist":
-      return item.cover ?? null;
-    case "mix":
-      return item.cover ?? null;
-    default:
-      return null;
-  }
-}
-
-function pillSubtitle(item: PageItem): string {
-  switch (item.kind) {
-    case "track":
-      return item.artists.map((a) => a.name).join(", ");
-    case "album":
-      return item.artists.map((a) => a.name).join(", ");
-    case "artist":
-      return "Artist";
-    case "playlist":
-      return item.creator || "Playlist";
-    case "mix":
-      return item.subtitle || "Mix";
-    default:
-      return "";
-  }
-}
-
-function CompactPill({
-  item,
-  rowTracks,
-}: {
-  item: PageItem;
-  rowTracks: Track[];
-}) {
-  // Tracks have three separate hit regions so the card behaves like
-  // Tidal's own client: cover plays, title opens the album, subtitle
-  // opens the artist. Non-track items (albums, artists, playlists,
-  // mixes) keep the simpler whole-pill-is-a-link behaviour.
-  if (item.kind === "track") {
-    return <TrackPill track={item} rowTracks={rowTracks} />;
-  }
-  return <EntityPill item={item} />;
-}
-
-const PILL_CLASS =
-  "flex items-center gap-3 rounded-md bg-card/60 p-2 pr-3 transition-colors hover:bg-accent";
-
-function EntityPill({ item }: { item: PageItem }) {
-  const to = pillRoute(item);
-  const cover = pillCover(item);
-  const name = "name" in item ? item.name : "title" in item ? item.title : "";
-  const subtitle = pillSubtitle(item);
-  const inner = (
-    <>
-      <PillCover cover={cover} />
-      <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-semibold">{name}</div>
-        {subtitle && (
-          <div className="truncate text-xs text-muted-foreground">
-            {subtitle}
-          </div>
-        )}
-      </div>
-      <MoreHorizontal className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
-    </>
-  );
-  if (to) {
-    return (
-      <Link to={to} className={PILL_CLASS}>
-        {inner}
-      </Link>
-    );
-  }
-  return <div className={PILL_CLASS}>{inner}</div>;
-}
-
-function TrackPill({ track, rowTracks }: { track: Track; rowTracks: Track[] }) {
-  const actions = usePlayerActions();
-  const meta = usePlayerMeta();
-  const isCurrent = meta.track?.id === track.id;
-  const isPlaying = isCurrent && meta.playing;
-  const cover = track.album?.cover ?? null;
-  const albumPath = track.album ? `/album/${track.album.id}` : null;
-  const primaryArtist = track.artists[0];
-  const artistPath = primaryArtist ? `/artist/${primaryArtist.id}` : null;
-  const artistLabel = track.artists.map((a) => a.name).join(", ");
-  const handlePlay = () => {
-    if (isCurrent) {
-      actions.toggle();
-    } else {
-      actions.play(track, rowTracks);
-    }
-  };
-  return (
-    <div className={`${PILL_CLASS} group`}>
-      <button
-        type="button"
-        onClick={handlePlay}
-        aria-label={isPlaying ? `Pause ${track.name}` : `Play ${track.name}`}
-        className="relative h-12 w-12 flex-shrink-0 overflow-hidden rounded bg-secondary"
-      >
-        {cover ? (
-          <img
-            src={imageProxy(cover)}
-            alt=""
-            className="h-full w-full object-cover"
-            loading="lazy"
-          />
-        ) : (
-          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
-            <Music className="h-5 w-5" />
-          </div>
-        )}
-        <span
-          className={`absolute inset-0 flex items-center justify-center bg-black/50 transition-opacity ${
-            isPlaying
-              ? "opacity-100"
-              : "opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
-          }`}
-        >
-          <Play className="h-5 w-5 text-foreground" fill="currentColor" />
-        </span>
-      </button>
-      <div className="min-w-0 flex-1">
-        {albumPath ? (
-          <Link
-            to={albumPath}
-            className="block truncate text-sm font-semibold hover:underline"
-          >
-            {track.name}
-          </Link>
-        ) : (
-          <div className="truncate text-sm font-semibold">{track.name}</div>
-        )}
-        {artistLabel && (
-          artistPath ? (
-            <Link
-              to={artistPath}
-              className="block truncate text-xs text-muted-foreground hover:underline"
-            >
-              {artistLabel}
-            </Link>
-          ) : (
-            <div className="truncate text-xs text-muted-foreground">
-              {artistLabel}
-            </div>
-          )
-        )}
-      </div>
-      <MoreHorizontal className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
-    </div>
-  );
-}
-
-function PillCover({ cover }: { cover: string | null }) {
-  return (
-    <div className="h-12 w-12 flex-shrink-0 overflow-hidden rounded bg-secondary">
-      {cover ? (
-        <img
-          src={imageProxy(cover)}
-          alt=""
-          className="h-full w-full object-cover"
-          loading="lazy"
-        />
-      ) : (
-        <div className="flex h-full w-full items-center justify-center text-muted-foreground">
-          <Music className="h-5 w-5" />
-        </div>
-      )}
-    </div>
-  );
+  return { ...page, categories: finalCategories };
 }
 
 export function Home({ onDownload }: { onDownload: OnDownload }) {
@@ -431,15 +137,12 @@ export function Home({ onDownload }: { onDownload: OnDownload }) {
   }
   if (error || !data) return <ErrorView error={error ?? "Couldn't load home"} />;
 
-  const { compactRows, page: filteredPage } = filterHomeRows(data);
+  const filteredPage = filterHomeRows(data);
 
   return (
     <div>
       <h1 className="mb-8 text-4xl font-bold tracking-tight">{greeting}</h1>
       <LastfmConnectNudge />
-      {compactRows.map((cat, i) => (
-        <CompactRow key={`compact-${i}`} category={cat} />
-      ))}
       <PageView page={filteredPage} onDownload={onDownload} forceSingleRow />
     </div>
   );

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import { Link } from "react-router-dom";
 import { ChevronRight, MoreHorizontal, Music } from "lucide-react";
 import { api } from "@/api/client";
@@ -169,29 +168,27 @@ function filterHomeRows(page: TidalPage): {
 // list to pick from" than "browse editorial wall", specifically
 // Recently played and the merged Suggested new songs for you.
 // ---------------------------------------------------------------------------
-const COMPACT_COLLAPSED_COUNT = 9;
+const COMPACT_VISIBLE_COUNT = 9;
 
 function CompactRow({ category }: { category: PageCategory }) {
-  const [expanded, setExpanded] = useState(false);
-  if (category.items.length === 0) return null;
-  const items = expanded
-    ? category.items
-    : category.items.slice(0, COMPACT_COLLAPSED_COUNT);
-  const hasMore = category.items.length > COMPACT_COLLAPSED_COUNT;
+  const items = category.items.slice(0, COMPACT_VISIBLE_COUNT);
+  if (items.length === 0) return null;
+  // View more routes to the dedicated drill-down page Tidal emits for
+  // this row (same pattern the card rows use via SectionHeader). Only
+  // renders when there's more to see AND Tidal gave us a viewAllPath.
+  const hasMore =
+    category.items.length > COMPACT_VISIBLE_COUNT && !!category.viewAllPath;
   return (
     <div className="mb-10">
       <div className="mb-4 flex items-baseline justify-between gap-4">
         <h2 className="text-xl font-bold tracking-tight">{category.title}</h2>
-        {hasMore && (
-          <button
-            onClick={() => setExpanded((v) => !v)}
+        {hasMore && category.viewAllPath && (
+          <Link
+            to={`/browse/${encodeURIComponent(category.viewAllPath)}`}
             className="flex flex-shrink-0 items-center gap-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground transition-colors hover:text-foreground"
           >
-            {expanded ? "Show less" : "View more"}
-            <ChevronRight
-              className={`h-3.5 w-3.5 transition-transform ${expanded ? "rotate-90" : ""}`}
-            />
-          </button>
+            View more <ChevronRight className="h-3.5 w-3.5" />
+          </Link>
         )}
       </div>
       <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -1,14 +1,15 @@
 import { Link } from "react-router-dom";
-import { ChevronRight, MoreHorizontal, Music } from "lucide-react";
+import { ChevronRight, MoreHorizontal, Music, Play } from "lucide-react";
 import { api } from "@/api/client";
 import type { OnDownload } from "@/api/download";
 import { useApi } from "@/hooks/useApi";
+import { usePlayerActions, usePlayerMeta } from "@/hooks/PlayerContext";
 import { PageView } from "@/components/PageView";
 import { ErrorView } from "@/components/ErrorView";
 import { GridSkeleton } from "@/components/Skeletons";
 import { LastfmConnectNudge } from "@/components/LastfmConnectNudge";
 import { imageProxy } from "@/lib/utils";
-import type { PageCategory, PageItem, TidalPage } from "@/api/types";
+import type { PageCategory, PageItem, TidalPage, Track } from "@/api/types";
 
 // Titles of Tidal editorial rows we do not want on our home page.
 // Matched case insensitively as a substring against the row title,
@@ -193,11 +194,22 @@ function CompactRow({ category }: { category: PageCategory }) {
       </div>
       <div className="grid grid-cols-1 gap-2 sm:grid-cols-2 lg:grid-cols-3">
         {items.map((item, i) => (
-          <CompactPill key={`${item.kind}-${pillId(item, i)}`} item={item} />
+          <CompactPill
+            key={`${item.kind}-${pillId(item, i)}`}
+            item={item}
+            rowTracks={rowTracks(items)}
+          />
         ))}
       </div>
     </div>
   );
+}
+
+// Pull the row's tracks out once so every CompactPill that represents a
+// track shares the same context queue. Clicking a track's cover plays
+// that track and sets next/prev to walk the rest of the row's tracks.
+function rowTracks(items: PageItem[]): Track[] {
+  return items.filter((it): it is Track => it.kind === "track");
 }
 
 function pillId(item: PageItem, fallback: number): string {
@@ -257,14 +269,80 @@ function pillSubtitle(item: PageItem): string {
   }
 }
 
-function CompactPill({ item }: { item: PageItem }) {
+function CompactPill({
+  item,
+  rowTracks,
+}: {
+  item: PageItem;
+  rowTracks: Track[];
+}) {
+  // Tracks have three separate hit regions so the card behaves like
+  // Tidal's own client: cover plays, title opens the album, subtitle
+  // opens the artist. Non-track items (albums, artists, playlists,
+  // mixes) keep the simpler whole-pill-is-a-link behaviour.
+  if (item.kind === "track") {
+    return <TrackPill track={item} rowTracks={rowTracks} />;
+  }
+  return <EntityPill item={item} />;
+}
+
+const PILL_CLASS =
+  "flex items-center gap-3 rounded-md bg-card/60 p-2 pr-3 transition-colors hover:bg-accent";
+
+function EntityPill({ item }: { item: PageItem }) {
   const to = pillRoute(item);
   const cover = pillCover(item);
   const name = "name" in item ? item.name : "title" in item ? item.title : "";
   const subtitle = pillSubtitle(item);
   const inner = (
     <>
-      <div className="h-12 w-12 flex-shrink-0 overflow-hidden rounded bg-secondary">
+      <PillCover cover={cover} />
+      <div className="min-w-0 flex-1">
+        <div className="truncate text-sm font-semibold">{name}</div>
+        {subtitle && (
+          <div className="truncate text-xs text-muted-foreground">
+            {subtitle}
+          </div>
+        )}
+      </div>
+      <MoreHorizontal className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+    </>
+  );
+  if (to) {
+    return (
+      <Link to={to} className={PILL_CLASS}>
+        {inner}
+      </Link>
+    );
+  }
+  return <div className={PILL_CLASS}>{inner}</div>;
+}
+
+function TrackPill({ track, rowTracks }: { track: Track; rowTracks: Track[] }) {
+  const actions = usePlayerActions();
+  const meta = usePlayerMeta();
+  const isCurrent = meta.track?.id === track.id;
+  const isPlaying = isCurrent && meta.playing;
+  const cover = track.album?.cover ?? null;
+  const albumPath = track.album ? `/album/${track.album.id}` : null;
+  const primaryArtist = track.artists[0];
+  const artistPath = primaryArtist ? `/artist/${primaryArtist.id}` : null;
+  const artistLabel = track.artists.map((a) => a.name).join(", ");
+  const handlePlay = () => {
+    if (isCurrent) {
+      actions.toggle();
+    } else {
+      actions.play(track, rowTracks);
+    }
+  };
+  return (
+    <div className={`${PILL_CLASS} group`}>
+      <button
+        type="button"
+        onClick={handlePlay}
+        aria-label={isPlaying ? `Pause ${track.name}` : `Play ${track.name}`}
+        className="relative h-12 w-12 flex-shrink-0 overflow-hidden rounded bg-secondary"
+      >
         {cover ? (
           <img
             src={imageProxy(cover)}
@@ -277,28 +355,64 @@ function CompactPill({ item }: { item: PageItem }) {
             <Music className="h-5 w-5" />
           </div>
         )}
-      </div>
+        <span
+          className={`absolute inset-0 flex items-center justify-center bg-black/50 transition-opacity ${
+            isPlaying
+              ? "opacity-100"
+              : "opacity-0 group-hover:opacity-100 focus-visible:opacity-100"
+          }`}
+        >
+          <Play className="h-5 w-5 text-foreground" fill="currentColor" />
+        </span>
+      </button>
       <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-semibold">{name}</div>
-        {subtitle && (
-          <div className="truncate text-xs text-muted-foreground">
-            {subtitle}
-          </div>
+        {albumPath ? (
+          <Link
+            to={albumPath}
+            className="block truncate text-sm font-semibold hover:underline"
+          >
+            {track.name}
+          </Link>
+        ) : (
+          <div className="truncate text-sm font-semibold">{track.name}</div>
+        )}
+        {artistLabel && (
+          artistPath ? (
+            <Link
+              to={artistPath}
+              className="block truncate text-xs text-muted-foreground hover:underline"
+            >
+              {artistLabel}
+            </Link>
+          ) : (
+            <div className="truncate text-xs text-muted-foreground">
+              {artistLabel}
+            </div>
+          )
         )}
       </div>
       <MoreHorizontal className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
-    </>
+    </div>
   );
-  const className =
-    "flex items-center gap-3 rounded-md bg-card/60 p-2 pr-3 transition-colors hover:bg-accent";
-  if (to) {
-    return (
-      <Link to={to} className={className}>
-        {inner}
-      </Link>
-    );
-  }
-  return <div className={className}>{inner}</div>;
+}
+
+function PillCover({ cover }: { cover: string | null }) {
+  return (
+    <div className="h-12 w-12 flex-shrink-0 overflow-hidden rounded bg-secondary">
+      {cover ? (
+        <img
+          src={imageProxy(cover)}
+          alt=""
+          className="h-full w-full object-cover"
+          loading="lazy"
+        />
+      ) : (
+        <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+          <Music className="h-5 w-5" />
+        </div>
+      )}
+    </div>
+  );
 }
 
 export function Home({ onDownload }: { onDownload: OnDownload }) {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -193,6 +193,25 @@ export function SettingsPage({ onLogout }: { onLogout: () => void }) {
           </select>
         </Field>
         <AudioEngineFields />
+        <Field
+          label="Explicit content"
+          hint="Tidal returns both clean and explicit edits of the same album or track. Pick which copy you want to see when both exist."
+        >
+          <select
+            value={settings.explicit_content_preference}
+            onChange={(e) =>
+              patch({
+                explicit_content_preference: e.target
+                  .value as Settings["explicit_content_preference"],
+              })
+            }
+            className="h-10 rounded-md border border-input bg-secondary px-3 text-sm"
+          >
+            <option value="explicit">Show explicit</option>
+            <option value="clean">Show clean</option>
+            <option value="both">Show both</option>
+          </select>
+        </Field>
       </Section>
 
       <AirPlaySection />


### PR DESCRIPTION
The Recently Played / Suggested new songs / Suggested new albums
rows render as compact pill lists and were hard capped at nine
items with no way to reveal the rest. Add a View more toggle that
flips to Show less, matching the card-row pattern.

On the backend, "View more" for Custom Mixes and Personal Radio
Stations was landing on a blank page. Two fixes:

- The Tidal V2 view-all response for mix-heavy rows comes back in
  a few shapes we did not handle (bare objects without a type
  wrapper, modules/rows nesting). Collect items through a small
  walker and sniff the shape when the type is absent.

- tidalapi ships mixes under several class names, so broaden the
  Mix check in the page-item serializer to match any class whose
  name starts with Mix.

Also emit a stderr log preview whenever a resolve path produces
zero renderable items, so the next missing row surfaces a shape
hint we can act on without further tracing.
