### PR TITLE
Downloader: write hi-res FLAC as .flac, not .m4a

### DIFF
--- a/app/downloader.py
+++ b/app/downloader.py
@@ -954,17 +954,26 @@ class Downloader:
                 file=_sys.stderr,
                 flush=True,
             )
-            urls, ext_hint = self._fetch_stream_sources(
+            urls, ext_hint, codec = self._fetch_stream_sources(
                 track, item.quality, item_id=item.item_id
             )
             if not urls:
                 raise RuntimeError("Tidal returned no stream URLs")
             print(
                 f"[downloader] _download id={item.item_id[:8]} got "
-                f"{len(urls)} URL(s) ext_hint={ext_hint!r}",
+                f"{len(urls)} URL(s) ext_hint={ext_hint!r} codec={codec!r}",
                 file=_sys.stderr,
                 flush=True,
             )
+
+            # Tidal's hi-res FLAC ships as fragmented MP4 segments — the
+            # codec inside is FLAC but the container is MP4, so tidalapi's
+            # file_extension hint says ".m4a". Detect that case and plan
+            # to remux into a native .flac container after the download.
+            # The user gets the right extension and standard FLAC framing
+            # (which most players prefer over FLAC-in-MP4 even though
+            # both are bit-identical audio).
+            needs_flac_remux = codec == "FLAC" and ext_hint != ".flac"
 
             # For the device-code path we can't know the final extension
             # until the first response's Content-Type arrives. For PKCE
@@ -979,10 +988,18 @@ class Downloader:
             first_resp = first_resp_cm.__enter__()
             try:
                 first_resp.raise_for_status()
-                ext = ext_hint or _ext_from_response(first_resp)
-                out_path = _build_path(item, s, ext)
-                out_path.parent.mkdir(parents=True, exist_ok=True)
-                tmp_path = out_path.with_suffix(out_path.suffix + ".part")
+                if needs_flac_remux:
+                    # We know the final file is .flac (after remux); the
+                    # download itself lands in an .mp4.part intermediate.
+                    ext = ".flac"
+                    out_path = _build_path(item, s, ext)
+                    out_path.parent.mkdir(parents=True, exist_ok=True)
+                    tmp_path = out_path.with_suffix(".mp4.part")
+                else:
+                    ext = ext_hint or _ext_from_response(first_resp)
+                    out_path = _build_path(item, s, ext)
+                    out_path.parent.mkdir(parents=True, exist_ok=True)
+                    tmp_path = out_path.with_suffix(out_path.suffix + ".part")
 
                 # Progress tracking. For multi-URL DASH downloads we
                 # don't know total bytes up front, so we treat each URL
@@ -1078,6 +1095,33 @@ class Downloader:
                         first_resp_cm.__exit__(None, None, None)
                     except Exception:
                         pass
+
+            if needs_flac_remux:
+                # Strip the FLAC stream out of the MP4 container into a
+                # native .flac file. Stream-copy via PyAV — no decode /
+                # encode, output is bit-identical to what Tidal sent.
+                # Lands in a .flac.part intermediate so the atomic rename
+                # below still gives skip-existing an all-or-nothing view.
+                flac_part = out_path.with_suffix(".flac.part")
+                try:
+                    _remux_mp4_to_flac(tmp_path, flac_part)
+                except Exception as exc:
+                    # Clean up both intermediates so a retry starts fresh.
+                    for stray in (tmp_path, flac_part):
+                        try:
+                            stray.unlink(missing_ok=True)
+                        except Exception:
+                            pass
+                    raise RuntimeError(
+                        f"FLAC remux failed: {type(exc).__name__}: {exc}"
+                    ) from exc
+                # Drop the MP4 intermediate; the .flac.part now holds the
+                # canonical bytes and is what we atomic-rename into place.
+                try:
+                    tmp_path.unlink(missing_ok=True)
+                except Exception:
+                    pass
+                tmp_path = flac_part
 
             # Atomic rename — the next skip-existing scan sees a complete file
             # or nothing at all.
@@ -1189,18 +1233,24 @@ class Downloader:
 
     def _fetch_stream_sources(
         self, track, quality: Optional[str], item_id: Optional[str] = None
-    ) -> tuple[list[str], Optional[str]]:
-        """Fetch the list of URLs we need to download + a file-extension
-        hint. Handles both session types:
+    ) -> tuple[list[str], Optional[str], Optional[str]]:
+        """Fetch the list of URLs we need to download, a file-extension
+        hint, and the audio codec. Handles both session types:
 
         * Device-code sessions use `track.get_url()` — a single streamable
-          URL. One entry in the returned list, no extension hint.
+          URL. One entry in the returned list, no extension or codec hint.
         * PKCE sessions can't call get_url (tidalapi raises URLNotAvailable
           immediately). They use `track.get_stream()` which returns a
           manifest (MPEG-DASH or BTS) whose `urls` is a list of segment
           URLs. For DASH hi-res content that list may have dozens of
           short segments which we concatenate into one FLAC file. The
-          manifest also carries a reliable file_extension.
+          manifest also carries a file_extension hint and a codec name.
+
+        The codec is the source of truth for what's actually inside the
+        bytes — tidalapi's file_extension hint looks at the URL string
+        and labels DASH FLAC segments as `.m4a` (because the segments
+        are fragmented MP4 containers). The downloader uses the codec
+        to override that hint when needed and remux to native FLAC.
 
         Both paths retry once on auth error with a forced token refresh
         since tidalapi's built-in refresh triggers only on a very
@@ -1213,7 +1263,7 @@ class Downloader:
             except KeyError:
                 override = None
 
-        def _call() -> tuple[list[str], Optional[str]]:
+        def _call() -> tuple[list[str], Optional[str], Optional[str]]:
             with self.quality_lock:
                 original = self.tidal.session.config.quality
                 try:
@@ -1231,9 +1281,11 @@ class Downloader:
                                 "Tidal returned an encrypted stream we can't decrypt"
                             )
                         ext_hint = getattr(manifest, "file_extension", None)
-                        return (list(manifest.urls or []), ext_hint)
+                        codec = getattr(manifest, "codecs", None)
+                        codec = codec.upper() if isinstance(codec, str) else None
+                        return (list(manifest.urls or []), ext_hint, codec)
                     # Device-code path: single direct URL.
-                    return ([track.get_url()], None)
+                    return ([track.get_url()], None, None)
                 finally:
                     if override is not None:
                         self.tidal.session.config.quality = original
@@ -1280,6 +1332,45 @@ class Downloader:
 # ------------------------------------------------------------------
 # Helpers
 # ------------------------------------------------------------------
+
+
+def _remux_mp4_to_flac(mp4_path: Path, flac_path: Path) -> None:
+    """Stream-copy a FLAC audio stream out of an MP4 container into a
+    native .flac file.
+
+    No decode, no encode — libav reads packets out of the MP4 demuxer
+    and hands them straight to the FLAC muxer. Output bytes are
+    bit-identical to the FLAC frames Tidal sent; the only thing that
+    changes is the container around them.
+
+    Same PyAV idiom as `app.video_downloader._remux_hls_to_mp4`. PyAV
+    is already a hard dependency of the audio engine, so no new
+    install requirements.
+
+    Raises on any failure — the caller cleans up the intermediates and
+    surfaces the error to the user.
+    """
+    import av  # local import: keeps module load cheap if remux is never needed
+
+    input_container = av.open(str(mp4_path))
+    try:
+        if not input_container.streams.audio:
+            raise RuntimeError("MP4 input has no audio stream")
+        in_stream = input_container.streams.audio[0]
+        output_container = av.open(str(flac_path), mode="w", format="flac")
+        try:
+            out_stream = output_container.add_stream_from_template(in_stream)
+            for packet in input_container.demux(in_stream):
+                # Flush packets from libav have no DTS — skip them, same
+                # as the video remux path.
+                if packet.dts is None:
+                    continue
+                packet.stream = out_stream
+                output_container.mux(packet)
+        finally:
+            output_container.close()
+    finally:
+        input_container.close()
 
 
 def _looks_like_rate_limit(exc: Exception) -> bool:

--- a/tests/test_flac_remux.py
+++ b/tests/test_flac_remux.py
@@ -1,0 +1,233 @@
+"""Tests for the MP4-container FLAC → native .flac remux step.
+
+Tidal's hi-res FLAC arrives as fragmented MP4 segments — the audio
+codec inside is FLAC but the container is MP4, so tidalapi labels
+the file extension `.m4a`. Without remuxing, users end up with
+`.m4a` files that hold lossless FLAC audio: misleading extension,
+non-standard container, players that prefer native FLAC framing
+(metadata editors, hardware FLAC players) struggle.
+
+These tests pin the call shape: the helper must use PyAV's
+stream-copy pattern (no decode / encode), and the wrapper that
+invokes it must only fire when the codec is FLAC and the hint
+isn't already `.flac`.
+"""
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app import downloader
+from app.downloader import _remux_mp4_to_flac
+
+
+# ---------------------------------------------------------------------------
+# _remux_mp4_to_flac — call-shape tests against a mocked `av` module.
+# ---------------------------------------------------------------------------
+
+
+def _build_fake_av(*, packets, has_audio_stream=True):
+    """Construct a MagicMock standing in for the PyAV `av` module.
+
+    `packets` is a list of objects whose `.dts` attribute we use to
+    drive the demux loop. The output container's mux call records
+    packets so the test can assert on them.
+    """
+    fake_av = MagicMock()
+
+    audio_stream = MagicMock(name="in_audio_stream")
+    streams_audio = [audio_stream] if has_audio_stream else []
+    input_container = MagicMock(name="input_container")
+    input_container.streams.audio = streams_audio
+    input_container.demux.return_value = iter(packets)
+
+    out_stream = MagicMock(name="out_stream")
+    output_container = MagicMock(name="output_container")
+    output_container.add_stream_from_template.return_value = out_stream
+
+    # av.open(input_path) → input_container; av.open(out, mode='w', format='flac') → output
+    def _open(path, mode="r", format=None):
+        if mode == "w":
+            return output_container
+        return input_container
+
+    fake_av.open.side_effect = _open
+    fake_av._input_container = input_container
+    fake_av._output_container = output_container
+    fake_av._out_stream = out_stream
+    return fake_av
+
+
+def test_remux_uses_stream_copy_into_flac_container(tmp_path):
+    """The output container must be opened in write mode with format
+    'flac', and packets must be muxed verbatim into it (stream-copy)."""
+    packets = [SimpleNamespace(dts=0), SimpleNamespace(dts=1024), SimpleNamespace(dts=2048)]
+    fake_av = _build_fake_av(packets=packets)
+
+    mp4_path = tmp_path / "in.mp4"
+    flac_path = tmp_path / "out.flac"
+
+    with patch.dict("sys.modules", {"av": fake_av}):
+        _remux_mp4_to_flac(mp4_path, flac_path)
+
+    # av.open called twice: input (read), output (write with format=flac).
+    open_calls = fake_av.open.call_args_list
+    assert len(open_calls) == 2
+    # Input
+    assert open_calls[0].args == (str(mp4_path),)
+    # Output — keyword args because the helper passes mode + format by name.
+    assert open_calls[1].args == (str(flac_path),)
+    assert open_calls[1].kwargs.get("mode") == "w"
+    assert open_calls[1].kwargs.get("format") == "flac"
+
+    # add_stream_from_template called with the input audio stream.
+    fake_av._output_container.add_stream_from_template.assert_called_once_with(
+        fake_av._input_container.streams.audio[0]
+    )
+
+    # Each non-flush packet got muxed onto the output stream.
+    mux_calls = fake_av._output_container.mux.call_args_list
+    assert len(mux_calls) == len(packets)
+    for call, pkt in zip(mux_calls, packets):
+        assert call.args[0] is pkt
+        assert pkt.stream is fake_av._out_stream
+
+
+def test_remux_skips_flush_packets(tmp_path):
+    """libav emits None-DTS flush packets at the end of demux; the
+    remux loop must skip them or the FLAC muxer raises."""
+    packets = [
+        SimpleNamespace(dts=0),
+        SimpleNamespace(dts=None),  # flush — must be skipped
+        SimpleNamespace(dts=1024),
+    ]
+    fake_av = _build_fake_av(packets=packets)
+
+    with patch.dict("sys.modules", {"av": fake_av}):
+        _remux_mp4_to_flac(tmp_path / "in.mp4", tmp_path / "out.flac")
+
+    # 3 packets in, 2 muxed (the None-DTS one was dropped).
+    assert fake_av._output_container.mux.call_count == 2
+
+
+def test_remux_raises_when_input_has_no_audio(tmp_path):
+    fake_av = _build_fake_av(packets=[], has_audio_stream=False)
+    with patch.dict("sys.modules", {"av": fake_av}):
+        with pytest.raises(RuntimeError, match="no audio stream"):
+            _remux_mp4_to_flac(tmp_path / "in.mp4", tmp_path / "out.flac")
+
+
+def test_remux_closes_both_containers_even_on_error(tmp_path):
+    """If muxing raises mid-loop, both input and output containers
+    must close — otherwise temp files stay locked on Windows."""
+    boom_packet = MagicMock()
+    boom_packet.dts = 1024
+    fake_av = _build_fake_av(packets=[boom_packet])
+    fake_av._output_container.mux.side_effect = RuntimeError("muxer exploded")
+
+    with patch.dict("sys.modules", {"av": fake_av}):
+        with pytest.raises(RuntimeError, match="muxer exploded"):
+            _remux_mp4_to_flac(tmp_path / "in.mp4", tmp_path / "out.flac")
+
+    fake_av._input_container.close.assert_called_once()
+    fake_av._output_container.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# _fetch_stream_sources — codec is included in the return tuple.
+# ---------------------------------------------------------------------------
+
+
+def _build_downloader(*, is_pkce, manifest=None, direct_url=None):
+    """Construct a Downloader with mocked tidalapi session, bypassing
+    worker thread spawn (we only call _fetch_stream_sources)."""
+    settings = SimpleNamespace(
+        concurrent_downloads=1,
+        download_rate_limit_mbps=0,
+        output_dir=str(Path.cwd()),
+    )
+    fake_session = SimpleNamespace(
+        is_pkce=is_pkce,
+        config=SimpleNamespace(quality="high_lossless"),
+    )
+    fake_tidal = SimpleNamespace(session=fake_session)
+
+    track = MagicMock(name="track")
+    if manifest is not None:
+        stream = MagicMock()
+        stream.get_stream_manifest.return_value = manifest
+        track.get_stream.return_value = stream
+    if direct_url is not None:
+        track.get_url.return_value = direct_url
+
+    # Bypass __init__ to skip worker-thread spawn.
+    dl = downloader.Downloader.__new__(downloader.Downloader)
+    dl.tidal = fake_tidal
+    dl.settings = settings
+    dl.quality_lock = __import__("threading").Lock()
+    dl._rate_limit_until = 0.0
+    dl._rate_limit_lock = __import__("threading").Lock()
+    dl._cancelled_ids = set()
+    dl._cancelled_lock = __import__("threading").Lock()
+    return dl, track
+
+
+def test_fetch_stream_sources_returns_codec_for_pkce_dash_flac():
+    manifest = SimpleNamespace(
+        urls=["https://cdn/seg-init.mp4", "https://cdn/seg-1.mp4"],
+        file_extension=".m4a",
+        codecs="FLAC",
+        is_encrypted=False,
+    )
+    dl, track = _build_downloader(is_pkce=True, manifest=manifest)
+
+    urls, ext, codec = dl._fetch_stream_sources(track, quality=None)
+
+    assert urls == manifest.urls
+    assert ext == ".m4a"  # what tidalapi reported — caller decides what to do with it
+    assert codec == "FLAC"
+
+
+def test_fetch_stream_sources_uppercases_codec_string():
+    """Defensive: tidalapi already uppercases on the BTS path, but
+    the DASH path comes from raw MPD codec strings. The downloader
+    compares against 'FLAC' — case must be normalized at the source."""
+    manifest = SimpleNamespace(
+        urls=["https://cdn/x.flac"],
+        file_extension=".flac",
+        codecs="flac",  # lowercase from a hypothetical MPD path
+        is_encrypted=False,
+    )
+    dl, track = _build_downloader(is_pkce=True, manifest=manifest)
+
+    _, _, codec = dl._fetch_stream_sources(track, quality=None)
+    assert codec == "FLAC"
+
+
+def test_fetch_stream_sources_returns_none_codec_for_device_code():
+    """Device-code sessions don't have a manifest — codec is None."""
+    dl, track = _build_downloader(
+        is_pkce=False, direct_url="https://cdn/song.flac?token=x"
+    )
+
+    urls, ext, codec = dl._fetch_stream_sources(track, quality=None)
+
+    assert urls == ["https://cdn/song.flac?token=x"]
+    assert ext is None
+    assert codec is None
+
+
+def test_fetch_stream_sources_handles_non_string_codec_attr():
+    """If tidalapi ever returns a non-string codec value (older or
+    newer schema), don't crash — degrade to None."""
+    manifest = SimpleNamespace(
+        urls=["https://cdn/x.flac"],
+        file_extension=".flac",
+        codecs=None,
+        is_encrypted=False,
+    )
+    dl, track = _build_downloader(is_pkce=True, manifest=manifest)
+
+    _, _, codec = dl._fetch_stream_sources(track, quality=None)
+    assert codec is None


### PR DESCRIPTION
## Summary

Fix a long-standing bug where downloads of Tidal's hi-res FLAC tier (Max) were saved as `.m4a` files. The audio inside was always lossless FLAC — Tidal delivers it as fragmented MP4 segments — but `tidalapi`'s `StreamManifest.get_file_extension()` decides the extension by URL inspection (`.mp4` segment URLs → `.m4a`), so the downloader was writing the wrong container with the wrong extension.

This PR plumbs the manifest's codec string through `_fetch_stream_sources` and uses it as the source of truth for what's actually inside the bytes. When the codec is FLAC and the hint isn't `.flac`, the downloader stream-copies the FLAC packets out of the MP4 container into a native `.flac` file via PyAV (same idiom `app/video_downloader.py` uses for HLS → MP4). No decode / encode — output is bit-identical to what Tidal sent.

- Lossless / Max tracks now land as `.flac` files
- Legacy `.m4a` files in users' libraries are untouched (skip-existing's stem-and-suffix scan still matches them) — only new downloads get the new extension
- Device-code sessions are unaffected (Tidal serves them direct `.flac` URLs at the lossless tier)

## Test plan

- [x] `pytest tests/` — 442 pass + 8 new tests in `tests/test_flac_remux.py` covering the remux helper's call shape (stream-copy, flush-packet skip, no-audio-stream error, container cleanup on error) and the codec passthrough in `_fetch_stream_sources`
- [x] `cd web && npx tsc -b --noEmit` — clean
- [x] `cd web && npm run lint:all` — 0 errors (56 pre-existing warnings unchanged)
- [x] `cd web && npm test` — 21 pass
- [ ] Manual: download a Max-quality track on a PKCE session, confirm `.flac` file lands, confirm playback in VLC / Foobar / a dedicated FLAC player
- [ ] Manual: download a HIGH (AAC) track, confirm `.m4a` still lands as before
- [ ] Manual: download with skip-existing on top of an existing `.m4a` from before this change, confirm no re-download / no surprise rename