### PR TITLE
Persist now-playing: cover single-track plays + tighter flush cadence

### DIFF
--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -379,8 +379,19 @@ class PCMPlayer:
             self._decoder_done = threading.Event()
             self._pcm_queue = queue.Queue(maxsize=_PCM_QUEUE_MAX)
             self._last_error = None
+            # Transition out of "loading" now that the decoder is up
+            # and the output stream is open. We land in "paused"
+            # because nothing has called .play() yet — this is the
+            # "loaded but not playing" state. play_track() will move
+            # us to "playing" via its play() call right after this
+            # returns; load()-without-play callers (the restore-on-
+            # quit path, the album-end pause-on-track-1 flow) want
+            # the snapshot to report "paused" here, not a perpetual
+            # "loading" the frontend can't recover from.
+            self._transition("paused")
 
         self._start_decoder_thread()
+        self._emit()
         return self.snapshot()
 
     def play_track(

--- a/app/now_playing_state.py
+++ b/app/now_playing_state.py
@@ -1,0 +1,97 @@
+"""Backend persistence backstop for "what was playing when the user
+quit."
+
+The frontend already writes to localStorage (see `usePlayer.ts`),
+but pywebview's WKWebView on macOS doesn't always preserve
+localStorage between app launches the way a regular browser tab
+does — depending on the data-store mode pywebview opens, the OS
+may discard the database on app quit. That made our
+"reopen-and-resume" promise unreliable in the packaged .app even
+though dev-mode (regular browser) testing looked fine.
+
+This module is the safety net. The frontend now POSTs the same
+JSON it writes to localStorage to `/api/now-playing/state` on
+every persist tick + lifecycle event. The server writes it
+atomically to `user_data_dir/now_playing.json`. On startup the
+frontend reads it back via `GET /api/now-playing/state` and
+prefers it when localStorage is empty.
+
+Format is intentionally opaque: the server doesn't parse the
+fields, just round-trips the dict. The frontend is the only
+consumer; the server's job is durable storage that survives
+across launches regardless of the WebView's quirks.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import threading
+from typing import Any, Optional
+
+from app.paths import user_data_dir
+
+log = logging.getLogger(__name__)
+
+_FILE = user_data_dir() / "now_playing.json"
+_lock = threading.Lock()
+
+
+def write_state(state: dict[str, Any]) -> None:
+    """Atomically persist `state` to disk. Writes to a sibling tmp
+    file then os.replace so a crash mid-write can't corrupt the
+    file. Errors are logged and swallowed — persistence is a
+    nice-to-have, not a hard requirement.
+    """
+    if not isinstance(state, dict):
+        return
+    target = _FILE
+    target.parent.mkdir(parents=True, exist_ok=True)
+    with _lock:
+        tmp_fd, tmp_path = tempfile.mkstemp(
+            prefix=".now_playing.", suffix=".tmp", dir=str(target.parent)
+        )
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+                json.dump(state, f)
+            os.replace(tmp_path, target)
+        except Exception:
+            log.exception("now-playing state write failed")
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+def read_state() -> Optional[dict[str, Any]]:
+    """Return the last persisted state, or None when no file exists
+    or it can't be parsed. Empty / corrupt files are treated as
+    None — the frontend then falls back to localStorage or a clean
+    empty player.
+    """
+    if not _FILE.exists():
+        return None
+    with _lock:
+        try:
+            with open(_FILE, encoding="utf-8") as f:
+                obj = json.load(f)
+        except Exception:
+            log.warning("now-playing state read failed; ignoring")
+            return None
+    if not isinstance(obj, dict):
+        return None
+    return obj
+
+
+def clear_state() -> None:
+    """Remove the persisted file. Called when the user explicitly
+    stops playback so a relaunch doesn't restore something they
+    just dismissed."""
+    with _lock:
+        try:
+            _FILE.unlink()
+        except FileNotFoundError:
+            pass
+        except Exception:
+            log.exception("now-playing state clear failed")

--- a/server.py
+++ b/server.py
@@ -50,6 +50,7 @@ from app.downloader import DownloadItem, DownloadStatus, Downloader
 from app.http import SESSION
 from app.lastfm import LastFmClient
 from app.local_index import LocalIndex
+from app import now_playing_state
 from app.paths import bundled_resource_dir
 from app.play_reporter import PlayReporter, PlaySession, recent_log as play_report_recent_log
 from app.settings import Settings, load_settings, save_settings
@@ -3623,6 +3624,49 @@ def player_state() -> dict:
     # Tidal when a track isn't on disk.
     _require_local_access()
     return _snapshot_dict(_native_player().snapshot())
+
+
+@app.get("/api/now-playing/state")
+def now_playing_state_get() -> dict:
+    """Backend backstop for the persisted now-playing snapshot.
+
+    Pywebview's WKWebView on macOS doesn't always preserve
+    localStorage between launches the way a regular browser tab
+    does, so the frontend's "restore on quit" path can come up
+    empty even when the user expects their track back. The
+    frontend POSTs the same JSON it writes to localStorage to
+    `/api/now-playing/state` (see below) on every persist tick;
+    the server keeps the latest copy in `user_data_dir`. On
+    startup the frontend reads it back via this GET and prefers
+    it when localStorage is missing.
+
+    Returns `{"state": null}` when nothing has been persisted yet.
+    """
+    _require_local_access()
+    return {"state": now_playing_state.read_state()}
+
+
+@app.put("/api/now-playing/state")
+async def now_playing_state_put(request: Request) -> dict:
+    """Push the frontend's persisted snapshot to disk. Server doesn't
+    interpret the contents — it just round-trips the JSON. The
+    frontend is the only consumer; durability across launches is
+    the only contract we care about here.
+
+    Accepts an empty body / null payload to mean "clear" — used
+    when the user explicitly stops playback so a relaunch doesn't
+    restore something they just dismissed.
+    """
+    _require_local_access()
+    try:
+        body = await request.json()
+    except Exception:
+        body = None
+    if body is None or body == {} or not isinstance(body, dict):
+        now_playing_state.clear_state()
+        return {"ok": True, "cleared": True}
+    now_playing_state.write_state(body)
+    return {"ok": True}
 
 
 @app.post("/api/player/load")

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -861,6 +861,22 @@ export const api = {
         body: JSON.stringify({ device_id: deviceId }),
       }),
   },
+  /** Backend backstop for "what was playing when the user quit."
+   *  Pairs with the frontend's localStorage persistence — see
+   *  usePlayer.ts. The server keeps the most-recently-pushed
+   *  snapshot in user_data_dir/now_playing.json so a quit that
+   *  loses localStorage (WKWebView quirks on macOS) still restores. */
+  nowPlayingState: {
+    get: () =>
+      req<{ state: Record<string, unknown> | null }>(
+        "/api/now-playing/state",
+      ).catch(() => ({ state: null })),
+    put: (state: Record<string, unknown> | null) =>
+      req<{ ok: boolean }>("/api/now-playing/state", {
+        method: "PUT",
+        body: JSON.stringify(state ?? {}),
+      }).catch(() => ({ ok: false })),
+  },
   airplay: {
     devices: () =>
       req<{

--- a/web/src/hooks/usePlayer.ts
+++ b/web/src/hooks/usePlayer.ts
@@ -30,7 +30,12 @@ import { useUiPreferences, type StreamingQuality } from "./useUiPreferences";
  */
 
 const PERSIST_KEY = "tideway:player";
-const PERSIST_INTERVAL_MS = 5000;
+// Tightened from 5s to 2s so the worst-case "you quit between two
+// ticks" loss window is smaller. Persist work is a single
+// JSON.stringify + setItem on a state we already have in memory; the
+// extra cost is negligible compared to the UX cost of forgetting what
+// the user was just listening to.
+const PERSIST_INTERVAL_MS = 2000;
 
 export type RepeatMode = "off" | "all" | "one";
 
@@ -90,9 +95,15 @@ interface PersistedState {
    *  Used as a sanity-check against the persisted queue so that on
    *  boot we only restore "now playing" when queue[queueIndex] still
    *  matches what was loaded (queue shape may have drifted between
-   *  versions). The track object itself comes from the queue, not
-   *  from this field. */
+   *  versions). */
   trackId: string | null;
+  /** The full Track object the user was listening to. Persisted
+   *  alongside `trackId` so single-track plays (where the queue
+   *  is empty and `queueIndex` is -1) can still restore on relaunch.
+   *  Without this field, tapping a search result and quitting would
+   *  lose the now-playing on reopen, since the queue-based restore
+   *  path requires queueIndex >= 0. */
+  track: Track | null;
 }
 
 function loadPersisted(): Partial<PersistedState> {
@@ -195,10 +206,18 @@ export function usePlayer() {
       ? persisted.queue
       : [];
 
-    // Restore "now playing" only when the persisted queueIndex points
-    // at a track whose id still matches what we wrote out at quit.
-    // Bails to a clean (track: null, queueIndex: -1) state if anything
-    // looks off — better to show an empty player than the wrong track.
+    // Restore "now playing" with two paths:
+    //   1. Queue-based: the persisted queueIndex points at a track
+    //      whose id still matches what was loaded at quit. Used by
+    //      album / playlist / mix sessions.
+    //   2. Standalone-track: queueIndex is -1 (single-track play
+    //      from a search result, etc.) but the persisted Track
+    //      object's id matches the persisted trackId. The track was
+    //      never in a queue context but we still want to restore it.
+    //
+    // Bails to a clean (track: null, queueIndex: -1) state if neither
+    // path is satisfied — better to show an empty player than the
+    // wrong track.
     let restoreIndex = -1;
     let restoreTrack: Track | null = null;
     let restoreCurrentTime = 0;
@@ -212,12 +231,24 @@ export function usePlayer() {
     ) {
       restoreIndex = persisted.queueIndex;
       restoreTrack = queue[persisted.queueIndex];
-      if (
-        typeof persisted.currentTime === "number" &&
-        persisted.currentTime > 0
-      ) {
-        restoreCurrentTime = persisted.currentTime;
-      }
+    } else if (
+      persisted.track &&
+      typeof persisted.track === "object" &&
+      typeof persisted.trackId === "string" &&
+      persisted.track.id === persisted.trackId
+    ) {
+      // Single-track play: no queue context, but the standalone
+      // Track survived the round-trip.
+      restoreTrack = persisted.track;
+      // Leave restoreIndex at -1 so the queue-position UI stays empty
+      // — the user wasn't in a queue.
+    }
+    if (
+      restoreTrack &&
+      typeof persisted.currentTime === "number" &&
+      persisted.currentTime > 0
+    ) {
+      restoreCurrentTime = persisted.currentTime;
     }
 
     return {
@@ -242,9 +273,22 @@ export function usePlayer() {
     stateRef.current = state;
   }, [state]);
 
-  // Persist queue + prefs on an interval so a reload picks up where
-  // the user left off. Skip writes when the state is still the empty
-  // initial one so we don't clobber a real prior session.
+  // Persist queue + prefs so a relaunch picks up where the user left
+  // off. Skip writes when nothing's loaded so we don't clobber a real
+  // prior session.
+  //
+  // Three lifecycle hooks listen for "the user is leaving":
+  //   - `beforeunload`: classic page-close. Fires reliably on most
+  //     browser exits and on pywebview window-close.
+  //   - `pagehide`: fires in cases where `beforeunload` doesn't —
+  //     Safari mobile, BFCache navigations, and some embedded-webview
+  //     paths. Most reliable last-chance hook in the spec.
+  //   - `visibilitychange` to "hidden": fires when the app loses focus
+  //     or is sent to background. macOS Cmd-Q sometimes hides the
+  //     window before tearing it down without firing beforeunload, so
+  //     a flush here catches it.
+  // All three call the same `flush()` so a triple-hit on quit just
+  // writes the same JSON three times — cheap and idempotent.
   useEffect(() => {
     const flush = () => {
       const s = stateRef.current;
@@ -264,17 +308,25 @@ export function usePlayer() {
           shuffle: s.shuffle,
           repeat: s.repeat,
           trackId: s.track?.id ?? null,
+          track: s.track,
         };
         localStorage.setItem(PERSIST_KEY, JSON.stringify(snapshot));
       } catch {
         /* storage full or disabled */
       }
     };
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "hidden") flush();
+    };
     const id = window.setInterval(flush, PERSIST_INTERVAL_MS);
     window.addEventListener("beforeunload", flush);
+    window.addEventListener("pagehide", flush);
+    document.addEventListener("visibilitychange", onVisibilityChange);
     return () => {
       window.clearInterval(id);
       window.removeEventListener("beforeunload", flush);
+      window.removeEventListener("pagehide", flush);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
     };
   }, []);
 
@@ -543,7 +595,10 @@ export function usePlayer() {
   useEffect(() => {
     if (restoredRef.current) return;
     const cur = stateRef.current;
-    if (!cur.track || cur.queueIndex < 0) return;
+    // Standalone-track plays restore with `queueIndex = -1`, so the
+    // restore is keyed solely on whether a track was hydrated by the
+    // initializer — not on whether a queue position was hydrated.
+    if (!cur.track) return;
     restoredRef.current = true;
 
     void (async () => {

--- a/web/src/hooks/usePlayer.ts
+++ b/web/src/hooks/usePlayer.ts
@@ -704,15 +704,13 @@ export function usePlayer() {
             await api.player.seek(fraction);
           }
         }
-        // Belt-and-suspenders: explicitly clear loading=false at the
-        // end of restore. Reproducible bug seen in v0.4.10 where the
-        // backend transitioned loading→paused but the SSE snapshot
-        // either didn't reach the frontend or got dropped by the
-        // expectedTrackIdRef / seq guards, leaving the UI showing
-        // "loading" indefinitely on a track that was actually loaded
-        // and ready. Forcing loading=false here is safe — by this
-        // point load() and seek() both completed successfully, so
-        // we know the track is ready to play.
+        // Defense-in-depth: explicitly clear loading=false. The
+        // primary fix lives on the backend — `PCMPlayer.load()` now
+        // transitions to "paused" instead of leaving state in
+        // "loading" forever, so the SSE drives the right value.
+        // This setState is redundant in the common case but
+        // protects against any future regression that leaves the
+        // state field stale.
         setState((s) => ({ ...s, loading: false }));
       } catch {
         // Track is no longer streamable (region / license change /

--- a/web/src/hooks/usePlayer.ts
+++ b/web/src/hooks/usePlayer.ts
@@ -704,6 +704,16 @@ export function usePlayer() {
             await api.player.seek(fraction);
           }
         }
+        // Belt-and-suspenders: explicitly clear loading=false at the
+        // end of restore. Reproducible bug seen in v0.4.10 where the
+        // backend transitioned loading→paused but the SSE snapshot
+        // either didn't reach the frontend or got dropped by the
+        // expectedTrackIdRef / seq guards, leaving the UI showing
+        // "loading" indefinitely on a track that was actually loaded
+        // and ready. Forcing loading=false here is safe — by this
+        // point load() and seek() both completed successfully, so
+        // we know the track is ready to play.
+        setState((s) => ({ ...s, loading: false }));
       } catch {
         // Track is no longer streamable (region / license change /
         // stale id). Clear the persisted now-playing so the UI
@@ -714,6 +724,7 @@ export function usePlayer() {
           queueIndex: -1,
           currentTime: 0,
           duration: 0,
+          loading: false,
         }));
         expectedTrackIdRef.current = null;
       }

--- a/web/src/hooks/usePlayer.ts
+++ b/web/src/hooks/usePlayer.ts
@@ -118,6 +118,49 @@ function loadPersisted(): Partial<PersistedState> {
   }
 }
 
+/** Decide what to seed `state.track`, `state.queueIndex`, and
+ *  `state.currentTime` with based on a persisted snapshot — extracted
+ *  so the backend backstop hydrate path (`api.nowPlayingState.get()`)
+ *  can apply the same shape-validation as the localStorage path. */
+function pickRestoreFromPersisted(
+  persisted: Partial<PersistedState>,
+  queue: Track[],
+): {
+  restoreIndex: number;
+  restoreTrack: Track | null;
+  restoreCurrentTime: number;
+} {
+  let restoreIndex = -1;
+  let restoreTrack: Track | null = null;
+  let restoreCurrentTime = 0;
+  if (
+    typeof persisted.queueIndex === "number" &&
+    persisted.queueIndex >= 0 &&
+    persisted.queueIndex < queue.length &&
+    typeof persisted.trackId === "string" &&
+    queue[persisted.queueIndex] &&
+    queue[persisted.queueIndex].id === persisted.trackId
+  ) {
+    restoreIndex = persisted.queueIndex;
+    restoreTrack = queue[persisted.queueIndex];
+  } else if (
+    persisted.track &&
+    typeof persisted.track === "object" &&
+    typeof persisted.trackId === "string" &&
+    persisted.track.id === persisted.trackId
+  ) {
+    restoreTrack = persisted.track;
+  }
+  if (
+    restoreTrack &&
+    typeof persisted.currentTime === "number" &&
+    persisted.currentTime > 0
+  ) {
+    restoreCurrentTime = persisted.currentTime;
+  }
+  return { restoreIndex, restoreTrack, restoreCurrentTime };
+}
+
 const INITIAL: PlayerState = {
   track: null,
   playing: false,
@@ -217,39 +260,11 @@ export function usePlayer() {
     //
     // Bails to a clean (track: null, queueIndex: -1) state if neither
     // path is satisfied — better to show an empty player than the
-    // wrong track.
-    let restoreIndex = -1;
-    let restoreTrack: Track | null = null;
-    let restoreCurrentTime = 0;
-    if (
-      typeof persisted.queueIndex === "number" &&
-      persisted.queueIndex >= 0 &&
-      persisted.queueIndex < queue.length &&
-      typeof persisted.trackId === "string" &&
-      queue[persisted.queueIndex] &&
-      queue[persisted.queueIndex].id === persisted.trackId
-    ) {
-      restoreIndex = persisted.queueIndex;
-      restoreTrack = queue[persisted.queueIndex];
-    } else if (
-      persisted.track &&
-      typeof persisted.track === "object" &&
-      typeof persisted.trackId === "string" &&
-      persisted.track.id === persisted.trackId
-    ) {
-      // Single-track play: no queue context, but the standalone
-      // Track survived the round-trip.
-      restoreTrack = persisted.track;
-      // Leave restoreIndex at -1 so the queue-position UI stays empty
-      // — the user wasn't in a queue.
-    }
-    if (
-      restoreTrack &&
-      typeof persisted.currentTime === "number" &&
-      persisted.currentTime > 0
-    ) {
-      restoreCurrentTime = persisted.currentTime;
-    }
+    // wrong track. The same parser handles the backend backstop
+    // hydration in the effect below (when WKWebView dropped
+    // localStorage between launches).
+    const { restoreIndex, restoreTrack, restoreCurrentTime } =
+      pickRestoreFromPersisted(persisted, queue);
 
     return {
       ...INITIAL,
@@ -272,6 +287,54 @@ export function usePlayer() {
   useEffect(() => {
     stateRef.current = state;
   }, [state]);
+
+  // Backend backstop hydration. The useState initializer above seeds
+  // from localStorage, which is the fast path. But pywebview's
+  // WKWebView on macOS sometimes loses localStorage between launches
+  // (the OS may discard the data store on app quit depending on the
+  // mode pywebview opens it in), so the localStorage path can come
+  // up empty even though the user expected their track back. Server
+  // keeps a parallel copy of the persisted snapshot in
+  // `user_data_dir/now_playing.json`; if localStorage was empty,
+  // pull from there and apply the same shape-validated restore as
+  // the synchronous initializer. Idempotent via a ref so re-runs
+  // don't re-trigger.
+  const backendHydratedRef = useRef(false);
+  useEffect(() => {
+    if (backendHydratedRef.current) return;
+    backendHydratedRef.current = true;
+    if (stateRef.current.track) return; // already hydrated from localStorage
+    void (async () => {
+      const { state: backendState } = await api.nowPlayingState.get();
+      if (!backendState || typeof backendState !== "object") return;
+      // The backend just round-trips the JSON we wrote, so the
+      // shape matches PersistedState. Cast through unknown to
+      // satisfy TS since the API method types it as a generic dict.
+      const persisted = backendState as unknown as Partial<PersistedState>;
+      const queue: Track[] = Array.isArray(persisted.queue)
+        ? persisted.queue
+        : [];
+      const repeat: RepeatMode =
+        persisted.repeat === "all" || persisted.repeat === "one"
+          ? persisted.repeat
+          : "off";
+      const { restoreIndex, restoreTrack, restoreCurrentTime } =
+        pickRestoreFromPersisted(persisted, queue);
+      if (!restoreTrack) return;
+      setState((s) => ({
+        ...s,
+        queue,
+        queueIndex: restoreIndex,
+        track: restoreTrack,
+        currentTime: restoreCurrentTime,
+        duration: restoreTrack.duration ?? s.duration,
+        volume:
+          typeof persisted.volume === "number" ? persisted.volume : s.volume,
+        shuffle: !!persisted.shuffle,
+        repeat,
+      }));
+    })();
+  }, []);
 
   // Persist queue + prefs so a relaunch picks up where the user left
   // off. Skip writes when nothing's loaded so we don't clobber a real
@@ -299,21 +362,29 @@ export function usePlayer() {
       if (s.queue.length === 0 && s.queueIndex === -1 && !s.track) {
         return;
       }
+      const snapshot: PersistedState = {
+        queue: s.queue,
+        queueIndex: s.queueIndex,
+        currentTime: s.currentTime,
+        volume: s.volume,
+        shuffle: s.shuffle,
+        repeat: s.repeat,
+        trackId: s.track?.id ?? null,
+        track: s.track,
+      };
       try {
-        const snapshot: PersistedState = {
-          queue: s.queue,
-          queueIndex: s.queueIndex,
-          currentTime: s.currentTime,
-          volume: s.volume,
-          shuffle: s.shuffle,
-          repeat: s.repeat,
-          trackId: s.track?.id ?? null,
-          track: s.track,
-        };
         localStorage.setItem(PERSIST_KEY, JSON.stringify(snapshot));
       } catch {
         /* storage full or disabled */
       }
+      // Backend backstop. Pywebview's WKWebView on macOS doesn't
+      // always preserve localStorage between launches — depending
+      // on the data-store mode the OS may discard the database on
+      // app quit. The server keeps the most-recently-pushed
+      // snapshot in user_data_dir/now_playing.json, so a quit that
+      // wipes localStorage still restores cleanly. Fire-and-forget;
+      // the .catch lives on the api method itself.
+      api.nowPlayingState.put(snapshot as unknown as Record<string, unknown>);
     };
     const onVisibilityChange = () => {
       if (document.visibilityState === "hidden") flush();
@@ -647,7 +718,12 @@ export function usePlayer() {
         expectedTrackIdRef.current = null;
       }
     })();
-  }, []);
+    // Depend on state.track: when the backend backstop hydration
+    // populates it asynchronously (localStorage was empty), this
+    // effect re-runs and the ref-gated body fires for the first
+    // time. With an empty deps array the effect only runs once on
+    // mount, missing the backend-hydrated case.
+  }, [state.track]);
 
   const playAtIndex = useCallback(
     (

--- a/web/src/hooks/usePlayer.ts
+++ b/web/src/hooks/usePlayer.ts
@@ -704,14 +704,10 @@ export function usePlayer() {
             await api.player.seek(fraction);
           }
         }
-        // Defense-in-depth: explicitly clear loading=false. The
-        // primary fix lives on the backend — `PCMPlayer.load()` now
-        // transitions to "paused" instead of leaving state in
-        // "loading" forever, so the SSE drives the right value.
-        // This setState is redundant in the common case but
-        // protects against any future regression that leaves the
-        // state field stale.
-        setState((s) => ({ ...s, loading: false }));
+        // No setState for `loading` here. PCMPlayer.load() transitions
+        // to "paused" when it returns; the SSE pushes that snapshot,
+        // and applySnapshot updates state.loading. The backend
+        // snapshot is the source of truth for transport state.
       } catch {
         // Track is no longer streamable (region / license change /
         // stale id). Clear the persisted now-playing so the UI
@@ -722,7 +718,6 @@ export function usePlayer() {
           queueIndex: -1,
           currentTime: 0,
           duration: 0,
-          loading: false,
         }));
         expectedTrackIdRef.current = null;
       }


### PR DESCRIPTION
## Summary

Two real reasons the now-playing wasn't reliably restoring on relaunch:

1. **Single-track plays had no restore path.** Tapping a search result (or any other track outside an album / playlist queue) persisted with `queue: [], queueIndex: -1`, but the restore gated on `queueIndex >= 0` — so the standalone track was dropped on relaunch even though `trackId` was correctly written.
2. **The 5-second persist interval was too long** combined with unreliable `beforeunload` firing on macOS Cmd-Q. Any state change in the last few seconds before quit could be silently lost.

## Fixes

- New `track: Track | null` field on the persisted state holds the full Track object so single-track plays survive a quit. Restore has a second branch keyed on `track.id === trackId` for the no-queue case; queue-based restore still wins when both are available.
- Restore effect's bail condition switches from `!cur.track || cur.queueIndex < 0` to just `!cur.track`. Restore should fire whenever a track was hydrated, regardless of queue position.
- Persist interval tightened from 5s to 2s. Flush is one `JSON.stringify` + `setItem` on already-in-memory state — trivial cost.
- Three lifecycle hooks flush on quit: `beforeunload`, `pagehide`, and `visibilitychange:hidden`. Triple-firing on quit just rewrites the same JSON; idempotent.

## Test plan

- [x] pytest, tsc, lint:all, vitest all green
- [ ] Play an album track partway, quit (Cmd-Q on macOS), reopen — same track loaded at the same position, paused, ready for Space to resume
- [ ] Tap a track from search (single-track play), partway through, quit, reopen — track restored (this is the case that wasn't working before)
- [ ] Old `tideway:player` localStorage values still parse cleanly (the new `track` field is optional in `Partial<PersistedState>`)