### PR TITLE
Spotify stats: widen search candidate pool + add artist-name fallback

### DIFF
--- a/app/spotify_public.py
+++ b/app/spotify_public.py
@@ -131,7 +131,17 @@ _db_path = user_data_dir() / "spotify_public_cache.db"
 #      cached as null. Wiping flushes those nulls so the now-working
 #      transport gets re-asked instead of waiting out the 1-day
 #      negative TTL on each row.
-_CACHE_SCHEMA_VERSION = 3
+#   4: search-limit bump (5 -> 50) and artist-name-search fallback.
+#      Pre-bump rows could carry undercount playcounts (canonical
+#      version wasn't in the top-5 search results so the resolver
+#      capped at a non-canonical version's count, e.g. Quadeca's
+#      SCRAPYARD tracks coming back at ~30% of Spotify's actual
+#      number) and null artist mappings (no primary-artist match
+#      found within the top-5 sample ISRCs, e.g. Justin Bieber's
+#      monthly listeners going blank because his top-N tracks on
+#      Tidal are all feature credits). Wipe to force re-resolution
+#      under the new code paths.
+_CACHE_SCHEMA_VERSION = 4
 
 
 def _db() -> sqlite3.Connection:
@@ -338,20 +348,37 @@ def _resolve_artist_via_name_match(
 ) -> Optional[str]:
     """Walk a list of sample ISRCs and return the Spotify artist id
     of the first track whose primary artist's name matches the Tidal
-    artist's name. Returns None if no candidate matches.
+    artist's name. Falls back to a direct artist-name search on
+    Spotify when the ISRC walk doesn't find a primary-artist match.
 
-    The single-ISRC path missed any artist whose top track on Tidal
-    was a feature credit — Spotify lists the host as primary, we
-    cached that host's id, and the page silently rendered the wrong
-    person's monthly listeners (or nothing, when the names later
-    failed a sanity check). Walking multiple ISRCs and requiring an
-    exact name match recovers in the common case where at least one
-    of the artist's top tracks is theirs as primary.
+    Two-stage resolution:
+
+    1. **ISRC walk (preferred).** For each of up to 15 sample ISRCs
+       (was 5), find the Spotify track and check whether its primary
+       artist's name matches `tidal_artist_name`. Returns the first
+       match. This is the most accurate path — the ISRC ties us to
+       a specific track Tidal has, so the artist we resolve through
+       it is provably someone Tidal also lists. Bumped from 5 to 15
+       because artists like Justin Bieber, who are heavy feature
+       collaborators, can have their entire top-15-on-Tidal be
+       feature credits where the host (Kid LAROI, Skrillex, etc.) is
+       Spotify's primary artist.
+
+    2. **Artist-name search fallback.** When the ISRC walk fails —
+       common for artists whose entire top-N is feature credits —
+       fall back to Spotify's `query_artists` endpoint with
+       `tidal_artist_name`. We accept the first result whose
+       displayed name equals our target (case-insensitive). Less
+       precise than the ISRC walk because two artists can share a
+       name (e.g. multiple "John Smith" entries on Spotify), but
+       precise enough for major artists with unique names — and
+       returning *something* is better than the wrong-person /
+       no-stats UX the ISRC-only path produces.
     """
     wanted = (tidal_artist_name or "").strip().lower()
     if not wanted:
         return None
-    for isrc in sample_isrcs[:5]:
+    for isrc in sample_isrcs[:15]:
         ic = (isrc or "").strip().upper()
         if not ic:
             continue
@@ -378,6 +405,46 @@ def _resolve_artist_via_name_match(
                 )
                 if name.strip().lower() == wanted:
                     return uri.split(":")[-1]
+    return _search_artist_by_name(tidal_artist_name)
+
+
+def _search_artist_by_name(name: str) -> Optional[str]:
+    """Spotify artist search keyed on display name. Returns the
+    Spotify artist id of the first hit whose name matches `name`
+    (case-insensitive, trimmed). Used as a fallback after the ISRC
+    walk in `_resolve_artist_via_name_match` fails.
+
+    Errors are logged and swallowed; callers treat None as "couldn't
+    resolve".
+    """
+    wanted = (name or "").strip().lower()
+    if not wanted:
+        return None
+    try:
+        _, artist_mod = _ensure_client()
+        res = artist_mod.query_artists(name, limit=10)
+    except Exception as exc:
+        log.warning("spotify artist search failed for %r: %s", name, exc)
+        return None
+    items = (
+        (res.get("data") or {})
+        .get("searchV2", {})
+        .get("artists", {})
+        .get("items")
+        or []
+    )
+    for entry in items:
+        item = (entry.get("item") or {}).get("data") or {}
+        uri = item.get("uri") or ""
+        if not uri.startswith("spotify:artist:"):
+            continue
+        item_name = str(
+            (item.get("profile") or {}).get("name")
+            or item.get("name")
+            or ""
+        )
+        if item_name.strip().lower() == wanted:
+            return uri.split(":")[-1]
     return None
 
 
@@ -854,10 +921,23 @@ def _search_track_candidates(query: str) -> list[tuple[str, str]]:
     `[(track_id, display_name), ...]` for hits whose URI is a
     spotify:track:. Errors are logged and swallowed — callers
     treat an empty list as "search produced nothing useful".
+
+    Limit is 50 (was 5). For tracks that exist in multiple Spotify
+    entries (album version, single release, lyric video, alt master,
+    pre-release) the canonical highest-playcount version is often
+    not in the top 5 results — Spotify's search ranks by relevance
+    against the query, not by playcount. The downstream
+    `_resolve_canonical_track` filter scans the candidate list for
+    title/artist matches and picks the highest playcount among those,
+    so widening the candidate list directly raises ceiling on what
+    we can find without making the lookup any less accurate. The
+    pre-filter on `name.lower() == wanted_title` gates the expensive
+    per-candidate `_song_info` calls so wider lookups don't blow up
+    cost.
     """
     try:
         song, _ = _ensure_client()
-        res = song.query_songs(query, limit=5)
+        res = song.query_songs(query, limit=50)
     except Exception as exc:
         log.warning("spotify track search failed for %r: %s", query, exc)
         return []

--- a/tests/test_spotify_resolution.py
+++ b/tests/test_spotify_resolution.py
@@ -554,3 +554,150 @@ def test_schema_bump_is_idempotent(tmp_path, monkeypatch):
     finally:
         conn.close()
     assert rows == [(1234567,)]
+
+
+# ---------------------------------------------------------------------------
+# Search-limit bump: candidate list widened from 5 to 50 so that albums
+# whose canonical version sits beyond the top-5 results (e.g. when a
+# track has many alternate releases / pre-release singles / lyric
+# videos) still surface the right playcount.
+# ---------------------------------------------------------------------------
+
+
+def test_search_limit_is_widened(isolated_cache, fake_clients):
+    """`_search_track_candidates` must request `limit=50` from
+    spotapi. With the old `limit=5`, tracks like Quadeca's SCRAPYARD
+    album returned undercounts because the canonical album version
+    wasn't in the top 5 ISRC-search results."""
+    song, _ = fake_clients
+    captured: list[int] = []
+
+    def _query(q, limit=5):
+        captured.append(limit)
+        return _search_payload({"id": "X", "name": "x"})
+
+    song.query_songs.side_effect = _query
+    song.get_track_info.return_value = _get_track_payload(
+        playcount=0, primary_artist_name="x"
+    )
+
+    spotify_public._search_track_candidates("isrc:USXX0001")
+    spotify_public._search_track_candidates("Quadeca DUSTCUTTER")
+
+    assert captured == [50, 50], (
+        f"expected limit=50 on every search call, got {captured}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Artist-name search fallback: when the ISRC walk fails to find a
+# primary-artist match (typical for collab-heavy artists like Justin
+# Bieber whose top tracks on Tidal are all feature credits), fall
+# back to Spotify's `query_artists` endpoint and accept the first
+# name match.
+# ---------------------------------------------------------------------------
+
+
+def _artist_search_payload(*candidates: dict) -> dict:
+    """Build a queryV2 artist-search response. Each candidate is
+    `{"id": "<spotify_artist_id>", "name": "<display name>"}`."""
+    return {
+        "data": {
+            "searchV2": {
+                "artists": {
+                    "items": [
+                        {
+                            "item": {
+                                "data": {
+                                    "uri": f"spotify:artist:{c['id']}",
+                                    "profile": {"name": c["name"]},
+                                }
+                            }
+                        }
+                        for c in candidates
+                    ]
+                }
+            }
+        }
+    }
+
+
+def test_artist_resolution_falls_back_to_name_search(
+    isolated_cache, fake_clients
+):
+    """Tidal artist 'Justin Bieber' has every sample ISRC on a
+    collab where Bieber is a feature, not the primary. ISRC walk
+    can't find a primary-artist match. Resolver must fall through
+    to `query_artists("Justin Bieber")` and pick up the canonical
+    Bieber artist id."""
+    song, artist = fake_clients
+
+    # Every ISRC search returns a track where someone else is primary.
+    song.query_songs.side_effect = lambda q, limit=50: _search_payload(
+        {"id": "FEAT_TRK_ID", "name": "Stay"},
+    )
+    song.get_track_info.return_value = _get_track_payload(
+        playcount=2_000_000_000,
+        primary_artist_id="KIDLAROI_ID",
+        primary_artist_name="The Kid LAROI",
+    )
+
+    # Artist search returns Bieber as the first hit.
+    artist.query_artists.return_value = _artist_search_payload(
+        {"id": "BIEBER_ARTIST_ID", "name": "Justin Bieber"},
+    )
+    artist.get_artist.return_value = _artist_overview_payload(
+        monthly_listeners=80_000_000, name="Justin Bieber"
+    )
+
+    stats = spotify_public.artist_stats_v2(
+        tidal_artist_id="bieber_tidal_id",
+        tidal_artist_name="Justin Bieber",
+        sample_isrcs=["USFEAT00001", "USFEAT00002", "USFEAT00003"],
+    )
+
+    assert stats is not None
+    assert stats.spotify_artist_id == "BIEBER_ARTIST_ID", (
+        "fallback didn't pick up the artist-name search hit; resolver "
+        "is still returning None when ISRC walk fails"
+    )
+    assert stats.monthly_listeners == 80_000_000
+    assert artist.query_artists.called, (
+        "artist-name search wasn't attempted after ISRC walk failed"
+    )
+
+
+def test_artist_name_search_rejects_non_matching_results(
+    isolated_cache, fake_clients
+):
+    """Artist search is fuzzy — query "Jim" can return "Jim and the
+    Hellcats", "Jimmy", "Jim Carrey", etc. The fallback must only
+    accept hits whose name matches case-insensitively, and skip
+    everything else."""
+    song, artist = fake_clients
+
+    song.query_songs.side_effect = lambda q, limit=50: _search_payload(
+        {"id": "T", "name": "x"}
+    )
+    song.get_track_info.return_value = _get_track_payload(
+        playcount=1, primary_artist_name="Someone Else"
+    )
+
+    # Search returns soundalikes only — none match "Jim" exactly.
+    artist.query_artists.return_value = _artist_search_payload(
+        {"id": "JIMMY_ID", "name": "Jimmy"},
+        {"id": "JIMC_ID", "name": "Jim Carrey"},
+        {"id": "JIMHELLCATS_ID", "name": "Jim and the Hellcats"},
+    )
+
+    stats = spotify_public.artist_stats_v2(
+        tidal_artist_id="99",
+        tidal_artist_name="Jim",
+        sample_isrcs=["USXXX0001"],
+    )
+
+    assert stats is None, (
+        "fallback accepted a soundalike artist whose name doesn't "
+        "match exactly — should have returned None"
+    )
+    artist.get_artist.assert_not_called()


### PR DESCRIPTION
## Summary

Two real bugs from production reports:

### 1. Track playcounts undercount

Quadeca's SCRAPYARD album: 14 of 15 tracks show ~30% of Spotify's actual numbers (e.g. DUSTCUTTER 1.5M in Tideway vs. 5.2M on Spotify). Only TEXAS BLUE matched correctly — the one track whose canonical version happens to land in the top 5 search hits.

**Root cause**: `_search_track_candidates` requested `limit=5`. For tracks with many Spotify entries (album version + single release + lyric video + alt master + pre-release) the canonical highest-playcount version often isn't in the top 5, because Spotify ranks by relevance not playcount. The downstream `_resolve_canonical_track` filter picks the highest playcount among candidates that pass the title+artist match, so widening the pool strictly raises the ceiling without losing accuracy. The expensive per-candidate `_song_info` calls are gated on `name.lower() == wanted_title`, so a bigger pool doesn't blow up cost.

**Fix**: bump to `limit=50`.

### 2. Monthly listeners blank for collab-heavy artists

Justin Bieber's monthly listeners doesn't render because his top-N tracks on Tidal are all feature credits. The ISRC walk in `_resolve_artist_via_name_match` pivoted through Spotify's `getTrack` and checked the **primary** artist — for Bieber's first 5 sample ISRCs the primary was always someone else (Kid LAROI, Skrillex, etc.), so no match was found and the resolver returned None.

**Fix**: two-stage:
- Bump the ISRC walk from `sample_isrcs[:5]` to `sample_isrcs[:15]`.
- New `_search_artist_by_name()` fallback hits Spotify's `query_artists` and accepts the first hit whose name matches case-insensitively. Less precise than the ISRC walk (two artists can share a name) but precise enough for major artists with unique names. Returning *something* beats the blank-stats UX of returning None.

### 3. Cache flush

Schema version bumped 3 → 4. Wipes pre-fix rows on first open: undercount playcounts cached for 7 days, null artist mappings cached forever. Without the bump, existing users would keep seeing the old wrong numbers until the per-row TTL expires.

## Test plan

- [x] 3 new tests cover the search-limit bump (regression guard), artist-name fallback succeeding when ISRC walk fails, and the fallback correctly rejecting soundalikes (118 backend tests pass)
- [ ] Open Quadeca's SCRAPYARD album in Tideway — track counts now match Spotify (5.2M for DUSTCUTTER, 8.3M for A LA CARTE, etc.)
- [ ] Open Justin Bieber's artist page — monthly listeners renders
- [ ] Existing artist pages that already worked (artists where ISRC walk succeeded) still render the same numbers (regression guard)