### PR TITLE
Popular page: persist resolved chart so app restart doesn't re-pay 18s

### DIFF
--- a/app/lastfm_disk_cache.py
+++ b/app/lastfm_disk_cache.py
@@ -1,0 +1,178 @@
+"""Disk-backed cache for expensive Last.fm-derived endpoints.
+
+The Last.fm endpoints in `server.py` use an in-memory dict cache
+(`_lastfm_cache`) with a 5-minute TTL by default. That's plenty for
+most callers. The exception is `lastfm_chart_top_tracks_resolved`,
+which fans out 50 sequential `tidal.search` calls server-side and
+takes ~18 seconds on cold load. Its 1-hour TTL was already long, but
+the in-memory dict dies on app restart, so anyone who quits Tideway
+between visits paid the 18 seconds again.
+
+This module is the disk layer. Same shape as `app.spotify_public`'s
+SQLite cache: one DB file in `user_data_dir()`, atomic write through
+SQLite's connection commit, and a schema-version sentinel that
+invalidates rows when a code change makes them unsafe to reuse.
+
+Storage shape: a single `entries` table keyed on the cache key
+(`{username}|{endpoint-key}`) with a JSON-encoded value blob and a
+fetched-at timestamp. JSON is fine for the chart-top-tracks-resolved
+payload (a list of `track_to_dict` results, ~50 KB).
+
+Errors are logged and swallowed everywhere — persistence is a
+performance optimization, not correctness. A disk failure should
+fall through to a fresh fetch, not crash the request.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+import threading
+import time
+from typing import Any, Optional
+
+from app.paths import user_data_dir
+
+log = logging.getLogger(__name__)
+
+_db_path = user_data_dir() / "lastfm_disk_cache.db"
+_db_lock = threading.Lock()
+
+# Bumped when a code change makes existing cached payloads unsafe
+# (e.g. the resolver started returning a different track-dict shape).
+# Wipes the entries table on first open after a bump so users see
+# corrected data without having to clear by hand.
+_SCHEMA_VERSION = 1
+
+
+def _connect() -> sqlite3.Connection:
+    """Open the DB. Tables are created on demand. A version sentinel
+    in `cache_meta` lets us drop stale rows when the cached payload
+    shape changes incompatibly. Caller must close.
+    """
+    _db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(_db_path), timeout=5.0)
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS cache_meta ("
+        "  key TEXT PRIMARY KEY,"
+        "  value TEXT"
+        ")"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS entries ("
+        "  key TEXT PRIMARY KEY,"
+        "  payload TEXT NOT NULL,"
+        "  fetched_at INTEGER NOT NULL"
+        ")"
+    )
+    row = conn.execute(
+        "SELECT value FROM cache_meta WHERE key='schema_version'"
+    ).fetchone()
+    stored = int(row[0]) if row and str(row[0]).isdigit() else 0
+    if stored < _SCHEMA_VERSION:
+        conn.execute("DELETE FROM entries")
+        conn.execute(
+            "INSERT OR REPLACE INTO cache_meta(key, value) "
+            "VALUES ('schema_version', ?)",
+            (str(_SCHEMA_VERSION),),
+        )
+        conn.commit()
+    return conn
+
+
+def get(key: str, ttl_sec: float) -> Optional[Any]:
+    """Return the cached value for `key` if it's still within
+    `ttl_sec`, else None. Caller decides what counts as fresh —
+    different endpoints have different TTLs."""
+    if not key:
+        return None
+    with _db_lock:
+        try:
+            conn = _connect()
+        except Exception:
+            log.exception("lastfm-disk-cache open failed")
+            return None
+        try:
+            row = conn.execute(
+                "SELECT payload, fetched_at FROM entries WHERE key=?",
+                (key,),
+            ).fetchone()
+        finally:
+            conn.close()
+    if row is None:
+        return None
+    payload, fetched_at = row
+    if (time.time() - float(fetched_at)) >= ttl_sec:
+        return None
+    try:
+        return json.loads(payload)
+    except (TypeError, ValueError):
+        # Corrupt row — fail open so the caller refetches and the
+        # next set() overwrites it.
+        log.warning("lastfm-disk-cache row %r had invalid JSON; ignoring", key)
+        return None
+
+
+def set(key: str, value: Any) -> None:
+    """Persist `value` under `key`. JSON-encoded; if `value` isn't
+    JSON-serializable the write is skipped (logged) so callers don't
+    crash mid-request."""
+    if not key:
+        return
+    try:
+        payload = json.dumps(value, ensure_ascii=False)
+    except (TypeError, ValueError):
+        log.warning(
+            "lastfm-disk-cache: value for key=%r isn't JSON-serializable; "
+            "skipping persist",
+            key,
+        )
+        return
+    with _db_lock:
+        try:
+            conn = _connect()
+        except Exception:
+            log.exception("lastfm-disk-cache open failed")
+            return
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO entries (key, payload, fetched_at) "
+                "VALUES (?, ?, ?)",
+                (key, payload, int(time.time())),
+            )
+            conn.commit()
+        except Exception:
+            log.exception("lastfm-disk-cache write failed for key=%r", key)
+        finally:
+            conn.close()
+
+
+def clear() -> None:
+    """Drop every persisted entry. Called from
+    `_invalidate_lastfm_cache` so disconnect / re-auth doesn't serve
+    a different account's data."""
+    with _db_lock:
+        try:
+            conn = _connect()
+        except Exception:
+            log.exception("lastfm-disk-cache open failed")
+            return
+        try:
+            conn.execute("DELETE FROM entries")
+            conn.commit()
+        except Exception:
+            log.exception("lastfm-disk-cache clear failed")
+        finally:
+            conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Test helpers — `monkeypatch _db_path` to redirect the cache to a tmp dir.
+# ---------------------------------------------------------------------------
+
+
+def _set_db_path_for_testing(path: Any) -> None:
+    """Redirect the on-disk cache file. Call only from pytest fixtures."""
+    global _db_path
+    _db_path = path

--- a/server.py
+++ b/server.py
@@ -2129,30 +2129,66 @@ _lastfm_cache_lock = threading.Lock()
 _LASTFM_CACHE_TTL_SEC = 300.0
 
 
-def _lastfm_cached(key: str, fetch, ttl_sec: float = _LASTFM_CACHE_TTL_SEC):
+def _lastfm_cached(
+    key: str, fetch, ttl_sec: float = _LASTFM_CACHE_TTL_SEC,
+    persistent: bool = False,
+):
     """Scope the cache to (username, endpoint, args). Username is part
     of the key so reconnecting to a different account doesn't serve
     the previous user's data, and disconnect clears the whole map.
 
-    `ttl_sec` defaults to the shared 5-minute TTL but callers can override
-    when the underlying data changes slowly enough that a longer cache is
-    worthwhile (e.g. the resolved chart, whose cold load takes ~18 s)."""
+    `ttl_sec` defaults to the shared 5-minute TTL but callers can
+    override when the underlying data changes slowly enough that a
+    longer cache is worthwhile (e.g. the resolved chart, whose cold
+    load takes ~18 s).
+
+    `persistent=True` adds a SQLite-backed second layer at
+    `user_data_dir()/lastfm_disk_cache.db`. The in-memory hit stays
+    the hot path (microseconds); on a miss we check disk before
+    paying the upstream cost; on a successful upstream fetch we
+    populate both. The motivating case is the resolved chart — its
+    1-hour TTL was already long, but the in-memory dict died on
+    every app restart so anyone who quit Tideway between visits paid
+    the full 18 seconds again. With persistence, the cold load
+    happens once per real cache miss instead of once per process
+    lifetime.
+    """
+    from app import lastfm_disk_cache
+
     username = lastfm.status().get("username") or ""
     full_key = f"{username}|{key}"
     now = time.monotonic()
+    # 1. Memory hit — hot path.
     with _lastfm_cache_lock:
         cached = _lastfm_cache.get(full_key)
         if cached and (now - cached[0]) < ttl_sec:
             return cached[1]
+    # 2. Disk hit (only if the caller opted in). Promote to memory
+    #    so subsequent lookups in this process skip the disk read.
+    if persistent:
+        disk_value = lastfm_disk_cache.get(full_key, ttl_sec)
+        if disk_value is not None:
+            with _lastfm_cache_lock:
+                _lastfm_cache[full_key] = (now, disk_value)
+            return disk_value
+    # 3. Real fetch.
     data = fetch()
     with _lastfm_cache_lock:
         _lastfm_cache[full_key] = (now, data)
+    if persistent:
+        lastfm_disk_cache.set(full_key, data)
     return data
 
 
 def _invalidate_lastfm_cache() -> None:
+    """Drop both cache layers. Called when the user disconnects from
+    Last.fm (or reconnects under a different account); keeping the
+    previous account's results around would be a privacy bug."""
+    from app import lastfm_disk_cache
+
     with _lastfm_cache_lock:
         _lastfm_cache.clear()
+    lastfm_disk_cache.clear()
 
 
 @app.get("/api/lastfm/user-info")
@@ -2848,12 +2884,18 @@ def lastfm_chart_top_tracks_resolved(limit: int = 50) -> list[dict]:
 
         return [r for r in results if r is not None]
 
-    # 1-hour TTL (vs the default 5 min). The Last.fm global chart
-    # turns over slowly, and the cold load is expensive enough that
-    # any user who lands on the page twice within an hour really
-    # shouldn't pay for it twice.
+    # 1-hour TTL with disk persistence. The Last.fm global chart
+    # turns over slowly, and the cold-load cost (~18 s for 50 rows
+    # against Tidal at 3 workers) is expensive enough that we don't
+    # want to pay it again on every app restart. The in-memory
+    # layer alone died with the process; the SQLite-backed layer
+    # rides through restarts so the user only pays the resolve
+    # once per hour even across launches.
     return _lastfm_cached(
-        f"chart-top-tracks-resolved:{limit}", _resolve_all, ttl_sec=3600.0
+        f"chart-top-tracks-resolved:{limit}",
+        _resolve_all,
+        ttl_sec=3600.0,
+        persistent=True,
     )
 
 

--- a/tests/test_lastfm_cache_ttl.py
+++ b/tests/test_lastfm_cache_ttl.py
@@ -123,3 +123,97 @@ def test_invalidate_clears_all_entries():
         server._lastfm_cached("a", fetch)
         server._lastfm_cached("b", fetch)
         assert fetch_count[0] == 4
+
+
+# ---------------------------------------------------------------------------
+# persistent=True: the SQLite-backed second layer that survives app
+# restarts. Pin both the round-trip and the integration with the
+# in-memory layer.
+# ---------------------------------------------------------------------------
+
+
+def test_persistent_layer_promotes_disk_hit_to_memory(tmp_path, monkeypatch):
+    """First call populates both memory and disk. Clearing only the
+    memory layer simulates an app restart — the next call must serve
+    from disk and re-populate memory, all without paying for the
+    upstream fetch again."""
+    from app import lastfm_disk_cache
+
+    monkeypatch.setattr(
+        lastfm_disk_cache, "_db_path", tmp_path / "lastfm_disk_cache.db"
+    )
+
+    fetch_count = [0]
+
+    def fetch():
+        fetch_count[0] += 1
+        return ["resolved chart row"]
+
+    with patch.object(server.lastfm, "status", return_value={"username": "u"}):
+        server._lastfm_cached("k", fetch, ttl_sec=3600.0, persistent=True)
+        assert fetch_count[0] == 1
+
+        # Simulate app restart by wiping ONLY the memory layer.
+        server._lastfm_cache.clear()
+
+        result = server._lastfm_cached(
+            "k", fetch, ttl_sec=3600.0, persistent=True
+        )
+        assert result == ["resolved chart row"]
+        assert fetch_count[0] == 1, (
+            "persistent layer should have served the value without "
+            "re-invoking fetch"
+        )
+
+        # And the memory layer should now be re-populated for the
+        # rest of the process lifetime.
+        assert "u|k" in server._lastfm_cache
+
+
+def test_persistent_layer_off_by_default(tmp_path, monkeypatch):
+    """Callers that don't opt in must NOT touch disk. Otherwise every
+    Stats-page mount would write 8+ rows of short-lived data we'd
+    never use."""
+    from app import lastfm_disk_cache
+
+    monkeypatch.setattr(
+        lastfm_disk_cache, "_db_path", tmp_path / "lastfm_disk_cache.db"
+    )
+
+    def fetch():
+        return "v"
+
+    with patch.object(server.lastfm, "status", return_value={"username": "u"}):
+        server._lastfm_cached("k", fetch)  # default: persistent=False
+
+    # No disk hit on a follow-up persistent=True read with the in-
+    # memory layer cleared — proves the first call didn't write.
+    server._lastfm_cache.clear()
+    assert (
+        lastfm_disk_cache.get("u|k", ttl_sec=3600.0) is None
+    )
+
+
+def test_invalidate_clears_disk_layer_too(tmp_path, monkeypatch):
+    """Disconnect / re-auth uses _invalidate_lastfm_cache. Disk
+    rows must clear too — otherwise the next user's session could
+    serve the previous user's resolved chart."""
+    from app import lastfm_disk_cache
+
+    monkeypatch.setattr(
+        lastfm_disk_cache, "_db_path", tmp_path / "lastfm_disk_cache.db"
+    )
+
+    fetch_count = [0]
+
+    def fetch():
+        fetch_count[0] += 1
+        return ["secret chart"]
+
+    with patch.object(server.lastfm, "status", return_value={"username": "u"}):
+        server._lastfm_cached("k", fetch, ttl_sec=3600.0, persistent=True)
+        server._invalidate_lastfm_cache()
+
+        # Both layers gone: refetch happens.
+        server._lastfm_cached("k", fetch, ttl_sec=3600.0, persistent=True)
+        assert fetch_count[0] == 2

--- a/tests/test_lastfm_disk_cache.py
+++ b/tests/test_lastfm_disk_cache.py
@@ -1,0 +1,182 @@
+"""Tests for the SQLite-backed Last.fm cache.
+
+The motivating case is the resolved chart whose cold load is ~18 s.
+With this cache, that work survives app restart instead of dying
+with the in-memory dict. Tests cover the round-trip, TTL expiry,
+the schema-version sentinel that wipes incompatible payloads on
+upgrade, and the JSON-serialization guard.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import time
+
+import pytest
+
+from app import lastfm_disk_cache
+
+
+@pytest.fixture
+def isolated_db(tmp_path, monkeypatch):
+    """Redirect the cache to a per-test sqlite file. The module
+    re-resolves `_db_path` on every call (no module-level connection
+    is held), so a monkeypatch is enough."""
+    db_path = tmp_path / "lastfm_disk_cache.db"
+    monkeypatch.setattr(lastfm_disk_cache, "_db_path", db_path)
+    return db_path
+
+
+def test_set_then_get_roundtrips(isolated_db):
+    lastfm_disk_cache.set("alice|chart-top-tracks-resolved:50", [{"id": "1"}])
+    out = lastfm_disk_cache.get(
+        "alice|chart-top-tracks-resolved:50", ttl_sec=3600
+    )
+    assert out == [{"id": "1"}]
+
+
+def test_get_returns_none_for_missing_key(isolated_db):
+    assert (
+        lastfm_disk_cache.get("alice|nonexistent", ttl_sec=3600) is None
+    )
+
+
+def test_get_returns_none_when_expired(isolated_db):
+    """A row whose `fetched_at` is older than the caller's ttl
+    counts as a miss. Caller refetches and the next set() overwrites."""
+    lastfm_disk_cache.set("alice|short-lived", "value")
+    # Manually backdate the row by one hour and check a 5-second TTL.
+    conn = sqlite3.connect(str(isolated_db))
+    conn.execute(
+        "UPDATE entries SET fetched_at = ? WHERE key = 'alice|short-lived'",
+        (int(time.time()) - 3600,),
+    )
+    conn.commit()
+    conn.close()
+    assert lastfm_disk_cache.get("alice|short-lived", ttl_sec=5) is None
+
+
+def test_get_honors_long_ttl(isolated_db):
+    """Same backdating but a TTL longer than the row's age — the row
+    should still be served. Sanity check that the comparison goes
+    the right way."""
+    lastfm_disk_cache.set("alice|fresh", "value")
+    conn = sqlite3.connect(str(isolated_db))
+    conn.execute(
+        "UPDATE entries SET fetched_at = ? WHERE key = 'alice|fresh'",
+        (int(time.time()) - 60,),
+    )
+    conn.commit()
+    conn.close()
+    assert lastfm_disk_cache.get("alice|fresh", ttl_sec=3600) == "value"
+
+
+def test_clear_drops_all_entries(isolated_db):
+    """Disconnect / re-auth uses this. Two accounts' rows must not
+    leak across a clear."""
+    lastfm_disk_cache.set("alice|x", 1)
+    lastfm_disk_cache.set("bob|y", 2)
+    lastfm_disk_cache.clear()
+    assert lastfm_disk_cache.get("alice|x", ttl_sec=3600) is None
+    assert lastfm_disk_cache.get("bob|y", ttl_sec=3600) is None
+
+
+def test_set_overwrites_existing_key(isolated_db):
+    lastfm_disk_cache.set("alice|k", "first")
+    lastfm_disk_cache.set("alice|k", "second")
+    assert lastfm_disk_cache.get("alice|k", ttl_sec=3600) == "second"
+
+
+def test_set_skips_non_serializable_value(isolated_db, caplog):
+    """Pathological caller hands us something json.dumps can't
+    handle. The cache must skip the write rather than crash the
+    request — caching is a perf optimization, not correctness."""
+
+    class NotSerializable:
+        pass
+
+    lastfm_disk_cache.set("alice|bad", NotSerializable())
+    # Nothing was persisted; subsequent get() returns None.
+    assert lastfm_disk_cache.get("alice|bad", ttl_sec=3600) is None
+
+
+def test_get_skips_corrupt_row(isolated_db):
+    """A row whose JSON is corrupt (manual DB edit, half-written
+    file from a crashed sqlite session) returns None instead of
+    raising. The next set() overwrites."""
+    # Open a connection that bypasses the module's set() so we can
+    # write garbage.
+    conn = lastfm_disk_cache._connect()
+    try:
+        conn.execute(
+            "INSERT OR REPLACE INTO entries (key, payload, fetched_at) "
+            "VALUES (?, ?, ?)",
+            ("alice|corrupt", "{not-json", int(time.time())),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    assert lastfm_disk_cache.get("alice|corrupt", ttl_sec=3600) is None
+
+
+def test_get_returns_none_for_empty_key(isolated_db):
+    """The cache key is `{username}|{endpoint-key}`. An empty key
+    can only happen via a programming bug; defend against it
+    rather than letting an empty-string row leak across users."""
+    assert lastfm_disk_cache.get("", ttl_sec=3600) is None
+
+
+def test_set_skips_empty_key(isolated_db):
+    """Force the DB to exist via a real set first, then verify the
+    empty-key set didn't add a second row."""
+    lastfm_disk_cache.set("alice|valid", "ok")
+    lastfm_disk_cache.set("", "anything")
+    conn = sqlite3.connect(str(isolated_db))
+    rows = conn.execute("SELECT COUNT(*) FROM entries").fetchone()
+    conn.close()
+    assert rows[0] == 1  # only the valid entry from above
+
+
+def test_schema_bump_wipes_existing_rows(tmp_path, monkeypatch):
+    """When we bump _SCHEMA_VERSION because the cached payload shape
+    changed, opening the DB on the new code must drop the stale rows.
+    Same pattern app/spotify_public.py uses."""
+    db_path = tmp_path / "lastfm_disk_cache.db"
+    monkeypatch.setattr(lastfm_disk_cache, "_db_path", db_path)
+    # Build a DB at the OLD schema version (0 = pre-sentinel) with
+    # a row that the new code might not understand.
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript(
+        """
+        CREATE TABLE cache_meta (key TEXT PRIMARY KEY, value TEXT);
+        CREATE TABLE entries (
+            key TEXT PRIMARY KEY,
+            payload TEXT NOT NULL,
+            fetched_at INTEGER NOT NULL
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO entries VALUES ('alice|old', ?, ?)",
+        (json.dumps({"old_shape": True}), int(time.time())),
+    )
+    conn.commit()
+    conn.close()
+    # Bump the in-process schema version above what's persisted, then
+    # reopen via the production path.
+    monkeypatch.setattr(lastfm_disk_cache, "_SCHEMA_VERSION", 99)
+    lastfm_disk_cache._connect().close()
+    # Row from the old schema should be gone; the new sentinel value
+    # should be in cache_meta.
+    conn = sqlite3.connect(str(db_path))
+    try:
+        row = conn.execute(
+            "SELECT COUNT(*) FROM entries"
+        ).fetchone()
+        assert row[0] == 0
+        ver = conn.execute(
+            "SELECT value FROM cache_meta WHERE key='schema_version'"
+        ).fetchone()[0]
+        assert int(ver) == 99
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

The Popular page's Tracks tab calls `/api/lastfm/chart/top-tracks-resolved`, which resolves 50 Last.fm entries against Tidal with 3 parallel workers. The 3-worker cap is deliberate (higher counts look like scrape behavior to Tidal's anti-abuse layer), so cold load is ~18 seconds by design.

The 1-hour in-memory TTL was supposed to make repeat visits free. But the in-memory cache lived in a Python dict that died on every process exit, so anyone who quit Tideway between visits paid the 18 seconds again.

## What changed

- New `app/lastfm_disk_cache.py` — SQLite-backed key/value store at `user_data_dir()/lastfm_disk_cache.db`. Schema-version sentinel matches the pattern in `app/spotify_public.py`.
- `_lastfm_cached` in `server.py` gains an opt-in `persistent=True` flag. The hot path (in-memory dict) stays microsecond-fast; on a miss we now check disk before paying upstream; on a successful fetch we populate both layers.
- The chart-top-tracks-resolved endpoint opts in. Other Last.fm calls keep the in-memory-only behavior (no point persisting Stats-page mounts that turn over every 5 minutes).
- `_invalidate_lastfm_cache` clears disk too — matters for privacy when the user disconnects or reconnects to a different Last.fm account.

## Test plan

- [x] 11 unit tests for the disk module: round-trip, TTL expiry in both directions, schema-bump wipe, JSON-serialization guard, empty-key guard, corrupt-row tolerance
- [x] 3 integration tests on `_lastfm_cached(persistent=True)`: disk hit promotes to memory, off-by-default for non-opting callers, invalidate clears both layers
- [x] Existing 7 tests in `test_lastfm_cache_ttl.py` still pass (default in-memory behavior preserved)
- [ ] Manual: visit Popular page (cold load ~18s), quit Tideway, reopen, visit again — second visit should be instant