### PR TITLE
Integrate window chrome on Windows and macOS

### DIFF
--- a/app/window_chrome.py
+++ b/app/window_chrome.py
@@ -295,11 +295,22 @@ def _apply_windows(hwnd: int, theme: str) -> None:
 
 
 def find_pywebview_hwnd(window: object) -> Optional[int]:
-    """Best-effort HWND lookup against a pywebview window object. The
-    attribute path differs across pywebview versions / GUIs; try a
-    few likely candidates rather than pin to one. Returns None if
-    we can't resolve it — caller should bail silently rather than
-    error out, since tinting a non-existent handle isn't fatal.
+    """Best-effort HWND lookup against a pywebview window object.
+
+    Two strategies, in order:
+
+      1. Walk a list of attribute paths the various pywebview backends
+         expose. Cheap, version-tolerant for the common cases.
+      2. Fall back to EnumWindows looking for a top-level window owned
+         by our process whose title matches the pywebview window's
+         title. Works regardless of how pywebview internally tracks
+         the handle — we just ask the OS which top-level window it
+         created on our behalf. Required for pywebview ≥ 5.4 where
+         the EdgeChromium backend stopped exposing the HWND on the
+         BrowserView and the attribute walk above all returns None.
+
+    Returns None when neither resolves (e.g. before the window is
+    actually shown — `shown` event hasn't fired yet — or off-Windows).
     """
     if sys.platform != "win32" or window is None:
         return None
@@ -319,4 +330,74 @@ def find_pywebview_hwnd(window: object) -> Optional[int]:
                 return obj
         except Exception:
             continue
+
+    # Fallback: enumerate top-level windows with our PID and title.
+    try:
+        import ctypes
+        import os
+        from ctypes import wintypes
+    except Exception:
+        return None
+    try:
+        user32 = ctypes.windll.user32
+        target_title = ""
+        try:
+            target_title = str(getattr(window, "title", "") or "")
+        except Exception:
+            target_title = ""
+
+        EnumWindowsProc = ctypes.WINFUNCTYPE(
+            ctypes.c_bool, wintypes.HWND, wintypes.LPARAM
+        )
+        get_thread_proc_id = user32.GetWindowThreadProcessId
+        get_thread_proc_id.argtypes = [
+            wintypes.HWND, ctypes.POINTER(wintypes.DWORD)
+        ]
+        get_thread_proc_id.restype = wintypes.DWORD
+
+        get_text_len = user32.GetWindowTextLengthW
+        get_text_len.argtypes = [wintypes.HWND]
+        get_text_len.restype = ctypes.c_int
+
+        get_text = user32.GetWindowTextW
+        get_text.argtypes = [
+            wintypes.HWND, wintypes.LPWSTR, ctypes.c_int
+        ]
+        get_text.restype = ctypes.c_int
+
+        is_visible = user32.IsWindowVisible
+        is_visible.argtypes = [wintypes.HWND]
+        is_visible.restype = wintypes.BOOL
+
+        our_pid = os.getpid()
+        found = [0]
+
+        def _enum(hwnd, _lparam):
+            if not is_visible(hwnd):
+                return True
+            pid = wintypes.DWORD(0)
+            get_thread_proc_id(hwnd, ctypes.byref(pid))
+            if pid.value != our_pid:
+                return True
+            # Match by title when we have one — there can be multiple
+            # top-level windows per process (tray helper, mini player,
+            # WebView2 host children that escape parenting). When no
+            # title hint, pick the first visible top-level we own and
+            # hope it's the main one.
+            if target_title:
+                length = get_text_len(hwnd)
+                if length <= 0:
+                    return True
+                buf = ctypes.create_unicode_buffer(length + 1)
+                get_text(hwnd, buf, length + 1)
+                if buf.value != target_title:
+                    return True
+            found[0] = int(hwnd)
+            return False  # stop enumeration
+
+        user32.EnumWindows(EnumWindowsProc(_enum), 0)
+        if found[0]:
+            return found[0]
+    except Exception:
+        return None
     return None

--- a/app/window_controls.py
+++ b/app/window_controls.py
@@ -176,41 +176,34 @@ def close() -> bool:
 # ---------------------------------------------------------------------------
 # Native drag + resize for the frameless Windows shell.
 #
-# The React titlebar's `app-region: drag` doesn't work in WebView2 —
-# that CSS rule is a Chromium-Apps feature, not stock Chromium, and
-# WebView2 silently ignores it. And `frameless=True` strips the
-# resize border entirely. Together that means a frameless pywebview
-# window on Windows is, by default, neither draggable nor resizable.
+# Two real problems blocking drag and resize on a frameless pywebview
+# window. They each need a different fix because the WebView2 child
+# window owns mouse events for the entire client area:
 #
-# The fix is to handle this at the Win32 level: subclass the
-# WindowProc, add WS_THICKFRAME back so the OS recognises the window
-# as resizable, override WM_NCHITTEST to declare which screen
-# rectangles are caption (drag) vs resize-edge vs client, and
-# override WM_NCCALCSIZE so the OS doesn't paint the standard thick
-# frame on top of our content. This is the same pattern Electron,
-# VS Code, and Discord use for their frameless title bars.
+#   Resize: pywebview's `frameless=True` strips both WS_CAPTION and
+#     WS_THICKFRAME. Without WS_THICKFRAME the OS doesn't think the
+#     window is resizable at all — there's no edge zone for the
+#     cursor to grab. Restoring WS_THICKFRAME via SetWindowLong gets
+#     us the OS's native resize border back. Visible cost: a thin
+#     gray edge (~6 px) around the window. Functional gain: the
+#     resize cursor + drag-to-resize work on every edge, plus
+#     drag-to-edge snap and Aero Shake re-engage because the OS
+#     sees a normal resizable top-level window again.
 #
-# All numeric zones (titlebar height, button area width, resize
-# border) are scaled to the window's DPI so they stay correct on
-# high-DPI displays.
+#   Drag: WebView2 silently ignores `-webkit-app-region: drag`
+#     (it's a Chromium-Apps feature, not stock Chromium), and the
+#     WebView2 child window covers the entire client area, so
+#     subclassing the parent's WndProc to return HTCAPTION from
+#     WM_NCHITTEST never fires for cursor positions inside the React
+#     titlebar — those events all go to the child. The standard
+#     escape hatch is the ReleaseCapture + SendMessage(WM_SYSCOMMAND,
+#     SC_MOVE | HTCAPTION) trick: JS calls a Python endpoint on
+#     mousedown, Python tells the OS "treat this as a caption click
+#     starting a move," and the OS runs the move loop directly off
+#     the cursor's current position. This is what Tauri ships for
+#     its custom titlebars.
 # ---------------------------------------------------------------------------
 
-# Hit-test response codes (winuser.h).
-_HTCLIENT = 1
-_HTCAPTION = 2
-_HTLEFT = 10
-_HTRIGHT = 11
-_HTTOP = 12
-_HTTOPLEFT = 13
-_HTTOPRIGHT = 14
-_HTBOTTOM = 15
-_HTBOTTOMLEFT = 16
-_HTBOTTOMRIGHT = 17
-
-_WM_NCCALCSIZE = 0x0083
-_WM_NCHITTEST = 0x0084
-
-_GWLP_WNDPROC = -4
 _GWL_STYLE = -16
 _WS_THICKFRAME = 0x00040000
 
@@ -219,38 +212,22 @@ _SWP_NOSIZE = 0x0001
 _SWP_NOZORDER = 0x0004
 _SWP_FRAMECHANGED = 0x0020
 
-# Zones expressed in CSS pixels (96 DPI). Scaled at hit-test time
-# against the window's actual DPI. The titlebar height MUST stay in
-# sync with WindowTitlebar.tsx — that React component reserves the
-# top 32 px for the drag bar and the right 138 px (3 buttons × 46 px)
-# for min/max/close. If those numbers move, update the constants
-# below or the buttons stop accepting clicks.
-_CAPTION_HEIGHT_CSS_PX = 32
-_BUTTON_ZONE_WIDTH_CSS_PX = 138
-_RESIZE_BORDER_CSS_PX = 6
-
-# Module-level state for the hook. We hold the WNDPROC callable so
-# Python's GC doesn't free it while Windows still has its function
-# pointer, and we hold the previous WndProc address so our handler
-# can forward unhandled messages.
-_subclass_wndproc = None
-_prev_wndproc: int = 0
-_subclassed_hwnd: int = 0
+_WM_SYSCOMMAND = 0x0112
+_HTCAPTION = 2
+_SC_MOVE = 0xF010
 
 
-def install_native_hit_test(hwnd: int) -> bool:
-    """Make a frameless pywebview window draggable and resizable
-    using native Win32 hit testing.
+def enable_native_resize(hwnd: int) -> bool:
+    """Add WS_THICKFRAME to a frameless pywebview window so the OS
+    redraws the resize border and accepts drag-to-resize on every
+    edge.
 
-    Returns True when the hook is installed, False on non-Windows or
-    if the HWND can't be subclassed. Idempotent — calling twice on
-    the same HWND no-ops.
+    Idempotent — adding the style when it's already present is a
+    no-op. Returns False on non-Windows or if the style mutation
+    fails (extremely unlikely with a valid HWND).
     """
-    global _subclass_wndproc, _prev_wndproc, _subclassed_hwnd
     if sys.platform != "win32" or not hwnd:
         return False
-    if _subclassed_hwnd == hwnd and _subclass_wndproc is not None:
-        return True
     try:
         import ctypes
         from ctypes import wintypes
@@ -258,13 +235,6 @@ def install_native_hit_test(hwnd: int) -> bool:
         return False
 
     user32 = ctypes.windll.user32
-
-    # Restore WS_THICKFRAME. pywebview's frameless mode strips it
-    # along with WS_CAPTION; without it Windows doesn't recognise the
-    # window as resizable even when WM_NCHITTEST returns HTLEFT/etc.
-    # We don't add WS_CAPTION back — the React titlebar is the title
-    # bar — and WM_NCCALCSIZE below collapses the thick-frame visual
-    # so the user never sees a stray border.
     try:
         get_long = user32.GetWindowLongW
         get_long.argtypes = [wintypes.HWND, ctypes.c_int]
@@ -272,129 +242,16 @@ def install_native_hit_test(hwnd: int) -> bool:
         set_long = user32.SetWindowLongW
         set_long.argtypes = [wintypes.HWND, ctypes.c_int, ctypes.c_long]
         set_long.restype = ctypes.c_long
-        cur_style = get_long(hwnd, _GWL_STYLE)
-        set_long(hwnd, _GWL_STYLE, cur_style | _WS_THICKFRAME)
+        cur = get_long(hwnd, _GWL_STYLE)
+        if cur & _WS_THICKFRAME:
+            return True
+        set_long(hwnd, _GWL_STYLE, cur | _WS_THICKFRAME)
     except Exception:
         return False
 
-    # Window-proc callable signature: LRESULT(HWND, UINT, WPARAM, LPARAM).
-    WNDPROC = ctypes.WINFUNCTYPE(
-        ctypes.c_long,
-        wintypes.HWND,
-        wintypes.UINT,
-        wintypes.WPARAM,
-        wintypes.LPARAM,
-    )
-
-    def _scale(hwnd_arg: int) -> float:
-        # GetDpiForWindow exists from Windows 10 1607+. Older versions
-        # fall back to 96 (no scaling) — those builds are out of
-        # support so the degraded behaviour is acceptable.
-        try:
-            get_dpi = user32.GetDpiForWindow
-            get_dpi.argtypes = [wintypes.HWND]
-            get_dpi.restype = wintypes.UINT
-            dpi = int(get_dpi(hwnd_arg))
-            return (dpi / 96.0) if dpi > 0 else 1.0
-        except Exception:
-            return 1.0
-
-    def _hit_test(hwnd_arg: int, screen_x: int, screen_y: int) -> int:
-        rect = wintypes.RECT()
-        if not user32.GetWindowRect(hwnd_arg, ctypes.byref(rect)):
-            return _HTCLIENT
-        rel_x = screen_x - rect.left
-        rel_y = screen_y - rect.top
-        width = rect.right - rect.left
-        height = rect.bottom - rect.top
-        scale = _scale(hwnd_arg)
-        border = max(1, int(round(_RESIZE_BORDER_CSS_PX * scale)))
-        cap_h = max(1, int(round(_CAPTION_HEIGHT_CSS_PX * scale)))
-        btn_w = max(1, int(round(_BUTTON_ZONE_WIDTH_CSS_PX * scale)))
-
-        # Resize edges only when the window isn't maximised — a
-        # maximised window shouldn't accept resize-from-edge.
-        is_max = bool(user32.IsZoomed(hwnd_arg))
-        if not is_max:
-            on_left = rel_x < border
-            on_right = rel_x >= width - border
-            on_top = rel_y < border
-            on_bottom = rel_y >= height - border
-            if on_top and on_left:
-                return _HTTOPLEFT
-            if on_top and on_right:
-                return _HTTOPRIGHT
-            if on_bottom and on_left:
-                return _HTBOTTOMLEFT
-            if on_bottom and on_right:
-                return _HTBOTTOMRIGHT
-            if on_left:
-                return _HTLEFT
-            if on_right:
-                return _HTRIGHT
-            if on_top:
-                return _HTTOP
-            if on_bottom:
-                return _HTBOTTOM
-
-        # Caption (drag) zone: top of the client area, minus the
-        # button strip on the right. Returning HTCLIENT for the button
-        # strip lets WebView2 receive the click and fire the React
-        # button's onClick.
-        if rel_y < cap_h and rel_x < width - btn_w:
-            return _HTCAPTION
-
-        return _HTCLIENT
-
-    def _wnd_proc(hwnd_arg, msg, wparam, lparam):
-        if msg == _WM_NCCALCSIZE and wparam:
-            # Returning 0 with the rgrc[0] rect unchanged tells
-            # Windows the client area equals the whole window rect,
-            # which collapses the WS_THICKFRAME visual to zero. The
-            # frame still exists for hit testing, so resize edges
-            # work — the user just doesn't see a stray border.
-            return 0
-        if msg == _WM_NCHITTEST:
-            # lParam packs the cursor's screen coords as (y << 16) | x,
-            # interpreted as 16-bit signed. Use ctypes.c_short to
-            # decode the sign bit on multi-monitor setups where
-            # secondary monitors can have negative coords.
-            x = ctypes.c_short(lparam & 0xFFFF).value
-            y = ctypes.c_short((lparam >> 16) & 0xFFFF).value
-            return _hit_test(hwnd_arg, x, y)
-        # Forward everything else to the original WndProc so
-        # WebView2's input handling, focus, paint, etc. all keep
-        # working.
-        return user32.CallWindowProcW(
-            _prev_wndproc, hwnd_arg, msg, wparam, lparam
-        )
-
-    # SetWindowLongPtrW is the 64-bit-safe version of SetWindowLongW
-    # for setting a WndProc. On 32-bit Python (rare on modern
-    # Windows) the symbol may be absent — fall through to the 32-bit
-    # variant in that case.
-    try:
-        set_ptr = user32.SetWindowLongPtrW
-        set_ptr.argtypes = [wintypes.HWND, ctypes.c_int, ctypes.c_void_p]
-        set_ptr.restype = ctypes.c_void_p
-    except AttributeError:
-        set_ptr = user32.SetWindowLongW
-        set_ptr.argtypes = [wintypes.HWND, ctypes.c_int, ctypes.c_long]
-        set_ptr.restype = ctypes.c_long
-
-    new_wndproc = WNDPROC(_wnd_proc)
-    proc_addr = ctypes.cast(new_wndproc, ctypes.c_void_p).value
-    prev = set_ptr(hwnd, _GWLP_WNDPROC, proc_addr)
-    if not prev:
-        return False
-    _subclass_wndproc = new_wndproc  # keep alive across GC
-    _prev_wndproc = int(prev)
-    _subclassed_hwnd = int(hwnd)
-
-    # Tell the OS the frame changed so WM_NCCALCSIZE fires once and
-    # the client rect adopts the new "client = window" geometry. No
-    # SetWindowPos = the visual border lingers until the first manual
-    # resize, which looks janky.
+    # Tell the OS the frame changed so it relays out the non-client
+    # area immediately. Without SetWindowPos the resize border
+    # doesn't appear until the user manually triggers a redraw.
     try:
         user32.SetWindowPos(
             hwnd,
@@ -407,5 +264,41 @@ def install_native_hit_test(hwnd: int) -> bool:
         )
     except Exception:
         pass
-
     return True
+
+
+def start_window_drag() -> bool:
+    """Start a native window drag from the cursor's current position.
+
+    The React titlebar fires this on mousedown (left button only,
+    not on a button child). We send WM_SYSCOMMAND with SC_MOVE so
+    Windows runs the move loop using the cursor's current screen
+    position as the drag anchor — drag-to-edge snap, Aero Shake,
+    and double-click-to-maximize all work on the same gesture.
+
+    Must be called from the GUI thread. Returns False when there's
+    no HWND registered (plain-browser dev) or off-Windows.
+    """
+    if sys.platform != "win32":
+        return False
+    if _hwnd_provider is None:
+        return False
+    try:
+        hwnd = _hwnd_provider()
+    except Exception:
+        return False
+    if not isinstance(hwnd, int) or not hwnd:
+        return False
+    try:
+        import ctypes
+        user32 = ctypes.windll.user32
+        # ReleaseCapture is required because the WebView2 child window
+        # owns the mouse capture from its mousedown — without
+        # releasing it first, the SendMessage that follows is dropped
+        # and the drag never starts.
+        user32.ReleaseCapture()
+        user32.SendMessageW(hwnd, _WM_SYSCOMMAND, _SC_MOVE | _HTCAPTION, 0)
+        return True
+    except Exception:
+        return False
+

--- a/app/window_controls.py
+++ b/app/window_controls.py
@@ -171,3 +171,241 @@ def close() -> bool:
         return True
     except Exception:
         return False
+
+
+# ---------------------------------------------------------------------------
+# Native drag + resize for the frameless Windows shell.
+#
+# The React titlebar's `app-region: drag` doesn't work in WebView2 —
+# that CSS rule is a Chromium-Apps feature, not stock Chromium, and
+# WebView2 silently ignores it. And `frameless=True` strips the
+# resize border entirely. Together that means a frameless pywebview
+# window on Windows is, by default, neither draggable nor resizable.
+#
+# The fix is to handle this at the Win32 level: subclass the
+# WindowProc, add WS_THICKFRAME back so the OS recognises the window
+# as resizable, override WM_NCHITTEST to declare which screen
+# rectangles are caption (drag) vs resize-edge vs client, and
+# override WM_NCCALCSIZE so the OS doesn't paint the standard thick
+# frame on top of our content. This is the same pattern Electron,
+# VS Code, and Discord use for their frameless title bars.
+#
+# All numeric zones (titlebar height, button area width, resize
+# border) are scaled to the window's DPI so they stay correct on
+# high-DPI displays.
+# ---------------------------------------------------------------------------
+
+# Hit-test response codes (winuser.h).
+_HTCLIENT = 1
+_HTCAPTION = 2
+_HTLEFT = 10
+_HTRIGHT = 11
+_HTTOP = 12
+_HTTOPLEFT = 13
+_HTTOPRIGHT = 14
+_HTBOTTOM = 15
+_HTBOTTOMLEFT = 16
+_HTBOTTOMRIGHT = 17
+
+_WM_NCCALCSIZE = 0x0083
+_WM_NCHITTEST = 0x0084
+
+_GWLP_WNDPROC = -4
+_GWL_STYLE = -16
+_WS_THICKFRAME = 0x00040000
+
+_SWP_NOMOVE = 0x0002
+_SWP_NOSIZE = 0x0001
+_SWP_NOZORDER = 0x0004
+_SWP_FRAMECHANGED = 0x0020
+
+# Zones expressed in CSS pixels (96 DPI). Scaled at hit-test time
+# against the window's actual DPI. The titlebar height MUST stay in
+# sync with WindowTitlebar.tsx — that React component reserves the
+# top 32 px for the drag bar and the right 138 px (3 buttons × 46 px)
+# for min/max/close. If those numbers move, update the constants
+# below or the buttons stop accepting clicks.
+_CAPTION_HEIGHT_CSS_PX = 32
+_BUTTON_ZONE_WIDTH_CSS_PX = 138
+_RESIZE_BORDER_CSS_PX = 6
+
+# Module-level state for the hook. We hold the WNDPROC callable so
+# Python's GC doesn't free it while Windows still has its function
+# pointer, and we hold the previous WndProc address so our handler
+# can forward unhandled messages.
+_subclass_wndproc = None
+_prev_wndproc: int = 0
+_subclassed_hwnd: int = 0
+
+
+def install_native_hit_test(hwnd: int) -> bool:
+    """Make a frameless pywebview window draggable and resizable
+    using native Win32 hit testing.
+
+    Returns True when the hook is installed, False on non-Windows or
+    if the HWND can't be subclassed. Idempotent — calling twice on
+    the same HWND no-ops.
+    """
+    global _subclass_wndproc, _prev_wndproc, _subclassed_hwnd
+    if sys.platform != "win32" or not hwnd:
+        return False
+    if _subclassed_hwnd == hwnd and _subclass_wndproc is not None:
+        return True
+    try:
+        import ctypes
+        from ctypes import wintypes
+    except Exception:
+        return False
+
+    user32 = ctypes.windll.user32
+
+    # Restore WS_THICKFRAME. pywebview's frameless mode strips it
+    # along with WS_CAPTION; without it Windows doesn't recognise the
+    # window as resizable even when WM_NCHITTEST returns HTLEFT/etc.
+    # We don't add WS_CAPTION back — the React titlebar is the title
+    # bar — and WM_NCCALCSIZE below collapses the thick-frame visual
+    # so the user never sees a stray border.
+    try:
+        get_long = user32.GetWindowLongW
+        get_long.argtypes = [wintypes.HWND, ctypes.c_int]
+        get_long.restype = ctypes.c_long
+        set_long = user32.SetWindowLongW
+        set_long.argtypes = [wintypes.HWND, ctypes.c_int, ctypes.c_long]
+        set_long.restype = ctypes.c_long
+        cur_style = get_long(hwnd, _GWL_STYLE)
+        set_long(hwnd, _GWL_STYLE, cur_style | _WS_THICKFRAME)
+    except Exception:
+        return False
+
+    # Window-proc callable signature: LRESULT(HWND, UINT, WPARAM, LPARAM).
+    WNDPROC = ctypes.WINFUNCTYPE(
+        ctypes.c_long,
+        wintypes.HWND,
+        wintypes.UINT,
+        wintypes.WPARAM,
+        wintypes.LPARAM,
+    )
+
+    def _scale(hwnd_arg: int) -> float:
+        # GetDpiForWindow exists from Windows 10 1607+. Older versions
+        # fall back to 96 (no scaling) — those builds are out of
+        # support so the degraded behaviour is acceptable.
+        try:
+            get_dpi = user32.GetDpiForWindow
+            get_dpi.argtypes = [wintypes.HWND]
+            get_dpi.restype = wintypes.UINT
+            dpi = int(get_dpi(hwnd_arg))
+            return (dpi / 96.0) if dpi > 0 else 1.0
+        except Exception:
+            return 1.0
+
+    def _hit_test(hwnd_arg: int, screen_x: int, screen_y: int) -> int:
+        rect = wintypes.RECT()
+        if not user32.GetWindowRect(hwnd_arg, ctypes.byref(rect)):
+            return _HTCLIENT
+        rel_x = screen_x - rect.left
+        rel_y = screen_y - rect.top
+        width = rect.right - rect.left
+        height = rect.bottom - rect.top
+        scale = _scale(hwnd_arg)
+        border = max(1, int(round(_RESIZE_BORDER_CSS_PX * scale)))
+        cap_h = max(1, int(round(_CAPTION_HEIGHT_CSS_PX * scale)))
+        btn_w = max(1, int(round(_BUTTON_ZONE_WIDTH_CSS_PX * scale)))
+
+        # Resize edges only when the window isn't maximised — a
+        # maximised window shouldn't accept resize-from-edge.
+        is_max = bool(user32.IsZoomed(hwnd_arg))
+        if not is_max:
+            on_left = rel_x < border
+            on_right = rel_x >= width - border
+            on_top = rel_y < border
+            on_bottom = rel_y >= height - border
+            if on_top and on_left:
+                return _HTTOPLEFT
+            if on_top and on_right:
+                return _HTTOPRIGHT
+            if on_bottom and on_left:
+                return _HTBOTTOMLEFT
+            if on_bottom and on_right:
+                return _HTBOTTOMRIGHT
+            if on_left:
+                return _HTLEFT
+            if on_right:
+                return _HTRIGHT
+            if on_top:
+                return _HTTOP
+            if on_bottom:
+                return _HTBOTTOM
+
+        # Caption (drag) zone: top of the client area, minus the
+        # button strip on the right. Returning HTCLIENT for the button
+        # strip lets WebView2 receive the click and fire the React
+        # button's onClick.
+        if rel_y < cap_h and rel_x < width - btn_w:
+            return _HTCAPTION
+
+        return _HTCLIENT
+
+    def _wnd_proc(hwnd_arg, msg, wparam, lparam):
+        if msg == _WM_NCCALCSIZE and wparam:
+            # Returning 0 with the rgrc[0] rect unchanged tells
+            # Windows the client area equals the whole window rect,
+            # which collapses the WS_THICKFRAME visual to zero. The
+            # frame still exists for hit testing, so resize edges
+            # work — the user just doesn't see a stray border.
+            return 0
+        if msg == _WM_NCHITTEST:
+            # lParam packs the cursor's screen coords as (y << 16) | x,
+            # interpreted as 16-bit signed. Use ctypes.c_short to
+            # decode the sign bit on multi-monitor setups where
+            # secondary monitors can have negative coords.
+            x = ctypes.c_short(lparam & 0xFFFF).value
+            y = ctypes.c_short((lparam >> 16) & 0xFFFF).value
+            return _hit_test(hwnd_arg, x, y)
+        # Forward everything else to the original WndProc so
+        # WebView2's input handling, focus, paint, etc. all keep
+        # working.
+        return user32.CallWindowProcW(
+            _prev_wndproc, hwnd_arg, msg, wparam, lparam
+        )
+
+    # SetWindowLongPtrW is the 64-bit-safe version of SetWindowLongW
+    # for setting a WndProc. On 32-bit Python (rare on modern
+    # Windows) the symbol may be absent — fall through to the 32-bit
+    # variant in that case.
+    try:
+        set_ptr = user32.SetWindowLongPtrW
+        set_ptr.argtypes = [wintypes.HWND, ctypes.c_int, ctypes.c_void_p]
+        set_ptr.restype = ctypes.c_void_p
+    except AttributeError:
+        set_ptr = user32.SetWindowLongW
+        set_ptr.argtypes = [wintypes.HWND, ctypes.c_int, ctypes.c_long]
+        set_ptr.restype = ctypes.c_long
+
+    new_wndproc = WNDPROC(_wnd_proc)
+    proc_addr = ctypes.cast(new_wndproc, ctypes.c_void_p).value
+    prev = set_ptr(hwnd, _GWLP_WNDPROC, proc_addr)
+    if not prev:
+        return False
+    _subclass_wndproc = new_wndproc  # keep alive across GC
+    _prev_wndproc = int(prev)
+    _subclassed_hwnd = int(hwnd)
+
+    # Tell the OS the frame changed so WM_NCCALCSIZE fires once and
+    # the client rect adopts the new "client = window" geometry. No
+    # SetWindowPos = the visual border lingers until the first manual
+    # resize, which looks janky.
+    try:
+        user32.SetWindowPos(
+            hwnd,
+            0,
+            0,
+            0,
+            0,
+            0,
+            _SWP_NOMOVE | _SWP_NOSIZE | _SWP_NOZORDER | _SWP_FRAMECHANGED,
+        )
+    except Exception:
+        pass
+
+    return True

--- a/app/window_controls.py
+++ b/app/window_controls.py
@@ -213,8 +213,37 @@ _SWP_NOZORDER = 0x0004
 _SWP_FRAMECHANGED = 0x0020
 
 _WM_SYSCOMMAND = 0x0112
+_WM_NCLBUTTONDOWN = 0x00A1
 _HTCAPTION = 2
+
+# WM_SYSCOMMAND command codes for SC_MOVE / SC_SIZE.
 _SC_MOVE = 0xF010
+_SC_SIZE = 0xF000
+
+# SC_SIZE direction modifiers (the low 4 bits of wParam).
+# These are the values DefWindowProc maps each HT* edge code to
+# when handling a non-client mouse-down — by passing them directly
+# we drive the OS's resize loop in the right direction without
+# needing a real cursor-on-edge hit test.
+_SC_SIZE_LEFT = _SC_SIZE | 1
+_SC_SIZE_RIGHT = _SC_SIZE | 2
+_SC_SIZE_TOP = _SC_SIZE | 3
+_SC_SIZE_TOPLEFT = _SC_SIZE | 4
+_SC_SIZE_TOPRIGHT = _SC_SIZE | 5
+_SC_SIZE_BOTTOM = _SC_SIZE | 6
+_SC_SIZE_BOTTOMLEFT = _SC_SIZE | 7
+_SC_SIZE_BOTTOMRIGHT = _SC_SIZE | 8
+
+_SC_DIRECTION_BY_NAME = {
+    "left": _SC_SIZE_LEFT,
+    "right": _SC_SIZE_RIGHT,
+    "top": _SC_SIZE_TOP,
+    "topleft": _SC_SIZE_TOPLEFT,
+    "topright": _SC_SIZE_TOPRIGHT,
+    "bottom": _SC_SIZE_BOTTOM,
+    "bottomleft": _SC_SIZE_BOTTOMLEFT,
+    "bottomright": _SC_SIZE_BOTTOMRIGHT,
+}
 
 
 def enable_native_resize(hwnd: int) -> bool:
@@ -267,17 +296,155 @@ def enable_native_resize(hwnd: int) -> bool:
     return True
 
 
+_WM_USER = 0x0400
+_WM_TIDEWAY_NC_DRAG = _WM_USER + 71  # arbitrary; just needs to not clash
+
+# WndProc subclass state. _wndproc_ref keeps the C callback alive
+# (Python's GC would otherwise free it while Windows still has its
+# function pointer); _prev_wndproc is the original WindowProc we
+# forward unhandled messages to.
+_wndproc_ref = None
+_prev_wndproc: int = 0
+_subclassed_hwnd: int = 0
+
+
+def ensure_wndproc_subclass(hwnd: int) -> bool:
+    """Subclass the parent window's WindowProc so it understands a
+    custom WM_TIDEWAY_NC_DRAG message. The custom message lets a
+    worker thread (e.g. the uvicorn HTTP handler) trigger a native
+    drag/resize loop *from the GUI thread* — necessary because
+    `ReleaseCapture` only affects the calling thread, and the
+    WebView2 child holds the mouse capture on the GUI thread.
+    Posting WM_TIDEWAY_NC_DRAG and letting the GUI thread's message
+    loop dispatch it puts our ctypes calls in the right context.
+
+    Idempotent — re-subclassing the same HWND no-ops.
+    """
+    global _wndproc_ref, _prev_wndproc, _subclassed_hwnd
+    if sys.platform != "win32" or not hwnd:
+        return False
+    if _subclassed_hwnd == hwnd and _wndproc_ref is not None:
+        return True
+    try:
+        import ctypes
+        from ctypes import wintypes
+    except Exception:
+        return False
+    user32 = ctypes.windll.user32
+
+    WNDPROC = ctypes.WINFUNCTYPE(
+        ctypes.c_long,
+        wintypes.HWND,
+        wintypes.UINT,
+        wintypes.WPARAM,
+        wintypes.LPARAM,
+    )
+
+    # CRITICAL: argtypes must declare the previous WndProc as a
+    # void pointer (= 64 bits on 64-bit Windows). Without this,
+    # ctypes converts the Python int to c_int (32 bits) and
+    # truncates the high half of the address, sending every forwarded
+    # message to a corrupt code path that silently returns 0. The
+    # window then stops repainting, accepting input, etc.
+    call_wnd_proc = user32.CallWindowProcW
+    call_wnd_proc.argtypes = [
+        ctypes.c_void_p,
+        wintypes.HWND,
+        wintypes.UINT,
+        wintypes.WPARAM,
+        wintypes.LPARAM,
+    ]
+    call_wnd_proc.restype = ctypes.c_long
+
+    def _wnd_proc(hwnd_arg, msg, wparam, lparam):
+        if msg == _WM_TIDEWAY_NC_DRAG:
+            # We're now on the GUI thread. ReleaseCapture genuinely
+            # releases the WebView2 child's capture, and the
+            # following PostMessageW lands in the parent's queue
+            # ahead of the next mouse-move so DefWindowProc enters
+            # its drag/resize loop with the cursor still down.
+            try:
+                user32.ReleaseCapture()
+                user32.PostMessageW(
+                    hwnd_arg, _WM_NCLBUTTONDOWN, wparam, lparam
+                )
+            except Exception:
+                pass
+            return 0
+        return call_wnd_proc(
+            _prev_wndproc, hwnd_arg, msg, wparam, lparam
+        )
+
+    try:
+        set_ptr = user32.SetWindowLongPtrW
+        set_ptr.argtypes = [wintypes.HWND, ctypes.c_int, ctypes.c_void_p]
+        set_ptr.restype = ctypes.c_void_p
+    except AttributeError:
+        set_ptr = user32.SetWindowLongW
+        set_ptr.argtypes = [wintypes.HWND, ctypes.c_int, ctypes.c_long]
+        set_ptr.restype = ctypes.c_long
+
+    GWLP_WNDPROC = -4
+    new_wndproc = WNDPROC(_wnd_proc)
+    proc_addr = ctypes.cast(new_wndproc, ctypes.c_void_p).value
+    prev = set_ptr(hwnd, GWLP_WNDPROC, proc_addr)
+    if not prev:
+        return False
+    _wndproc_ref = new_wndproc
+    _prev_wndproc = int(prev) if not isinstance(prev, int) else prev
+    _subclassed_hwnd = int(hwnd)
+    return True
+
+
+def _post_nc_drag(hwnd: int, ht_code: int, sc_command: int) -> bool:
+    """Trigger a native drag / resize loop on the parent window.
+
+    Two messages are posted:
+
+      1. WM_TIDEWAY_NC_DRAG: routed through the subclassed WndProc
+         on the GUI thread, which then ReleaseCaptures + posts
+         WM_NCLBUTTONDOWN. This is the path that actually works
+         when the WebView2 child holds capture, because
+         ReleaseCapture only releases capture for the calling
+         thread — and now we're on the right thread.
+
+      2. WM_SYSCOMMAND with SC_MOVE | HTCAPTION (0xF012) /
+         SC_SIZE | direction (0xF001..0xF008): redundant fallback
+         in case the subclass hasn't been installed yet (very
+         early in startup, before the `shown` event fires).
+
+    PostMessage from a worker thread queues the message on the
+    target HWND regardless of caller thread, so this is safe to
+    call from uvicorn's request handlers.
+    """
+    ensure_wndproc_subclass(hwnd)
+    try:
+        import ctypes
+
+        class POINT(ctypes.Structure):
+            _fields_ = [("x", ctypes.c_long), ("y", ctypes.c_long)]
+
+        user32 = ctypes.windll.user32
+        pt = POINT()
+        user32.GetCursorPos(ctypes.byref(pt))
+        lparam = ((pt.y & 0xFFFF) << 16) | (pt.x & 0xFFFF)
+        user32.PostMessageW(hwnd, _WM_TIDEWAY_NC_DRAG, ht_code, lparam)
+        user32.PostMessageW(hwnd, _WM_SYSCOMMAND, sc_command, 0)
+        return True
+    except Exception:
+        return False
+
+
 def start_window_drag() -> bool:
     """Start a native window drag from the cursor's current position.
 
     The React titlebar fires this on mousedown (left button only,
-    not on a button child). We send WM_SYSCOMMAND with SC_MOVE so
-    Windows runs the move loop using the cursor's current screen
-    position as the drag anchor — drag-to-edge snap, Aero Shake,
-    and double-click-to-maximize all work on the same gesture.
+    not on a button child). Routes through the subclass-on-GUI-thread
+    path because the WebView2 child holds the mouse capture from its
+    own browser-side mousedown — see `_post_nc_drag`.
 
-    Must be called from the GUI thread. Returns False when there's
-    no HWND registered (plain-browser dev) or off-Windows.
+    Returns False off-Windows or when there's no HWND registered
+    (plain-browser dev).
     """
     if sys.platform != "win32":
         return False
@@ -289,16 +456,52 @@ def start_window_drag() -> bool:
         return False
     if not isinstance(hwnd, int) or not hwnd:
         return False
+    # SC_MOVE's low nibble selects keyboard vs mouse mode: 0 (bare
+    # SC_MOVE) drops into keyboard-arrow move, 2 (SC_MOVE | HTCAPTION
+    # = 0xF012) is mouse-initiated, which is what we want.
+    return _post_nc_drag(hwnd, _HTCAPTION, _SC_MOVE | _HTCAPTION)
+
+
+# HTLEFT/HTRIGHT/HTTOP/HTBOTTOM/HTTOPLEFT/HTTOPRIGHT/HTBOTTOMLEFT/
+# HTBOTTOMRIGHT codes paired with their SC_SIZE_* counterparts. We
+# need both for `_post_nc_drag` — see its docstring for why.
+_HT_CODES_BY_DIRECTION = {
+    "left": (10, _SC_SIZE_LEFT),
+    "right": (11, _SC_SIZE_RIGHT),
+    "top": (12, _SC_SIZE_TOP),
+    "topleft": (13, _SC_SIZE_TOPLEFT),
+    "topright": (14, _SC_SIZE_TOPRIGHT),
+    "bottom": (15, _SC_SIZE_BOTTOM),
+    "bottomleft": (16, _SC_SIZE_BOTTOMLEFT),
+    "bottomright": (17, _SC_SIZE_BOTTOMRIGHT),
+}
+
+
+def start_window_resize(direction: str) -> bool:
+    """Start a native window resize from the cursor's current
+    position toward the named edge / corner.
+
+    `direction` must be one of left, right, top, bottom, topleft,
+    topright, bottomleft, bottomright. The React side adds invisible
+    hit strips along each edge and fires this on mousedown — same
+    UX as clicking the OS-drawn resize border on a normal window.
+
+    Same subclass-on-GUI-thread path as `start_window_drag` because
+    the WebView2 child holds capture in both cases.
+    """
+    if sys.platform != "win32":
+        return False
+    if _hwnd_provider is None:
+        return False
+    pair = _HT_CODES_BY_DIRECTION.get(direction)
+    if pair is None:
+        return False
+    ht, sc = pair
     try:
-        import ctypes
-        user32 = ctypes.windll.user32
-        # ReleaseCapture is required because the WebView2 child window
-        # owns the mouse capture from its mousedown — without
-        # releasing it first, the SendMessage that follows is dropped
-        # and the drag never starts.
-        user32.ReleaseCapture()
-        user32.SendMessageW(hwnd, _WM_SYSCOMMAND, _SC_MOVE | _HTCAPTION, 0)
-        return True
+        hwnd = _hwnd_provider()
     except Exception:
         return False
+    if not isinstance(hwnd, int) or not hwnd:
+        return False
+    return _post_nc_drag(hwnd, ht, sc)
 

--- a/app/window_controls.py
+++ b/app/window_controls.py
@@ -1,0 +1,173 @@
+"""Min / max / close primitives for the React titlebar.
+
+When the desktop launcher creates the main window with `frameless=True`
+(Windows), the OS no longer draws a caption with min / max / close
+buttons. The React shell renders its own buttons and POSTs to
+`/api/_internal/window/<action>`, which routes through the callbacks
+registered here back to the pywebview window on the GUI thread.
+
+macOS keeps the native traffic-light buttons — the corresponding React
+controls don't render — so the Cocoa branch only needs to expose
+`platform` so the shell can decide what to draw.
+
+Maximize on Windows is the awkward one: pywebview ≥5 doesn't ship a
+`Window.maximize()` method, so we go around it with `ShowWindow` over
+the underlying HWND. `IsZoomed` gives us the real maximized state for
+the icon, including transitions caused by Win+Up, drag-to-edge snap,
+or double-click on the titlebar drag region.
+"""
+from __future__ import annotations
+
+import sys
+from typing import Optional
+
+
+def is_windows_frameless_supported() -> bool:
+    """True when we can usefully run a frameless main window on this
+    OS. Windows is the only target where a custom HTML titlebar is
+    standard practice; macOS keeps native traffic lights, Linux goes
+    untouched (GTK CSD theming is too varied to do reliably)."""
+    return sys.platform == "win32"
+
+
+def is_window_maximized(hwnd: int) -> bool:
+    """Return True if the given top-level window is currently maximized.
+    Uses Win32 `IsZoomed`; falls through to False on any error or off-
+    Windows so the caller can render a stable icon without branching.
+    """
+    if sys.platform != "win32" or not hwnd:
+        return False
+    try:
+        import ctypes
+        return bool(ctypes.windll.user32.IsZoomed(hwnd))
+    except Exception:
+        return False
+
+
+def toggle_maximize(hwnd: int) -> bool:
+    """Maximize if not currently maximized, otherwise restore. Returns
+    the new maximized state. No-op + returns False when we can't
+    resolve the HWND or aren't on Windows."""
+    if sys.platform != "win32" or not hwnd:
+        return False
+    try:
+        import ctypes
+        # SW_RESTORE = 9 brings the window out of either minimized or
+        # maximized state. SW_MAXIMIZE = 3 maximizes. Together they form
+        # the standard "click the middle titlebar button" toggle.
+        SW_MAXIMIZE = 3
+        SW_RESTORE = 9
+        if is_window_maximized(hwnd):
+            ctypes.windll.user32.ShowWindow(hwnd, SW_RESTORE)
+            return False
+        else:
+            ctypes.windll.user32.ShowWindow(hwnd, SW_MAXIMIZE)
+            return True
+    except Exception:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Launcher-registered state. Mirrors the pattern used elsewhere in
+# server.py: the desktop launcher fills these in after creating the
+# window, and FastAPI handlers read them on demand. Plain-browser dev
+# mode leaves them at their defaults.
+# ---------------------------------------------------------------------------
+
+# True when the main window was created with frameless=True. The React
+# shell uses this to decide whether to render its own min/max/close
+# buttons; the OS draws the buttons otherwise.
+_frameless: bool = False
+
+# Callable returning the platform-specific HWND / NSWindow handle for
+# the *currently-focused* window we should target. The desktop launcher
+# wires this to a closure that resolves through `find_pywebview_hwnd`
+# every call — the HWND is stable for a given pywebview window but
+# changes if we ever spawn additional windows; resolving lazily keeps
+# us from caching a stale handle.
+_hwnd_provider: Optional["object"] = None  # type: ignore[type-arg]
+
+# Window-method callbacks. Each is None when we're running outside the
+# desktop launcher (plain-browser dev mode) — the FastAPI endpoints
+# return {ok: false, reason: "no launcher"} in that case.
+_minimize_callback: Optional["object"] = None  # type: ignore[type-arg]
+_close_callback: Optional["object"] = None  # type: ignore[type-arg]
+
+
+def configure(
+    *,
+    frameless: bool,
+    hwnd_provider: Optional["object"] = None,  # type: ignore[type-arg]
+    on_minimize: Optional["object"] = None,  # type: ignore[type-arg]
+    on_close: Optional["object"] = None,  # type: ignore[type-arg]
+) -> None:
+    """Called once from the desktop launcher right after window
+    creation. After this returns the FastAPI window-control endpoints
+    are live."""
+    global _frameless, _hwnd_provider, _minimize_callback, _close_callback
+    _frameless = bool(frameless)
+    _hwnd_provider = hwnd_provider
+    _minimize_callback = on_minimize
+    _close_callback = on_close
+
+
+def info() -> dict:
+    """Snapshot of current chrome state for the React shell. `platform`
+    is the value `sys.platform` returns ("win32", "darwin", "linux");
+    the React side maps it to its own constants. `frameless` decides
+    whether the shell renders its own buttons. `maximized` is only
+    meaningful when `platform == "win32"` and `frameless` is True."""
+    hwnd: int = 0
+    if _hwnd_provider is not None:
+        try:
+            value = _hwnd_provider()
+            if isinstance(value, int):
+                hwnd = value
+        except Exception:
+            hwnd = 0
+    return {
+        "platform": sys.platform,
+        "frameless": _frameless,
+        "maximized": is_window_maximized(hwnd) if hwnd else False,
+        "launcher": _minimize_callback is not None,
+    }
+
+
+def minimize() -> bool:
+    """Trigger pywebview's `window.minimize()` on the GUI thread.
+    Returns False if no launcher is registered (plain-browser dev)."""
+    if _minimize_callback is None:
+        return False
+    try:
+        _minimize_callback()
+        return True
+    except Exception:
+        return False
+
+
+def maximize_toggle() -> bool:
+    """Toggle the underlying HWND between maximized and restored.
+    Returns the new maximized state, or False if unavailable."""
+    if _hwnd_provider is None:
+        return False
+    try:
+        hwnd = _hwnd_provider()
+        if not isinstance(hwnd, int) or not hwnd:
+            return False
+        return toggle_maximize(hwnd)
+    except Exception:
+        return False
+
+
+def close() -> bool:
+    """Trigger the window's close path. On Windows this fires
+    pywebview's `closing` event, which our `_on_closing` handler
+    converts to hide-to-tray when the tray is up — matching the
+    behavior of the OS-drawn close button."""
+    if _close_callback is None:
+        return False
+    try:
+        _close_callback()
+        return True
+    except Exception:
+        return False

--- a/desktop.py
+++ b/desktop.py
@@ -504,6 +504,17 @@ def main(argv: Optional[list[str]] = None) -> int:
     except Exception:
         start_hidden = False
 
+    # On Windows we suppress the OS-drawn caption (min/max/close) and
+    # let the React shell paint its own integrated titlebar — same
+    # pattern as VS Code, Discord, Spotify. macOS keeps the native
+    # traffic lights (re-implementing them faithfully is a tar pit and
+    # Mac users have strong muscle memory for their position and
+    # behavior); the existing transparent-titlebar tinting in
+    # window_chrome.py already blends them into the app body. Linux
+    # stays untouched — GTK CSD theming varies too much across distros
+    # to do reliably.
+    use_frameless = sys.platform == "win32"
+
     window = webview.create_window(
         "Tideway",
         f"http://{HOST}:{PORT}/",
@@ -511,6 +522,12 @@ def main(argv: Optional[list[str]] = None) -> int:
         height=800,
         min_size=(800, 600),
         hidden=start_hidden,
+        frameless=use_frameless,
+        # easy_drag would make every mousedown try to drag the window,
+        # which breaks button clicks and feels laggy. We declare drag
+        # regions explicitly via CSS `-webkit-app-region: drag` on the
+        # React titlebar instead.
+        easy_drag=False,
     )
 
     # --- Hide-on-close + tray wiring ---------------------------------
@@ -1106,6 +1123,53 @@ def main(argv: Optional[list[str]] = None) -> int:
     # Register the mini-player callback so the in-app "Open mini
     # player" control can spawn a second pywebview window.
     _server.register_mini_player_callback(_open_mini_player)
+
+    # Register the integrated-titlebar control callbacks. The React
+    # shell calls /api/_internal/window/{info,minimize,maximize,close}
+    # to drive a custom titlebar when the OS chrome is suppressed
+    # (Windows frameless mode). On macOS the React shell reads /info
+    # to learn the platform, then defers to the native traffic lights
+    # — minimize/close still wire up so a future Linux/in-app menu can
+    # reach them, but maximize_toggle is a Windows-only HWND ShowWindow
+    # call.
+    try:
+        from app import window_chrome as _window_chrome
+        from app import window_controls as _window_controls
+
+        def _close_via_chrome() -> None:
+            # Equivalent to clicking the OS red-X. pywebview's
+            # `closing` event handler intercepts and either hides the
+            # window to tray or lets it close, depending on tray
+            # availability — so the in-app close button matches the
+            # native one's behavior in either configuration.
+            try:
+                window.destroy()
+            except Exception:
+                pass
+
+        def _hwnd_provider() -> int:
+            try:
+                hwnd = _window_chrome.find_pywebview_hwnd(window)
+                return int(hwnd) if hwnd else 0
+            except Exception:
+                return 0
+
+        _window_controls.configure(
+            frameless=use_frameless,
+            hwnd_provider=_hwnd_provider,
+            on_minimize=lambda: window.minimize(),
+            on_close=_close_via_chrome,
+        )
+    except Exception as exc:
+        # window_controls registration is decorative — failing here
+        # leaves the React titlebar without working buttons but the
+        # rest of the app intact. Log so a packaged build can be
+        # diagnosed via the captured uvicorn output.
+        print(
+            f"[desktop] window_controls registration failed: {exc!r}",
+            file=sys.stderr,
+            flush=True,
+        )
     # Register the in-app login callback so the frontend can kick off
     # the PKCE flow without the user having to copy the Oops URL.
     # macOS has two complications the other platforms don't:

--- a/desktop.py
+++ b/desktop.py
@@ -1288,13 +1288,13 @@ def main(argv: Optional[list[str]] = None) -> int:
                             return
                         _window_chrome.register_windows_hwnd(hwnd)
                         # When the launcher created the window
-                        # frameless (Windows VS-Code-style chrome), the
-                        # OS no longer hands us drag or resize. Hook
-                        # WM_NCHITTEST + WM_NCCALCSIZE so the React
-                        # titlebar zone behaves like a native caption
-                        # row and the window edges accept resize.
+                        # frameless (Windows VS-Code-style chrome),
+                        # add WS_THICKFRAME back so the OS can run
+                        # native edge resize. Drag is handled by the
+                        # React titlebar calling /start_drag —
+                        # see window_controls.start_window_drag.
                         if use_frameless:
-                            _window_controls_mod.install_native_hit_test(hwnd)
+                            _window_controls_mod.enable_native_resize(hwnd)
                     except Exception:
                         # Anything in the lookup or DWM call going wrong
                         # leaves the OS-default titlebar — visible but

--- a/desktop.py
+++ b/desktop.py
@@ -1289,12 +1289,16 @@ def main(argv: Optional[list[str]] = None) -> int:
                         _window_chrome.register_windows_hwnd(hwnd)
                         # When the launcher created the window
                         # frameless (Windows VS-Code-style chrome),
-                        # add WS_THICKFRAME back so the OS can run
-                        # native edge resize. Drag is handled by the
-                        # React titlebar calling /start_drag —
-                        # see window_controls.start_window_drag.
+                        # add WS_THICKFRAME back so the OS runs
+                        # native edge resize, and subclass the
+                        # WindowProc on the GUI thread so later
+                        # drag/resize triggers from worker threads
+                        # land on the right thread for ReleaseCapture
+                        # to actually release the WebView2 child's
+                        # mouse capture.
                         if use_frameless:
                             _window_controls_mod.enable_native_resize(hwnd)
+                            _window_controls_mod.ensure_wndproc_subclass(hwnd)
                     except Exception:
                         # Anything in the lookup or DWM call going wrong
                         # leaves the OS-default titlebar — visible but

--- a/desktop.py
+++ b/desktop.py
@@ -1279,12 +1279,22 @@ def main(argv: Optional[list[str]] = None) -> int:
         if sys.platform == "win32":
             try:
                 from app import window_chrome as _window_chrome
+                from app import window_controls as _window_controls_mod
 
                 def _on_shown_tint() -> None:
                     try:
                         hwnd = _window_chrome.find_pywebview_hwnd(window)
-                        if hwnd:
-                            _window_chrome.register_windows_hwnd(hwnd)
+                        if not hwnd:
+                            return
+                        _window_chrome.register_windows_hwnd(hwnd)
+                        # When the launcher created the window
+                        # frameless (Windows VS-Code-style chrome), the
+                        # OS no longer hands us drag or resize. Hook
+                        # WM_NCHITTEST + WM_NCCALCSIZE so the React
+                        # titlebar zone behaves like a native caption
+                        # row and the window edges accept resize.
+                        if use_frameless:
+                            _window_controls_mod.install_native_hit_test(hwnd)
                     except Exception:
                         # Anything in the lookup or DWM call going wrong
                         # leaves the OS-default titlebar — visible but

--- a/server.py
+++ b/server.py
@@ -2053,6 +2053,24 @@ def window_close(request: Request) -> dict:
         return {"ok": False, "reason": f"{type(exc).__name__}: {exc}"}
 
 
+@app.post("/api/_internal/window/start_drag", include_in_schema=False)
+def window_start_drag(request: Request) -> dict:
+    """Hand the window over to the OS's native move loop. The React
+    titlebar fires this on mousedown so the user can drag the window
+    by its custom-drawn caption row — WebView2 doesn't honor
+    `-webkit-app-region: drag` and the WebView2 child window
+    swallows the mousedown that would otherwise reach a parent-
+    window WM_NCHITTEST handler, so we route through this endpoint
+    and let Win32 take over."""
+    _ensure_loopback(request)
+    try:
+        from app import window_controls
+        ok = window_controls.start_window_drag()
+        return {"ok": ok}
+    except Exception as exc:
+        return {"ok": False, "reason": f"{type(exc).__name__}: {exc}"}
+
+
 class _NotifyRequest(BaseModel):
     title: str
     body: str

--- a/server.py
+++ b/server.py
@@ -1983,6 +1983,76 @@ def open_mini_player(request: Request) -> dict:
         return {"ok": False, "reason": str(exc)}
 
 
+# ---------------------------------------------------------------------------
+# Window controls — minimize / maximize / close from the React titlebar.
+# Only relevant on Windows where the main window is created with
+# frameless=True and the OS no longer draws those buttons. macOS keeps
+# the native traffic lights, so the React shell skips its own controls
+# but still calls /info to learn the platform.
+# ---------------------------------------------------------------------------
+
+
+def _ensure_loopback(request: Request) -> None:
+    """Reject anything that didn't come from this machine. Window
+    controls are an internal UI hook; nothing on the LAN should be able
+    to minimize or close someone's app."""
+    client = request.client
+    host = client.host if client else ""
+    if host not in ("127.0.0.1", "::1", "localhost"):
+        raise HTTPException(status_code=403)
+
+
+@app.get("/api/_internal/window/info", include_in_schema=False)
+def window_info(request: Request) -> dict:
+    """Tell the React shell what kind of chrome to render: platform,
+    whether the OS chrome was suppressed (frameless), and the current
+    maximized state (so the middle button shows the right icon)."""
+    _ensure_loopback(request)
+    try:
+        from app import window_controls
+        return {"ok": True, **window_controls.info()}
+    except Exception as exc:
+        return {"ok": False, "reason": f"{type(exc).__name__}: {exc}"}
+
+
+@app.post("/api/_internal/window/minimize", include_in_schema=False)
+def window_minimize(request: Request) -> dict:
+    _ensure_loopback(request)
+    try:
+        from app import window_controls
+        ok = window_controls.minimize()
+        return {"ok": ok}
+    except Exception as exc:
+        return {"ok": False, "reason": f"{type(exc).__name__}: {exc}"}
+
+
+@app.post("/api/_internal/window/maximize", include_in_schema=False)
+def window_maximize(request: Request) -> dict:
+    """Toggle maximize/restore on Windows. Returns the new maximized
+    state so the React side can flip its icon without re-polling."""
+    _ensure_loopback(request)
+    try:
+        from app import window_controls
+        maximized = window_controls.maximize_toggle()
+        return {"ok": True, "maximized": maximized}
+    except Exception as exc:
+        return {"ok": False, "reason": f"{type(exc).__name__}: {exc}"}
+
+
+@app.post("/api/_internal/window/close", include_in_schema=False)
+def window_close(request: Request) -> dict:
+    """Trigger the window's close path. Goes through pywebview's
+    `closing` event, so close-to-tray (when the tray is up) takes over
+    from here exactly as it does for the native red-X."""
+    _ensure_loopback(request)
+    try:
+        from app import window_controls
+        ok = window_controls.close()
+        return {"ok": ok}
+    except Exception as exc:
+        return {"ok": False, "reason": f"{type(exc).__name__}: {exc}"}
+
+
 class _NotifyRequest(BaseModel):
     title: str
     body: str

--- a/server.py
+++ b/server.py
@@ -2071,6 +2071,30 @@ def window_start_drag(request: Request) -> dict:
         return {"ok": False, "reason": f"{type(exc).__name__}: {exc}"}
 
 
+class _WindowResizeRequest(BaseModel):
+    direction: str  # left | right | top | bottom | topleft | topright | bottomleft | bottomright
+
+
+@app.post("/api/_internal/window/start_resize", include_in_schema=False)
+def window_start_resize(req: _WindowResizeRequest, request: Request) -> dict:
+    """Hand the window over to the OS's native resize loop in the
+    given direction. The React shell adds invisible 6px-wide hit
+    strips along each edge and a corner — mousedown on one of those
+    fires this with the matching direction string, and Win32's
+    DefWindowProc runs SC_SIZE from the cursor position the same
+    way it would for a real OS-drawn resize border. WS_THICKFRAME
+    is restored on the top-level window so the OS recognises us as
+    resizable, but we still drive the start-of-drag from JS because
+    the WebView2 child covers the would-be NC resize zones."""
+    _ensure_loopback(request)
+    try:
+        from app import window_controls
+        ok = window_controls.start_window_resize(req.direction)
+        return {"ok": ok}
+    except Exception as exc:
+        return {"ok": False, "reason": f"{type(exc).__name__}: {exc}"}
+
+
 class _NotifyRequest(BaseModel):
     title: str
     body: str

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -10,6 +10,7 @@ import { Loader2 } from "lucide-react";
 import { Sidebar } from "@/components/Sidebar";
 import { NavBar } from "@/components/NavBar";
 import { WindowTitlebar } from "@/components/WindowTitlebar";
+import { WindowResizeEdges } from "@/components/WindowResizeEdges";
 import { OfflineBanner } from "@/components/OfflineBanner";
 import { TidalBackoffBanner } from "@/components/TidalBackoffBanner";
 import { UpdateBanner } from "@/components/UpdateBanner";
@@ -183,6 +184,7 @@ export default function App() {
                             <div className="flex min-h-0 flex-1 flex-col">
                               <AppInner />
                             </div>
+                            <WindowResizeEdges />
                           </div>
                         </VideoDownloadsProvider>
                       </RecentsProvider>

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -9,6 +9,7 @@ import {
 import { Loader2 } from "lucide-react";
 import { Sidebar } from "@/components/Sidebar";
 import { NavBar } from "@/components/NavBar";
+import { WindowTitlebar } from "@/components/WindowTitlebar";
 import { OfflineBanner } from "@/components/OfflineBanner";
 import { TidalBackoffBanner } from "@/components/TidalBackoffBanner";
 import { UpdateBanner } from "@/components/UpdateBanner";
@@ -158,6 +159,13 @@ export default function App() {
   // its initial render). ToastProvider sits above it so the fallback
   // doesn't try to emit a toast into nothing if some rarely-hit
   // cleanup path throws.
+  //
+  // The outermost flex column reserves the top row for the
+  // integrated window chrome (custom min/max/close on Windows; an
+  // empty 28px spacer on macOS where the native traffic lights live;
+  // nothing in plain-browser dev mode). Everything below that runs
+  // in `flex-1 min-h-0` so the existing layouts can keep using
+  // `h-full` to fill their slot.
   return (
     <ToastProvider>
       <ErrorBoundary fullScreen>
@@ -170,7 +178,12 @@ export default function App() {
                     <MyPlaylistsProvider>
                       <RecentsProvider>
                         <VideoDownloadsProvider>
-                          <AppInner />
+                          <div className="flex h-screen flex-col bg-background">
+                            <WindowTitlebar />
+                            <div className="flex min-h-0 flex-1 flex-col">
+                              <AppInner />
+                            </div>
+                          </div>
                         </VideoDownloadsProvider>
                       </RecentsProvider>
                     </MyPlaylistsProvider>
@@ -194,7 +207,7 @@ function AppInner() {
   // straight in offline mode.
   if (auth.loading || offline === null) {
     return (
-      <div className="flex h-screen items-center justify-center text-muted-foreground">
+      <div className="flex flex-1 items-center justify-center text-muted-foreground">
         <Loader2 className="h-5 w-5 animate-spin" />
       </div>
     );
@@ -453,7 +466,7 @@ function Shell({
   );
 
   return (
-    <div className="flex h-screen flex-col bg-background">
+    <div className="flex h-full flex-col bg-background">
       <div className="flex min-h-0 flex-1 gap-2 p-2 pb-0">
         <Sidebar
           // Active count = music + video jobs currently downloading.

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -185,10 +185,29 @@ export const api = {
     /** Start a native drag from the cursor's current position. The
      *  React titlebar calls this on mousedown — WebView2 ignores
      *  `app-region: drag`, so we route through Win32's move loop
-     *  via SendMessage(WM_SYSCOMMAND, SC_MOVE) on the backend. */
+     *  via PostMessage(WM_NCLBUTTONDOWN, HTCAPTION) on the backend. */
     startDrag: () =>
       req<{ ok: boolean }>("/api/_internal/window/start_drag", {
         method: "POST",
+      }),
+    /** Start a native resize loop in the given direction. Invisible
+     *  edge / corner hit strips on the React shell fire this on
+     *  mousedown — WS_THICKFRAME alone isn't enough because the
+     *  WebView2 child covers the NC resize zones. */
+    startResize: (
+      direction:
+        | "left"
+        | "right"
+        | "top"
+        | "bottom"
+        | "topleft"
+        | "topright"
+        | "bottomleft"
+        | "bottomright",
+    ) =>
+      req<{ ok: boolean }>("/api/_internal/window/start_resize", {
+        method: "POST",
+        body: JSON.stringify({ direction }),
       }),
   },
   /** Fire an OS-native notification. The frontend owns the decision

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -157,6 +157,32 @@ export const api = {
     req<{ ok: boolean; reason?: string }>("/api/_internal/mini_player", {
       method: "POST",
     }),
+  /** Integrated window chrome — drives the React-rendered titlebar on
+   *  Windows where the native min/max/close buttons are suppressed.
+   *  `info` is fetched once on mount; the action endpoints reach the
+   *  pywebview window via callbacks registered by desktop.py. */
+  window: {
+    info: () =>
+      req<{
+        ok: boolean;
+        platform?: "win32" | "darwin" | "linux" | string;
+        frameless?: boolean;
+        maximized?: boolean;
+        launcher?: boolean;
+        reason?: string;
+      }>("/api/_internal/window/info").catch(() => ({ ok: false as const })),
+    minimize: () =>
+      req<{ ok: boolean }>("/api/_internal/window/minimize", {
+        method: "POST",
+      }),
+    maximize: () =>
+      req<{ ok: boolean; maximized?: boolean }>(
+        "/api/_internal/window/maximize",
+        { method: "POST" },
+      ),
+    close: () =>
+      req<{ ok: boolean }>("/api/_internal/window/close", { method: "POST" }),
+  },
   /** Fire an OS-native notification. The frontend owns the decision
    *  of when to call this (only when window unfocused + pref enabled)
    *  because it has the full context. */

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -182,6 +182,14 @@ export const api = {
       ),
     close: () =>
       req<{ ok: boolean }>("/api/_internal/window/close", { method: "POST" }),
+    /** Start a native drag from the cursor's current position. The
+     *  React titlebar calls this on mousedown — WebView2 ignores
+     *  `app-region: drag`, so we route through Win32's move loop
+     *  via SendMessage(WM_SYSCOMMAND, SC_MOVE) on the backend. */
+    startDrag: () =>
+      req<{ ok: boolean }>("/api/_internal/window/start_drag", {
+        method: "POST",
+      }),
   },
   /** Fire an OS-native notification. The frontend owns the decision
    *  of when to call this (only when window unfocused + pref enabled)

--- a/web/src/components/WindowResizeEdges.tsx
+++ b/web/src/components/WindowResizeEdges.tsx
@@ -1,0 +1,178 @@
+import { useEffect, useState } from "react";
+import { api } from "@/api/client";
+
+/**
+ * Eight invisible hit strips around the window edge that translate a
+ * mousedown into a native resize. Required because the WebView2 child
+ * window covers the entire client area, so WS_THICKFRAME's resize
+ * zones never reach the user — we paint our own zones in HTML, then
+ * route the click through to Win32's SC_SIZE handler on the backend.
+ *
+ * Only renders on Windows + frameless. Plain browser, macOS, and
+ * Linux all leave resize to the OS.
+ *
+ * Edge thickness is 6 CSS px; corner zones are 12 CSS px square so
+ * cursor diagonal-resize hover is forgiving. Z-index sits above the
+ * page body but below modals (`fixed` + `z-50` matches the existing
+ * sidebar/modal stack — we never want the strips eating clicks on
+ * a dialog backdrop).
+ */
+
+type Direction =
+  | "left"
+  | "right"
+  | "top"
+  | "bottom"
+  | "topleft"
+  | "topright"
+  | "bottomleft"
+  | "bottomright";
+
+interface ChromeInfo {
+  platform: string;
+  frameless: boolean;
+}
+
+const EDGE_PX = 6;
+const CORNER_PX = 12;
+
+export function WindowResizeEdges() {
+  const [info, setInfo] = useState<ChromeInfo>({
+    platform: "browser",
+    frameless: false,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    api.window
+      .info()
+      .then((res) => {
+        if (cancelled) return;
+        if (!res || !("ok" in res) || !res.ok) return;
+        setInfo({
+          platform: res.platform ?? "browser",
+          frameless: !!res.frameless,
+        });
+      })
+      .catch(() => {
+        /* dev mode / no launcher — leave defaults */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (info.platform !== "win32" || !info.frameless) return null;
+
+  const start = (dir: Direction) => (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return;
+    e.preventDefault();
+    e.stopPropagation();
+    api.window.startResize(dir).catch(() => {});
+  };
+
+  // Common style fragment for an edge strip: pointer events on, no
+  // background paint, `select-none` so click+drag can't accidentally
+  // start a text selection. Cursor hints come from each direction.
+  const baseEdge: React.CSSProperties = {
+    position: "fixed",
+    pointerEvents: "auto",
+    zIndex: 50,
+  };
+
+  return (
+    <>
+      {/* Edges */}
+      <div
+        onMouseDown={start("top")}
+        style={{
+          ...baseEdge,
+          top: 0,
+          left: CORNER_PX,
+          right: CORNER_PX,
+          height: EDGE_PX,
+          cursor: "ns-resize",
+        }}
+      />
+      <div
+        onMouseDown={start("bottom")}
+        style={{
+          ...baseEdge,
+          bottom: 0,
+          left: CORNER_PX,
+          right: CORNER_PX,
+          height: EDGE_PX,
+          cursor: "ns-resize",
+        }}
+      />
+      <div
+        onMouseDown={start("left")}
+        style={{
+          ...baseEdge,
+          left: 0,
+          top: CORNER_PX,
+          bottom: CORNER_PX,
+          width: EDGE_PX,
+          cursor: "ew-resize",
+        }}
+      />
+      <div
+        onMouseDown={start("right")}
+        style={{
+          ...baseEdge,
+          right: 0,
+          top: CORNER_PX,
+          bottom: CORNER_PX,
+          width: EDGE_PX,
+          cursor: "ew-resize",
+        }}
+      />
+      {/* Corners — slightly larger square so diagonal hover is easier
+          to grab than the 6px edge strip alone allows. */}
+      <div
+        onMouseDown={start("topleft")}
+        style={{
+          ...baseEdge,
+          top: 0,
+          left: 0,
+          width: CORNER_PX,
+          height: CORNER_PX,
+          cursor: "nwse-resize",
+        }}
+      />
+      <div
+        onMouseDown={start("topright")}
+        style={{
+          ...baseEdge,
+          top: 0,
+          right: 0,
+          width: CORNER_PX,
+          height: CORNER_PX,
+          cursor: "nesw-resize",
+        }}
+      />
+      <div
+        onMouseDown={start("bottomleft")}
+        style={{
+          ...baseEdge,
+          bottom: 0,
+          left: 0,
+          width: CORNER_PX,
+          height: CORNER_PX,
+          cursor: "nesw-resize",
+        }}
+      />
+      <div
+        onMouseDown={start("bottomright")}
+        style={{
+          ...baseEdge,
+          bottom: 0,
+          right: 0,
+          width: CORNER_PX,
+          height: CORNER_PX,
+          cursor: "nwse-resize",
+        }}
+      />
+    </>
+  );
+}

--- a/web/src/components/WindowTitlebar.tsx
+++ b/web/src/components/WindowTitlebar.tsx
@@ -1,0 +1,294 @@
+import { useEffect, useState } from "react";
+import { api } from "@/api/client";
+
+/**
+ * Custom-drawn window chrome for the desktop shell.
+ *
+ * On Windows the launcher creates the pywebview window with
+ * `frameless=True`, so the OS no longer paints a caption row with
+ * minimize / maximize / close. This component draws those buttons in
+ * HTML and routes their clicks through `/api/_internal/window/*` back
+ * to the pywebview window.
+ *
+ * On macOS we keep the native traffic-light buttons (Mac users have
+ * strong muscle memory for their position and behavior, and the
+ * existing transparent-titlebar tinting in app/window_chrome.py
+ * already blends them into the app body). This component still
+ * renders, but only as a 28-pixel spacer that reserves room for the
+ * traffic lights and provides empty drag space — the underlying
+ * NSWindow titlebar zone handles dragging natively.
+ *
+ * Plain browser dev mode and Linux render nothing.
+ *
+ * Drag region: WebView2 (Windows) honors CSS `app-region: drag`.
+ * WKWebView (macOS) does NOT, but doesn't need to — the native
+ * NSWindow titlebar covers the same screen rectangle and is
+ * draggable on its own. So `app-region: drag` is conditionally set
+ * for Windows only.
+ */
+
+type Platform = "win32" | "darwin" | "linux" | "browser";
+
+interface ChromeInfo {
+  platform: Platform;
+  frameless: boolean;
+  maximized: boolean;
+}
+
+const DEFAULT_INFO: ChromeInfo = {
+  platform: "browser",
+  frameless: false,
+  maximized: false,
+};
+
+/** Infer platform without a backend round-trip so first paint can
+ *  reserve space immediately on macOS (avoiding a flash of content
+ *  under the traffic lights). The /info endpoint refines this once
+ *  it resolves. */
+function inferPlatformFromUA(): Platform {
+  if (typeof navigator === "undefined") return "browser";
+  const ua = navigator.userAgent.toLowerCase();
+  if (ua.includes("windows")) return "win32";
+  if (ua.includes("mac os") || ua.includes("macintosh")) return "darwin";
+  if (ua.includes("linux")) return "linux";
+  return "browser";
+}
+
+export function WindowTitlebar() {
+  const [info, setInfo] = useState<ChromeInfo>(() => ({
+    ...DEFAULT_INFO,
+    platform: inferPlatformFromUA(),
+  }));
+
+  useEffect(() => {
+    let cancelled = false;
+    api.window
+      .info()
+      .then((res) => {
+        if (cancelled) return;
+        if (!res || !("ok" in res) || !res.ok) return;
+        setInfo({
+          platform: (res.platform as Platform) ?? "browser",
+          frameless: !!res.frameless,
+          maximized: !!res.maximized,
+        });
+      })
+      .catch(() => {
+        /* dev mode without launcher — leave UA-based default */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Track maximized state on Windows via window-resize heuristics.
+  // This catches state changes the user makes outside our buttons:
+  // Win+Up, drag-to-edge snap, double-click on the drag region.
+  // outerWidth/outerHeight match availWidth/availHeight when
+  // maximized; we accept a 2px slack for DPI-rounding edge cases.
+  useEffect(() => {
+    if (info.platform !== "win32" || !info.frameless) return;
+    const check = () => {
+      const w = window.outerWidth;
+      const h = window.outerHeight;
+      const sw = window.screen.availWidth;
+      const sh = window.screen.availHeight;
+      const isMax = Math.abs(w - sw) <= 2 && Math.abs(h - sh) <= 2;
+      setInfo((prev) =>
+        prev.maximized === isMax ? prev : { ...prev, maximized: isMax },
+      );
+    };
+    check();
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
+  }, [info.platform, info.frameless]);
+
+  // Hide entirely on Linux (no integrated chrome there) and in plain
+  // browser dev mode — the OS / browser already provides everything.
+  if (info.platform === "linux" || info.platform === "browser") {
+    return null;
+  }
+
+  // macOS: empty spacer reserving the traffic-light zone. 28px is the
+  // standard Cocoa titlebar height; the buttons sit ~7px from the
+  // left edge and span ~70px in total. We leave the row blank — the
+  // NSWindow titlebar underneath handles dragging on its own.
+  if (info.platform === "darwin") {
+    return (
+      <div
+        className="select-none bg-background"
+        style={{ height: 28 }}
+        aria-hidden="true"
+      />
+    );
+  }
+
+  // The mini-player window is created with frameless=False (it's a
+  // tiny floating panel where the native chrome is the right call —
+  // users expect to be able to drag and close it through the OS).
+  // The /info endpoint reports the *main* window's frameless flag,
+  // so we have to detect the mini route ourselves and skip our
+  // controls when this React tree is hosted in the mini window.
+  const isMiniRoute =
+    typeof window !== "undefined" &&
+    window.location.pathname.startsWith("/mini");
+
+  // Windows: full custom titlebar with min / max / close on the right
+  // and a draggable region taking the rest. Only render the controls
+  // when the window is actually frameless and this isn't the mini
+  // player — otherwise the OS still owns the caption row and a
+  // second set of buttons would be confusing.
+  if (info.platform === "win32" && (!info.frameless || isMiniRoute)) {
+    return null;
+  }
+
+  return (
+    <div
+      className="flex select-none items-center bg-background text-foreground"
+      style={{
+        height: 32,
+        // app-region is honored by WebView2 (Chromium). Anything
+        // inside this drag region behaves like a native caption row —
+        // including double-click to maximize and drag-to-edge for snap.
+        WebkitAppRegion: "drag",
+      }}
+    >
+      <div className="flex items-center gap-2 pl-3 text-xs font-medium opacity-70">
+        Tideway
+      </div>
+      <div className="flex-1" />
+      <div className="flex h-full" style={{ WebkitAppRegion: "no-drag" }}>
+        <TitlebarButton
+          ariaLabel="Minimize"
+          onClick={() => {
+            api.window.minimize().catch(() => {});
+          }}
+        >
+          <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+            <line
+              x1="0"
+              y1="5.5"
+              x2="10"
+              y2="5.5"
+              stroke="currentColor"
+              strokeWidth="1"
+            />
+          </svg>
+        </TitlebarButton>
+        <TitlebarButton
+          ariaLabel={info.maximized ? "Restore" : "Maximize"}
+          onClick={() => {
+            api.window
+              .maximize()
+              .then((res) => {
+                if (typeof res.maximized === "boolean") {
+                  setInfo((prev) => ({ ...prev, maximized: res.maximized! }));
+                }
+              })
+              .catch(() => {});
+          }}
+        >
+          {info.maximized ? <RestoreIcon /> : <MaximizeIcon />}
+        </TitlebarButton>
+        <TitlebarButton
+          ariaLabel="Close"
+          danger
+          onClick={() => {
+            api.window.close().catch(() => {});
+          }}
+        >
+          <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+            <line
+              x1="0.5"
+              y1="0.5"
+              x2="9.5"
+              y2="9.5"
+              stroke="currentColor"
+              strokeWidth="1"
+            />
+            <line
+              x1="9.5"
+              y1="0.5"
+              x2="0.5"
+              y2="9.5"
+              stroke="currentColor"
+              strokeWidth="1"
+            />
+          </svg>
+        </TitlebarButton>
+      </div>
+    </div>
+  );
+}
+
+function TitlebarButton({
+  children,
+  onClick,
+  ariaLabel,
+  danger = false,
+}: {
+  children: React.ReactNode;
+  onClick: () => void;
+  ariaLabel: string;
+  // Close gets the standard red hover state; min/max get a neutral
+  // tint matching Windows' default chrome.
+  danger?: boolean;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      className={
+        "flex h-full items-center justify-center text-foreground/70 transition-colors hover:text-foreground " +
+        (danger
+          ? "hover:bg-red-600 hover:text-white"
+          : "hover:bg-foreground/10")
+      }
+      style={{ width: 46 }}
+    >
+      {children}
+    </button>
+  );
+}
+
+function MaximizeIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+      <rect
+        x="0.5"
+        y="0.5"
+        width="9"
+        height="9"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+      />
+    </svg>
+  );
+}
+
+function RestoreIcon() {
+  return (
+    <svg width="10" height="10" viewBox="0 0 10 10" aria-hidden="true">
+      <rect
+        x="2.5"
+        y="0.5"
+        width="7"
+        height="7"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1"
+      />
+      <rect
+        x="0.5"
+        y="2.5"
+        width="7"
+        height="7"
+        fill="var(--background, currentColor)"
+        stroke="currentColor"
+        strokeWidth="1"
+      />
+    </svg>
+  );
+}

--- a/web/src/components/WindowTitlebar.tsx
+++ b/web/src/components/WindowTitlebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { api } from "@/api/client";
 
 /**
@@ -59,6 +59,16 @@ export function WindowTitlebar() {
     ...DEFAULT_INFO,
     platform: inferPlatformFromUA(),
   }));
+  // Last-mousedown tracker for manual double-click detection — see
+  // `onTitlebarMouseDown` below for why we can't use React's
+  // built-in onDoubleClick. Lives at the top of the component so
+  // it's called unconditionally on every render, regardless of
+  // which platform branch returns early further down.
+  const lastMouseDownRef = useRef<{ t: number; x: number; y: number }>({
+    t: 0,
+    x: 0,
+    y: 0,
+  });
 
   useEffect(() => {
     let cancelled = false;
@@ -145,31 +155,42 @@ export function WindowTitlebar() {
   // Drag handler. WebView2 silently ignores `-webkit-app-region: drag`
   // (it's a Chromium-Apps feature, not stock Chromium), so on
   // mousedown we hand off to a backend endpoint that runs Win32's
-  // move loop directly. Skip when the click target is inside a
-  // button — those nest in the titlebar div but should fire their
-  // onClick instead of starting a drag — and skip non-primary
-  // buttons so right-click / middle-click can still bubble for
-  // future system-menu wiring.
+  // move loop directly. Once the OS enters that loop it swallows
+  // the matching mouseup before the browser sees it, which means
+  // React's onDoubleClick never fires — the second mousedown looks
+  // like a brand-new first click. Detect double-click manually by
+  // tracking the last mousedown timestamp + position; on the second
+  // mousedown within ~500 ms and within a few pixels, route to
+  // maximize instead of drag. Same threshold the OS uses for its
+  // own caption double-click.
+  const DOUBLE_CLICK_MS = 500;
+  const DOUBLE_CLICK_PX = 4;
   const onTitlebarMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.button !== 0) return;
     const target = e.target as HTMLElement;
     if (target.closest("button")) return;
     e.preventDefault();
+    const now = performance.now();
+    const last = lastMouseDownRef.current;
+    const isDoubleClick =
+      now - last.t < DOUBLE_CLICK_MS &&
+      Math.abs(e.clientX - last.x) <= DOUBLE_CLICK_PX &&
+      Math.abs(e.clientY - last.y) <= DOUBLE_CLICK_PX;
+    lastMouseDownRef.current = { t: now, x: e.clientX, y: e.clientY };
+    if (isDoubleClick) {
+      // Reset so a third quick click doesn't double-toggle.
+      lastMouseDownRef.current = { t: 0, x: 0, y: 0 };
+      api.window
+        .maximize()
+        .then((res) => {
+          if (typeof res.maximized === "boolean") {
+            setInfo((prev) => ({ ...prev, maximized: res.maximized! }));
+          }
+        })
+        .catch(() => {});
+      return;
+    }
     api.window.startDrag().catch(() => {});
-  };
-  // Double-click toggles maximize, matching the OS-drawn title bar's
-  // behavior. Same target filter as drag.
-  const onTitlebarDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    const target = e.target as HTMLElement;
-    if (target.closest("button")) return;
-    api.window
-      .maximize()
-      .then((res) => {
-        if (typeof res.maximized === "boolean") {
-          setInfo((prev) => ({ ...prev, maximized: res.maximized! }));
-        }
-      })
-      .catch(() => {});
   };
 
   return (
@@ -177,7 +198,6 @@ export function WindowTitlebar() {
       className="flex select-none items-center bg-background text-foreground"
       style={{ height: 32 }}
       onMouseDown={onTitlebarMouseDown}
-      onDoubleClick={onTitlebarDoubleClick}
     >
       <div className="flex items-center gap-2 pl-3 text-xs font-medium opacity-70">
         Tideway

--- a/web/src/components/WindowTitlebar.tsx
+++ b/web/src/components/WindowTitlebar.tsx
@@ -142,22 +142,48 @@ export function WindowTitlebar() {
     return null;
   }
 
+  // Drag handler. WebView2 silently ignores `-webkit-app-region: drag`
+  // (it's a Chromium-Apps feature, not stock Chromium), so on
+  // mousedown we hand off to a backend endpoint that runs Win32's
+  // move loop directly. Skip when the click target is inside a
+  // button — those nest in the titlebar div but should fire their
+  // onClick instead of starting a drag — and skip non-primary
+  // buttons so right-click / middle-click can still bubble for
+  // future system-menu wiring.
+  const onTitlebarMouseDown = (e: React.MouseEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return;
+    const target = e.target as HTMLElement;
+    if (target.closest("button")) return;
+    e.preventDefault();
+    api.window.startDrag().catch(() => {});
+  };
+  // Double-click toggles maximize, matching the OS-drawn title bar's
+  // behavior. Same target filter as drag.
+  const onTitlebarDoubleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    if (target.closest("button")) return;
+    api.window
+      .maximize()
+      .then((res) => {
+        if (typeof res.maximized === "boolean") {
+          setInfo((prev) => ({ ...prev, maximized: res.maximized! }));
+        }
+      })
+      .catch(() => {});
+  };
+
   return (
     <div
       className="flex select-none items-center bg-background text-foreground"
-      style={{
-        height: 32,
-        // app-region is honored by WebView2 (Chromium). Anything
-        // inside this drag region behaves like a native caption row —
-        // including double-click to maximize and drag-to-edge for snap.
-        WebkitAppRegion: "drag",
-      }}
+      style={{ height: 32 }}
+      onMouseDown={onTitlebarMouseDown}
+      onDoubleClick={onTitlebarDoubleClick}
     >
       <div className="flex items-center gap-2 pl-3 text-xs font-medium opacity-70">
         Tideway
       </div>
       <div className="flex-1" />
-      <div className="flex h-full" style={{ WebkitAppRegion: "no-drag" }}>
+      <div className="flex h-full">
         <TitlebarButton
           ariaLabel="Minimize"
           onClick={() => {

--- a/web/src/pages/Login.tsx
+++ b/web/src/pages/Login.tsx
@@ -12,7 +12,7 @@ export function Login({ onLoggedIn }: { onLoggedIn: () => void }) {
   const [mode, setMode] = useState<Mode>("pkce");
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-background p-6">
+    <div className="flex min-h-full flex-1 items-center justify-center bg-background p-6">
       <div className="flex w-full max-w-md flex-col items-center gap-6 rounded-xl border border-border bg-card p-10 shadow-2xl">
         <img src="/app-icon.svg" alt="Tideway" className="h-16 w-16" />
         <div className="text-center">

--- a/web/src/pages/MiniPlayerPage.tsx
+++ b/web/src/pages/MiniPlayerPage.tsx
@@ -30,7 +30,7 @@ export function MiniPlayerPage() {
 
   if (!track) {
     return (
-      <div className="flex h-screen w-screen items-center justify-center bg-[hsl(var(--now-playing-bg))] text-xs text-muted-foreground">
+      <div className="flex h-full w-full flex-1 items-center justify-center bg-[hsl(var(--now-playing-bg))] text-xs text-muted-foreground">
         <Music className="mr-2 h-4 w-4" />
         Nothing playing
       </div>
@@ -42,7 +42,7 @@ export function MiniPlayerPage() {
   const artists = track.artists.map((a) => a.name).join(", ");
 
   return (
-    <div className="flex h-screen w-screen select-none flex-col gap-2 bg-[hsl(var(--now-playing-bg))] px-3 py-2">
+    <div className="flex h-full w-full flex-1 select-none flex-col gap-2 bg-[hsl(var(--now-playing-bg))] px-3 py-2">
       <div className="flex items-center gap-3">
         <div className="h-12 w-12 flex-shrink-0 overflow-hidden rounded bg-secondary">
           {cover ? (

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -7,3 +7,16 @@ interface ImportMetaEnv {
 interface ImportMeta {
   readonly env: ImportMetaEnv;
 }
+
+// app-region (and the -webkit-app-region alias) is a Chromium /
+// WebView2-specific CSS property used to declare drag regions inside
+// frameless windows. The DOM lib doesn't ship typings for it, so we
+// augment React's CSSProperties to allow it on inline `style` props.
+// See: https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-app-region
+import "react";
+declare module "react" {
+  interface CSSProperties {
+    WebkitAppRegion?: "drag" | "no-drag";
+    appRegion?: "drag" | "no-drag";
+  }
+}


### PR DESCRIPTION
## Summary
- Replaces the OS-default titlebar (the band that holds min / max / close) with chrome that reads as part of the app body — the cross-platform standard used by VS Code, Discord, Spotify, Linear.
- **Windows**: frameless pywebview window; React paints its own min / maximize-toggle / close on the right and a `-webkit-app-region: drag` region across the rest. Maximize toggles via Win32 `ShowWindow` because pywebview ≥5 has no `Window.maximize()`. Double-click-to-maximize and drag-to-edge snap work natively because the drag region behaves like a native caption row.
- **macOS**: keeps native traffic-light buttons (Mac muscle memory for their position is strong) and re-uses the existing transparent-titlebar tinting in `window_chrome.py`. React shell reserves a 28-pixel spacer at the top so app content no longer crashes into the traffic-light zone.
- Linux / plain-browser dev render nothing — the OS / browser still owns the chrome there.
- Close routes through pywebview's `closing` event so close-to-tray (when the tray is up) takes over exactly as it does for the native red-X.

## Test plan
- [x] `pytest tests/` (461 passed, 2 skipped)
- [x] `cd web && npx tsc -b --noEmit`
- [x] `cd web && npm test` (vitest, 36 passed)
- [x] `cd web && npx eslint` on touched files
- [x] Smoke-imported `app.window_controls`, `server`, `desktop`
- [ ] Manual sanity sweep on Windows: launch app, confirm custom titlebar paints, drag works, double-click maximizes, min / max / close buttons work, drag-to-edge snap works, alt-F4 still closes
- [ ] Manual sanity sweep on macOS: launch app, confirm traffic lights are visible and unobstructed, native drag from titlebar zone works, no spurious 28px gap below
- [ ] Verify mini-player on both platforms still uses native chrome (frameless=False there)