### PR TITLE
Release CI: auto-populate draft body from tag commit, pin tag binding

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -307,9 +307,49 @@ jobs:
           name: Tideway-Windows-arm64
           path: artifacts
 
+      # Pull the release notes out of the tagged commit's message body.
+      # The release-commit convention (CONTRIBUTING.md, "Tag the release")
+      # is "Release X.Y.Z: <subject>" on the subject line and the
+      # user-visible notes in the body, so this just becomes the GitHub
+      # release body verbatim. Removes the "I tagged but the draft is
+      # empty so I have to write notes twice" failure mode that bit
+      # v0.4.11.
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 1
+
+      - name: Extract release notes from tag commit body
+        id: notes
+        # `git log -1 --format=%b` prints just the body (everything
+        # after the subject line + blank line), preserving paragraph
+        # breaks and markdown. Empty body = empty file = empty release
+        # body, which is no worse than the old behavior.
+        run: |
+          set -e
+          git log -1 --format=%b "${{ github.ref }}" > release_body.md
+          echo "Release body (${{ github.ref_name }}):"
+          echo "----"
+          cat release_body.md
+          echo "----"
+
       - name: Create / update release
         uses: softprops/action-gh-release@v2
         with:
+          # Pin the tag explicitly. The action defaults to github.ref_name
+          # but if a draft was created out-of-band (e.g. by a previous
+          # failed run that succeeded as far as the publish job) the
+          # action can end up creating an "untagged-<sha>" release
+          # instead of binding to v<X.Y.Z>. That bit v0.4.11 — the
+          # release published with tag_name="untagged-..." and the
+          # auto-updater (which compares the tag string against the
+          # installed version) couldn't see it.
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          # Body comes from the tag commit's message body. Stays as a
+          # draft for human review before publishing — see CONTRIBUTING.md
+          # "Tag the release" for the full flow.
+          body_path: release_body.md
           # Glob rather than explicit filename so the version-stamped
           # asset names (Tideway-0.1.0.dmg, Tideway-setup-0.1.0.exe,
           # Tideway-setup-0.1.0-arm64.exe) land without hardcoding the
@@ -317,17 +357,15 @@ jobs:
           files: |
             artifacts/Tideway-*.dmg
             artifacts/Tideway-setup-*.exe
-          # draft: true preserves an existing draft's state. If the
-          # release doesn't exist yet (a push with no manually-created
-          # draft), one is created as a draft for the maintainer to
-          # review before publishing. Keeps curated release notes
-          # written before the tag was pushed from getting wiped.
+          # draft: true so the maintainer can review the auto-populated
+          # notes (and edit / restructure if needed) before publishing.
+          # Publishing a draft is what actually triggers the auto-update
+          # check on user installs — /releases/latest excludes drafts.
           draft: true
-          # generate_release_notes: false so curated notes written
-          # into a pre-existing draft aren't overwritten. When
-          # creating a fresh release from scratch the body will be
-          # empty; run `gh release edit vX.Y.Z --notes-file ...` or
-          # fill it in the GitHub UI before publishing.
+          # generate_release_notes: false because we already have notes
+          # from the commit body. Setting true would make the action
+          # append GitHub's auto-generated changelog (linked PRs since
+          # last tag) on TOP of our curated body, which doubles up.
           generate_release_notes: false
           # Mark tags containing a hyphen (v0.2.0-rc1 etc.) as
           # prereleases automatically.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,12 +79,21 @@ single deploy, the workflow is:
    and manually verified — main never had the problem and the
    deploy branch is the only place we can catch it.
 6. **Tag the release.** `git tag v<X.Y.Z>` on the deploy branch's
-   tip and push the tag.
-7. **Run the release pipeline.** GitHub Actions builds artifacts off
-   the tag.
-8. **Catch main back up.** Fast-forward `main` to the deploy branch:
+   tip and push the tag. The release commit's body becomes the
+   GitHub release notes — the workflow extracts it via
+   `git log -1 --format=%b`, so write user-facing notes there
+   (not the engineer-facing "what files changed" kind).
+7. **Run the release pipeline.** GitHub Actions builds the three
+   platform installers and creates a **draft** release on GitHub
+   with the notes auto-populated from the tag commit body.
+8. **Publish the draft.** Open the Releases page, skim the
+   auto-populated notes, click Publish. Drafts are invisible to
+   the auto-updater (`/releases/latest` excludes them), so a
+   tagged-but-unpublished release ships nothing to users. If you
+   tag and walk away, no one gets the update.
+9. **Catch main back up.** Fast-forward `main` to the deploy branch:
    `git checkout main && git merge --ff-only deploy/v<X.Y.Z> && git push`.
-9. **Clean up.** Delete merged PR branches locally and on GitHub.
+10. **Clean up.** Delete merged PR branches locally and on GitHub.
 
 The integration-branch step is what differentiates this from the
 "merge each PR straight to main" pattern. Reasons:
@@ -120,7 +129,9 @@ When NOT to use this workflow:
   happens on GitHub; the user merges when ready, or directs Claude
   to do it.
 - **Never tag, push tags, or run release workflows without explicit
-  instruction.** Tagging is a release action.
+  instruction.** Tagging is a release action. Publishing the draft
+  release that the workflow produces is the same flavor of release
+  action — also requires explicit instruction.
 - **Never fast-forward main without explicit instruction.** Even if
   the deploy branch is ready, main moves only when the user says so.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,22 @@ git merge --no-ff feature/branch-three
 # Resolve any conflicts here, in the integration branch.
 # The individual PR branches stay clean.
 
-# Bump version (e.g. desktop.py, package.json) and write release
-# notes, then commit.
-git commit -m "Release 0.X.Y"
+# Bump the VERSION file and write the release notes commit. The
+# notes go into the commit message body — the release workflow
+# pulls them out of `git log -1 --format=%b` and uses them as the
+# GitHub release body, so anything you'd want a user to read on
+# the Releases page goes here. Subject line stays a one-liner.
+git commit -m "Release 0.X.Y: <one-line summary>
+
+## <Section heading>
+
+### <What changed, user-facing>
+
+Paragraph explaining the change in plain language — same shape
+as the v0.4.10 / v0.4.11 release notes.
+
+## <Another section>
+..."
 
 # Test the integrated branch BEFORE tagging.
 ./scripts/preflight.sh
@@ -71,7 +84,32 @@ git push -u origin deploy/v0.X.Y
 git push origin v0.X.Y
 ```
 
-GitHub Actions picks up the tag and builds the release artifacts.
+### Publish the draft release
+
+GitHub Actions picks up the tag and runs the Release workflow,
+which builds the three platform installers (mac DMG + Windows
+x64 EXE + Windows ARM64 EXE) and creates a **draft** release on
+the Releases page with:
+
+- Title and tag binding set to `v0.X.Y`
+- Body populated from your release commit's message body
+- All three installers attached as assets
+
+The draft sits there for a final human review:
+
+1. Open https://github.com/J-M-PUNK/tideway/releases — there will
+   be a "Draft" badge on `v0.X.Y` at the top of the list.
+2. Skim the auto-populated body. Edit on the GitHub UI if you
+   want to tweak wording, reorder sections, etc. (Permanent
+   improvements should also land back in the release commit so
+   `git log` and the Releases page stay in sync.)
+3. Click **Publish release**.
+
+Publishing is what actually ships. The auto-updater on user
+installs hits `GET /repos/.../releases/latest`, which excludes
+drafts — so a release in draft state is invisible to users and
+the auto-update notification never fires. If you tag, walk away,
+and forget to publish, no one gets the update.
 
 ### Catch main back up
 


### PR DESCRIPTION
## Summary

v0.4.11 hit two release-workflow footguns:

1. **Empty-draft footgun.** The publish job expected the maintainer to pre-create a draft with curated notes. When that step was skipped, the release went up with a blank description even after publishing.
2. **Placeholder-tag footgun.** The draft was created with \`tag_name=\"untagged-71be8bf3...\"\` instead of \`v0.4.11\`. Publishing kept the placeholder tag, so the auto-updater (which compares \`tag_name\` against the installed version) never recognised it as a newer release. Users on 0.4.10 stayed silent.

This PR fixes both:

- **Auto-populate the draft body from the tag commit's message.** \`git log -1 --format=%b\` extracts the body and the action receives it as \`body_path\`. The release-commit convention already puts user-facing notes in the body; this just plumbs them through to the right place. Empty body still produces an empty release — same as before, just no longer the default outcome.
- **Pin \`tag_name\` and \`name\` to \`github.ref_name\` explicitly.** softprops defaults to \`ref_name\` but in the v0.4.11 incident it bound to a placeholder anyway (probably an earlier failed publish-skipped run leaving a half-created draft). Explicit pin closes that gap.
- **Document the draft → publish flow** in [CONTRIBUTING.md](CONTRIBUTING.md) and [CLAUDE.md](CLAUDE.md) so the publish step doesn't get forgotten. Drafts are invisible to \`/releases/latest\`, so tagged-but-unpublished = ships nothing.

## Test plan

- [x] YAML parses (\`yaml.safe_load\` clean)
- [ ] Verified on the next release: draft is created with the v0.X.Y body populated and the tag bound correctly. (Won't be exercised until v0.4.12.)

## Notes

This doesn't change behaviour at the merge step — the next release pipeline will run on the next tag push. v0.4.11 itself was patched manually via API to fix the tag binding (the release page now correctly shows tag_name=v0.4.11), so no users are stuck on the broken state.