### PR TITLE
Server split: introduce app/routers/, extract autostart + hotkey + notify (proof-of-concept)

### DIFF
--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,0 +1,22 @@
+"""FastAPI routers, one per domain.
+
+Splitting `server.py`'s 200+ route handlers into per-domain routers
+is a long, mechanical refactor — this package is the destination for
+that work, but each domain moves in its own commit so review stays
+tractable. Each router module:
+
+  - Defines `router = APIRouter()` plus its endpoints.
+  - Imports auth helpers + singletons from `server` lazily inside
+    handlers (top-of-module imports would create a circular import
+    because `server.py` registers each router via `include_router`).
+  - Uses the same path prefixes the original handlers exposed (no
+    breaking changes to URLs).
+
+`server.py` retains:
+  - The FastAPI app instance + middleware + exception handlers.
+  - Module-level singletons (TidalClient, Downloader, settings, etc.)
+    until they migrate to a shared state module.
+  - Auth + loopback helpers (`_require_auth`, `_require_local_access`,
+    `_ensure_loopback`) that routers can import.
+  - The lifespan + startup wiring.
+"""

--- a/app/routers/autostart.py
+++ b/app/routers/autostart.py
@@ -1,0 +1,51 @@
+"""`/api/autostart` — launch-at-login toggle.
+
+Self-contained: the routes delegate everything to `app.autostart`
+(which knows the platform-specific specifics — LaunchAgent on macOS,
+HKCU\\Run on Windows, .desktop file on Linux). The router exists
+mostly to expose the get/set pair under loopback auth.
+
+First domain extracted as part of the gradual server.py → routers/
+split. See `app/routers/__init__.py` for the playbook.
+"""
+from __future__ import annotations
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+
+router = APIRouter(prefix="/api/autostart", tags=["autostart"])
+
+
+class _AutostartRequest(BaseModel):
+    enabled: bool
+
+
+@router.get("")
+def autostart_status() -> dict:
+    """Report whether the app is registered to launch at login.
+
+    `available` is False in dev mode (no frozen exe path); the UI
+    grays out the toggle in that case.
+    """
+    # Lazy imports avoid a circular `server` ↔ router dependency;
+    # `server.py` populates these on startup and registers this
+    # router with `app.include_router`, so the symbols are
+    # available by the time any request lands here.
+    from server import _require_local_access
+    from app import autostart
+
+    _require_local_access()
+    return autostart.status()
+
+
+@router.put("")
+def autostart_set(req: _AutostartRequest) -> dict:
+    from server import _require_local_access
+    from app import autostart
+
+    _require_local_access()
+    try:
+        return autostart.set_enabled(req.enabled)
+    except RuntimeError as exc:
+        raise HTTPException(status_code=500, detail=str(exc))

--- a/app/routers/hotkey.py
+++ b/app/routers/hotkey.py
@@ -1,0 +1,139 @@
+"""`/api/hotkey/*` — global media-key event bus.
+
+Global hotkeys (play-pause / next / previous) fire on a pynput
+thread in the backend. We publish each to a thread-safe bus; the
+frontend subscribes via SSE and runs the corresponding action
+through its player hook — that way queue/shuffle/repeat decisions
+stay in the frontend instead of being re-implemented server-side.
+
+Two surfaces:
+  - POST `/api/hotkey/{play_pause,next,previous}` — the global-key
+    listener (`app.global_keys`) HTTP-POSTs here when it sees a
+    media key.
+  - GET `/api/hotkey/events` — SSE stream the frontend subscribes
+    to from `usePlayer`.
+
+`bus.bind_loop(loop)` must be called once on startup with the
+running asyncio event loop so `publish()` (called from the pynput
+thread) can `call_soon_threadsafe` payloads onto subscribers'
+queues. `server.py`'s `lifespan` does this.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import threading
+from typing import Optional
+
+from fastapi import APIRouter, Request
+from fastapi.responses import StreamingResponse
+
+
+router = APIRouter(prefix="/api/hotkey", tags=["hotkey"])
+
+
+class _HotkeyBus:
+    """Thread-safe fan-out from the pynput listener thread to any
+    number of SSE subscribers running on the asyncio loop."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._subscribers: list[asyncio.Queue] = []
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
+    def bind_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        with self._lock:
+            self._loop = loop
+
+    def publish(self, action: str) -> None:
+        """Safe to call from any thread (including pynput's listener
+        thread). Schedules the payload put on the FastAPI event loop."""
+        with self._lock:
+            loop = self._loop
+            subs = list(self._subscribers)
+        if loop is None:
+            return
+        for q in subs:
+            try:
+                loop.call_soon_threadsafe(q.put_nowait, action)
+            except Exception:
+                pass
+
+    def subscribe(self) -> asyncio.Queue:
+        q: asyncio.Queue = asyncio.Queue(maxsize=32)
+        with self._lock:
+            self._subscribers.append(q)
+        return q
+
+    def unsubscribe(self, q: asyncio.Queue) -> None:
+        with self._lock:
+            try:
+                self._subscribers.remove(q)
+            except ValueError:
+                pass
+
+
+# Module-level singleton — same instance for every subscriber + every
+# publish. `server.py` imports `bus` for the startup `bind_loop` call.
+bus = _HotkeyBus()
+
+
+def _emit(action: str) -> dict:
+    bus.publish(action)
+    return {"ok": True, "action": action}
+
+
+@router.post("/play_pause")
+def play_pause() -> dict:
+    from server import _require_local_access
+    _require_local_access()
+    return _emit("play_pause")
+
+
+@router.post("/next")
+def next_track() -> dict:
+    from server import _require_local_access
+    _require_local_access()
+    return _emit("next")
+
+
+@router.post("/previous")
+def previous_track() -> dict:
+    from server import _require_local_access
+    _require_local_access()
+    return _emit("previous")
+
+
+@router.get("/events")
+async def events(request: Request):
+    """SSE stream of hotkey events. The frontend's usePlayer hook
+    subscribes and maps each action onto its own toggle/next/prev so
+    queue state + advance logic stay in one place."""
+    from server import _require_local_access
+    _require_local_access()
+    bus.bind_loop(asyncio.get_running_loop())
+    q = bus.subscribe()
+
+    async def _gen():
+        try:
+            # Initial ping so the frontend knows the subscription is up.
+            yield "data: {\"action\": \"_ready\"}\n\n"
+            while True:
+                if await request.is_disconnected():
+                    break
+                try:
+                    action = await asyncio.wait_for(q.get(), timeout=20.0)
+                except asyncio.TimeoutError:
+                    # Keepalive comment — prevents proxies from closing
+                    # a silent connection.
+                    yield ": keepalive\n\n"
+                    continue
+                yield f"data: {json.dumps({'action': action})}\n\n"
+        finally:
+            bus.unsubscribe(q)
+
+    return StreamingResponse(
+        _gen(),
+        media_type="text/event-stream",
+        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
+    )

--- a/app/routers/notify.py
+++ b/app/routers/notify.py
@@ -1,0 +1,40 @@
+"""`/api/notify` — fire an OS-level notification.
+
+The frontend owns the "should I notify?" decision because it has
+the context the backend doesn't — track title/artist, whether the
+window is focused, which user preference is set. The server is just
+a thin shim that exposes the platform-specific notification shell
+so this can run from inside a sandbox where the browser
+Notification API isn't available (pywebview's WKWebView doesn't
+surface it as system-level).
+
+Loopback-only: rejects requests from anything other than 127.0.0.1
+/ ::1 / localhost. The endpoint is hidden from OpenAPI for the
+same reason — there's no legitimate caller from outside the app.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel
+
+
+router = APIRouter(prefix="/api/notify", tags=["notify"])
+
+
+class _NotifyRequest(BaseModel):
+    title: str
+    body: str
+    subtitle: Optional[str] = None
+
+
+@router.post("", include_in_schema=False)
+def fire_notification(req: _NotifyRequest, request: Request) -> dict:
+    client = request.client
+    host = client.host if client else ""
+    if host not in ("127.0.0.1", "::1", "localhost"):
+        raise HTTPException(status_code=403)
+    from app.notify import notify as _notify
+    _notify(req.title, req.body, req.subtitle)
+    return {"ok": True}

--- a/server.py
+++ b/server.py
@@ -723,9 +723,11 @@ app.add_middleware(
 # moved. New extractions add their `include_router` call here.
 from app.routers.autostart import router as autostart_router
 from app.routers.hotkey import router as hotkey_router
+from app.routers.notify import router as notify_router
 
 app.include_router(autostart_router)
 app.include_router(hotkey_router)
+app.include_router(notify_router)
 
 
 # ---------------------------------------------------------------------------
@@ -2118,12 +2120,6 @@ def window_start_resize(req: _WindowResizeRequest, request: Request) -> dict:
         return {"ok": False, "reason": f"{type(exc).__name__}: {exc}"}
 
 
-class _NotifyRequest(BaseModel):
-    title: str
-    body: str
-    subtitle: Optional[str] = None
-
-
 
 class _VideoDownloadRequest(BaseModel):
     quality: Optional[str] = None  # "HIGH" | "MEDIUM" | "LOW"
@@ -2225,26 +2221,7 @@ def video_downloads_list() -> list[dict]:
 # module + `app/routers/__init__.py` for the splitting playbook.
 
 
-@app.post("/api/notify", include_in_schema=False)
-def fire_notification(req: _NotifyRequest, request: Request) -> dict:
-    """Fire an OS-level notification. Loopback-only.
-
-    The frontend owns the "should I notify?" decision because it has
-    the context the backend doesn't — track title/artist, whether the
-    window is focused, which user preference is set. The server is
-    just a thin shim that exposes the platform-specific notification
-    shell so this can run from inside a sandbox where the browser
-    Notification API isn't available (pywebview's WKWebView doesn't
-    surface it as system-level).
-    """
-    client = request.client
-    host = client.host if client else ""
-    if host not in ("127.0.0.1", "::1", "localhost"):
-        raise HTTPException(status_code=403)
-    from app.notify import notify as _notify
-    _notify(req.title, req.body, req.subtitle)
-    return {"ok": True}
-
+# /api/notify route moved to `app/routers/notify.py`.
 
 @app.get("/api/auth/status")
 def auth_status() -> dict:

--- a/server.py
+++ b/server.py
@@ -717,6 +717,13 @@ app.add_middleware(
     allow_credentials=True,
 )
 
+# Per-domain routers extracted from the all-in-one server.py — see
+# `app/routers/__init__.py` for the playbook + which domains have
+# moved. New extractions add their `include_router` call here.
+from app.routers.autostart import router as autostart_router
+
+app.include_router(autostart_router)
+
 
 # ---------------------------------------------------------------------------
 # Serialization helpers
@@ -2114,9 +2121,6 @@ class _NotifyRequest(BaseModel):
     subtitle: Optional[str] = None
 
 
-class _AutostartRequest(BaseModel):
-    enabled: bool
-
 
 class _VideoDownloadRequest(BaseModel):
     quality: Optional[str] = None  # "HIGH" | "MEDIUM" | "LOW"
@@ -2214,26 +2218,8 @@ def video_downloads_list() -> list[dict]:
     return video_downloader.list_all()
 
 
-@app.get("/api/autostart")
-def autostart_status() -> dict:
-    """Report whether the app is registered to launch at login.
-
-    `available` is False in dev mode (no frozen exe path); the UI
-    grays out the toggle in that case.
-    """
-    _require_local_access()
-    from app import autostart
-    return autostart.status()
-
-
-@app.put("/api/autostart")
-def autostart_set(req: _AutostartRequest) -> dict:
-    _require_local_access()
-    from app import autostart
-    try:
-        return autostart.set_enabled(req.enabled)
-    except RuntimeError as exc:
-        raise HTTPException(status_code=500, detail=str(exc))
+# Autostart routes moved to `app/routers/autostart.py` — see that
+# module + `app/routers/__init__.py` for the splitting playbook.
 
 
 @app.post("/api/notify", include_in_schema=False)

--- a/server.py
+++ b/server.py
@@ -516,6 +516,7 @@ def _cleanup_part_files(root: Path) -> None:
 @asynccontextmanager
 async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     broker.bind_loop(asyncio.get_running_loop())
+    from app.routers.hotkey import bus as _hotkey_bus
     _hotkey_bus.bind_loop(asyncio.get_running_loop())
     output_root = Path(settings.output_dir).expanduser()
     _cleanup_part_files(output_root)
@@ -721,8 +722,10 @@ app.add_middleware(
 # `app/routers/__init__.py` for the playbook + which domains have
 # moved. New extractions add their `include_router` call here.
 from app.routers.autostart import router as autostart_router
+from app.routers.hotkey import router as hotkey_router
 
 app.include_router(autostart_router)
+app.include_router(hotkey_router)
 
 
 # ---------------------------------------------------------------------------
@@ -4896,113 +4899,9 @@ def airplay_disconnect() -> dict:
 # directly.
 
 
-# ---------------------------------------------------------------------------
-# Global media-key event bus
-#
-# Global hotkeys (play-pause / next / previous) fire on a pynput thread
-# in the backend. We publish each to this bus; the frontend subscribes
-# via SSE and runs the corresponding action through its player hook —
-# that way queue/shuffle/repeat decisions stay in the frontend instead
-# of being re-implemented server-side.
-# ---------------------------------------------------------------------------
-
-
-class _HotkeyBus:
-    def __init__(self) -> None:
-        self._lock = threading.Lock()
-        self._subscribers: list[asyncio.Queue] = []
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
-
-    def bind_loop(self, loop: asyncio.AbstractEventLoop) -> None:
-        with self._lock:
-            self._loop = loop
-
-    def publish(self, action: str) -> None:
-        """Safe to call from any thread (including pynput's listener
-        thread). Schedules the payload put on the FastAPI event loop."""
-        with self._lock:
-            loop = self._loop
-            subs = list(self._subscribers)
-        if loop is None:
-            return
-        for q in subs:
-            try:
-                loop.call_soon_threadsafe(q.put_nowait, action)
-            except Exception:
-                pass
-
-    def subscribe(self) -> asyncio.Queue:
-        q: asyncio.Queue = asyncio.Queue(maxsize=32)
-        with self._lock:
-            self._subscribers.append(q)
-        return q
-
-    def unsubscribe(self, q: asyncio.Queue) -> None:
-        with self._lock:
-            try:
-                self._subscribers.remove(q)
-            except ValueError:
-                pass
-
-
-_hotkey_bus = _HotkeyBus()
-
-
-def _emit_hotkey(action: str) -> dict:
-    _hotkey_bus.publish(action)
-    return {"ok": True, "action": action}
-
-
-@app.post("/api/hotkey/play_pause")
-def hotkey_play_pause() -> dict:
-    _require_local_access()
-    return _emit_hotkey("play_pause")
-
-
-@app.post("/api/hotkey/next")
-def hotkey_next() -> dict:
-    _require_local_access()
-    return _emit_hotkey("next")
-
-
-@app.post("/api/hotkey/previous")
-def hotkey_previous() -> dict:
-    _require_local_access()
-    return _emit_hotkey("previous")
-
-
-@app.get("/api/hotkey/events")
-async def hotkey_events(request: Request):
-    """SSE stream of hotkey events. The frontend's usePlayer hook
-    subscribes and maps each action onto its own toggle/next/prev
-    so queue state + advance logic stay in one place."""
-    _require_local_access()
-    _hotkey_bus.bind_loop(asyncio.get_running_loop())
-    q = _hotkey_bus.subscribe()
-
-    async def _gen():
-        try:
-            # Initial ping so the frontend knows the subscription is up.
-            yield "data: {\"action\": \"_ready\"}\n\n"
-            while True:
-                if await request.is_disconnected():
-                    break
-                try:
-                    action = await asyncio.wait_for(q.get(), timeout=20.0)
-                except asyncio.TimeoutError:
-                    # Keepalive comment — prevents proxies from closing
-                    # a silent connection.
-                    yield ": keepalive\n\n"
-                    continue
-                yield f"data: {json.dumps({'action': action})}\n\n"
-        finally:
-            _hotkey_bus.unsubscribe(q)
-
-    return StreamingResponse(
-        _gen(),
-        media_type="text/event-stream",
-        headers={"Cache-Control": "no-cache", "X-Accel-Buffering": "no"},
-    )
+# Hotkey bus + routes moved to `app/routers/hotkey.py`. The
+# lifespan call below binds the bus to the running event loop on
+# startup so the pynput listener thread can fan events out.
 
 
 @app.get("/api/player/events")


### PR DESCRIPTION
## Summary

Chunk #3 of the cleanup tour — partial. Establishes the playbook
for splitting `server.py` (8964 lines, 200 routes, 26 domains)
into per-domain `APIRouter` modules under `app/routers/`, and
extracts three small self-contained domains as proof the pattern
works end-to-end.

## What's in this PR

| Commit | Domain | Routes | LOC out of server.py |
|---|---|---:|---:|
| `3592243` | autostart | 2 | 22 |
| `f1918f3` | hotkey | 4 | 115 |
| `743d517` | notify | 1 | 23 |

server.py: 8964 → 8826 lines (-138 in this PR).

## What's NOT in this PR

The other 23 domains. The remaining ~7400 lines of route handlers
in server.py are mechanical extractions following the same shape,
but each one needs its own commit because:

- Some have heavier shared-state coupling (player, library,
  downloads access half-a-dozen module-level singletons each).
- Each needs its own pytest run + manual sanity check.
- Bundling them all into one PR would make review impossible.

The recommended next batches, low-risk first:

| Tier | Domains | Why |
|---|---|---|
| 1 | cast, airplay, tidal-connect, debug, play-report | Self-contained external-output / diagnostic domains |
| 2 | settings, auth, page, autostart-related | Some shared state but small surface |
| 3 | favorites, folders, playlists, user, video, track, artist | Tidal-API delegation, follow same template |
| 4 | downloads, import, library, search | Heavier shared state |
| 5 | player, lastfm, spotify | Largest domains, most coupling |

## The playbook

Codified in `app/routers/__init__.py`. Each domain module:

  - Defines `router = APIRouter(prefix=...)` plus its endpoints.
  - **Lazy-imports `server` for shared helpers inside handlers**.
    Top-of-module imports would create a circular import (server.py
    `include_router`s these modules at registration time). Lazy
    imports inside handlers only resolve when a request lands, by
    which point `server` is fully populated.
  - Owns its own state singletons where applicable (e.g.
    `app.routers.hotkey.bus`).

`server.py` retains:

  - The FastAPI app, middleware, exception handlers.
  - Module-level singletons (TidalClient, Downloader, settings, etc.).
  - Auth helpers (`_require_auth`, `_require_local_access`,
    `_ensure_loopback`).
  - The `lifespan` + startup wiring.

New extractions add a `from app.routers.<name> import router` +
`app.include_router(...)` to the block introduced in this PR.

## Test plan

- [x] pytest 465 passed, 2 skipped — unchanged from main at every
  commit.
- [x] Each extraction commit independently green.
- [ ] Manual: hit the endpoints — `/api/autostart`, the
  hotkey play_pause / events SSE, /api/notify — confirm they
  still respond.

## Why stop here

The remaining work is straightforward but volumetric. Better to
ship the playbook + a few examples in a PR small enough to review
properly, then land the rest in batches sized to your appetite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)