### PR TITLE
Search input: disable autocomplete and autocorrect

### DIFF
--- a/web/src/components/NavBar.tsx
+++ b/web/src/components/NavBar.tsx
@@ -149,6 +149,20 @@ function NavBarSearch({ className }: { className?: string }) {
         onChange={onChange}
         placeholder="Search"
         aria-label="Search"
+        // Search queries are artist / track / album names; the OS's
+        // autocorrect, autocomplete, autocapitalize, and spellcheck
+        // helpers don't know any of them and consistently rewrite
+        // legitimate names into nonsense ("Diplo" -> "Diploma",
+        // "Phoebe Bridgers" -> "Phoebe Burgers", etc.). Disabling all
+        // four matches what Spotify, Apple Music, and YouTube Music do
+        // in their own search bars. `enterKeyHint="search"` is a small
+        // mobile nicety: the on-screen keyboard's enter key labels as
+        // a magnifying glass.
+        autoComplete="off"
+        autoCorrect="off"
+        autoCapitalize="off"
+        spellCheck={false}
+        enterKeyHint="search"
         className="h-9 pl-9"
       />
     </div>


### PR DESCRIPTION
## Summary

- Adds `autoComplete`, `autoCorrect`, `autoCapitalize`, and `spellCheck` to the navbar search input, all turned off.
- Adds `enterKeyHint="search"` for a small mobile / touch-keyboard nicety (enter key shows as a magnifying glass).
- Limited to `NavBarSearch` — the shared `Input` component keeps default browser behavior, so Settings inputs like the Spotify client id can still get password-manager autofill.

## Why

The OS autocorrect was rewriting artist and track names ("Diplo" → "Diploma", "Phoebe Bridgers" → "Phoebe Burgers") and `autocomplete` had no domain-relevant suggestions to offer in the first place. Matches what Spotify, Apple Music, and YouTube Music do in their own search bars.

## Test plan

- [x] pytest, tsc, lint:all, vitest all green
- [ ] Type a misspelled artist name in the search bar — no red squiggle, no autocorrect substitution
- [ ] First letter typed stays lowercase (no autocapitalize)