### PR TITLE
Cast: fix float32 silent skip and HTTP/1.1 protocol mismatch

### DIFF
--- a/app/audio/cast.py
+++ b/app/audio/cast.py
@@ -151,6 +151,16 @@ class _SessionState:
     media_loaded: bool = False
     # The media stream URL we handed the device. Logged for support.
     stream_url: str = ""
+    # Latest receiver-side MediaStatus. Populated by the status
+    # listener registered in connect(). Critical for diagnosing
+    # "media_loaded but the TV's not playing" — values like
+    # ("IDLE", "ERROR") tell us the receiver tried our URL and
+    # rejected it (typically a format-support gap on vendor
+    # receivers like Hisense / TCL). All Optional so the snapshot
+    # still works before the first status arrives.
+    receiver_state: Optional[str] = None
+    receiver_idle_reason: Optional[str] = None
+    receiver_status_at: float = 0.0
 
 
 # ---------------------------------------------------------------------
@@ -292,6 +302,55 @@ class CastManager:
             disc["connected_name"] = sess.device.friendly_name if sess else None
             disc["bytes_encoded"] = sess.bytes_encoded if sess else 0
             disc["media_loaded"] = bool(sess and sess.media_loaded)
+            disc["receiver_state"] = sess.receiver_state if sess else None
+            disc["receiver_idle_reason"] = (
+                sess.receiver_idle_reason if sess else None
+            )
+            disc["receiver_status_age_s"] = (
+                round(time.monotonic() - sess.receiver_status_at, 1)
+                if sess and sess.receiver_status_at > 0.0
+                else None
+            )
+        # Pull cached state directly from pychromecast on top of the
+        # listener-push values. Listener fires only on transitions, so
+        # if the receiver settled into a state before we registered (or
+        # never sends another update) the listener fields stay None
+        # forever; the cached values give us the receiver's current
+        # truth on every poll. Best-effort — pychromecast's accessors
+        # can race with disconnect / reconnect cycles, and the whole
+        # block is diagnostic.
+        if sess is not None:
+            try:
+                cast_obj = sess.cast
+                mc = getattr(cast_obj, "media_controller", None)
+                ms = getattr(mc, "status", None) if mc is not None else None
+                if ms is not None:
+                    disc["mc_player_state"] = (
+                        getattr(ms, "player_state", None) or None
+                    )
+                    disc["mc_idle_reason"] = (
+                        getattr(ms, "idle_reason", None) or None
+                    )
+                    disc["mc_content_type"] = (
+                        getattr(ms, "content_type", None) or None
+                    )
+                    disc["mc_content_id"] = (
+                        getattr(ms, "content_id", None) or None
+                    )
+                cs = getattr(cast_obj, "status", None)
+                if cs is not None:
+                    disc["app_id"] = (
+                        getattr(cs, "app_id", None) or None
+                    )
+                    disc["app_display_name"] = (
+                        getattr(cs, "display_name", None) or None
+                    )
+                    disc["is_active_input"] = getattr(
+                        cs, "is_active_input", None
+                    )
+                    disc["is_stand_by"] = getattr(cs, "is_stand_by", None)
+            except Exception as exc:
+                log.debug("cast: receiver-status pull failed: %r", exc)
         return disc
 
     # ---- session lifecycle -----------------------------------------
@@ -400,6 +459,17 @@ class CastManager:
             )
             mc.block_until_active(timeout=10.0)
             session.media_loaded = True
+            # Subscribe to MediaStatus so the receiver's player_state
+            # / idle_reason transitions show up in /api/cast/devices
+            # and on stdout. Without this we have no visibility into
+            # why a receiver that claims "active" then doesn't play —
+            # vendor Cast receivers (Hisense, TCL, Vizio) routinely
+            # accept play_media, transition to IDLE/ERROR a second
+            # later because they can't decode our format, and the
+            # sender side never finds out.
+            mc.register_status_listener(
+                _MediaStatusListener(self, session)
+            )
         except Exception as exc:
             try:
                 if session.http_server is not None:
@@ -704,6 +774,53 @@ class CastManager:
             print(f"[cast] discovered: {device.friendly_name} "
                   f"({device.model_name or 'unknown model'}) "
                   f"@ {device.host}:{device.port}", flush=True)
+
+
+class _MediaStatusListener:
+    """pychromecast MediaStatus subscriber.
+
+    pychromecast invokes `new_media_status(status)` on every receiver
+    state transition. We capture player_state and idle_reason on the
+    associated session so /api/cast/devices can surface them, and
+    print transitions to stdout for live debugging. The receiver
+    pushes status messages on its own protocol thread so we mutate
+    via the manager's session lock to stay consistent with status()
+    readers.
+
+    Held for the lifetime of the session — pychromecast doesn't take
+    a strong ref, so the listener has to outlive the
+    register_status_listener call. CastSession holds the controller,
+    which holds this listener via pychromecast's internal list."""
+
+    def __init__(
+        self, manager: "CastManager", session: "_SessionState"
+    ) -> None:
+        self._manager = manager
+        self._session = session
+
+    def new_media_status(self, status) -> None:  # pychromecast API
+        player_state = getattr(status, "player_state", None) or None
+        idle_reason = getattr(status, "idle_reason", None) or None
+        prev_state = self._session.receiver_state
+        prev_reason = self._session.receiver_idle_reason
+        # Update under the session lock so /api/cast/devices reads
+        # are consistent. We only ever mutate this session's fields,
+        # so contention is negligible.
+        with self._manager._session_lock:
+            self._session.receiver_state = player_state
+            self._session.receiver_idle_reason = idle_reason
+            self._session.receiver_status_at = time.monotonic()
+        # High-signal print for the dev console. The combination
+        # (state, idle_reason) is what the receiver uses to mean
+        # "couldn't play": e.g. ('IDLE', 'ERROR') after a play_media
+        # is the format-rejection fingerprint we're chasing.
+        if (player_state, idle_reason) != (prev_state, prev_reason):
+            print(
+                f"[cast] receiver status: "
+                f"player_state={player_state!r} "
+                f"idle_reason={idle_reason!r}",
+                flush=True,
+            )
 
 
 def _uuid_or_str(s: str):

--- a/app/audio/cast.py
+++ b/app/audio/cast.py
@@ -512,7 +512,12 @@ class CastManager:
     def push_pcm(self, pcm: np.ndarray, sample_rate: int, dtype: str) -> None:
         """Feed a chunk of PCM into the active session's encoder.
 
-        `pcm` is a 2-D ndarray (frames, channels), int16 or int32.
+        `pcm` is a 2-D ndarray (frames, channels). `dtype` may be
+        "int16", "int32", or "float32"; float32 is converted to int32
+        here because FLAC is integer-only and Windows WASAPI shared
+        mode delivers the audio callback's PCM as float32 (the
+        device-mixer format). Without that conversion every Windows
+        shared-mode user would silently get a zero-byte stream.
         `sample_rate` and `dtype` describe the current source so we
         can rebuild the encoder when the source changes (e.g., a
         track-change to a different rate). When no session is
@@ -530,6 +535,18 @@ class CastManager:
             session = self._session
         if session is None:
             return
+        if dtype == "float32":
+            # WASAPI shared-mode samples are normalized floats in
+            # [-1.0, 1.0]. Scale to int32 full range; clip to handle
+            # intersample peaks > 1.0 that would otherwise wrap.
+            # Math runs in float64 because int32-max (2147483647)
+            # is not representable in float32 — clipping to it in
+            # float32 actually rounds up to 2147483648 and overflows
+            # to int32-min on the cast.
+            scaled = pcm.astype(np.float64) * 2147483647.0
+            np.clip(scaled, -2147483648.0, 2147483647.0, out=scaled)
+            pcm = scaled.astype(np.int32)
+            dtype = "int32"
         channels = 1 if pcm.ndim == 1 else pcm.shape[1]
         with session.encoder_lock:
             need_new = (

--- a/app/audio/http_stream.py
+++ b/app/audio/http_stream.py
@@ -285,6 +285,17 @@ class StreamHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
 
 
 class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
+    # Python's BaseHTTPRequestHandler defaults to HTTP/1.0. Combined
+    # with our chunked Transfer-Encoding, that's a spec violation —
+    # chunked encoding is HTTP/1.1+ only. Cast / AirPlay receivers
+    # that see "HTTP/1.0 200 OK" plus "Transfer-Encoding: chunked"
+    # apply HTTP/1.0's "close after body" semantics, get a stream
+    # that never closes a body they can't parse, and bail silently.
+    # Hisense's Cast receiver in particular drops back to its prior
+    # screen with no error to either side. Force HTTP/1.1 so the
+    # response line and the chunked encoding agree.
+    protocol_version = "HTTP/1.1"
+
     def log_message(self, format, *args):  # type: ignore[override]
         # Quiet by default; switch to log.debug so `run.sh` doesn't
         # drown in per-chunk access-log lines during streaming.

--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -2012,10 +2012,11 @@ class PCMPlayer:
         # locally shouldn't silence the remote speaker. The
         # is_active() probe is lock-free in the common 'no
         # session' case, so the cost when nobody's casting is one
-        # attribute read per audio callback. Skipped for float32
-        # sources because FLAC is integer-only; in practice every
-        # Tidal source decodes to int16 or int32, so the float
-        # skip is a safety net rather than a normal code path.
+        # attribute read per audio callback. Tidal sources decode
+        # to int16 or int32, but on Windows WASAPI shared mode the
+        # OutputStream comes out as float32 (device mixer format),
+        # so we hand all three through; cast_manager.push_pcm
+        # converts float32 to int32 internally for the FLAC encoder.
         try:
             from app.audio import cast as _cast_mod
             if _cast_mod.cast_manager.is_active():
@@ -2023,6 +2024,8 @@ class PCMPlayer:
                     _dtype_name = "int16"
                 elif outdata.dtype == np.int32:
                     _dtype_name = "int32"
+                elif outdata.dtype == np.float32:
+                    _dtype_name = "float32"
                 else:
                     _dtype_name = None
                 if _dtype_name is not None:

--- a/tests/test_cast_session.py
+++ b/tests/test_cast_session.py
@@ -113,6 +113,32 @@ class TestFirstCallBuild:
         assert sess.encoder_dtype == "int32"
         assert sess.encoder_rate == 96000
 
+    def test_float32_path_converts_to_int32(self):
+        """Windows WASAPI shared mode hands the audio callback
+        float32 PCM normalized to [-1.0, 1.0]. Without conversion
+        the FLAC encoder rejects float and the receiver hangs at
+        'Connecting' forever. push_pcm must scale + clip + cast to
+        int32 internally and build an int32-configured encoder."""
+        mgr = CastManager()
+        sess = _attach_session(mgr)
+        pcm = np.full((512, 2), 0.5, dtype=np.float32)
+        mgr.push_pcm(pcm, sample_rate=48000, dtype="float32")
+        assert sess.encoder is not None
+        assert sess.encoder_dtype == "int32"
+        assert sess.encoder_rate == 48000
+
+    def test_float32_intersample_peak_clips_safely(self):
+        """A float32 sample above 1.0 (intersample overshoot from
+        a brick-walled master) would overflow int32 if the scale
+        wasn't clipped. Verifies that push_pcm doesn't raise on
+        out-of-range floats — silent clip is correct here, the
+        same behavior every DAC's int conversion stage applies."""
+        mgr = CastManager()
+        _attach_session(mgr)
+        pcm = np.array([[1.5, -1.5]] * 256, dtype=np.float32)
+        # Should not raise; clip handles the overshoot.
+        mgr.push_pcm(pcm, sample_rate=44100, dtype="float32")
+
     def test_mono_input(self):
         """1-D arrays are reshaped to (frames, 1) inside push_pcm.
         The encoder sees mono and lays out the FLAC stream

--- a/tests/test_http_stream.py
+++ b/tests/test_http_stream.py
@@ -19,7 +19,9 @@ import pytest
 from app.audio.http_stream import (
     FlacStreamEncoder,
     RingBuffer,
+    _StreamRequestHandler,
     primary_lan_ip,
+    start_stream_http_server,
 )
 
 
@@ -234,3 +236,63 @@ class TestPrimaryLanIp:
 
         monkeypatch.setattr(_socket, "socket", _BrokenSocket)
         assert primary_lan_ip() == "127.0.0.1"
+
+
+# ---------------------------------------------------------------------
+# Stream HTTP server protocol-version contract
+# ---------------------------------------------------------------------
+
+
+class TestStreamHTTPServerProtocol:
+    def test_handler_uses_http_1_1(self):
+        """The request handler must advertise HTTP/1.1. Python's
+        BaseHTTPRequestHandler defaults to HTTP/1.0; combined with
+        the chunked Transfer-Encoding the handler emits, that's a
+        spec violation that makes Cast / AirPlay receivers (Hisense
+        especially) silently drop the stream. Pinned as a class
+        attribute so the value is observable without spinning up a
+        real server."""
+        assert _StreamRequestHandler.protocol_version == "HTTP/1.1"
+
+    def test_get_response_line_is_http_1_1(self):
+        """End-to-end: the bytes on the wire actually start with
+        'HTTP/1.1 200 OK', not 'HTTP/1.0 200 OK'. Spins up a real
+        server bound to loopback, pumps a small FLAC frame into
+        the ring buffer so the handler has something to send, and
+        reads the raw response line via a plain socket so we see
+        exactly what a Cast receiver would see."""
+        import socket as _socket
+
+        buffer = RingBuffer()
+        # The do_GET loop blocks on buffer.read() until something
+        # arrives. Seed enough bytes that the first read returns
+        # immediately; otherwise the test races the 2s read timeout.
+        buffer.write(b"\x00" * 256)
+        server = start_stream_http_server(
+            buffer, stream_path="/test", content_type="audio/flac"
+        )
+        try:
+            # server.server_address is ('0.0.0.0', port) — that's a
+            # bind address, not connectable on Windows. Reach the
+            # listener through loopback explicitly.
+            port = server.server_address[1]
+            sock = _socket.create_connection(("127.0.0.1", port), timeout=3.0)
+            try:
+                sock.sendall(
+                    b"GET /test HTTP/1.1\r\n"
+                    b"Host: localhost\r\n"
+                    b"\r\n"
+                )
+                # First line of the response is the status line. Read
+                # just enough to capture it; we don't care about the
+                # body payload here.
+                data = sock.recv(64)
+            finally:
+                sock.close()
+            assert data.startswith(b"HTTP/1.1 200"), (
+                f"expected HTTP/1.1 status line, got: {data!r}"
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()


### PR DESCRIPTION
Three changes that combine to fix Chromecast on Windows. End-to-end verified by curling the live stream port during a hung cast attempt and watching `/api/cast/devices` while changing one variable at a time. Final state: track playing on Hisense Cast TV with `mc_player_state: PLAYING` and `bytes_encoded` climbing.

## Bug 1: float32 PCM silently skipped (commit a91e989)

Symptom: TV stays on "Connecting..." forever. `bytes_encoded` stuck at 0.

The Cast PCM tap in PCMPlayer's audio callback skipped any sample dtype other than int16/int32, on the rationale that Tidal sources decode to int. That rationale is wrong on Windows: WASAPI shared mode (the default) opens the OutputStream at the device mixer format, which is float32. Every chunk got silently dropped, the encoder never built, the buffer stayed empty, the receiver fetched a stream that never produced bytes.

Fix lives in `cast_manager.push_pcm`, where the FLAC integer-only constraint actually is. Float32 → scale to full int32 range, clip in float64 to handle intersample peaks > 1.0 (clipping in float32 would round int32-max up to 2³¹ and overflow the cast), then `.astype(np.int32)`.

## Bug 2: HTTP/1.0 + chunked = spec violation (commit c63e228)

Symptom (with bug 1 fixed): TV shows "streaming" on Tideway's UI, but the TV stays on whatever it was playing before. `bytes_encoded` climbs to several MB; receiver never consumes them.

Python's `BaseHTTPRequestHandler` defaults to HTTP/1.0. The stream handler uses `Transfer-Encoding: chunked`, which is HTTP/1.1-only per spec — combining them is invalid. Cast / AirPlay receivers that see `HTTP/1.0 200 OK` plus `Transfer-Encoding: chunked` apply HTTP/1.0's close-after-body rule, get a chunked stream they can't parse a body out of, and silently bail. Pin `protocol_version = "HTTP/1.1"` on the request handler.

Same fix benefits AirPlay (uses the same handler).

## Diagnostic: receiver MediaStatus on /api/cast/devices (commit 06e2bb9)

While debugging this, the existing diagnostic fields (connected_id, media_loaded, bytes_encoded) said "session active and we're encoding" but couldn't tell us anything about what the receiver was doing. Subscribe to pychromecast's MediaStatus and pull the cached MediaController + CastStatus directly inside `status()` so the receiver's actual state surfaces in `/api/cast/devices` and on stdout.

New fields:
- `receiver_state`, `receiver_idle_reason`, `receiver_status_age_s` — listener-push (transitions only)
- `mc_player_state`, `mc_idle_reason`, `mc_content_type`, `mc_content_id` — cached MediaController status
- `app_id`, `app_display_name`, `is_active_input`, `is_stand_by` — receiver-app-level status

`is_active_input: False` after a successful play_media is the canonical fingerprint for "TV bailed back to its previous content" — the symptom for vendor-receiver format rejection.

## Test plan

- [x] `pytest tests/` — all 434 backend tests pass; 4 new regression tests across `test_cast_session.py` (float32 path, intersample-peak clip) and `test_http_stream.py` (handler attribute, end-to-end response line on a real socket).
- [x] Local Windows build via PyInstaller; manual cast attempt to a Hisense SmartTV 4K successfully transitions through `BUFFERING` → `PLAYING` with audio reaching the TV.
- [x] `/api/cast/devices` snapshot during success: `mc_player_state: PLAYING`, `mc_content_type: audio/flac`, `is_active_input: True`, `app_id: CC1AD845`, `bytes_encoded` climbing.
- [ ] Manual sanity on macOS: should be unchanged (callback was already int16/int32; HTTP/1.1 fix is invisible to a working receiver; new diagnostic fields are additive on the JSON shape).