### PR TITLE
Release CI: drop tls_client bundle-verification check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,18 +53,22 @@ jobs:
 
       - name: Verify native libraries bundled
         # Backstop against the curl-cffi-missing-from-bundle (v0.4.7)
-        # and tls-client-missing-from-bundle (v0.4.8) regressions.
-        # Both shipped because PyInstaller's static analysis missed
-        # native libs that get loaded via ctypes / CFFI at runtime.
-        # If anyone removes the matching collect_all() in the spec,
-        # the grep below trips and the release fails before users
-        # install a broken bundle.
+        # regression. PyInstaller's static analysis routinely misses
+        # native libs that get loaded via ctypes / CFFI at runtime,
+        # and curl-cffi falling back to plain requests would silently
+        # drop our TLS-fingerprint match.
+        #
+        # tls_client used to be checked here too — we deliberately
+        # stopped bundling it in v0.4.11 because its Go-CGO DLL was
+        # crashing the Windows app, and spotapi now talks to Spotify
+        # through curl-cffi via app/spotify_curl_session.py instead.
+        # If you're tempted to add it back: don't, the broken
+        # transport stays out of the bundle on purpose.
         run: |
           set -e
           APP_DIR="dist/Tideway.app/Contents"
           required_globs=(
             "*/curl_cffi/_wrapper*.so"
-            "*/tls_client/dependencies/tls-client-arm64.dylib"
           )
           for pat in "${required_globs[@]}"; do
             count=$(find "$APP_DIR" -path "$pat" 2>/dev/null | wc -l | tr -d ' ')
@@ -134,16 +138,23 @@ jobs:
 
       - name: Verify native libraries bundled
         # Backstop against the curl-cffi-missing-from-bundle (v0.4.7)
-        # and tls-client-missing-from-bundle (v0.4.8) regressions.
-        # Both shipped because PyInstaller's static analysis missed
-        # native libs that get loaded via ctypes / CFFI at runtime.
-        # If the spec stops collecting them the build fails here
-        # rather than at the user's machine on first Spotify call.
+        # regression. PyInstaller's static analysis routinely misses
+        # native libs that get loaded via ctypes / CFFI at runtime,
+        # and curl-cffi falling back to plain requests would silently
+        # drop our TLS-fingerprint match.
+        #
+        # tls-client-*.dll used to be checked here too — we
+        # deliberately stopped bundling it in v0.4.11 because its
+        # Go-CGO DLL was crashing the Windows app at offset 0x66621
+        # on first Spotify enrichment call, and spotapi now talks to
+        # Spotify through curl-cffi via app/spotify_curl_session.py
+        # instead. If you're tempted to add it back: don't, the
+        # broken transport stays out of the bundle on purpose.
         shell: pwsh
         run: |
           $appRoot = "dist\Tideway"
           $missing = $false
-          foreach ($pat in @("_wrapper*", "tls-client-*.dll")) {
+          foreach ($pat in @("_wrapper*")) {
             $files = Get-ChildItem -Path $appRoot -Recurse -Filter $pat -ErrorAction SilentlyContinue
             if (-not $files) {
               Write-Host "::error ::Missing native library matching $pat in Windows bundle"
@@ -221,16 +232,23 @@ jobs:
 
       - name: Verify native libraries bundled
         # Backstop against the curl-cffi-missing-from-bundle (v0.4.7)
-        # and tls-client-missing-from-bundle (v0.4.8) regressions.
-        # Both shipped because PyInstaller's static analysis missed
-        # native libs that get loaded via ctypes / CFFI at runtime.
-        # If the spec stops collecting them the build fails here
-        # rather than at the user's machine on first Spotify call.
+        # regression. PyInstaller's static analysis routinely misses
+        # native libs that get loaded via ctypes / CFFI at runtime,
+        # and curl-cffi falling back to plain requests would silently
+        # drop our TLS-fingerprint match.
+        #
+        # tls-client-*.dll used to be checked here too — we
+        # deliberately stopped bundling it in v0.4.11 because its
+        # Go-CGO DLL was crashing the Windows app at offset 0x66621
+        # on first Spotify enrichment call, and spotapi now talks to
+        # Spotify through curl-cffi via app/spotify_curl_session.py
+        # instead. If you're tempted to add it back: don't, the
+        # broken transport stays out of the bundle on purpose.
         shell: pwsh
         run: |
           $appRoot = "dist\Tideway"
           $missing = $false
-          foreach ($pat in @("_wrapper*", "tls-client-*.dll")) {
+          foreach ($pat in @("_wrapper*")) {
             $files = Get-ChildItem -Path $appRoot -Recurse -Filter $pat -ErrorAction SilentlyContinue
             if (-not $files) {
               Write-Host "::error ::Missing native library matching $pat in Windows bundle"


### PR DESCRIPTION
## Summary

- v0.4.11's Release workflow [failed](https://github.com/J-M-PUNK/tideway/actions/runs/25068223818) at the "Verify native libraries bundled" step on all three build jobs (mac, windows-x64, windows-arm64). The check was hardcoded to require \`tls-client-*.dll\` / \`tls-client-arm64.dylib\` in the bundle, but v0.4.11 deliberately stopped shipping those — the Go-CGO DLL was crashing the Windows app and spotapi now talks to Spotify through curl-cffi via \`app/spotify_curl_session.py\`.
- Drops \`tls_client\` from the verification globs in all three jobs. \`curl_cffi\`'s \`_wrapper*\` check stays — that one still matters; PyInstaller missing curl-cffi would silently fall back to plain requests.
- Comments spell out why tls_client is no longer expected, so a future reader doesn't add it back thinking the bundle's incomplete.

## Test plan

- [x] grep confirms only historical-context comments mention tls_client; no active checks remain
- [ ] Re-run the Release workflow against \`v0.4.11\` after merge — all three build jobs should now pass and the \`publish\` job should run

## Follow-up after merge

The v0.4.11 tag points at commit \`0ee3e5e\` (the release-notes commit on \`deploy/v0.4.11\`), which has the OLD release.yml. After this PR merges to main, we'll need to either:

1. **Move the v0.4.11 tag forward** to the merge commit so the workflow fix lives at the tag (\`git tag -f v0.4.11 <merge-sha>\` + \`git push --force origin v0.4.11\`). Force-push, but no artifacts went out so nothing user-visible changes.
2. **Re-trigger the existing tag** via the Release workflow's \`workflow_dispatch\` (the spec uses \`github.event.inputs.tag || github.ref\` so a manual run can be pointed at v0.4.11 and would check out the OLD code — same problem).

Option 1 is the right call. Will need explicit user authorization since force-tag is destructive.