### PR TITLE
macOS Now Playing: claim the active-media-player role

### DIFF
--- a/app/audio/macos_now_playing.py
+++ b/app/audio/macos_now_playing.py
@@ -1,0 +1,310 @@
+"""macOS Now Playing integration.
+
+Without this module, pressing the play / pause / next / previous media
+keys when Tideway isn't in the foreground opens Apple Music — even
+though Tideway is the app actually playing audio. macOS routes media
+keys to whichever app currently holds the "Now Playing" role via
+MPNowPlayingInfoCenter and MPRemoteCommandCenter. By default Apple
+Music claims that role, so unless we explicitly take it, the keys
+hit Music.app instead of us.
+
+This bridge:
+
+  1. Registers Tideway as the active media player by setting
+     `MPNowPlayingInfoCenter.defaultCenter().nowPlayingInfo` and
+     `playbackState` whenever the local player transitions states.
+     Once registered, macOS routes media-key events to our app's
+     remote-command handlers instead of Apple Music's.
+
+  2. Wires play / pause / toggle / next / previous remote commands
+     to local HTTP endpoints (`/api/player/play`, `.../pause`,
+     `.../hotkey/next`, etc.) — same pattern as `app/global_keys.py`'s
+     pynput listener uses, so the audio engine doesn't have to know
+     anything about Cocoa.
+
+  3. Mirrors the player's track / state / position into
+     `nowPlayingInfo` so the metadata shows up in Control Center,
+     the menu-bar Now Playing widget, and the lock screen.
+
+Cleanly degrades:
+  - Non-macOS: `start()` is a no-op.
+  - macOS but `MediaPlayer` framework not importable (older PyObjC,
+    stripped pyinstaller bundle, etc.): logs a single warning and
+    no-ops. The pynput global-key listener still picks up media keys
+    when Tideway IS in the foreground; this bridge just adds
+    background coverage on macOS.
+
+The pynput listener and this bridge coexist: pynput catches the raw
+key events at the OS level when Tideway is focused, this bridge
+catches the routed Now Playing remote commands when it isn't. Both
+end up firing the same HTTP endpoints.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+import threading
+from typing import Any, Optional
+from urllib import request as urlrequest
+
+log = logging.getLogger(__name__)
+
+
+def _say(msg: str) -> None:
+    """Visible log line. Mirrors the convention in tidal_realtime —
+    Python's `logging` isn't routed to a visible sink in this app, so
+    high-signal lines that the user might need to see use bare print."""
+    print(f"[macos-np] {msg}", flush=True)
+
+
+class MacOSNowPlayingBridge:
+    """Owns the MPNowPlayingInfoCenter + MPRemoteCommandCenter
+    integration. Constructed lazily by server.py at startup; safe to
+    instantiate on non-macOS systems (start() will return None).
+    """
+
+    def __init__(self, base_url: str = ""):
+        self._base_url = base_url.rstrip("/")
+        self._lock = threading.Lock()
+        self._enabled = False
+        self._info_center: Any = None
+        self._command_center: Any = None
+        # Cached metadata. The PlayerSnapshot has track_id but not
+        # title / artist / album, so callers (server.py, frontend
+        # via /api/now-playing) push richer metadata in here when
+        # the track changes. Until the first push lands we render
+        # whatever we know — usually nothing — and the menu-bar
+        # widget just shows the app name.
+        self._title = ""
+        self._artist = ""
+        self._album = ""
+        self._duration_ms = 0
+        self._artwork_url = ""
+        # Latest state from the player. Cached so a metadata push
+        # can re-render without waiting for the next state event.
+        self._state = "idle"
+        self._position_ms = 0
+        # Strong refs to the Cocoa block handlers so they don't get
+        # garbage-collected and silently stop firing remote commands.
+        self._handler_refs: list[Any] = []
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def set_base_url(self, base_url: str) -> None:
+        """Set the local HTTP base URL after construction. Used by
+        server.py's lifespan, which knows the port only after argparse
+        has run, while the bridge is constructed at module-import
+        time."""
+        self._base_url = base_url.rstrip("/")
+
+    def start(self) -> None:
+        """Register the remote command handlers and seed the now-
+        playing center. Idempotent and safe on non-macOS / stripped
+        builds — those paths log once and no-op the rest of the API.
+        """
+        if sys.platform != "darwin":
+            return
+        with self._lock:
+            if self._enabled:
+                return
+            try:
+                import MediaPlayer  # type: ignore[import-not-found]
+            except ImportError as exc:
+                _say(f"MediaPlayer framework unavailable: {exc!r}")
+                return
+            try:
+                self._info_center = (
+                    MediaPlayer.MPNowPlayingInfoCenter.defaultCenter()
+                )
+                self._command_center = (
+                    MediaPlayer.MPRemoteCommandCenter.sharedCommandCenter()
+                )
+                self._wire_command_handlers()
+                self._enabled = True
+            except Exception as exc:
+                _say(f"MediaPlayer init failed: {exc!r}")
+                return
+        _say("registered with macOS Now Playing")
+        self._push()
+
+    def _wire_command_handlers(self) -> None:
+        """Bind each MPRemoteCommand to a local handler that POSTs
+        the corresponding action to our HTTP API. Using HTTP rather
+        than a direct player reference so this module stays
+        independent of the audio engine's threading model — same
+        decoupling pattern `app/global_keys.py` uses for pynput.
+        """
+        # Imported here so non-macOS doesn't pay the import cost.
+        import MediaPlayer  # type: ignore[import-not-found]
+
+        # Handlers receive an MPRemoteCommandEvent and must return an
+        # MPRemoteCommandHandlerStatusSuccess. The block API expects
+        # an objc.callable that returns NSInteger; PyObjC bridges the
+        # Python callable shape automatically.
+        success = MediaPlayer.MPRemoteCommandHandlerStatusSuccess
+
+        def _on(action: str):
+            def handler(_event: Any) -> int:
+                threading.Thread(
+                    target=_safe_post,
+                    args=(self._base_url, action),
+                    daemon=True,
+                ).start()
+                return success
+            return handler
+
+        bindings = [
+            (self._command_center.playCommand(), _on("/api/player/play")),
+            (self._command_center.pauseCommand(), _on("/api/player/pause")),
+            (
+                self._command_center.togglePlayPauseCommand(),
+                _on("/api/hotkey/play_pause"),
+            ),
+            (self._command_center.nextTrackCommand(), _on("/api/hotkey/next")),
+            (
+                self._command_center.previousTrackCommand(),
+                _on("/api/hotkey/previous"),
+            ),
+        ]
+        for cmd, handler in bindings:
+            cmd.setEnabled_(True)
+            ref = cmd.addTargetWithHandler_(handler)
+            # Pin the returned target ref so ARC doesn't drop it.
+            self._handler_refs.append(ref)
+            self._handler_refs.append(handler)
+
+    # ------------------------------------------------------------------
+    # State + metadata updates
+    # ------------------------------------------------------------------
+
+    def update_state(self, snap: Any) -> None:
+        """Called from a PCMPlayer subscribe() listener on every state
+        change. Mirrors state + position into MPNowPlayingInfoCenter
+        so the menu-bar Now Playing widget stays in sync.
+
+        The PlayerSnapshot doesn't carry track title / artist
+        (those live on the frontend Track model), so we just update
+        state + position here. Track metadata flows in via
+        update_metadata(), called from the /api/now-playing endpoint
+        the frontend hits on track change.
+        """
+        with self._lock:
+            if not self._enabled:
+                return
+            self._state = getattr(snap, "state", "idle")
+            self._position_ms = int(getattr(snap, "position_ms", 0) or 0)
+            duration = int(getattr(snap, "duration_ms", 0) or 0)
+            if duration > 0:
+                self._duration_ms = duration
+        self._push()
+
+    def update_metadata(
+        self,
+        *,
+        title: str,
+        artist: str,
+        album: str = "",
+        duration_ms: int = 0,
+        artwork_url: str = "",
+    ) -> None:
+        """Push richer track metadata. Called by the
+        /api/now-playing endpoint, which the frontend hits whenever
+        the playing track changes (or on initial load when the
+        backend already has something playing)."""
+        with self._lock:
+            if not self._enabled:
+                return
+            self._title = title or ""
+            self._artist = artist or ""
+            self._album = album or ""
+            if duration_ms > 0:
+                self._duration_ms = int(duration_ms)
+            self._artwork_url = artwork_url or ""
+        self._push()
+
+    def clear(self) -> None:
+        """Drop the now-playing entry. Called when playback ends or
+        the user explicitly stops. Without this, the menu-bar widget
+        keeps showing the last track forever."""
+        with self._lock:
+            if not self._enabled:
+                return
+            self._title = ""
+            self._artist = ""
+            self._album = ""
+            self._duration_ms = 0
+            self._position_ms = 0
+            self._state = "idle"
+            self._artwork_url = ""
+            try:
+                import MediaPlayer  # type: ignore[import-not-found]
+
+                self._info_center.setNowPlayingInfo_(None)
+                self._info_center.setPlaybackState_(
+                    MediaPlayer.MPNowPlayingPlaybackStateStopped
+                )
+            except Exception as exc:
+                _say(f"clear failed: {exc!r}")
+
+    # ------------------------------------------------------------------
+    # Push to MPNowPlayingInfoCenter
+    # ------------------------------------------------------------------
+
+    def _push(self) -> None:
+        """Snapshot the cached state + metadata and send it to
+        MPNowPlayingInfoCenter. Called after every state or metadata
+        update. Cheap — one Cocoa call, no network — so we don't
+        bother coalescing."""
+        with self._lock:
+            if not self._enabled:
+                return
+            title = self._title or "Tideway"
+            artist = self._artist
+            album = self._album
+            duration_s = self._duration_ms / 1000.0
+            position_s = self._position_ms / 1000.0
+            state = self._state
+        try:
+            import MediaPlayer  # type: ignore[import-not-found]
+
+            info: dict[str, Any] = {
+                MediaPlayer.MPMediaItemPropertyTitle: title,
+                MediaPlayer.MPMediaItemPropertyArtist: artist,
+                MediaPlayer.MPMediaItemPropertyAlbumTitle: album,
+                MediaPlayer.MPMediaItemPropertyPlaybackDuration: duration_s,
+                MediaPlayer.MPNowPlayingInfoPropertyElapsedPlaybackTime: (
+                    position_s
+                ),
+                # Playback rate is 1.0 when playing, 0.0 when paused.
+                # macOS uses this to decide whether the Control Center
+                # widget animates the progress bar.
+                MediaPlayer.MPNowPlayingInfoPropertyPlaybackRate: (
+                    1.0 if state == "playing" else 0.0
+                ),
+            }
+            self._info_center.setNowPlayingInfo_(info)
+            if state == "playing":
+                self._info_center.setPlaybackState_(
+                    MediaPlayer.MPNowPlayingPlaybackStatePlaying
+                )
+            elif state == "paused":
+                self._info_center.setPlaybackState_(
+                    MediaPlayer.MPNowPlayingPlaybackStatePaused
+                )
+            else:
+                self._info_center.setPlaybackState_(
+                    MediaPlayer.MPNowPlayingPlaybackStateStopped
+                )
+        except Exception as exc:
+            _say(f"push failed: {exc!r}")
+
+
+def _safe_post(base_url: str, path: str) -> None:
+    url = f"{base_url}{path}"
+    try:
+        req = urlrequest.Request(url, method="POST")
+        urlrequest.urlopen(req, timeout=2).close()  # noqa: S310
+    except Exception as exc:
+        log.debug("macos-np POST %s failed: %s", url, exc)

--- a/requirements.txt
+++ b/requirements.txt
@@ -54,6 +54,16 @@ pystray>=0.19.5
 # import, so the actual libs stay off the dependency list — ~15 MB
 # smaller install.
 spotapi>=1.2.7
+# macOS Now Playing integration. Without claiming the system's
+# "active media player" role via MPNowPlayingInfoCenter and
+# MPRemoteCommandCenter, media keys (Cmd-F8, hardware play/pause
+# keys, Touch Bar, Control Center) route to Apple Music when
+# Tideway isn't focused — even though Tideway is the app actually
+# playing audio. The bridge in app/audio/macos_now_playing.py
+# uses these PyObjC bindings. Skipped on non-darwin via the
+# environment marker so a Linux / Windows install doesn't pull
+# them.
+pyobjc-framework-MediaPlayer>=10.0; sys_platform == "darwin"
 # UPnP / DLNA MediaRenderer output. Same library Home Assistant's
 # DLNA integration uses. Covers SSDP discovery, AVTransport control
 # (play/pause/seek), RenderingControl (volume), and OpenHome for

--- a/server.py
+++ b/server.py
@@ -43,6 +43,7 @@ from sse_starlette.sse import EventSourceResponse
 
 from app import deezer_import
 from app import global_keys as global_keys_mod
+from app.audio.macos_now_playing import MacOSNowPlayingBridge
 from app.audio.player import PCMPlayer
 from app import playlist_import
 from app import spotify_import
@@ -157,6 +158,12 @@ _tidal_page.SimpleList.get_item = _patched_get_item
 tidal = TidalClient()
 lastfm = LastFmClient()
 play_reporter = PlayReporter(tidal)
+# macOS Now Playing bridge — claims the system "active media player"
+# role so media keys route to Tideway instead of Apple Music when our
+# window isn't focused. Constructed empty; the lifespan startup hook
+# fills in base_url and calls .start(). No-ops on non-macOS so this
+# is safe to instantiate unconditionally.
+macos_now_playing_bridge = MacOSNowPlayingBridge()
 settings: Settings = load_settings()
 # Guards the `settings` rebind + downloader.settings swap so workers never
 # see a torn state (new global, old downloader field or vice versa).
@@ -525,6 +532,18 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
         stop_hotkeys = global_keys_mod.start_global_hotkeys(port)
     except Exception as exc:
         print(f"[global-keys] startup failed: {exc}", flush=True)
+
+    # Register Tideway with macOS Now Playing so media keys
+    # (Cmd-F8, hardware keys on a connected keyboard, the Touch
+    # Bar's play/pause button, the Control Center widget) route
+    # to us instead of Apple Music when Tideway isn't focused.
+    # No-ops on non-macOS. See app/audio/macos_now_playing.py.
+    try:
+        port = int(os.environ.get("TIDAL_DL_PORT", "47823"))
+        macos_now_playing_bridge.set_base_url(f"http://127.0.0.1:{port}")
+        macos_now_playing_bridge.start()
+    except Exception as exc:
+        print(f"[macos-np] startup failed: {exc}", flush=True)
 
     try:
         yield
@@ -3551,6 +3570,11 @@ def _native_player() -> PCMPlayer:
             else None,
             quality_clamp=tidal.clamp_quality_to_subscription,
         )
+        # Mirror state changes into macOS Now Playing so media keys
+        # can find us. update_state() no-ops on non-macOS / when the
+        # MediaPlayer framework isn't available, so unconditional
+        # subscription is safe.
+        _pcm_player_singleton.subscribe(macos_now_playing_bridge.update_state)
 
     # One-shot: re-apply persisted EQ + output device so users who
     # set a USB-DAC preference or an EQ preset keep it across restart.
@@ -3623,6 +3647,37 @@ def player_state() -> dict:
     # Tidal when a track isn't on disk.
     _require_local_access()
     return _snapshot_dict(_native_player().snapshot())
+
+
+class _NowPlayingMetadata(BaseModel):
+    title: str = ""
+    artist: str = ""
+    album: str = ""
+    duration_ms: int = 0
+    artwork_url: str = ""
+
+
+@app.post("/api/now-playing")
+def now_playing_update(payload: _NowPlayingMetadata) -> dict:
+    """Push the current track's display metadata into macOS Now
+    Playing. Frontend hits this on track change so Control Center,
+    the menu-bar widget, and the lock screen show the song title /
+    artist / album / duration alongside the play state.
+
+    No-ops on non-macOS or when the MediaPlayer framework isn't
+    available; the bridge handles the platform check internally.
+    Returns `{"ok": true}` either way so the frontend doesn't have
+    to branch on platform.
+    """
+    _require_local_access()
+    macos_now_playing_bridge.update_metadata(
+        title=payload.title,
+        artist=payload.artist,
+        album=payload.album,
+        duration_ms=payload.duration_ms,
+        artwork_url=payload.artwork_url,
+    )
+    return {"ok": True}
 
 
 @app.post("/api/player/load")

--- a/tests/test_macos_now_playing.py
+++ b/tests/test_macos_now_playing.py
@@ -1,0 +1,139 @@
+"""Tests for the macOS Now Playing bridge.
+
+The bridge calls into PyObjC's MediaPlayer framework, which only
+exists on macOS. Tests run on every platform — pytest is part of CI
+that has Linux runners — so the tests focus on the platform-gated
+no-op paths and the metadata mirroring logic that doesn't depend
+on Cocoa at all.
+
+End-to-end "does the menu bar actually show the track" is manual
+QA on macOS only.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from app.audio import macos_now_playing
+
+
+class _FakeSnapshot:
+    """Minimal duck-typed PlayerSnapshot for the bridge's
+    update_state() input."""
+
+    def __init__(
+        self,
+        state: str = "playing",
+        position_ms: int = 0,
+        duration_ms: int = 0,
+    ):
+        self.state = state
+        self.position_ms = position_ms
+        self.duration_ms = duration_ms
+
+
+def test_start_is_noop_on_non_macos():
+    bridge = macos_now_playing.MacOSNowPlayingBridge("http://localhost:8000")
+    with patch.object(macos_now_playing.sys, "platform", "linux"):
+        bridge.start()
+    # Subsequent operations must not raise even though start did
+    # nothing — on non-darwin we just want a silent fallback.
+    bridge.update_state(_FakeSnapshot())
+    bridge.update_metadata(title="x", artist="y")
+    bridge.clear()
+    # Nothing crashed; no assertions on visible state since there
+    # isn't any on non-darwin.
+
+
+def test_start_is_noop_when_mediaplayer_import_fails():
+    """On a stripped pyinstaller bundle or older PyObjC, the
+    MediaPlayer framework may not be importable. The bridge must
+    log once and degrade rather than crashing the server."""
+    bridge = macos_now_playing.MacOSNowPlayingBridge("http://localhost:8000")
+    with patch.object(macos_now_playing.sys, "platform", "darwin"):
+        # Force the import to fail.
+        with patch.dict("sys.modules", {"MediaPlayer": None}):
+            bridge.start()
+    bridge.update_state(_FakeSnapshot())
+    bridge.update_metadata(title="x", artist="y")
+    # No crash, no enabled state.
+    assert bridge._enabled is False
+
+
+def test_set_base_url_strips_trailing_slash():
+    bridge = macos_now_playing.MacOSNowPlayingBridge("")
+    bridge.set_base_url("http://example.com:1234/")
+    assert bridge._base_url == "http://example.com:1234"
+
+
+def test_update_state_caches_when_disabled():
+    """When the bridge isn't enabled, update_state should cache
+    nothing — no point because there's no Cocoa target to push to,
+    and we don't want stale state to leak if the bridge enables
+    later in the session (currently it can't, but future code
+    might)."""
+    bridge = macos_now_playing.MacOSNowPlayingBridge("")
+    # _enabled stays False because start() was never called.
+    bridge.update_state(_FakeSnapshot(state="playing", position_ms=42_000))
+    assert bridge._state == "idle"  # default, not the snapshot's value
+    assert bridge._position_ms == 0
+
+
+def test_update_metadata_caches_when_enabled(monkeypatch):
+    """With the bridge enabled (mocked Cocoa target), update_metadata
+    must mirror the values into the bridge's instance state and call
+    the Cocoa setNowPlayingInfo_ method. Real PyObjC isn't loaded —
+    we only verify the metadata caching here, since the Cocoa call
+    is platform-specific."""
+    bridge = macos_now_playing.MacOSNowPlayingBridge("")
+    # Pretend start() succeeded.
+    bridge._enabled = True
+    bridge._info_center = MagicMock()
+    bridge._command_center = MagicMock()
+    # Also stub out the import inside _push() so the test runs on
+    # any platform.
+    fake_mp = MagicMock()
+    with patch.dict("sys.modules", {"MediaPlayer": fake_mp}):
+        bridge.update_metadata(
+            title="DUSTCUTTER",
+            artist="Quadeca",
+            album="SCRAPYARD",
+            duration_ms=164_000,
+        )
+    assert bridge._title == "DUSTCUTTER"
+    assert bridge._artist == "Quadeca"
+    assert bridge._album == "SCRAPYARD"
+    assert bridge._duration_ms == 164_000
+    bridge._info_center.setNowPlayingInfo_.assert_called()
+
+
+def test_update_state_caches_when_enabled():
+    """Symmetric to update_metadata — when enabled, update_state
+    mirrors snapshot fields into bridge state."""
+    bridge = macos_now_playing.MacOSNowPlayingBridge("")
+    bridge._enabled = True
+    bridge._info_center = MagicMock()
+    fake_mp = MagicMock()
+    with patch.dict("sys.modules", {"MediaPlayer": fake_mp}):
+        bridge.update_state(
+            _FakeSnapshot(state="paused", position_ms=12_345, duration_ms=180_000)
+        )
+    assert bridge._state == "paused"
+    assert bridge._position_ms == 12_345
+    assert bridge._duration_ms == 180_000
+
+
+def test_clear_resets_cached_state():
+    bridge = macos_now_playing.MacOSNowPlayingBridge("")
+    bridge._enabled = True
+    bridge._info_center = MagicMock()
+    bridge._title = "old"
+    bridge._artist = "stale"
+    bridge._state = "playing"
+    bridge._position_ms = 99
+    fake_mp = MagicMock()
+    with patch.dict("sys.modules", {"MediaPlayer": fake_mp}):
+        bridge.clear()
+    assert bridge._title == ""
+    assert bridge._artist == ""
+    assert bridge._state == "idle"
+    assert bridge._position_ms == 0

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -802,6 +802,21 @@ export const api = {
         method: "POST",
         body: JSON.stringify({ track_ids: trackIds, quality }),
       }).catch(() => ({ prefetched: 0, total: trackIds.length })),
+    /** Push display metadata for the currently-playing track into
+     *  macOS Now Playing. Fired on track change so Control Center,
+     *  the menu-bar widget, and the lock screen show title / artist
+     *  / album / duration. No-ops on non-macOS server-side. */
+    nowPlaying: (info: {
+      title: string;
+      artist: string;
+      album?: string;
+      duration_ms?: number;
+      artwork_url?: string;
+    }) =>
+      req<{ ok: boolean }>("/api/now-playing", {
+        method: "POST",
+        body: JSON.stringify(info),
+      }).catch(() => ({ ok: false })),
     play: () => req<PlayerSnapshot>("/api/player/play", { method: "POST" }),
     pause: () => req<PlayerSnapshot>("/api/player/pause", { method: "POST" }),
     resume: () => req<PlayerSnapshot>("/api/player/resume", { method: "POST" }),

--- a/web/src/hooks/usePlayer.ts
+++ b/web/src/hooks/usePlayer.ts
@@ -489,6 +489,42 @@ export function usePlayer() {
     api.player.volume(Math.round(state.volume * 100)).catch(() => {});
   }, [state.volume]);
 
+  // macOS Now Playing metadata push. The backend's PlayerSnapshot has
+  // track_id but no title / artist / album / cover, and on macOS we
+  // need that data on Tideway's MPNowPlayingInfo dict for the menu-
+  // bar widget and Control Center to render anything useful (and to
+  // keep media keys routed to us — without a populated entry, macOS
+  // can fall back to Apple Music). Fire on every track change with
+  // the data the frontend already has. Fire-and-forget; the bridge
+  // no-ops on non-macOS so this is safe to ship unconditionally.
+  const lastNowPlayingIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    const track = state.track;
+    if (!track) {
+      lastNowPlayingIdRef.current = null;
+      return;
+    }
+    if (lastNowPlayingIdRef.current === track.id) return;
+    lastNowPlayingIdRef.current = track.id;
+    const artistName =
+      Array.isArray(track.artists) && track.artists.length > 0
+        ? track.artists
+            .map((a) => a.name)
+            .filter(Boolean)
+            .join(", ")
+        : "";
+    api.player
+      .nowPlaying({
+        title: track.name || "",
+        artist: artistName,
+        album: track.album?.name ?? "",
+        duration_ms: Math.round((track.duration ?? 0) * 1000),
+      })
+      .catch(() => {
+        /* fire-and-forget */
+      });
+  }, [state.track]);
+
   // Album-end "continue with artist radio" preference, mirrored from
   // the backend Settings dataclass. Read on mount and refreshed
   // whenever the SettingsPage dispatches the `tidal-settings-updated`


### PR DESCRIPTION
## Summary

When Tideway isn't focused, pressing the play / pause / next / previous media keys opens Apple Music instead of pausing Tideway — even though Tideway is the app actually playing audio. macOS routes media keys to whichever app holds the "Now Playing" role via `MPNowPlayingInfoCenter` and `MPRemoteCommandCenter`. By default Apple Music claims it. Without Tideway explicitly registering, the keys hit Music.app.

## What this adds

- **New `app/audio/macos_now_playing.py` MacOSNowPlayingBridge.**
  - Registers Tideway with `MPNowPlayingInfoCenter` + `MPRemoteCommandCenter` on startup. Once registered, macOS routes media-key events to our remote-command handlers instead of Apple Music's.
  - Wires play / pause / toggle / next / previous remote commands to local HTTP endpoints — same decoupling pattern `app/global_keys.py` uses for pynput.
  - Mirrors player state into `nowPlayingInfo` on every state change so the menu-bar widget, Control Center, and the lock screen show what Tideway is playing.
- **New `POST /api/now-playing` endpoint.** Frontend pushes track title / artist / album / duration on every track change. The PCMPlayer's snapshot only has `track_id`; this endpoint gives the bridge the full display metadata.
- **`pyobjc-framework-MediaPlayer>=10.0; sys_platform == "darwin"`** in requirements.txt. The env marker keeps Linux / Windows installs unchanged.

## Cleanly degrades

- Non-macOS: `start()` is a no-op; the new endpoint accepts and ignores. The existing pynput global-key listener still catches keys when Tideway is focused.
- macOS without `MediaPlayer` (older PyObjC, stripped pyinstaller bundle): bridge logs once and no-ops. pynput-when-focused coverage stays intact.

## Test plan

- [x] 7 new unit tests cover platform gates, metadata mirroring, the disabled-state caching guard, and `clear()` reset (122 backend tests pass)
- [ ] On macOS: play a track, send Tideway to the background, press the play / pause media key — Tideway pauses, Apple Music doesn't open
- [ ] On macOS: play a track, open Control Center → Music widget — shows Tideway as the active player with title and artist
- [ ] On macOS: lock screen shows the track that's playing in Tideway
- [ ] On Linux: server starts cleanly, `/api/now-playing` returns `{"ok": true}`, no MediaPlayer-related errors in the log