### PR TITLE
Album / artist pages: bulk-fetch Spotify playcounts on mount

### DIFF
--- a/web/src/hooks/useSpotifyEnrichment.ts
+++ b/web/src/hooks/useSpotifyEnrichment.ts
@@ -204,9 +204,8 @@ export function setSpotifyEnrichmentEnabled(enabled: boolean): void {
 
 /**
  * Seed the playcount cache with a batch of pre-fetched results. Used
- * by the Popular page to avoid firing N concurrent per-track lookups
- * from the browser — instead the page pulls every playcount in one
- * server-side bounded-pool request and preseeds here so the per-row
+ * by `useSpotifyTrackPlaycountBatch` (and the Popular page directly
+ * for its `refresh: true` case) so the per-row
  * `useSpotifyTrackPlaycount` hook renders from cache on first paint.
  */
 export function preseedSpotifyPlaycounts(
@@ -225,4 +224,75 @@ export function preseedSpotifyPlaycounts(
   for (const key of keys) {
     notify(playcountSubs, key);
   }
+}
+
+interface PreseedTrack {
+  id?: string;
+  isrc?: string | null;
+  name?: string;
+  artists?: { name: string }[];
+}
+
+/**
+ * One bulk request for all tracks' playcounts when a page mounts a
+ * list of them. Without this, every TrackList row's
+ * `useSpotifyTrackPlaycount` fires its own browser→backend round
+ * trip, the browser throttles to ~6 parallel, and a 12-track album
+ * cold-cache takes 5-6 seconds to fill in numbers (two waves of
+ * 500-1000ms each). The batch endpoint runs the per-track lookups
+ * through a 5-worker pool server-side so the wall time is one
+ * round-trip plus parallel work — typically 1-3 seconds for a
+ * full album.
+ *
+ * Idempotent: the same set of ISRCs hits the same server-side cache
+ * key, so calling this from AlbumDetail, ArtistDetail, and the
+ * tracklist's own per-row hooks won't double-up the upstream cost.
+ *
+ * Skips the request entirely when none of the tracks carry an ISRC
+ * (rare; obscure catalog entries) or when the cache already has every
+ * key — no point paying for a no-op.
+ */
+export function useSpotifyTrackPlaycountBatch(
+  tracks: PreseedTrack[] | null | undefined,
+): void {
+  // Stable comma-joined ISRC key so the effect only refires when the
+  // set of tracks actually changes — page mounts and re-renders that
+  // produce the same list don't re-batch.
+  const lookup =
+    tracks
+      ?.map((t) => ({
+        isrc: (t.isrc ?? "").toUpperCase(),
+        title: t.name ?? "",
+        artist: t.artists?.[0]?.name ?? "",
+      }))
+      .filter((x) => x.isrc) ?? [];
+  const cacheKey = lookup
+    .map((x) => x.isrc)
+    .sort()
+    .join(",");
+
+  useEffect(() => {
+    if (!cacheKey || !spotifyEnabled) return;
+    // Already cached for every ISRC? Skip the round trip.
+    const allCached = lookup.every((x) => playcountCache.has(x.isrc));
+    if (allCached) return;
+    let cancelled = false;
+    api.spotify
+      .trackPlaycounts(lookup)
+      .then((r) => {
+        if (cancelled) return;
+        preseedSpotifyPlaycounts(r.playcounts);
+      })
+      .catch(() => {
+        /* per-row hooks fall back to their own fetch */
+      });
+    return () => {
+      cancelled = true;
+    };
+    // `cacheKey` covers the contents of `lookup`. Re-deriving lookup
+    // from `tracks` on every render would tempt a deps-array thrash;
+    // we capture it once per cacheKey and the effect doesn't read it
+    // again after the call.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [cacheKey]);
 }

--- a/web/src/pages/AlbumDetail.tsx
+++ b/web/src/pages/AlbumDetail.tsx
@@ -21,7 +21,10 @@ import { MediaCard } from "@/components/MediaCard";
 import { HeroSkeleton, TrackListSkeleton } from "@/components/Skeletons";
 import { Dialog, DialogContent } from "@/components/ui/dialog";
 import { useLastfmAlbumPlaycount } from "@/hooks/useLastfmPlaycount";
-import { useSpotifyAlbumTotalPlays } from "@/hooks/useSpotifyEnrichment";
+import {
+  useSpotifyAlbumTotalPlays,
+  useSpotifyTrackPlaycountBatch,
+} from "@/hooks/useSpotifyEnrichment";
 import { cn, formatDuration, imageProxy } from "@/lib/utils";
 
 export function AlbumDetail({ onDownload }: { onDownload: OnDownload }) {
@@ -37,6 +40,13 @@ export function AlbumDetail({ onDownload }: { onDownload: OnDownload }) {
       prefetchMany(album.tracks.map((t) => t.id));
     }
   }, [album, prefetchMany]);
+  // Batch-fetch Spotify playcounts for every track on the album in
+  // one request, instead of letting each TrackList row fire its own.
+  // The per-row hook reads from the preseed cache the batch
+  // populates, so first paint of the playcount column on a 12-track
+  // cold-cache album drops from ~6s (two browser-throttled waves of
+  // serial requests) to ~1-3s (one server-side parallel pool).
+  useSpotifyTrackPlaycountBatch(album?.tracks);
   // Prefetch the primary artist's detail payload as soon as the
   // album loads. The backend's artist endpoint fans out 10 Tidal
   // calls and takes ~1s on a cold load; clicking the artist name

--- a/web/src/pages/ArtistDetail.tsx
+++ b/web/src/pages/ArtistDetail.tsx
@@ -7,6 +7,7 @@ import type { OnDownload } from "@/api/download";
 import { useApi } from "@/hooks/useApi";
 import { useColumnCount } from "@/hooks/useColumnCount";
 import { useLikedByArtist } from "@/hooks/useLikedByArtist";
+import { useSpotifyTrackPlaycountBatch } from "@/hooks/useSpotifyEnrichment";
 import { useVideoPlayer } from "@/hooks/useVideoPlayer";
 import { ArtistHero } from "@/components/ArtistHero";
 import { ArtistTopCities } from "@/components/ArtistTopCities";
@@ -36,6 +37,10 @@ export function ArtistDetail({ onDownload }: { onDownload: OnDownload }) {
   // library fetch is in flight; we just don't render the section in
   // that window.
   const liked = useLikedByArtist(artist?.id);
+  // Batch-fetch Spotify playcounts for the top tracks in one
+  // request, instead of letting each TrackList row fire its own.
+  // Same fix as AlbumDetail; see hook for cost / benefit detail.
+  useSpotifyTrackPlaycountBatch(artist?.top_tracks);
 
   if (loading) {
     return (


### PR DESCRIPTION
## Summary

The Popular page already bulk-fetches Spotify playcounts using the batch endpoint + `preseedSpotifyPlaycounts`. Album and artist pages didn't, so each `TrackList` row fired its own browser→backend round-trip via `useSpotifyTrackPlaycount`. The browser throttled to ~6 parallel, the cold-cache cost is 500-1000ms per track, so a 12-track album took two waves (~6s) to fill in the playcount column.

## What changed

- New `useSpotifyTrackPlaycountBatch(tracks)` hook wraps the existing pattern. Sends every ISRC in one request to the server's 5-worker batch endpoint, then `preseedSpotifyPlaycounts` populates the per-row cache. Idempotent — same set of ISRCs hits the same cache key. Short-circuits when every ISRC is already in the per-row cache. Skips entirely when no track has an ISRC.
- `AlbumDetail` and `ArtistDetail` call it on mount with their full track list.
- Per-row `useSpotifyTrackPlaycount` reads from the preseed cache, so the playcount column fills in via one round-trip (~1-3s) instead of two waves (~6s).

## Test plan

- [x] tsc, lint, prettier, vitest all clean (15 tests pass; existing `preseedSpotifyPlaycounts` coverage remains)
- [ ] Open a 12-track album with cold Spotify cache (e.g. an album you haven't visited since the v0.4.10 schema bump). Playcount column on track rows fills in within ~3s instead of ~6s.
- [ ] Open the same album twice in a row. Second visit serves entirely from per-row cache; no second HTTP request fires.
- [ ] Open an artist page. Top tracks' playcounts fill in via the same batch path.