### PR TITLE
README: add Ko-fi badge under Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,8 @@ development, you can [buy me a coffee on Ko-fi](https://ko-fi.com/jmpunk).
 Tideway is free and will stay that way; donations are appreciated
 but never expected.
 
+[![Support on Ko-fi](https://ko-fi.com/img/githubbutton_sm.svg)](https://ko-fi.com/jmpunk)
+
 ## Install a released build
 
 Grab the latest from the Releases page for whichever fork of this


### PR DESCRIPTION
## Summary

The repo already has a Ko-fi text link in the README's Support section and a Sponsor button at the top of the GitHub page (via [.github/FUNDING.yml](.github/FUNDING.yml)). This adds the visual Ko-fi badge so it's harder to miss when someone scans the README — the text link is easy to skim past.

## Test plan

- [x] Markdown renders cleanly (badge image links to https://ko-fi.com/jmpunk)
- [ ] Manual: confirm the GitHub Sponsor button is visible at the top of the repo page (Settings → General → Sponsorships toggle if not)