### PR TITLE
Quality picker shows actual playback tier, not user's preference

### DIFF
--- a/web/src/components/NowPlaying.tsx
+++ b/web/src/components/NowPlaying.tsx
@@ -18,6 +18,12 @@ import {
   VolumeX,
 } from "lucide-react";
 import type { OnDownload } from "@/api/download";
+import type { StreamInfo } from "@/api/types";
+import {
+  type QualityTier,
+  tierFromPreference,
+  tierFromStreamInfo,
+} from "@/lib/quality";
 import { formatDuration, imageProxy } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import {
@@ -307,7 +313,7 @@ export function NowPlaying({
           >
             <ListMusic className="h-4 w-4" />
           </Button>
-          <StreamingQualityPicker isLocal={isLocal} />
+          <StreamingQualityPicker isLocal={isLocal} streamInfo={streamInfo} />
           <SleepTimerButton />
           <OutputDevicePicker />
           <VolumeControl
@@ -380,22 +386,39 @@ const QUALITY_OPTIONS: {
 // palette entries read on both dark and light backgrounds without
 // needing a mode-specific override. `primary` is the brand accent,
 // reserved for Max so the top tier is visually distinct.
-const QUALITY_BADGE_CLASS: Record<StreamingQuality, string> = {
-  low_96k: "bg-neutral-500/15 text-neutral-400 hover:bg-neutral-500/25",
-  low_320k: "bg-amber-500/15 text-amber-500 hover:bg-amber-500/25",
-  high_lossless: "bg-sky-500/15 text-sky-500 hover:bg-sky-500/25",
-  hi_res_lossless: "bg-primary/15 text-primary hover:bg-primary/25",
+const TIER_BADGE_CLASS: Record<QualityTier, string> = {
+  Low: "bg-neutral-500/15 text-neutral-400 hover:bg-neutral-500/25",
+  Medium: "bg-amber-500/15 text-amber-500 hover:bg-amber-500/25",
+  High: "bg-sky-500/15 text-sky-500 hover:bg-sky-500/25",
+  Max: "bg-primary/15 text-primary hover:bg-primary/25",
 };
 
 /**
- * Quality picker pill on the Now Playing bar. When the current track is
- * a downloaded local file, this is a no-op badge (playback is already at
- * the file's native quality) — only the streaming path actually switches.
+ * Quality picker pill on the Now Playing bar. The label and color
+ * reflect the *actual* playback tier (derived from `streamInfo`),
+ * not the user's preference — so a Max-preference user playing a
+ * Lossless-only track sees "High" here and on the small badge to
+ * the left of the title. When nothing is playing yet (`streamInfo`
+ * is null on a fresh launch), the label falls back to the
+ * preference so the picker shows something useful.
+ *
+ * The dropdown still exposes all four preference options. Picking
+ * one updates `streamingQuality`; the next track that loads at
+ * the new ceiling is reflected in this badge automatically when
+ * the SSE pushes its first snapshot.
+ *
+ * Local files keep the existing "Downloaded" treatment since the
+ * file's quality is fixed by the disk content, not by Tidal's
+ * tier system.
  */
-function StreamingQualityPicker({ isLocal }: { isLocal: boolean }) {
+function StreamingQualityPicker({
+  isLocal,
+  streamInfo,
+}: {
+  isLocal: boolean;
+  streamInfo: StreamInfo | null;
+}) {
   const { streamingQuality, set } = useUiPreferences();
-  const current = QUALITY_OPTIONS.find((q) => q.value === streamingQuality);
-  const label = isLocal ? "Downloaded" : (current?.label ?? "Streaming");
 
   if (isLocal) {
     return (
@@ -403,11 +426,16 @@ function StreamingQualityPicker({ isLocal }: { isLocal: boolean }) {
         className="flex items-center gap-1.5 rounded-full bg-primary/15 px-2.5 py-1 text-[10px] font-bold uppercase tracking-wider text-primary"
         title="Playing the local file at its downloaded quality"
       >
-        <AudioLines className="h-3 w-3" /> {label}
+        <AudioLines className="h-3 w-3" /> Downloaded
       </div>
     );
   }
-  const badgeClass = QUALITY_BADGE_CLASS[streamingQuality];
+
+  const effectiveTier: QualityTier = streamInfo
+    ? tierFromStreamInfo(streamInfo)
+    : tierFromPreference(streamingQuality);
+  const label = effectiveTier;
+  const badgeClass = TIER_BADGE_CLASS[effectiveTier];
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>

--- a/web/src/components/StreamQualityBadge.tsx
+++ b/web/src/components/StreamQualityBadge.tsx
@@ -4,6 +4,7 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { tierFromStreamInfo } from "@/lib/quality";
 import { cn } from "@/lib/utils";
 
 /**
@@ -36,7 +37,7 @@ export function StreamQualityBadge({
   const codec = info.codec.toUpperCase();
   const rate = formatRate(info.sample_rate_hz);
   const depth = info.bit_depth ? `${info.bit_depth}-bit` : null;
-  const tier = tierLabel(info);
+  const tier = tierFromStreamInfo(info);
   // Tone matches tier without rendering the tier name in the pill —
   // the pill is just the user-facing label, the color carries the
   // hi-res / lossless / lossy distinction.
@@ -82,32 +83,4 @@ function formatRate(hz: number | null): string | null {
   // off whole-number kHz values.
   const khz = hz / 1000;
   return khz % 1 === 0 ? String(khz) : khz.toFixed(1);
-}
-
-/**
- * Map a StreamInfo to one of the four user-facing labels. Tidal
- * streams carry the tier in `audio_quality` directly, so prefer
- * that. Local files don't have it (Tidal isn't involved at all),
- * so we fall back to deriving from codec + sample rate / bit
- * depth — local files can never be "Low" since that's a Tidal-
- * specific 96k AAC tier.
- */
-function tierLabel(info: StreamInfo): "Low" | "Medium" | "High" | "Max" {
-  const aq = (info.audio_quality || "").toUpperCase();
-  if (aq === "LOW") return "Low";
-  if (aq === "HIGH") return "Medium";
-  if (aq === "LOSSLESS") return "High";
-  if (aq === "HI_RES" || aq === "HI_RES_LOSSLESS") return "Max";
-
-  const codec = (info.codec || "").toLowerCase();
-  if (codec === "flac" || codec === "alac") {
-    const isHiRes =
-      (info.bit_depth !== null && info.bit_depth >= 24) ||
-      (info.sample_rate_hz !== null && info.sample_rate_hz > 48000);
-    return isHiRes ? "Max" : "High";
-  }
-  // Lossy local file (rare). "Medium" is the closest user-facing
-  // bucket; we have no way to distinguish 96 kbps from 320 kbps
-  // sources without Tidal's tier string.
-  return "Medium";
 }

--- a/web/src/lib/quality.test.ts
+++ b/web/src/lib/quality.test.ts
@@ -1,6 +1,23 @@
 import { describe, expect, it } from "vitest";
 
-import { effectiveFormatLabel } from "./quality";
+import type { StreamInfo } from "@/api/types";
+import {
+  effectiveFormatLabel,
+  tierFromPreference,
+  tierFromStreamInfo,
+} from "./quality";
+
+function makeInfo(over: Partial<StreamInfo> = {}): StreamInfo {
+  return {
+    source: "stream",
+    codec: "flac",
+    bit_depth: 16,
+    sample_rate_hz: 44100,
+    audio_quality: null,
+    audio_mode: null,
+    ...over,
+  };
+}
 
 describe("effectiveFormatLabel", () => {
   it("returns null for non-Max qualities regardless of tags", () => {
@@ -45,5 +62,106 @@ describe("effectiveFormatLabel", () => {
 
   it("returns null for an unrecognized tag on Max", () => {
     expect(effectiveFormatLabel("hi_res_lossless", ["DOLBY_ATMOS"])).toBeNull();
+  });
+});
+
+describe("tierFromStreamInfo", () => {
+  it("uses Tidal's audio_quality string when present", () => {
+    expect(tierFromStreamInfo(makeInfo({ audio_quality: "LOW" }))).toBe("Low");
+    expect(tierFromStreamInfo(makeInfo({ audio_quality: "HIGH" }))).toBe(
+      "Medium",
+    );
+    expect(tierFromStreamInfo(makeInfo({ audio_quality: "LOSSLESS" }))).toBe(
+      "High",
+    );
+    expect(
+      tierFromStreamInfo(makeInfo({ audio_quality: "HI_RES_LOSSLESS" })),
+    ).toBe("Max");
+  });
+
+  it("treats HI_RES (legacy MQA tier) as Max", () => {
+    expect(tierFromStreamInfo(makeInfo({ audio_quality: "HI_RES" }))).toBe(
+      "Max",
+    );
+  });
+
+  it("normalizes case on the audio_quality string", () => {
+    expect(tierFromStreamInfo(makeInfo({ audio_quality: "lossless" }))).toBe(
+      "High",
+    );
+    expect(
+      tierFromStreamInfo(makeInfo({ audio_quality: "hi_res_lossless" })),
+    ).toBe("Max");
+  });
+
+  it("derives from codec + sample rate / bit depth for local files", () => {
+    // Local FLAC at CD quality → High
+    expect(
+      tierFromStreamInfo(
+        makeInfo({
+          codec: "flac",
+          bit_depth: 16,
+          sample_rate_hz: 44100,
+          audio_quality: null,
+        }),
+      ),
+    ).toBe("High");
+
+    // Local FLAC at 24-bit → Max
+    expect(
+      tierFromStreamInfo(
+        makeInfo({
+          codec: "flac",
+          bit_depth: 24,
+          sample_rate_hz: 96000,
+          audio_quality: null,
+        }),
+      ),
+    ).toBe("Max");
+
+    // Local FLAC at 16-bit but >48 kHz → Max
+    expect(
+      tierFromStreamInfo(
+        makeInfo({
+          codec: "flac",
+          bit_depth: 16,
+          sample_rate_hz: 88200,
+          audio_quality: null,
+        }),
+      ),
+    ).toBe("Max");
+
+    // Local ALAC at CD quality → High
+    expect(
+      tierFromStreamInfo(
+        makeInfo({
+          codec: "alac",
+          bit_depth: 16,
+          sample_rate_hz: 44100,
+          audio_quality: null,
+        }),
+      ),
+    ).toBe("High");
+
+    // Local lossy file (rare; falls back to Medium)
+    expect(
+      tierFromStreamInfo(
+        makeInfo({
+          codec: "mp3",
+          bit_depth: null,
+          sample_rate_hz: 44100,
+          audio_quality: null,
+        }),
+      ),
+    ).toBe("Medium");
+  });
+});
+
+describe("tierFromPreference", () => {
+  it("maps each preference to its tier label exhaustively", () => {
+    expect(tierFromPreference("low_96k")).toBe("Low");
+    expect(tierFromPreference("low_320k")).toBe("Medium");
+    expect(tierFromPreference("high_lossless")).toBe("High");
+    expect(tierFromPreference("hi_res_lossless")).toBe("Max");
   });
 });

--- a/web/src/lib/quality.ts
+++ b/web/src/lib/quality.ts
@@ -1,3 +1,6 @@
+import type { StreamInfo } from "@/api/types";
+import type { StreamingQuality } from "@/hooks/useUiPreferences";
+
 /**
  * Does this track/album benefit from the Max tier? Returns a short
  * tag to surface on the Max entry in a download-quality menu:
@@ -20,4 +23,60 @@ export function effectiveFormatLabel(
   if (T.has("HIRES_LOSSLESS")) return "Hi-Res";
   if (T.has("LOSSLESS")) return "Same as High";
   return null;
+}
+
+export type QualityTier = "Low" | "Medium" | "High" | "Max";
+
+/**
+ * Map a streaming-quality preference to its tier label. Same labels
+ * the picker dropdown shows in its options. Used by the now-playing
+ * picker as a fallback when nothing's playing yet (no `streamInfo`
+ * to derive from).
+ */
+export function tierFromPreference(q: StreamingQuality): QualityTier {
+  switch (q) {
+    case "low_96k":
+      return "Low";
+    case "low_320k":
+      return "Medium";
+    case "high_lossless":
+      return "High";
+    case "hi_res_lossless":
+      return "Max";
+  }
+}
+
+/**
+ * Map a backend `StreamInfo` to the four user-facing tier labels
+ * (Low, Medium, High, Max). Tidal streams carry the tier in
+ * `audio_quality` directly, so prefer that. Local files don't have
+ * it — Tidal isn't involved at all — so we fall back to deriving
+ * from codec + sample rate / bit depth. Local files can never be
+ * "Low" since that's a Tidal-specific 96k AAC tier.
+ *
+ * Shared between the small `StreamQualityBadge` (left of the now-
+ * playing bar) and the `StreamingQualityPicker` (right side
+ * dropdown). Both render the actual playback tier, not the user's
+ * setting, so a Max-preference user playing a track Tidal only has
+ * at Lossless sees "High" in both places. The picker's dropdown
+ * still presents the four preference options.
+ */
+export function tierFromStreamInfo(info: StreamInfo): QualityTier {
+  const aq = (info.audio_quality || "").toUpperCase();
+  if (aq === "LOW") return "Low";
+  if (aq === "HIGH") return "Medium";
+  if (aq === "LOSSLESS") return "High";
+  if (aq === "HI_RES" || aq === "HI_RES_LOSSLESS") return "Max";
+
+  const codec = (info.codec || "").toLowerCase();
+  if (codec === "flac" || codec === "alac") {
+    const isHiRes =
+      (info.bit_depth !== null && info.bit_depth >= 24) ||
+      (info.sample_rate_hz !== null && info.sample_rate_hz > 48000);
+    return isHiRes ? "Max" : "High";
+  }
+  // Lossy local file (rare). "Medium" is the closest user-facing
+  // bucket; we have no way to distinguish 96 kbps from 320 kbps
+  // sources without Tidal's tier string.
+  return "Medium";
 }


### PR DESCRIPTION
## Summary

Bottom-right \"streaming quality\" pill in the now-playing bar showed the user's preference value (Max, High, Medium, Low) regardless of what was actually playing. When Tidal couldn't deliver the user's preferred tier for a track (e.g. Quadeca's \"Dustcutter\" tops out at Lossless even with Max selected), the pill kept showing \"Max\" while the small badge to the left correctly read \"High\" off `streamInfo.audio_quality`. Two badges, two answers.

## What changed

- `StreamingQualityPicker` now reads `streamInfo` from the player meta context and renders the actual playback tier as both the label and the color.
- The dropdown still exposes all four preference options keyed on `streamingQuality`; selecting one updates the user's setting and the badge updates when the next track loads at the new ceiling.
- Local files keep the existing \"Downloaded\" treatment.

## Refactor

- Extracted the `StreamInfo → tier` mapping from inside `StreamQualityBadge` into `lib/quality.ts` as `tierFromStreamInfo`. Both badges now consume the same function (used to be a private helper that could drift).
- Added `tierFromPreference` for the picker's \"nothing playing yet\" fallback.
- Replaced `QUALITY_BADGE_CLASS` (keyed on `StreamingQuality`) with `TIER_BADGE_CLASS` (keyed on `QualityTier`) so the color follows the displayed label, not the user's preference.

## Test plan

- [x] 8 new vitest cases pin tier-mapping for streaming + local files (20 tests pass)
- [x] tsc, eslint, prettier, htmlhint, stylelint all clean
- [ ] Play Quadeca's \"Dustcutter\" with Max selected — bottom-right pill shows \"High\"
- [ ] Switch streaming quality to Low in the dropdown, play any track — pill shows \"Low\" once playback starts
- [ ] Play a 24-bit hi-res Tidal track with Max selected — pill shows \"Max\"
- [ ] Play a downloaded local file — pill shows \"Downloaded\" (no change)