### PR TITLE
Player: fix skip resetting to beginning on rapid Next / Prev clicks

### DIFF
--- a/web/src/hooks/usePlayer.ts
+++ b/web/src/hooks/usePlayer.ts
@@ -1035,7 +1035,21 @@ export function usePlayer() {
   }, []);
 
   const next = useCallback(() => {
-    const n = pickNextIndex(stateRef.current);
+    // The naive answer is `pickNextIndex(stateRef.current)`, but
+    // stateRef updates through a useEffect that runs *after* React
+    // commits — so a quick second Next click before that commit
+    // sees stale `queueIndex`, computes the same next index we
+    // already asked for, and the user sees the skip as the song
+    // restarting from the beginning. `expectedTrackIdRef` is set
+    // synchronously inside `playAtIndex`, so it's the truth-of-
+    // what-we-just-asked-for; resolve it back to an index here.
+    const s = stateRef.current;
+    const intendedId = expectedTrackIdRef.current;
+    const intendedIdx = intendedId
+      ? s.queue.findIndex((t) => t.id === intendedId)
+      : -1;
+    const fromIdx = intendedIdx >= 0 ? intendedIdx : s.queueIndex;
+    const n = pickNextIndex({ ...s, queueIndex: fromIdx });
     if (n !== null) playAtIndex(n);
   }, [playAtIndex]);
 
@@ -1045,7 +1059,14 @@ export function usePlayer() {
       void api.player.seek(0).catch(() => {});
       return;
     }
-    const p = pickPrevIndex(stateRef.current);
+    // Same stale-stateRef guard as `next`; see comment there.
+    const s = stateRef.current;
+    const intendedId = expectedTrackIdRef.current;
+    const intendedIdx = intendedId
+      ? s.queue.findIndex((t) => t.id === intendedId)
+      : -1;
+    const fromIdx = intendedIdx >= 0 ? intendedIdx : s.queueIndex;
+    const p = pickPrevIndex({ ...s, queueIndex: fromIdx });
     if (p !== null) playAtIndex(p);
   }, [playAtIndex]);
 


### PR DESCRIPTION
## Summary

User-reported bug #1 from the bug list:

> "Skipping through songs is glitchy. Sometimes resets back to the
> beginning. Especially when trying to skip right when song starts
> playing."

## Root cause

`next()` and `prev()` in `usePlayer.ts` compute the next/prev
queue index from `stateRef.current.queueIndex`. `stateRef` is kept
in sync with React state through a `useEffect`, which runs **after**
React's commit phase — so:

1. User clicks Next while track A is playing. `playAtIndex(B)`
   queues a setState with `queueIndex: indexOfB` and synchronously
   sets `expectedTrackIdRef.current = B.id`.
2. User clicks Next again ~16 ms later, before React commits +
   the useEffect copies state → stateRef.
3. `next()` reads `stateRef.current.queueIndex` — still
   `indexOfA`. `pickNextIndex` returns `indexOfB` again. The user
   wanted C, got B re-issued.
4. Backend's `play_track(B)` lands on Path 0 (already on B), but
   the frontend's `playAtIndex(B)` already set
   `currentTime: 0` optimistically — visually the bar jumps to
   0:00 and the user perceives "the skip reset the song to the
   beginning."

## Fix

`expectedTrackIdRef.current` updates synchronously inside
`playAtIndex` — it's the truth-of-what-we-just-asked-for and
doesn't have the commit-lag. Resolve it back to an index in the
live queue and feed that to `pickNextIndex` / `pickPrevIndex`.
Falls through to the original `s.queueIndex` when
`expectedTrackIdRef` is null (cold start) or points at a track
not in the current queue (rehydrate edge case).

Two callsites, ~10 LOC each, kept inline rather than extracted to
a helper so the useCallback deps don't churn over a 4-line
snippet.

## Test plan

- [x] tsc clean
- [x] vitest 36 passed (no regression in the existing suite)
- [ ] Manual: in a built .exe, play a track, immediately click Next
  twice in quick succession. Should advance to the second-next
  track in the queue, not re-issue the first-next track.

## Notes

Fix is small and targeted. The rest of `playAtIndex`, the SSE
handler, and the optimistic-update flow are untouched. No
backend changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)