### PR TITLE
Artist page: Songs you've liked section

### DIFF
--- a/web/src/hooks/useFavorites.tsx
+++ b/web/src/hooks/useFavorites.tsx
@@ -150,6 +150,12 @@ export function FavoritesProvider({ children }: { children: ReactNode }) {
       try {
         if (already) await api.favorites.remove(kind, id);
         else await api.favorites.add(kind, id);
+        // Notify other surfaces that depend on the full library/tracks
+        // payload (e.g. `useLikedTracksByArtist` on the artist page's
+        // "Liked songs" section) so they can refetch. The event is
+        // a low-cost broadcast; only listeners on a current artist
+        // page actually do anything with it.
+        window.dispatchEvent(new CustomEvent("tideway:favorite-toggled"));
       } catch (err) {
         // Only roll back if the current state still reflects *our* optimistic
         // change. A rapid second click may have toggled again between the

--- a/web/src/hooks/useLikedTracksByArtist.ts
+++ b/web/src/hooks/useLikedTracksByArtist.ts
@@ -1,0 +1,98 @@
+import { useEffect, useMemo, useState } from "react";
+import { api } from "@/api/client";
+import type { Track } from "@/api/types";
+
+/**
+ * Returns the user's liked tracks filtered to those credited to a
+ * specific artist. Matches Spotify's "Liked songs by [Artist]" surface
+ * on the artist page.
+ *
+ * Implementation notes:
+ *
+ *   * Fetches `api.library.tracks()` once and caches the full list at
+ *     module scope so navigating between artist pages reuses it. The
+ *     filter is O(N) per call — fine even for libraries in the
+ *     thousands.
+ *   * Listens for the `tideway:favorite-toggled` window event,
+ *     dispatched from `useFavorites.toggle`, and invalidates the
+ *     cache so the next render reflects the new state. Without this
+ *     the section would freeze at the snapshot taken on first call.
+ *   * Includes featured-credit tracks. Spotify counts a track if the
+ *     artist appears anywhere in `artists[]`; we match that.
+ *   * Returns `null` while the first fetch is in flight so callers
+ *     can render a skeleton. An empty array means the user has no
+ *     liked tracks for this artist.
+ */
+const FAVORITE_TOGGLED_EVENT = "tideway:favorite-toggled";
+
+let cache: Track[] | null = null;
+let inflight: Promise<Track[]> | null = null;
+const subscribers = new Set<(tracks: Track[]) => void>();
+
+async function loadLibraryTracks(): Promise<Track[]> {
+  if (cache !== null) return cache;
+  if (inflight) return inflight;
+  inflight = api.library
+    .tracks()
+    .then((list) => {
+      cache = list;
+      subscribers.forEach((fn) => fn(list));
+      return list;
+    })
+    .finally(() => {
+      inflight = null;
+    });
+  return inflight;
+}
+
+/**
+ * Drop the in-memory cache and notify any active subscribers so they
+ * trigger a fresh fetch. Called from `useFavorites.toggle` so the
+ * artist page's "Liked songs" section stays in sync with the heart
+ * button. Safe to call from anywhere; idempotent when the cache is
+ * already empty.
+ */
+export function invalidateLikedTracksCache(): void {
+  cache = null;
+  // Active subscribers refetch on the next effect pass when the
+  // event handler below sets state to null and the dependent effect
+  // re-runs.
+}
+
+export function useLikedTracksByArtist(
+  artistId: string | null | undefined,
+): Track[] | null {
+  const [allLiked, setAllLiked] = useState<Track[] | null>(cache);
+
+  useEffect(() => {
+    // Subscriber fires when a fetch completes — covers the cold
+    // mount case as well as post-invalidation refetches.
+    const handle = (list: Track[]) => setAllLiked(list);
+    subscribers.add(handle);
+    void loadLibraryTracks().then((list) => setAllLiked(list));
+    return () => {
+      subscribers.delete(handle);
+    };
+  }, []);
+
+  // Invalidate + refetch on heart toggles.
+  useEffect(() => {
+    const listener = () => {
+      invalidateLikedTracksCache();
+      setAllLiked(null);
+      void loadLibraryTracks().then((list) => setAllLiked(list));
+    };
+    window.addEventListener(FAVORITE_TOGGLED_EVENT, listener);
+    return () => {
+      window.removeEventListener(FAVORITE_TOGGLED_EVENT, listener);
+    };
+  }, []);
+
+  return useMemo(() => {
+    if (allLiked === null || !artistId) return allLiked;
+    const wanted = String(artistId);
+    return allLiked.filter((t) =>
+      (t.artists ?? []).some((a) => String(a.id) === wanted),
+    );
+  }, [allLiked, artistId]);
+}

--- a/web/src/pages/ArtistDetail.tsx
+++ b/web/src/pages/ArtistDetail.tsx
@@ -6,6 +6,7 @@ import type { Album, Artist, Video } from "@/api/types";
 import type { OnDownload } from "@/api/download";
 import { useApi } from "@/hooks/useApi";
 import { useColumnCount } from "@/hooks/useColumnCount";
+import { useLikedTracksByArtist } from "@/hooks/useLikedTracksByArtist";
 import { useVideoPlayer } from "@/hooks/useVideoPlayer";
 import { ArtistHero } from "@/components/ArtistHero";
 import { ArtistTopCities } from "@/components/ArtistTopCities";
@@ -28,6 +29,11 @@ export function ArtistDetail({ onDownload }: { onDownload: OnDownload }) {
   // mount like it used to.
   const { data: artist, loading, error } = useApi(() => api.artist(id), [id]);
   const [popularExpanded, setPopularExpanded] = useState(false);
+  // The user's liked tracks credited to this artist. Spotify renders
+  // this above Albums on the artist page; we mirror the same slot.
+  // Hook returns null while the first library/tracks fetch is in
+  // flight; we just don't render the section in that window.
+  const likedByArtist = useLikedTracksByArtist(artist?.id);
 
   if (loading) {
     return (
@@ -81,6 +87,25 @@ export function ArtistDetail({ onDownload }: { onDownload: OnDownload }) {
             >
               {popularExpanded ? "Show less" : "View more"}
             </button>
+          )}
+        </>
+      )}
+
+      {likedByArtist && likedByArtist.length > 0 && (
+        <>
+          <SectionHeader
+            title={`Songs you've liked${
+              likedByArtist.length > 5 ? ` · ${likedByArtist.length}` : ""
+            }`}
+          />
+          <TrackList
+            tracks={likedByArtist.slice(0, 5)}
+            onDownload={onDownload}
+          />
+          {likedByArtist.length > 5 && (
+            <div className="mb-8 mt-2">
+              <ViewMoreLink to={`/artist/${id}/all/liked`} />
+            </div>
           )}
         </>
       )}

--- a/web/src/pages/ArtistSection.tsx
+++ b/web/src/pages/ArtistSection.tsx
@@ -4,6 +4,7 @@ import { api } from "@/api/client";
 import type { Album, Artist, Track, Video } from "@/api/types";
 import type { OnDownload } from "@/api/download";
 import { useApi } from "@/hooks/useApi";
+import { useLikedTracksByArtist } from "@/hooks/useLikedTracksByArtist";
 import { useVideoPlayer } from "@/hooks/useVideoPlayer";
 import { Grid } from "@/components/Grid";
 import { MediaCard } from "@/components/MediaCard";
@@ -18,11 +19,14 @@ export type ArtistSectionKey =
   | "eps"
   | "appears-on"
   | "similar"
-  | "videos";
+  | "videos"
+  | "liked";
 
 interface SectionMeta {
   title: string;
-  field: keyof ArtistData;
+  /** Field on the artist payload to read from. Set to `null` for
+   *  sections sourced from elsewhere (e.g. the user's library). */
+  field: keyof ArtistData | null;
   /** Render shape: tracks → TrackList; videos → video grid; media →
    *  MediaCard grid (albums and artists). Used by both the loading
    *  skeleton picker and the body dispatcher so the two stay in sync. */
@@ -36,6 +40,10 @@ const SECTIONS: Record<ArtistSectionKey, SectionMeta> = {
   "appears-on": { title: "Appears on", field: "appears_on", kind: "media" },
   similar: { title: "Fans also like", field: "similar", kind: "media" },
   videos: { title: "Videos", field: "videos", kind: "videos" },
+  // Liked songs aren't in the artist payload — they come from the
+  // user's library filtered by artist. Field is null and the body
+  // dispatcher pulls from `useLikedTracksByArtist` below.
+  liked: { title: "Songs you've liked", field: null, kind: "tracks" },
 };
 
 interface ArtistData {
@@ -60,6 +68,11 @@ export function ArtistSection({ onDownload }: { onDownload: OnDownload }) {
   }>();
   const { data: artist, loading, error } = useApi(() => api.artist(id), [id]);
   const meta = SECTIONS[section as ArtistSectionKey];
+  // Liked-songs source: pull from the user's library filtered to this
+  // artist. Returns null while the library fetch is loading. The
+  // dispatcher below takes precedence over the artist-payload field
+  // when meta.field is null (i.e. the "liked" section).
+  const likedByArtist = useLikedTracksByArtist(artist?.id);
 
   if (!meta) {
     return <ErrorView error={`Unknown artist section "${section}"`} />;
@@ -80,11 +93,18 @@ export function ArtistSection({ onDownload }: { onDownload: OnDownload }) {
     return <ErrorView error={error ?? "Artist not found"} />;
   }
 
-  const items = (artist as unknown as ArtistData)[meta.field] as
-    | Track[]
-    | Album[]
-    | Artist[]
-    | Video[];
+  const items: Track[] | Album[] | Artist[] | Video[] =
+    meta.field === null
+      ? // liked-songs section sources from the library filter, not the
+        // artist payload. While the filter is in flight we render
+        // empty — the loading skeleton above handles the initial
+        // window for the artist payload itself.
+        (likedByArtist ?? [])
+      : ((artist as unknown as ArtistData)[meta.field] as
+          | Track[]
+          | Album[]
+          | Artist[]
+          | Video[]);
 
   return (
     <div>


### PR DESCRIPTION
Folds into the unpublished v0.4.10 draft per request.

Adds the Spotify-style "Liked songs by [Artist]" surface on artist pages. When the user has hearted tracks credited to the current artist, a new section renders between Popular and Albums. First five inline, then a View more link to the full list.

## Implementation

* `useLikedTracksByArtist` hook fetches `/api/library/tracks` once, caches at module scope, filters client-side by artist id. Featured-credit-inclusive (matches Spotify).
* `useFavorites.toggle` dispatches a `tideway:favorite-toggled` window event after the mutation completes; the hook listens + invalidates so the section is reactive to heart taps.
* New `liked` key in `ArtistSection.tsx`'s SECTIONS map; route `/artist/:id/all/liked` already works through the existing route pattern.
* No backend changes.

## Verification

| Check | Result |
|---|---|
| `tsc -b --noEmit` | clean |
| ESLint | 0 errors / 50 warnings (same as before) |
| Vitest | 15 / 15 |
| Prettier `format:check` | clean |

## Post-merge plan

After this lands on main, I'll delete the existing v0.4.10 draft + tag and re-tag main HEAD so CI rebuilds the release artifacts with this feature included.