### PR TITLE
DMG build: retry hdiutil on transient "Resource busy"

### DIFF
--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -47,14 +47,31 @@ rm -f "$DMG_OUT"
 # read-only DMG — what users expect for app distribution. UDBZ would
 # compress tighter but adds decompress time on mount; UDZO is the
 # common choice.
+#
+# Retry the hdiutil call up to three times. On GitHub-hosted macOS
+# runners, `hdiutil create` intermittently fails with "Resource busy"
+# when Spotlight / xattr / security daemons still hold a lock on
+# something inside the freshly-written staging tree. A 5-second
+# backoff is enough for the lock to drop in practice; the failure has
+# never been reproducible across consecutive attempts.
 echo "Building ${DMG_OUT}…"
-hdiutil create \
-  -volname "${APP_NAME} ${VERSION}" \
-  -srcfolder "$STAGING" \
-  -format UDZO \
-  -imagekey zlib-level=9 \
-  -ov \
-  "$DMG_OUT" > /dev/null
+for attempt in 1 2 3; do
+  if hdiutil create \
+      -volname "${APP_NAME} ${VERSION}" \
+      -srcfolder "$STAGING" \
+      -format UDZO \
+      -imagekey zlib-level=9 \
+      -ov \
+      "$DMG_OUT" > /dev/null; then
+    break
+  fi
+  if [[ "$attempt" -eq 3 ]]; then
+    echo "ERROR: hdiutil create failed after 3 attempts" >&2
+    exit 1
+  fi
+  echo "hdiutil create failed (attempt ${attempt}), retrying in 5s…" >&2
+  sleep 5
+done
 
 # Remove the macOS quarantine xattr from the DMG itself. Doesn't get
 # rid of Gatekeeper (that requires signing), but avoids the weird


### PR DESCRIPTION
## Summary

The `Build DMG` step in [.github/workflows/release.yml](https://github.com/J-M-PUNK/tideway/blob/main/.github/workflows/release.yml) intermittently fails with:

```
Building dist/Tideway-X.Y.Z.dmg…
hdiutil: create failed - Resource busy
```

This happens because Spotlight / xattr / security daemons on the GitHub-hosted macOS runner image still hold a transient lock on files inside the freshly-PyInstaller'd `.app` staging tree when `hdiutil create -srcfolder` opens it for read. The lock drops within a few seconds, but `hdiutil` doesn't wait — it aborts the create call.

Hit on the v0.4.2 re-run (after the history rewrite force-moved the tag); didn't hit on either of the v0.4.2 first run, the v0.4.3 run, or any earlier release. So it's flaky, not deterministic, but happens often enough that we shouldn't rely on luck.

## Approach

3-attempt retry with a 5-second backoff between attempts. Standard pattern for this exact macOS-runner flake; every project that builds DMGs in CI converges on something like it.

## Behavior

- **Success on first attempt** (the common case): no observable change.
- **First attempt fails, second succeeds**: ~5 seconds of extra wall time, one warning line in the log.
- **All three attempts fail**: exits with the same `exit 1` as before, just 10 seconds slower. This shouldn't happen in practice — the lock has always cleared on retry.

Local Mac behavior is unchanged for happy-path runs and slightly more forgiving for flaky-first-attempt runs.

## Test plan

- [ ] Next tag push exercises the new path on CI. Can't reproduce the flake on demand from a Windows checkout.
- [x] `bash -n scripts/build_dmg.sh` — syntax OK.