### PR TITLE
Filename template: support folder structure and richer tokens

### DIFF
--- a/app/downloader.py
+++ b/app/downloader.py
@@ -243,6 +243,16 @@ class DownloadItem:
     # value being stale at COMPLETE / TAGGING wouldn't matter, but
     # we zero it anyway so the field never carries surprising data.
     speed_bps: float = 0.0
+    # Extra metadata used by the filename template engine. Empty / zero
+    # defaults are intentional — any of these may be unavailable from
+    # tidalapi (older catalog entries, single-track submits without an
+    # album lookup) and the template renderer treats missing values as
+    # empty strings rather than crashing the download.
+    album_artist: str = ""
+    year: Optional[int] = None
+    disc_num: int = 0
+    track_explicit: bool = False
+    album_explicit_flag: bool = False
 
 
 class Downloader:
@@ -412,11 +422,7 @@ class Downloader:
         )
         for track, album_obj in pairs:
             item = DownloadItem(item_id=str(uuid.uuid4()), url="")
-            item.title = track.name
-            item.artist = _artist_names(track)
-            item.album = _album_name(album_obj or getattr(track, "album", None))
-            item.track_num = getattr(track, "track_num", 0)
-            item.quality = quality
+            _populate_item_from_track(item, track, album_obj, quality)
             self._track_map_put(item.item_id, (track, album_obj))
             self.on_add(item)
             # Persist so a restart can resume. Per-track records use
@@ -560,11 +566,7 @@ class Downloader:
 
         if len(pairs) == 1:
             track, album_obj = pairs[0]
-            placeholder.title = track.name
-            placeholder.artist = _artist_names(track)
-            placeholder.album = _album_name(album_obj or getattr(track, "album", None))
-            placeholder.track_num = getattr(track, "track_num", 0)
-            placeholder.quality = quality
+            _populate_item_from_track(placeholder, track, album_obj, quality)
             self._track_map_put(placeholder.item_id, (track, album_obj))
             self.on_update(placeholder)
             tid = getattr(track, "id", None)
@@ -587,11 +589,7 @@ class Downloader:
 
             for track, album_obj in pairs:
                 item = DownloadItem(item_id=str(uuid.uuid4()), url=url)
-                item.title = track.name
-                item.artist = _artist_names(track)
-                item.album = _album_name(album_obj or getattr(track, "album", None))
-                item.track_num = getattr(track, "track_num", 0)
-                item.quality = quality
+                _populate_item_from_track(item, track, album_obj, quality)
                 self._track_map_put(item.item_id, (track, album_obj))
                 self.on_add(item)
                 tid = getattr(track, "id", None)
@@ -1340,6 +1338,25 @@ def _looks_like_auth_error(exc: Exception) -> bool:
     return "401" in msg or "Unauthorized" in msg
 
 
+def _populate_item_from_track(
+    item: DownloadItem, track, album_obj, quality: Optional[str]
+) -> None:
+    """Single source of truth for setting a DownloadItem's metadata
+    from tidalapi objects. Called from every enqueue path so adding a
+    new template token only needs one wiring change here, not three."""
+    resolved_album = album_obj or getattr(track, "album", None)
+    item.title = track.name
+    item.artist = _artist_names(track)
+    item.album = _album_name(resolved_album)
+    item.track_num = getattr(track, "track_num", 0)
+    item.quality = quality
+    item.album_artist = _album_artist_name(resolved_album, track)
+    item.year = _album_year(resolved_album)
+    item.disc_num = getattr(track, "volume_num", 0) or 0
+    item.track_explicit = bool(getattr(track, "explicit", False))
+    item.album_explicit_flag = bool(getattr(resolved_album, "explicit", False))
+
+
 def _artist_names(track) -> str:
     try:
         return ", ".join(a.name for a in track.artists)
@@ -1356,6 +1373,50 @@ def _album_name(album_obj) -> str:
         return album_obj.name
     except Exception:
         return ""
+
+
+def _album_artist_name(album_obj, track) -> str:
+    """Return the album-level artist (single name), falling back to the
+    track's primary artist when the album object doesn't carry one.
+
+    This matters most for compilations / VA releases / collabs, where
+    the track artist is just a contributor and the album artist is the
+    canonical credit (e.g. "Various Artists" or "DJ Khaled" while
+    individual tracks list a different artist). Without a separate
+    album-artist token, library scanners group every contributor's
+    track under its own artist tree instead of one album folder.
+    """
+    try:
+        if album_obj is not None and getattr(album_obj, "artist", None):
+            name = getattr(album_obj.artist, "name", None)
+            if name:
+                return name
+    except Exception:
+        pass
+    try:
+        if track is not None and getattr(track, "artist", None):
+            return getattr(track.artist, "name", "") or ""
+    except Exception:
+        pass
+    return ""
+
+
+def _album_year(album_obj) -> Optional[int]:
+    """Year an album was released, parsed off whichever date field
+    tidalapi populated. `release_date` is the editorial release date;
+    `tidal_release_date` is when Tidal first hosted the stream — for
+    most catalog music these match, for back-catalog reissues the
+    editorial date is what users want in their folder names."""
+    if album_obj is None:
+        return None
+    for attr in ("release_date", "tidal_release_date"):
+        try:
+            dt = getattr(album_obj, attr, None)
+            if dt is not None and getattr(dt, "year", None):
+                return int(dt.year)
+        except Exception:
+            continue
+    return None
 
 
 def _ext_from_response(resp) -> str:
@@ -1400,29 +1461,135 @@ def _sanitize_segment(name: str) -> str:
     return name or "_"
 
 
-def _build_path(item: DownloadItem, settings, ext: str) -> Path:
-    # Defense-in-depth: sanitize each interpolation value BEFORE the
-    # template renders it, then sanitize the whole name afterwards. That
-    # way a literal path separator in either the template or any tidalapi-
-    # supplied field still collapses to an underscore instead of escaping
-    # the output directory.
-    name = settings.filename_template.format(
-        title=_sanitize_segment(item.title),
-        artist=_sanitize_segment(item.artist),
-        album=_sanitize_segment(item.album),
-        track_num=str(item.track_num).zfill(2),
+class _SafeTokens(dict):
+    """str.format_map dict that returns the literal "{key}" for any
+    token the template references but the renderer doesn't supply.
+    Keeps a typo'd token (e.g. "{albmu}") visible in the output
+    filename so the user notices instead of silently dropping the
+    request, and never crashes the download with a KeyError."""
+
+    def __missing__(self, key):  # type: ignore[override]
+        return "{" + key + "}"
+
+
+def _explicit_marker(flag: bool) -> str:
+    """Render an explicit-content flag as a path-safe marker. Leading
+    space so users can write `{title}{explicit}` without an extra
+    separator and still get readable output. Empty when the track or
+    album isn't flagged so non-explicit items don't carry a trailing
+    space."""
+    return " [E]" if flag else ""
+
+
+def _render_template(template: str, item: DownloadItem) -> str:
+    """Interpolate the user's filename_template with sanitized token
+    values. Each token's VALUE is sanitized for path-unsafe chars
+    before rendering — that's how we keep an album literally named
+    "AC/DC" from creating a phantom subdirectory. The rendered string
+    may still contain `/` from the TEMPLATE itself; the caller treats
+    those as intentional directory separators.
+
+    Unknown tokens render as the literal `{key}` (see _SafeTokens) so
+    the user sees a wonky filename and fixes their template instead of
+    the download just dying with a KeyError mid-batch.
+    """
+    year_str = "" if item.year is None else str(item.year)
+    return template.format_map(
+        _SafeTokens(
+            title=_sanitize_segment(item.title),
+            track_title=_sanitize_segment(item.title),
+            artist=_sanitize_segment(item.artist),
+            album=_sanitize_segment(item.album),
+            album_title=_sanitize_segment(item.album),
+            album_artist=_sanitize_segment(item.album_artist or item.artist),
+            track_num=str(item.track_num).zfill(2),
+            disc_num=str(item.disc_num or 1).zfill(2) if item.disc_num else "01",
+            year=year_str,
+            explicit=_explicit_marker(item.track_explicit),
+            album_explicit=_explicit_marker(item.album_explicit_flag),
+        )
     )
+
+
+def _split_template_path(rendered: str) -> list[str]:
+    """Split a rendered template into path segments. Forward slash is
+    the documented separator; backslash is also accepted because
+    Windows users naturally type it and there's no scenario where a
+    literal `\\` should appear inside a single filename segment.
+
+    Empty segments (from leading slashes or `//` typos) are dropped so
+    the resulting Path doesn't accidentally root itself or carry a
+    no-op `.` segment."""
+    pieces = re.split(r"[/\\]+", rendered)
+    return [p for p in pieces if p]
+
+
+def _template_has_separator(template: str) -> bool:
+    """Does the user's template define its own directory structure? If
+    so, `create_album_folders` becomes a no-op — the template is in
+    charge. Detected by checking whether any `/` or `\\` appears
+    *outside* a token (so `{album}` containing slashes through user
+    data doesn't accidentally enable directory mode at the template
+    level — that's handled per-segment after rendering)."""
+    stripped = re.sub(r"\{[^{}]*\}", "", template)
+    return "/" in stripped or "\\" in stripped
+
+
+def _build_path(item: DownloadItem, settings, ext: str) -> Path:
+    """Render the user's filename template into an absolute output
+    path under settings.output_dir.
+
+    Two-stage sanitization, same intent as before but extended to
+    cope with templates that contain `/` separators:
+
+    1. Per-token values are sanitized BEFORE rendering so a literal
+       slash inside any tidalapi field collapses to `_`, never
+       escaping into the path structure.
+    2. The rendered string is split on `/` (and `\\`) into segments;
+       each segment is sanitized AGAIN to catch anything weird the
+       template's literal text introduced (control bytes, trailing
+       dots/spaces, Windows-reserved stems).
+
+    `create_album_folders` is a backward-compat shortcut for users who
+    haven't customized their template — it prepends an album folder
+    only when the template is single-segment. Once the user adopts a
+    template with `/`, the template controls structure and the toggle
+    is silent (avoid double-nesting like
+    `output_dir/AlbumName/AlbumName/Track.flac`).
+    """
+    rendered = _render_template(settings.filename_template, item)
+    segments = _split_template_path(rendered)
+    # Render produced nothing usable (template was all-whitespace or
+    # all-empty-tokens). Fall back to a stable identifier so the
+    # download lands somewhere instead of crashing on a zero-length
+    # filename — `_` is what _sanitize_segment would have produced for
+    # an empty string anyway.
+    if not segments:
+        segments = ["_"]
+    safe_segments = [_sanitize_segment(s) for s in segments]
+
     base = Path(settings.output_dir)
-    if settings.create_album_folders and item.album:
+    if (
+        settings.create_album_folders
+        and item.album
+        and not _template_has_separator(settings.filename_template)
+    ):
         base = base / _sanitize_segment(item.album)
-    final = base / (_sanitize_segment(name) + ext)
+
+    *dirs, last = safe_segments
+    final = base
+    for d in dirs:
+        final = final / d
+    final = final / (last + ext)
+
     # Hard containment check: after all the sanitization, the resolved
     # path must still live under output_dir. If it somehow doesn't, a
     # future regression introduced a vector we missed — fail loudly
     # rather than silently write outside the sandbox.
     try:
         root = Path(settings.output_dir).resolve()
-        if root not in final.resolve().parents and final.resolve() != root:
+        resolved = final.resolve()
+        if resolved != root and root not in resolved.parents:
             raise RuntimeError(f"Resolved path escaped output_dir: {final}")
     except RuntimeError:
         raise

--- a/tests/test_filename_template.py
+++ b/tests/test_filename_template.py
@@ -1,0 +1,277 @@
+"""Tests for the expanded filename-template engine.
+
+Covers token interpolation, `/`-as-directory-separator, per-segment
+sanitization, path-traversal protection, and the backward-compat
+gating of `create_album_folders` against templates that already
+declare their own structure.
+"""
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from app.downloader import (
+    DownloadItem,
+    _build_path,
+    _explicit_marker,
+    _render_template,
+    _split_template_path,
+    _template_has_separator,
+)
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _item(**overrides) -> DownloadItem:
+    base = dict(
+        item_id="abc",
+        url="",
+        title="Song Title",
+        artist="Track Artist",
+        album="Album Name",
+        track_num=3,
+        album_artist="Album Artist",
+        year=2024,
+        disc_num=1,
+        track_explicit=False,
+        album_explicit_flag=False,
+    )
+    base.update(overrides)
+    return DownloadItem(**base)
+
+
+def _settings(template, *, output_dir, create_album_folders=True):
+    return SimpleNamespace(
+        filename_template=template,
+        output_dir=str(output_dir),
+        create_album_folders=create_album_folders,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _render_template — token interpolation
+# ---------------------------------------------------------------------------
+
+
+def test_render_supports_legacy_tokens():
+    """Pre-existing tokens keep working — no behavior change for users
+    who never touched the default template."""
+    item = _item(track_num=7, title="Hello", artist="Adele", album="25")
+    assert _render_template("{artist} - {title}", item) == "Adele - Hello"
+    assert _render_template("{track_num} {title}", item) == "07 Hello"
+    assert _render_template("{album}/{title}", item) == "25/Hello"
+
+
+def test_render_supports_new_tokens():
+    item = _item(
+        title="Sicko Mode",
+        album="Astroworld",
+        album_artist="Travis Scott",
+        artist="Travis Scott, Drake",
+        year=2018,
+        disc_num=1,
+        track_num=2,
+        track_explicit=True,
+        album_explicit_flag=True,
+    )
+    rendered = _render_template(
+        "{album_artist} - {year}/{album}{album_explicit}/{track_num} {title}{explicit}",
+        item,
+    )
+    assert rendered == (
+        "Travis Scott - 2018/Astroworld [E]/02 Sicko Mode [E]"
+    )
+
+
+def test_render_track_title_alias_matches_title():
+    """`{track_title}` is offered as an alias for `{title}` because
+    other downloaders use that name — keeps configs portable."""
+    item = _item(title="Hello")
+    assert _render_template("{track_title}", item) == "Hello"
+    assert _render_template("{album_title}", item) == _render_template("{album}", item)
+
+
+def test_render_year_empty_when_unknown():
+    """Missing year shouldn't write the literal string 'None' into a
+    folder name — render as empty, let the template author decide
+    how to handle that gap."""
+    item = _item(year=None)
+    assert _render_template("{year}", item) == ""
+    assert _render_template("{album} ({year})", item) == "Album Name ()"
+
+
+def test_render_explicit_marker_only_when_flagged():
+    item_clean = _item(track_explicit=False, album_explicit_flag=False)
+    item_explicit = _item(track_explicit=True, album_explicit_flag=True)
+    assert _render_template("{title}{explicit}", item_clean) == "Song Title"
+    assert _render_template("{title}{explicit}", item_explicit) == "Song Title [E]"
+    assert _render_template("{album}{album_explicit}", item_clean) == "Album Name"
+    assert (
+        _render_template("{album}{album_explicit}", item_explicit) == "Album Name [E]"
+    )
+
+
+def test_render_album_artist_falls_back_to_track_artist():
+    """If we don't have a separate album_artist (single-track submit
+    without an album lookup), don't blank the field — fall back to
+    the track artist so the template doesn't render a void where the
+    user expected a name."""
+    item = _item(album_artist="", artist="Solo Artist")
+    assert _render_template("{album_artist}/{title}", item) == "Solo Artist/Song Title"
+
+
+def test_render_unknown_token_kept_literal():
+    """A typo in the user's template must not crash the download.
+    Render the unknown key as `{key}` so the user spots the bad
+    filename and fixes their template — silently dropping it would
+    just produce confusingly-named files."""
+    item = _item()
+    assert _render_template("{albmu}/{title}", item) == "{albmu}/Song Title"
+
+
+def test_render_token_value_with_slash_does_not_create_directory():
+    """The whole point of sanitizing token values BEFORE rendering: a
+    literal `/` in tidalapi-supplied data (band name "AC/DC") must
+    not split into two directories. The template's own `/` is what
+    creates structure, never the data."""
+    item = _item(album="AC/DC", artist="AC/DC")
+    rendered = _render_template("{artist} - {album}", item)
+    assert rendered == "AC_DC - AC_DC"
+
+
+# ---------------------------------------------------------------------------
+# _split_template_path & _template_has_separator
+# ---------------------------------------------------------------------------
+
+
+def test_split_drops_empty_segments_from_leading_or_doubled_slash():
+    """A leading `/` would otherwise root the path off the user's
+    output dir. A `//` from a typo'd template would yield a `.`
+    segment. Both get filtered."""
+    assert _split_template_path("/a/b/c") == ["a", "b", "c"]
+    assert _split_template_path("a//b") == ["a", "b"]
+
+
+def test_split_accepts_backslash_too():
+    """Windows users naturally type `\\` — accept it as a separator
+    so the same template works across platforms."""
+    assert _split_template_path("a\\b/c") == ["a", "b", "c"]
+
+
+def test_template_has_separator_ignores_slashes_inside_tokens():
+    """An album literally named "AC/DC" expands to a single segment;
+    that user-data slash doesn't count as a structural separator."""
+    assert not _template_has_separator("{album} - {title}")
+    assert _template_has_separator("{album}/{title}")
+    # Token with literal `/` in its name (impossible in our docs but
+    # worth pinning the behaviour): the regex strips the whole `{...}`
+    # so what's inside doesn't count.
+    assert not _template_has_separator("{album/with/slash}")
+
+
+# ---------------------------------------------------------------------------
+# _build_path — full-path assembly
+# ---------------------------------------------------------------------------
+
+
+def test_build_path_single_segment_with_album_folder_toggle(tmp_path):
+    """Default behaviour: flat template + create_album_folders=True
+    nests the file under an album folder."""
+    item = _item(album="Astroworld", artist="Travis Scott", title="Sicko Mode")
+    settings = _settings(
+        "{artist} - {title}", output_dir=tmp_path, create_album_folders=True
+    )
+
+    out = _build_path(item, settings, ".flac")
+
+    assert out == tmp_path / "Astroworld" / "Travis Scott - Sicko Mode.flac"
+
+
+def test_build_path_template_with_separator_disables_album_folder_shortcut(tmp_path):
+    """Once the user adopts a multi-segment template, `create_album_folders`
+    is a no-op — otherwise we'd get duplicate album folders nested
+    inside the template's own structure."""
+    item = _item(album="Astroworld", title="Sicko Mode")
+    settings = _settings(
+        "{album_artist}/{album}/{track_num} {title}",
+        output_dir=tmp_path,
+        create_album_folders=True,  # would double-nest if respected
+    )
+
+    out = _build_path(item, settings, ".flac")
+
+    # No leading "Astroworld/" — only the template's structure.
+    assert out == (
+        tmp_path / "Album Artist" / "Astroworld" / "03 Sicko Mode.flac"
+    )
+
+
+def test_build_path_per_segment_sanitization(tmp_path):
+    """A token value with reserved chars must collapse to `_` inside
+    its own segment — and only its own segment. The surrounding
+    template structure stays intact."""
+    item = _item(album="A:B*C", title='He said "hi"')
+    settings = _settings(
+        "{album}/{title}", output_dir=tmp_path, create_album_folders=False
+    )
+
+    out = _build_path(item, settings, ".flac")
+
+    assert out == tmp_path / "A_B_C" / "He said _hi_.flac"
+
+
+def test_build_path_blocks_traversal_via_token_value(tmp_path):
+    """A title of `../escape` is sanitized at the token-value step
+    (the slash becomes `_`), so the `..` can't reach the resolver."""
+    item = _item(title="../escape", album="A")
+    settings = _settings("{title}", output_dir=tmp_path, create_album_folders=False)
+
+    out = _build_path(item, settings, ".flac")
+
+    # The `/` in `../escape` was sanitized to `_` before render —
+    # the path stays under output_dir.
+    assert tmp_path in out.resolve().parents
+    assert ".." not in out.parts
+
+
+def test_build_path_blocks_absolute_template(tmp_path):
+    """A maliciously absolute template (e.g. `/etc/passwd`) splits
+    into segments after the leading slash is dropped. Resulting path
+    stays under output_dir — we never fall through to the OS root."""
+    item = _item(title="x")
+    settings = _settings(
+        "/etc/passwd/{title}", output_dir=tmp_path, create_album_folders=False
+    )
+
+    out = _build_path(item, settings, ".flac")
+
+    assert tmp_path in out.resolve().parents
+
+
+def test_build_path_falls_back_when_template_renders_empty(tmp_path):
+    """Pathological template: every token is empty. We must still
+    write *somewhere* under output_dir rather than crash with a
+    zero-length filename or — worse — write to the dir itself."""
+    item = _item(title="", artist="", album="", album_artist="", year=None)
+    settings = _settings(
+        "{year}/{album}", output_dir=tmp_path, create_album_folders=False
+    )
+
+    out = _build_path(item, settings, ".flac")
+
+    # Some safe fallback under output_dir.
+    assert tmp_path in out.parents or out.parent == tmp_path
+    assert out.suffix == ".flac"
+
+
+# ---------------------------------------------------------------------------
+# _explicit_marker — small but worth pinning
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("flag,expected", [(True, " [E]"), (False, "")])
+def test_explicit_marker(flag, expected):
+    assert _explicit_marker(flag) == expected

--- a/web/src/lib/filenameTemplate.test.ts
+++ b/web/src/lib/filenameTemplate.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  previewFilenameTemplateAsString,
+  renderTemplate,
+  sanitizeSegment,
+  splitTemplatePath,
+  templateHasSeparator,
+  SAMPLE_TRACK,
+} from "./filenameTemplate";
+
+describe("sanitizeSegment", () => {
+  it("replaces forbidden chars with underscore", () => {
+    expect(sanitizeSegment('A:B/C\\D"E')).toBe("A_B_C_D_E");
+  });
+  it("strips trailing dots and spaces (Windows-hostile)", () => {
+    expect(sanitizeSegment("file...   ")).toBe("file");
+  });
+  it("prefixes Windows-reserved stems so they don't collide", () => {
+    expect(sanitizeSegment("CON")).toBe("_CON");
+    expect(sanitizeSegment("CON.txt")).toBe("_CON.txt");
+  });
+  it("returns underscore for empty / fully-stripped input", () => {
+    expect(sanitizeSegment("")).toBe("_");
+    expect(sanitizeSegment("...")).toBe("_");
+  });
+});
+
+describe("renderTemplate", () => {
+  it("interpolates known tokens", () => {
+    expect(renderTemplate("{artist} - {title}", SAMPLE_TRACK)).toBe(
+      "Travis Scott, Drake - Sicko Mode",
+    );
+  });
+  it("keeps unknown tokens as their literal {key}", () => {
+    expect(renderTemplate("{album}/{xyz}", SAMPLE_TRACK)).toBe(
+      "Astroworld/{xyz}",
+    );
+  });
+  it("sanitizes token values before substituting", () => {
+    expect(
+      renderTemplate("{artist}", { ...SAMPLE_TRACK, artist: "AC/DC" }),
+    ).toBe("AC_DC");
+  });
+});
+
+describe("templateHasSeparator", () => {
+  it("returns false when only tokens, no template-level slash", () => {
+    expect(templateHasSeparator("{artist} - {title}")).toBe(false);
+  });
+  it("returns true when template literal contains /", () => {
+    expect(templateHasSeparator("{album}/{title}")).toBe(true);
+  });
+  it("ignores slashes inside token braces", () => {
+    expect(templateHasSeparator("{album/with/slash}")).toBe(false);
+  });
+});
+
+describe("splitTemplatePath", () => {
+  it("splits on / and \\", () => {
+    expect(splitTemplatePath("a/b\\c")).toEqual(["a", "b", "c"]);
+  });
+  it("drops empty segments from leading or doubled slashes", () => {
+    expect(splitTemplatePath("/a//b")).toEqual(["a", "b"]);
+  });
+});
+
+describe("previewFilenameTemplateAsString", () => {
+  it("renders the default flat template under output_dir with album folder", () => {
+    const out = previewFilenameTemplateAsString(
+      "{artist} - {title}",
+      "/Music/Tidal",
+      true,
+    );
+    expect(out).toBe(
+      "/Music/Tidal/Astroworld/Travis Scott, Drake - Sicko Mode.flac",
+    );
+  });
+
+  it("uses template-defined structure and skips the album-folder shortcut", () => {
+    const out = previewFilenameTemplateAsString(
+      "{album_artist}/{album}/{track_num} {title}",
+      "/Music/Tidal",
+      true,
+    );
+    expect(out).toBe(
+      "/Music/Tidal/Travis Scott/Astroworld/02 Sicko Mode.flac",
+    );
+  });
+
+  it("appends the explicit marker only where placed in the template", () => {
+    const out = previewFilenameTemplateAsString(
+      "{album}{album_explicit}/{title}{explicit}",
+      "/Music",
+      false,
+    );
+    expect(out).toBe("/Music/Astroworld [E]/Sicko Mode [E].flac");
+  });
+});

--- a/web/src/lib/filenameTemplate.ts
+++ b/web/src/lib/filenameTemplate.ts
@@ -1,0 +1,165 @@
+/**
+ * Frontend mirror of the Python filename-template renderer in
+ * `app/downloader.py`. Used by the settings UI to show the user a
+ * live preview of what their template will produce. Must stay in
+ * sync with the backend; the unit tests cover the same shape of
+ * cases as `tests/test_filename_template.py`.
+ *
+ * The preview is illustrative — the actual on-disk path is computed
+ * by the backend with real track metadata. We use a fixed sample
+ * track here so the user sees a stable example, regardless of what
+ * they happen to be browsing.
+ */
+
+// eslint-disable-next-line no-control-regex -- mirrors the Python sanitizer's control-byte stripping; matches `_sanitize_segment` in app/downloader.py
+const FORBIDDEN_CHARS = /[<>:"/\\|?*\x00-\x1f]/g;
+const TRAILING_DOTS_OR_SPACES = /[. ]+$/;
+const SEPARATOR = /[/\\]+/;
+// Mirror of _WIN_RESERVED in app/downloader.py — Windows refuses
+// these stems regardless of extension.
+const WIN_RESERVED = new Set<string>([
+  "CON",
+  "PRN",
+  "AUX",
+  "NUL",
+  ...Array.from({ length: 9 }, (_, i) => `COM${i + 1}`),
+  ...Array.from({ length: 9 }, (_, i) => `LPT${i + 1}`),
+]);
+
+/** Sample track values rendered into the preview. Picked so each
+ *  token produces something distinct (rather than e.g. an artist
+ *  string that happens to match the album_artist string). */
+export const SAMPLE_TRACK = {
+  title: "Sicko Mode",
+  album: "Astroworld",
+  artist: "Travis Scott, Drake",
+  album_artist: "Travis Scott",
+  track_num: "02",
+  disc_num: "01",
+  year: "2018",
+  explicit: " [E]",
+  album_explicit: " [E]",
+} as const;
+
+export type TemplateTokens = Record<string, string>;
+
+/** Sanitize a single path segment — same rules as the Python
+ *  `_sanitize_segment` so the preview matches what hits disk. */
+export function sanitizeSegment(name: string): string {
+  if (!name) return "_";
+  let out = name.replace(FORBIDDEN_CHARS, "_");
+  out = out.replace(TRAILING_DOTS_OR_SPACES, "");
+  const stem = out.split(".", 1)[0]!.toUpperCase();
+  if (WIN_RESERVED.has(stem)) {
+    out = `_${out}`;
+  }
+  return out || "_";
+}
+
+/** Mirror of the backend SafeDict — unknown tokens render as their
+ *  literal `{key}` form so the user sees a wonky filename and fixes
+ *  the typo. */
+export function renderTemplate(template: string, tokens: TemplateTokens): string {
+  return template.replace(/\{([^{}]*)\}/g, (_, key: string) => {
+    if (Object.prototype.hasOwnProperty.call(tokens, key)) {
+      return sanitizeSegment(tokens[key] ?? "");
+    }
+    return `{${key}}`;
+  });
+}
+
+/** Does the user's template define its own folder structure?
+ *  Slashes inside `{token}` markers don't count — those are user
+ *  data, not template structure. */
+export function templateHasSeparator(template: string): boolean {
+  const stripped = template.replace(/\{[^{}]*\}/g, "");
+  return stripped.includes("/") || stripped.includes("\\");
+}
+
+export function splitTemplatePath(rendered: string): string[] {
+  return rendered.split(SEPARATOR).filter((s) => s.length > 0);
+}
+
+/** Build the preview path the user sees under the template input.
+ *  Returns the segments AS THEY WOULD APPEAR under output_dir; the
+ *  caller decides how to render them (with separator characters and
+ *  the output_dir prefix). */
+export function previewFilenameTemplate(
+  template: string,
+  outputDir: string,
+  createAlbumFolders: boolean,
+): { segments: string[]; usedAlbumFolderShortcut: boolean } {
+  const rendered = renderTemplate(template, SAMPLE_TRACK);
+  let segments = splitTemplatePath(rendered);
+  if (segments.length === 0) {
+    segments = ["_"];
+  }
+  segments = segments.map(sanitizeSegment);
+
+  const usedAlbumFolderShortcut =
+    createAlbumFolders &&
+    !templateHasSeparator(template) &&
+    SAMPLE_TRACK.album.length > 0;
+  if (usedAlbumFolderShortcut) {
+    segments = [sanitizeSegment(SAMPLE_TRACK.album), ...segments];
+  }
+
+  // Append the extension to the final segment so the preview reads
+  // like a real path (the backend appends `.flac` for FLAC streams,
+  // `.m4a` for AAC — show `.flac` since that's the most common
+  // delivery for Lossless / Max which is what most users pick).
+  const last = segments.pop()!;
+  segments.push(`${last}.flac`);
+
+  // Only the segments — let the caller assemble the full path with
+  // the output_dir and the right separator for display. Avoids
+  // baking forward-slash-only output into the helper.
+  void outputDir;
+  return { segments, usedAlbumFolderShortcut };
+}
+
+/** Convenience for the UI: render the preview as a single display
+ *  string with `/` between segments, prefixed by the output dir if
+ *  one was supplied. */
+export function previewFilenameTemplateAsString(
+  template: string,
+  outputDir: string,
+  createAlbumFolders: boolean,
+): string {
+  const { segments } = previewFilenameTemplate(
+    template,
+    outputDir,
+    createAlbumFolders,
+  );
+  const trimmedDir = outputDir.replace(/[/\\]+$/, "");
+  const joined = segments.join("/");
+  return trimmedDir ? `${trimmedDir}/${joined}` : joined;
+}
+
+/** Tokens the template engine knows about, surfaced so the UI can
+ *  render them as a clickable / copy-pasteable list. */
+export const TEMPLATE_TOKENS: ReadonlyArray<{
+  token: string;
+  description: string;
+}> = [
+  { token: "{title}", description: "Track title" },
+  { token: "{track_title}", description: "Alias for {title}" },
+  { token: "{artist}", description: "Track artist (joined if multiple)" },
+  { token: "{album}", description: "Album title" },
+  { token: "{album_title}", description: "Alias for {album}" },
+  {
+    token: "{album_artist}",
+    description: "Album artist (falls back to track artist)",
+  },
+  { token: "{track_num}", description: "Two-digit track number, e.g. 03" },
+  { token: "{disc_num}", description: "Two-digit disc number, e.g. 01" },
+  { token: "{year}", description: "Release year (empty if unknown)" },
+  {
+    token: "{explicit}",
+    description: 'Renders " [E]" on explicit tracks, otherwise empty',
+  },
+  {
+    token: "{album_explicit}",
+    description: 'Same marker, but driven by the album-level flag',
+  },
+];

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -28,6 +28,10 @@ import {
 } from "lucide-react";
 import { api } from "@/api/client";
 import type { QualityOption, Settings } from "@/api/types";
+import {
+  TEMPLATE_TOKENS,
+  previewFilenameTemplateAsString,
+} from "@/lib/filenameTemplate";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
@@ -327,10 +331,11 @@ export function SettingsPage({ onLogout }: { onLogout: () => void }) {
               <Field
                 label="Filename template"
                 hint={
-                  <>
-                    Tokens: <code>{"{artist}"}</code> <code>{"{title}"}</code>{" "}
-                    <code>{"{album}"}</code> <code>{"{track_num}"}</code>
-                  </>
+                  <FilenameTemplateHint
+                    template={settings.filename_template}
+                    outputDir={settings.output_dir}
+                    createAlbumFolders={settings.create_album_folders}
+                  />
                 }
               >
                 <Input
@@ -344,6 +349,7 @@ export function SettingsPage({ onLogout }: { onLogout: () => void }) {
                 checked={settings.create_album_folders}
                 onChange={(v) => patch({ create_album_folders: v })}
                 label="Create a subfolder per album"
+                hint="Only takes effect when the filename template doesn't already contain a folder separator (/). With a multi-segment template the template itself defines the folder structure."
               />
               <Toggle
                 checked={settings.skip_existing}
@@ -584,6 +590,44 @@ function Section({
       </div>
       {children}
     </section>
+  );
+}
+
+function FilenameTemplateHint({
+  template,
+  outputDir,
+  createAlbumFolders,
+}: {
+  template: string;
+  outputDir: string;
+  createAlbumFolders: boolean;
+}) {
+  // Live preview against a stable sample track so the user sees
+  // what their template will produce regardless of what they're
+  // currently browsing. `/` in the template creates folders.
+  const preview = previewFilenameTemplateAsString(
+    template,
+    outputDir,
+    createAlbumFolders,
+  );
+  return (
+    <div className="flex flex-col gap-2">
+      <div>
+        Use <code>/</code> to nest folders. Available tokens:
+      </div>
+      <ul className="grid grid-cols-1 gap-x-4 gap-y-0.5 sm:grid-cols-2">
+        {TEMPLATE_TOKENS.map(({ token, description }) => (
+          <li key={token} className="leading-snug">
+            <code>{token}</code>{" "}
+            <span className="text-muted-foreground/80">— {description}</span>
+          </li>
+        ))}
+      </ul>
+      <div className="mt-1">
+        <span className="text-muted-foreground/80">Preview:</span>{" "}
+        <code className="break-all">{preview}</code>
+      </div>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Address the second half of the user feedback that prompted the FLAC fix: the filename template was four tokens and a flat-or-album-folder toggle, which isn't enough for a downloader-first app. This PR expands the template language so users can define their own folder structure.

**What changed:**

- `/` (and `\`) in the template now create directory structure. Each segment is sanitized individually — a literal `/` inside a token value (e.g. band name "AC/DC") still collapses to `_` like before, only the template's own `/` survives.
- New tokens: `{album_artist}`, `{year}`, `{disc_num}`, `{explicit}` (renders `" [E]"` or empty), `{album_explicit}`. Aliases `{track_title}` / `{album_title}` for users porting templates from other downloaders.
- Unknown tokens render as the literal `{key}` instead of crashing the download.
- `create_album_folders` keeps working as a backward-compat shortcut, but only takes effect when the template is single-segment. Once the template contains `/` it's silent (otherwise: `output_dir/Album/Album/Track.flac` double-nesting).
- Settings UI gets a token reference list and a live preview of what the current template renders to for a sample track.

**What didn't change:**

- Default template (`{artist} - {title}`) and `create_album_folders=True` produce identical output to before — no surprise migration for existing users.
- `_find_existing` still scans the same suffix set, so re-running downloads against an existing collection produces skip-existing matches without any renames or moves. Users adopting a new template only see new structure for new downloads.
- Wire schema is unchanged — `item_to_dict` still only sends the four original metadata fields. The new fields are backend-only, used at write time for path rendering.

**Security:** path-traversal protection is unchanged in spirit. Per-token sanitization handles user-data slashes, the post-render per-segment sanitize covers anything from the template literal text, and the existing containment check refuses to write outside `output_dir` if anything else slipped through. New tests cover `..` in token values and absolute-path templates.

## Test plan

- [x] `pytest tests/` — 453 pass + 19 new in [tests/test_filename_template.py](tests/test_filename_template.py) covering each new token, `/` as separator, per-segment sanitization, traversal protection, and the `create_album_folders` gating
- [x] `cd web && npx tsc -b --noEmit` — clean
- [x] `cd web && npm run lint:all` — 0 errors (56 pre-existing warnings unchanged)
- [x] `cd web && npm test` — 36 pass (+15 new in `web/src/lib/filenameTemplate.test.ts`)
- [ ] Manual: open Settings → Downloads, confirm the token list and preview render. Type a multi-segment template, confirm the preview path updates. Toggle "Create a subfolder per album" on/off and confirm the preview shows it being silenced once the template has `/`
- [ ] Manual: download one album with the default template (confirm flat behaviour unchanged), then with a template like `{album_artist}/{year} - {album}/{track_num} {title}` (confirm nested structure)