### PR TITLE
Popular tab: cache per-track resolution so chart-cache miss is fast

### DIFF
--- a/server.py
+++ b/server.py
@@ -3271,16 +3271,55 @@ def lastfm_chart_top_tracks_resolved(limit: int = 50) -> list[dict]:
     limit = max(1, min(limit, 100))
 
     def _resolve_all() -> list[dict]:
+        from app import lastfm_disk_cache
+
         entries = lastfm.get_chart_top_tracks(limit=limit)
 
         pref = (settings.explicit_content_preference or "explicit").lower()
+        username = lastfm.status().get("username") or ""
+
+        # Per-track resolution cache.
+        #
+        # The 1-hour chart-level cache (further down) makes repeat
+        # visits within an hour instant. But when it expires, the
+        # whole 50-search fan-out runs again — even though most of
+        # those 50 chart entries are typically the same songs as
+        # before. Cache each (artist, title) → Tidal track dict for
+        # a long TTL so a chart-cache miss only pays the resolve
+        # cost for entries that *changed*.
+        #
+        # 30-day TTL is conservative enough that a Tidal track id
+        # going stale (track removal, region change) refreshes on
+        # its own, but long enough that the user only pays the
+        # resolve cost for genuinely new chart entries between
+        # visits.
+        #
+        # `pref` is in the key because filter_explicit_dupes is
+        # settings-dependent — flipping the explicit-content
+        # preference can change which dedupe survivor we pick.
+        # Different `pref` → different cache lane.
+        #
+        # Failures (None) are *not* cached — a transient Tidal
+        # hiccup shouldn't blank a popular song from the chart for
+        # 30 days. Genuine "not on Tidal" cases will re-resolve
+        # each time but that's still a single search, not 50.
+        _PER_TRACK_TTL = 86400.0 * 30  # 30 days
 
         def _one(entry: dict) -> Optional[dict]:
-            tidal_jitter_sleep()
             title = (entry.get("name") or "").strip()
             artist = (entry.get("artist") or "").strip()
             if not title or not artist:
                 return None
+
+            cache_key = (
+                f"{username}|resolve-track:{pref}:"
+                f"{artist.lower()}:{title.lower()}"
+            )
+            cached = lastfm_disk_cache.get(cache_key, _PER_TRACK_TTL)
+            if cached is not None:
+                return cached
+
+            tidal_jitter_sleep()
             try:
                 results = tidal.search(f"{artist} {title}", limit=5)
             except Exception:
@@ -3304,13 +3343,24 @@ def lastfm_chart_top_tracks_resolved(limit: int = 50) -> list[dict]:
                 ),
                 None,
             )
-            return track_to_dict(exact or tracks[0])
+            resolved = track_to_dict(exact or tracks[0])
+            # Only persist on success — see comment above.
+            try:
+                lastfm_disk_cache.set(cache_key, resolved)
+            except Exception:
+                # Disk write failed. Fall through with the resolved
+                # value; persistence is a perf optimisation, not a
+                # correctness requirement.
+                pass
+            return resolved
 
         # 3 workers. The whole-chart resolve was one of the heavier
         # bursts of Tidal traffic per user session — 50 searches in
         # ~7 s is exactly the kind of pattern that trips abuse
-        # detection over time. Slower wall-clock (~18 s cold load)
-        # but the result is cached so subsequent visits are instant.
+        # detection over time. The per-track cache above means a
+        # chart-cache miss usually only fires a handful of fresh
+        # searches (the entries that changed), so the wall-clock
+        # bursts are typically much smaller in practice.
         with ThreadPoolExecutor(max_workers=3) as pool:
             results = list(pool.map(_one, entries))
 


### PR DESCRIPTION
## Summary

User-reported bug #5 from the bug list:

> "Tracks on Popular tab takes very long to load."

## Root cause

`lastfm_chart_top_tracks_resolved` resolves 50 Last.fm chart
entries to Tidal Track objects via 3-worker fan-out searches. The
handler had a 1-hour SQLite-backed cache on the **whole resolved
chart payload** — repeat visits within the hour were instant.

But when that cache expired, the entire 50-search fan-out fired
again — even though most of those 50 entries are typically the
same songs as an hour ago. The handler comment acknowledged the
cold-load cost (~18 s) but the cache layer was at the wrong
granularity.

## Fix

Add a **per-track resolution cache** keyed on
`(username, explicit-pref, lowercased artist, lowercased title)`
with a 30-day TTL, layered underneath the existing chart cache.

Now when the chart cache expires:

  - `_resolve_all` runs.
  - For each of 50 entries, `_one` checks the per-track cache.
  - Entries that were already in the chart resolve from disk in
    milliseconds (no `tidal.search`).
  - Only **changed** entries (newly-charting songs) actually fire
    a fresh Tidal search.

For a typical chart turnover of 5-10 songs/hour, the chart-cache
miss drops from ~18 s to ~2-4 s.

## Edges handled

  - **Explicit-content preference** is in the cache key:
    `filter_explicit_dupes` is settings-dependent — flipping the
    preference can change which dedupe survivor we pick. Different
    preferences get different cache lanes.

  - **Failures are NOT cached.** A transient Tidal hiccup
    shouldn't blank a popular song from the chart for 30 days.
    Genuine "not on Tidal" cases re-resolve each visit, but that's
    still a single search per visit — not 50.

  - **Last.fm disconnect** already calls
    `_invalidate_lastfm_cache()` which clears the disk cache
    wholesale, so per-track entries are dropped along with
    everything else when the user changes accounts.

  - **Schema version sentinel** in `lastfm_disk_cache` already
    handles the case where `track_to_dict`'s shape changes — bump
    `_SCHEMA_VERSION` and old entries get wiped.

## What's NOT changed

  - The 1-hour chart cache stays (still useful for repeat visits
    inside the hour).
  - The 3-worker rate-limit posture stays — the handler comment
    flagged 50-searches-in-7s as abuse-detection-tripping, and
    nothing in this PR changes that.
  - First-ever cold load (no chart cache, no per-track cache) is
    still ~18 s. Fixing that requires progressive streaming or a
    background warmer, both bigger changes.

## Test plan

- [x] pytest 465 passed, 2 skipped — unchanged from main.
- [ ] Manual: open Popular Tracks; wait 1 h+; reopen Popular
  Tracks. Expect the second load to be much faster than the first
  (most rows hit disk cache).

🤖 Generated with [Claude Code](https://claude.com/claude-code)