### PR TITLE
Audio device picker: hide Windows-disabled devices and host-API duplicates

### DIFF
--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -780,6 +780,18 @@ class PCMPlayer:
         the audio callback thread to die mid-flight, which we never
         want during playback. When a stream is active the device
         list reflects whatever was visible at stream-open time.
+
+        Windows note: PortAudio exposes the same physical device
+        through multiple host APIs (MME, DirectSound, WASAPI,
+        WDM-KS). Without filtering, every speaker / DAC shows up
+        four times in the picker, and the MME / DirectSound entries
+        also include devices the user has DISABLED in System Sound
+        settings (those backends ignore device state). We filter to
+        the WASAPI host API on Windows, which (a) deduplicates and
+        (b) skips disabled endpoints because WASAPI's enumeration
+        respects the IMMDevice DEVICE_STATE_ACTIVE filter. macOS
+        and Linux only have one usable host API each (Core Audio,
+        ALSA) so they're unaffected.
         """
         out: list[dict] = [{"id": "", "name": "System default"}]
         # Refresh PortAudio's device list when no stream is open.
@@ -804,10 +816,17 @@ class PCMPlayer:
         except Exception:
             log.exception("sd.query_devices failed")
             return out
+        wasapi_idx = _wasapi_host_api_index()
         for i, d in enumerate(devices):
-            if int(d.get("max_output_channels", 0) or 0) > 0:
-                name = d.get("name") or f"Device {i}"
-                out.append({"id": str(i), "name": name})
+            if int(d.get("max_output_channels", 0) or 0) <= 0:
+                continue
+            # Windows: keep only WASAPI entries. Falls through to
+            # "show everything" on macOS / Linux (wasapi_idx is None
+            # there since the host API doesn't exist).
+            if wasapi_idx is not None and d.get("hostapi") != wasapi_idx:
+                continue
+            name = d.get("name") or f"Device {i}"
+            out.append({"id": str(i), "name": name})
         return out
 
     def set_output_device(self, device_id: str) -> None:
@@ -2123,6 +2142,29 @@ def _safe_int(v: object) -> Optional[int]:
         return int(v)
     except (TypeError, ValueError):
         return None
+
+
+def _wasapi_host_api_index() -> Optional[int]:
+    """Return the PortAudio host-api index for WASAPI on Windows, or
+    None on every other platform / when WASAPI isn't built into this
+    PortAudio.
+
+    Used by `list_output_devices()` to filter out the duplicate
+    listings PortAudio creates when the same physical device is
+    exposed via MME, DirectSound, WASAPI, and WDM-KS — and to skip
+    devices the user has disabled in Windows Sound settings, which
+    the older host APIs still enumerate but WASAPI doesn't.
+    """
+    if sys.platform != "win32":
+        return None
+    try:
+        for idx, ha in enumerate(sd.query_hostapis()):
+            name = (ha.get("name") or "").lower()
+            if name == "windows wasapi" or "wasapi" in name:
+                return idx
+    except Exception:
+        log.exception("query_hostapis failed; falling back to all-host-API listing")
+    return None
 
 
 def _normalize_codec(raw: object) -> Optional[str]:

--- a/tests/test_audio_device_filter.py
+++ b/tests/test_audio_device_filter.py
@@ -1,0 +1,73 @@
+"""Tests for `_wasapi_host_api_index` — the helper that lets the
+output-device picker hide Windows-disabled devices and the duplicate
+MME / DirectSound / WDM-KS listings.
+
+Real device enumeration depends on PortAudio's runtime view of the
+system, which is platform-specific and isn't fixtureable. So we
+monkeypatch `sys.platform` and `sd.query_hostapis` to exercise the
+two paths the helper actually has."""
+from __future__ import annotations
+
+import sys
+from unittest.mock import patch
+
+from app.audio import player as player_module
+
+
+def test_returns_none_on_non_windows():
+    """The helper must short-circuit to None on macOS / Linux so the
+    device picker shows everything PortAudio enumerates (which is
+    correct behavior on those platforms — they have one host API)."""
+    with patch.object(player_module.sys, "platform", "darwin"):
+        assert player_module._wasapi_host_api_index() is None
+    with patch.object(player_module.sys, "platform", "linux"):
+        assert player_module._wasapi_host_api_index() is None
+
+
+def test_finds_wasapi_index_on_windows():
+    fake_host_apis = [
+        {"name": "MME"},
+        {"name": "Windows DirectSound"},
+        {"name": "Windows WASAPI"},
+        {"name": "Windows WDM-KS"},
+    ]
+    with patch.object(player_module.sys, "platform", "win32"), \
+         patch.object(player_module.sd, "query_hostapis", return_value=fake_host_apis):
+        assert player_module._wasapi_host_api_index() == 2
+
+
+def test_finds_wasapi_with_alt_casing():
+    """sounddevice has reported both 'Windows WASAPI' and 'WASAPI'
+    across versions. The helper uses a case-insensitive substring
+    match so both forms work."""
+    fake_host_apis = [
+        {"name": "MME"},
+        {"name": "wasapi"},  # lowercase, no prefix
+    ]
+    with patch.object(player_module.sys, "platform", "win32"), \
+         patch.object(player_module.sd, "query_hostapis", return_value=fake_host_apis):
+        assert player_module._wasapi_host_api_index() == 1
+
+
+def test_returns_none_when_wasapi_missing():
+    """Older or stripped-down PortAudio builds may not include WASAPI.
+    The helper returns None so `list_output_devices` falls through to
+    the all-host-API listing (degraded but not broken)."""
+    fake_host_apis = [
+        {"name": "MME"},
+        {"name": "Windows DirectSound"},
+    ]
+    with patch.object(player_module.sys, "platform", "win32"), \
+         patch.object(player_module.sd, "query_hostapis", return_value=fake_host_apis):
+        assert player_module._wasapi_host_api_index() is None
+
+
+def test_returns_none_on_query_exception():
+    """If sd.query_hostapis raises (PortAudio in a weird state), the
+    helper logs and returns None rather than crashing the picker."""
+    def boom():
+        raise RuntimeError("PortAudio crashed")
+
+    with patch.object(player_module.sys, "platform", "win32"), \
+         patch.object(player_module.sd, "query_hostapis", side_effect=boom):
+        assert player_module._wasapi_host_api_index() is None


### PR DESCRIPTION
## Summary

PortAudio on Windows exposes every physical device through MME, DirectSound, WASAPI, and WDM-KS simultaneously, so every speaker / USB DAC was appearing four times in the output-device picker. The MME and DirectSound enumerations also include devices the user has DISABLED in Windows Sound settings (those host APIs ignore device state).

WASAPI's enumeration both deduplicates and respects the `DEVICE_STATE_ACTIVE` filter at the OS level, so a "WASAPI only" filter on Windows fixes both issues at once.

- New `_wasapi_host_api_index()` helper finds the WASAPI host API via case-insensitive substring match against `sd.query_hostapis()`. Returns `None` on non-Windows so the filter is a no-op on macOS / Linux (one usable host API each, no duplicate / disabled-device issue).
- `list_output_devices()` consults the helper and skips devices on the wrong host API.
- Defensive: if WASAPI isn't in this PortAudio build (older / stripped-down builds), the helper returns `None` and the picker falls back to the all-host-API listing rather than going empty.

## Test plan

- [x] 5 new unit tests cover both platform paths and the query-exception fallback (120 backend tests pass)
- [ ] On Windows: open the output device picker — duplicate listings of the same speaker / DAC are gone
- [ ] On Windows: disable a device in Sound settings, then refresh the picker — disabled device disappears
- [ ] On macOS: device picker still shows Core Audio devices unchanged