### PR TITLE
Home: AlbumOfTheYear top-of-year + new-releases sections

### DIFF
--- a/app/aoty.py
+++ b/app/aoty.py
@@ -1,0 +1,373 @@
+"""AlbumOfTheYear.org chart scraper.
+
+Two surfaces:
+
+  - `top_albums_of_year(year, limit)` reads
+    `/ratings/user-highest-rated/{year}/{page}/` — the year's
+    highest-user-rated albums. Stable list that turns over slowly
+    enough that an hour-level cache is comfortable.
+
+  - `recent_releases(limit)` reads `/releases/` — albums released
+    recently, ranked by AOTY's grid-card view. Refreshes more
+    quickly than the top-of-year list (a 30-minute cache feels
+    right).
+
+Both endpoints return a list of `AotyAlbum`. Resolving each entry
+to a Tidal album is the consumer's job (server.py / endpoint
+handler) — keeps this module pure parsing.
+
+Caching is in-memory only with a per-key TTL. AOTY data is hour-
+level fresh; a process restart re-pays ~1-2 s to refetch the
+chart, which is acceptable for the use case (Home page section
+visible on launch). Disk persistence isn't necessary at this
+scale.
+
+Failures are silent: HTTP errors, layout changes, or a missing
+selector return an empty list rather than raising. The caller
+sees zero results and renders a fallback empty state.
+"""
+from __future__ import annotations
+
+import logging
+import re
+import threading
+import time
+from dataclasses import dataclass, asdict
+from typing import Optional
+from urllib.parse import urljoin
+
+import requests
+from bs4 import BeautifulSoup
+
+log = logging.getLogger(__name__)
+
+_BASE_URL = "https://www.albumoftheyear.org"
+
+# A modern desktop UA — the page returns a 403 for an empty UA and
+# returns the mobile layout for some bot-string defaults. Plain
+# Chrome desktop matches what an actual browser sends and gives us
+# the desktop HTML the rest of this module is parsing for.
+_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+)
+
+_HTTP_TIMEOUT_SEC = 15.0
+
+# In-memory cache. Per-key TTL so the two surfaces can refresh on
+# different cadences without fighting over a single TTL constant.
+_cache_lock = threading.Lock()
+_cache: dict[str, tuple[float, list[dict]]] = {}
+
+# Default TTLs. Top-rated lists turn over slowly (the order changes
+# only as users rate over time); the releases page is a bit more
+# active because new albums get added daily.
+_TOP_OF_YEAR_TTL_SEC = 3600.0  # 1 hour
+_RECENT_RELEASES_TTL_SEC = 1800.0  # 30 min
+
+
+@dataclass
+class AotyAlbum:
+    """One album from an AOTY listing.
+
+    Fields are intentionally permissive (most are Optional) — AOTY
+    occasionally ships rows with missing scores during release week
+    or rows with no cover for unreleased albums. The consumer
+    decides how to render partial data."""
+
+    title: str
+    artist: str
+    score: Optional[int] = None
+    rating_count: Optional[int] = None
+    cover_url: Optional[str] = None
+    release_date: Optional[str] = None
+    rank: Optional[int] = None
+    must_hear: bool = False
+    aoty_url: Optional[str] = None
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+def top_albums_of_year(year: int, limit: int = 50) -> list[dict]:
+    """Highest-user-rated albums for the given year.
+
+    `limit` caps the result list. AOTY paginates at ~25 per page, so
+    a limit of 50 fetches two pages, 100 fetches four, and so on.
+    Capped at 100 to keep the worst-case fetch budget bounded.
+    """
+    limit = max(1, min(int(limit), 100))
+    cache_key = f"top:{year}:{limit}"
+    cached = _cache_get(cache_key, _TOP_OF_YEAR_TTL_SEC)
+    if cached is not None:
+        return cached
+
+    out: list[AotyAlbum] = []
+    page = 1
+    # AOTY's pagination: /ratings/user-highest-rated/{year}/{page}/.
+    # Each page renders ~25 rows. Walk pages until we hit `limit` or
+    # a page returns no rows.
+    while len(out) < limit and page <= 6:
+        path = f"/ratings/user-highest-rated/{year}/{page}/"
+        html = _fetch(urljoin(_BASE_URL, path))
+        if html is None:
+            break
+        rows = _parse_album_list_rows(html)
+        if not rows:
+            break
+        out.extend(rows)
+        page += 1
+
+    out = out[:limit]
+    payload = [a.to_dict() for a in out]
+    _cache_set(cache_key, payload)
+    return payload
+
+
+def recent_releases(limit: int = 30) -> list[dict]:
+    """Recently-released albums, AOTY's grid-card view at /releases/.
+
+    Rows here use a different DOM shape than the top-of-year page —
+    artist and title are in separate elements rather than combined
+    in a single anchor — so they have their own parser.
+    """
+    limit = max(1, min(int(limit), 100))
+    cache_key = f"recent:{limit}"
+    cached = _cache_get(cache_key, _RECENT_RELEASES_TTL_SEC)
+    if cached is not None:
+        return cached
+
+    html = _fetch(urljoin(_BASE_URL, "/releases/"))
+    if html is None:
+        _cache_set(cache_key, [])
+        return []
+    rows = _parse_album_block_cards(html)[:limit]
+    payload = [a.to_dict() for a in rows]
+    _cache_set(cache_key, payload)
+    return payload
+
+
+# --- internals -------------------------------------------------------------
+
+
+def _cache_get(key: str, ttl_sec: float) -> Optional[list[dict]]:
+    now = time.monotonic()
+    with _cache_lock:
+        entry = _cache.get(key)
+        if entry is None:
+            return None
+        cached_at, payload = entry
+        if now - cached_at > ttl_sec:
+            return None
+        # Defensive copy — AOTY entries are plain dicts but the
+        # consumer might mutate (sort, filter, decorate with Tidal
+        # fields). Don't let that poison the cache.
+        return [dict(d) for d in payload]
+
+
+def _cache_set(key: str, payload: list[dict]) -> None:
+    with _cache_lock:
+        _cache[key] = (time.monotonic(), payload)
+
+
+def _fetch(url: str) -> Optional[str]:
+    try:
+        r = requests.get(
+            url,
+            headers={
+                "User-Agent": _USER_AGENT,
+                "Accept": "text/html,application/xhtml+xml",
+                "Accept-Language": "en-US,en;q=0.9",
+            },
+            timeout=_HTTP_TIMEOUT_SEC,
+        )
+    except Exception as exc:
+        log.warning("aoty fetch %s failed: %s", url, exc)
+        return None
+    if r.status_code != 200:
+        log.warning("aoty fetch %s returned %d", url, r.status_code)
+        return None
+    # AOTY serves UTF-8 but doesn't always declare a charset in
+    # Content-Type, which makes requests fall back to ISO-8859-1
+    # for the .text attribute and mangle multi-byte characters
+    # (the middle-dot in "Apr 30 · LP" comes back as the U+FFFD
+    # replacement character). Force UTF-8 — the apparent_encoding
+    # check would also catch this, but it's an O(n) scan and we
+    # already know the right answer.
+    r.encoding = "utf-8"
+    return r.text
+
+
+def _parse_album_list_rows(html: str) -> list[AotyAlbum]:
+    """Parser for the `albumListRow` shape used on /ratings/* pages.
+
+    Each row has the artist and title combined in the title anchor
+    ("Artist - Title"). We split on the first " - " — AOTY uses
+    that as their separator, and artist names containing " - "
+    are vanishingly rare.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    rows = soup.select("div.albumListRow")
+    out: list[AotyAlbum] = []
+    for row in rows:
+        title_anchor = row.select_one("h2.albumListTitle a[itemprop='url']")
+        if title_anchor is None:
+            continue
+        combined = title_anchor.get_text(strip=True)
+        artist, title = _split_artist_title(combined)
+        if not artist or not title:
+            continue
+
+        rank: Optional[int] = None
+        rank_el = row.select_one("span.albumListRank span[itemprop='position']")
+        if rank_el is not None:
+            try:
+                rank = int(rank_el.get_text(strip=True))
+            except ValueError:
+                rank = None
+
+        score: Optional[int] = None
+        score_el = row.select_one("div.scoreValueContainer .scoreValue")
+        if score_el is not None:
+            try:
+                score = int(score_el.get_text(strip=True))
+            except ValueError:
+                score = None
+
+        rating_count = _parse_rating_count(
+            row.select_one("div.albumListScoreContainer .scoreText")
+        )
+
+        cover_url: Optional[str] = None
+        img = row.select_one("div.albumListCover img")
+        if img is not None:
+            src = img.get("src") or ""
+            if isinstance(src, str) and src:
+                cover_url = src
+
+        release_date_el = row.select_one("div.albumListDate")
+        release_date = (
+            release_date_el.get_text(strip=True) if release_date_el else None
+        )
+
+        must_hear = row.select_one("div.albumListCover.mustHear") is not None
+
+        aoty_url: Optional[str] = None
+        href = title_anchor.get("href")
+        if isinstance(href, str) and href:
+            aoty_url = urljoin(_BASE_URL, href)
+
+        out.append(
+            AotyAlbum(
+                title=title,
+                artist=artist,
+                score=score,
+                rating_count=rating_count,
+                cover_url=cover_url,
+                release_date=release_date,
+                rank=rank,
+                must_hear=must_hear,
+                aoty_url=aoty_url,
+            )
+        )
+    return out
+
+
+def _parse_album_block_cards(html: str) -> list[AotyAlbum]:
+    """Parser for the `albumBlock` shape used on /releases/.
+
+    Cards have the artist and title in separate elements, so no
+    splitting is needed. Score and rating count are present when
+    AOTY has rated the release; brand-new releases sometimes ship
+    with a 0 / no rating, which we surface as None rather than 0.
+    """
+    soup = BeautifulSoup(html, "html.parser")
+    blocks = soup.select("div.albumBlock")
+    out: list[AotyAlbum] = []
+    for block in blocks:
+        artist_el = block.select_one(".artistTitle")
+        title_el = block.select_one(".albumTitle")
+        if artist_el is None or title_el is None:
+            continue
+        artist = artist_el.get_text(strip=True)
+        title = title_el.get_text(strip=True)
+        if not artist or not title:
+            continue
+
+        score: Optional[int] = None
+        rating = block.select_one(".rating")
+        if rating is not None:
+            try:
+                value = int(rating.get_text(strip=True))
+                # AOTY shows "NR" or empty for no-rating yet; an
+                # explicit 0 is also "no real rating yet" rather
+                # than "literally 0/100", so surface that as None
+                # too.
+                score = value if value > 0 else None
+            except ValueError:
+                score = None
+
+        rating_count = _parse_rating_count(
+            block.select_one(".ratingText:nth-of-type(2)")
+        ) or _parse_rating_count(block.select_one(".ratingText + .ratingText"))
+
+        cover_url: Optional[str] = None
+        img = block.select_one(".image img")
+        if img is not None:
+            src = img.get("src") or ""
+            if isinstance(src, str) and src:
+                cover_url = src
+
+        release_label_el = block.select_one(".type")
+        release_label = (
+            release_label_el.get_text(strip=True) if release_label_el else None
+        )
+
+        aoty_url: Optional[str] = None
+        href_el = block.select_one(".albumTitle")
+        href_anchor = href_el.find_parent("a") if href_el else None
+        if href_anchor is not None:
+            href = href_anchor.get("href")
+            if isinstance(href, str) and href:
+                aoty_url = urljoin(_BASE_URL, href)
+
+        out.append(
+            AotyAlbum(
+                title=title,
+                artist=artist,
+                score=score,
+                rating_count=rating_count,
+                cover_url=cover_url,
+                release_date=release_label,
+                rank=None,
+                must_hear=False,
+                aoty_url=aoty_url,
+            )
+        )
+    return out
+
+
+def _split_artist_title(combined: str) -> tuple[str, str]:
+    """Split AOTY's "Artist - Title" form. Returns (artist, title)
+    with both empty on malformed input."""
+    if not combined:
+        return "", ""
+    idx = combined.find(" - ")
+    if idx < 0:
+        return "", combined.strip()
+    return combined[:idx].strip(), combined[idx + 3 :].strip()
+
+
+def _parse_rating_count(el) -> Optional[int]:
+    """Extract `12,598 ratings` → 12598 (or `(304)` → 304). Returns
+    None when the element is missing or the digits don't parse."""
+    if el is None:
+        return None
+    raw = el.get_text(" ", strip=True)
+    digits = re.sub(r"[^0-9]", "", raw)
+    if not digits:
+        return None
+    try:
+        return int(digits)
+    except ValueError:
+        return None

--- a/app/aoty_resolver.py
+++ b/app/aoty_resolver.py
@@ -78,7 +78,8 @@ def resolve_listing(listing: list[dict]) -> list[dict]:
         tidal_jitter_sleep()
         try:
             results = tidal.search(f"{artist} {title}", limit=5)
-        except Exception:
+        except Exception as exc:
+            log.warning("aoty resolve search %r/%r failed: %s", artist, title, exc)
             return {**entry, "tidal_album": None}
         albums = filter_explicit_dupes(
             results.get("albums", []), pref, kind="album"
@@ -102,7 +103,8 @@ def resolve_listing(listing: list[dict]) -> list[dict]:
         )
         try:
             resolved = album_to_dict(exact or albums[0])
-        except Exception:
+        except Exception as exc:
+            log.warning("aoty resolve serialize %r/%r failed: %s", artist, title, exc)
             return {**entry, "tidal_album": None}
 
         # Only persist successes — caching None for 30 days would
@@ -110,8 +112,8 @@ def resolve_listing(listing: list[dict]) -> list[dict]:
         # Tidal hiccup.
         try:
             lastfm_disk_cache.set(cache_key, resolved)
-        except Exception:
-            pass
+        except Exception as exc:
+            log.debug("aoty resolve cache write failed (%s); continuing", exc)
         return {**entry, "tidal_album": resolved}
 
     # 3 workers matches the rate-limit posture used by the

--- a/app/aoty_resolver.py
+++ b/app/aoty_resolver.py
@@ -1,0 +1,122 @@
+"""AOTY listing → Tidal-resolved listing.
+
+Takes raw `AotyAlbum` dicts from `app.aoty` and decorates each
+with a `tidal_album` field (or None when Tidal doesn't have the
+album). The resolution itself is a Tidal search per entry,
+parallelised across a small thread pool, with results cached
+per-album in a long-TTL persistent cache so chart-cache misses
+only re-resolve genuinely new entries.
+
+Same shape as the per-track resolver used by the Last.fm Popular
+page — see `lastfm_chart_top_tracks_resolved` in server.py for
+the prior art and the rate-limit rationale (3 workers + jittered
+sleeps; 50 concurrent searches in ~7 s trips Tidal's abuse
+detection over time).
+
+Lives outside server.py so the AOTY feature can ship without
+waiting for the larger server.py-into-routers split (PR #49).
+"""
+from __future__ import annotations
+
+import logging
+from concurrent.futures import ThreadPoolExecutor
+
+log = logging.getLogger(__name__)
+
+
+# Tidal album ids for popular albums are very stable. 30 days
+# mirrors the per-track cache used by the Last.fm Popular page so
+# both integrations age uniformly.
+_RESOLVE_TTL_SEC = 86400.0 * 30
+
+
+def resolve_listing(listing: list[dict]) -> list[dict]:
+    """Return a new list with each entry decorated with `tidal_album`.
+
+    `listing` is the output of `app.aoty.top_albums_of_year` /
+    `app.aoty.recent_releases` — a list of dicts with `artist` +
+    `title` keys (and other AOTY metadata).
+
+    The returned list is the same shape with one extra key per
+    entry: `tidal_album` is a Tidal album dict (per `album_to_dict`)
+    on success, or None when Tidal doesn't have a match or the
+    search failed.
+    """
+    if not listing:
+        return []
+
+    # Lazy imports to avoid a circular dependency on server module
+    # state — server.py defines `tidal`, `settings`,
+    # `tidal_jitter_sleep`, `album_to_dict`, `filter_explicit_dupes`
+    # at module-level, so by the time resolve_listing runs (in a
+    # request handler) the server module is fully populated.
+    from server import (
+        album_to_dict,
+        filter_explicit_dupes,
+        settings,
+        tidal,
+        tidal_jitter_sleep,
+    )
+    from app import lastfm_disk_cache
+
+    pref = (settings.explicit_content_preference or "explicit").lower()
+
+    def _resolve_one(entry: dict) -> dict:
+        artist = (entry.get("artist") or "").strip()
+        title = (entry.get("title") or "").strip()
+        if not artist or not title:
+            return {**entry, "tidal_album": None}
+
+        cache_key = (
+            f"aoty:resolve-album:{pref}:"
+            f"{artist.lower()}:{title.lower()}"
+        )
+        cached = lastfm_disk_cache.get(cache_key, _RESOLVE_TTL_SEC)
+        if cached is not None:
+            return {**entry, "tidal_album": cached}
+
+        tidal_jitter_sleep()
+        try:
+            results = tidal.search(f"{artist} {title}", limit=5)
+        except Exception:
+            return {**entry, "tidal_album": None}
+        albums = filter_explicit_dupes(
+            results.get("albums", []), pref, kind="album"
+        )
+        if not albums:
+            return {**entry, "tidal_album": None}
+
+        # Exact title + artist first; fall back to Tidal's top hit.
+        wt = title.lower()
+        wa = artist.lower()
+        exact = next(
+            (
+                a for a in albums
+                if getattr(a, "name", "").lower() == wt
+                and any(
+                    getattr(ar, "name", "").lower() == wa
+                    for ar in (getattr(a, "artists", None) or [])
+                )
+            ),
+            None,
+        )
+        try:
+            resolved = album_to_dict(exact or albums[0])
+        except Exception:
+            return {**entry, "tidal_album": None}
+
+        # Only persist successes — caching None for 30 days would
+        # blank an album from the chart on a single transient
+        # Tidal hiccup.
+        try:
+            lastfm_disk_cache.set(cache_key, resolved)
+        except Exception:
+            pass
+        return {**entry, "tidal_album": resolved}
+
+    # 3 workers matches the rate-limit posture used by the
+    # Popular page resolver. After the first run the per-album
+    # cache is hot, so this only fires fresh searches for entries
+    # that changed.
+    with ThreadPoolExecutor(max_workers=3) as pool:
+        return list(pool.map(_resolve_one, listing))

--- a/server.py
+++ b/server.py
@@ -3340,6 +3340,45 @@ def lastfm_chart_top_tags(limit: int = 50) -> list[dict]:
     )
 
 
+# --- AlbumOfTheYear charts -------------------------------------------------
+#
+# Two surfaces, both backed by `app.aoty` (HTML scraper, in-memory
+# cached) + `app.aoty_resolver` (per-album Tidal resolution, disk
+# cached). The endpoint itself is thin glue: it doesn't add another
+# cache layer because the two underlying caches already handle cost
+# correctly — a chart-listing hit + N disk-cache hits is milliseconds,
+# and brand-new entries trigger one rate-limited Tidal search each.
+#
+# `year` defaults to the current year. Callers can pass a past year
+# explicitly to browse historical charts (the AOTY URL works for any
+# year).
+
+
+@app.get("/api/aoty/top-of-year")
+def aoty_top_of_year(year: int | None = None, limit: int = 50) -> list[dict]:
+    """AOTY's highest-user-rated albums for the given year, decorated
+    with Tidal album dicts under `tidal_album` (or None when Tidal
+    doesn't have a match)."""
+    _require_auth()
+    from app import aoty as aoty_module
+    from app import aoty_resolver
+    y = int(year) if year is not None else datetime.now().year
+    listing = aoty_module.top_albums_of_year(y, limit=limit)
+    return aoty_resolver.resolve_listing(listing)
+
+
+@app.get("/api/aoty/recent-releases")
+def aoty_recent_releases(limit: int = 30) -> list[dict]:
+    """Recently-released albums from AOTY's /releases/ grid, decorated
+    with Tidal album dicts under `tidal_album` (or None when Tidal
+    doesn't have a match)."""
+    _require_auth()
+    from app import aoty as aoty_module
+    from app import aoty_resolver
+    listing = aoty_module.recent_releases(limit=limit)
+    return aoty_resolver.resolve_listing(listing)
+
+
 _weekly_scrobbles_cache: dict[str, tuple[float, list]] = {}
 _weekly_scrobbles_lock = threading.Lock()
 _WEEKLY_SCROBBLES_TTL_SEC = 900.0  # 15 minutes — cheap enough to refresh.

--- a/server.py
+++ b/server.py
@@ -41,6 +41,8 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel
 from sse_starlette.sse import EventSourceResponse
 
+from app import aoty as aoty_module
+from app import aoty_resolver
 from app import deezer_import
 from app import global_keys as global_keys_mod
 from app.audio.macos_now_playing import MacOSNowPlayingBridge
@@ -3360,9 +3362,7 @@ def aoty_top_of_year(year: int | None = None, limit: int = 50) -> list[dict]:
     with Tidal album dicts under `tidal_album` (or None when Tidal
     doesn't have a match)."""
     _require_auth()
-    from app import aoty as aoty_module
-    from app import aoty_resolver
-    y = int(year) if year is not None else datetime.now().year
+    y = year if year is not None else datetime.now().year
     listing = aoty_module.top_albums_of_year(y, limit=limit)
     return aoty_resolver.resolve_listing(listing)
 
@@ -3373,8 +3373,6 @@ def aoty_recent_releases(limit: int = 30) -> list[dict]:
     with Tidal album dicts under `tidal_album` (or None when Tidal
     doesn't have a match)."""
     _require_auth()
-    from app import aoty as aoty_module
-    from app import aoty_resolver
     listing = aoty_module.recent_releases(limit=limit)
     return aoty_resolver.resolve_listing(listing)
 

--- a/tests/test_aoty_parser.py
+++ b/tests/test_aoty_parser.py
@@ -1,0 +1,212 @@
+"""Tests for the AOTY HTML parsers in `app.aoty`.
+
+The parser is the most fragile part of the AOTY integration —
+AOTY is HTML-only and they don't commit to a stable layout, so a
+silent regression here would just blank the Home-page section
+without any visible error. These tests pin the row shape we
+currently parse against minimal inline HTML fixtures, so a layout
+change comes back as a clear test failure with a hint at what
+moved.
+
+If AOTY's HTML changes: re-grab a row from the live page, replace
+the corresponding fixture string, and update the expected values.
+"""
+from __future__ import annotations
+
+from app.aoty import (
+    _parse_album_block_cards,
+    _parse_album_list_rows,
+    _split_artist_title,
+)
+
+
+# Fixture: one row from /ratings/user-highest-rated/2026/, captured
+# 2026-04-30. Trimmed to the structurally-relevant elements +
+# stripped of inline external links + tracking attributes.
+_RATING_ROW_HTML = """
+<div class="albumListRow">
+  <h2 class="albumListTitle">
+    <span itemprop="itemListElement" itemscope itemtype="http://schema.org/ListItem">
+      <span class="albumListRank">
+        <span itemprop="position">1</span>.
+      </span>
+      <span itemprop="item" itemscope itemtype="http://schema.org/MusicAlbum">
+        <a href="/album/1460350-slayyyter-wort-girl-in-america.php" itemprop="url">Slayyyter - WOR$T GIRL IN AMERICA</a>
+        <meta itemprop="name" content="Slayyyter - WOR$T GIRL IN AMERICA" />
+      </span>
+    </span>
+  </h2>
+  <div class="albumListCover mustHear user">
+    <a href="/album/1460350-slayyyter-wort-girl-in-america.php">
+      <div class="mustHear"><i class="fas fa-star"></i></div>
+      <img src="https://cdn2.albumoftheyear.org/200x0/album/1460350-wort-girl-in-america_034044.jpg" alt="Slayyyter - WOR$T GIRL IN AMERICA"/>
+    </a>
+  </div>
+  <div class="albumListDate">March 27, 2026</div>
+  <div class="albumListGenre">
+    <a href="/genre/181-electroclash/">Electroclash</a>,
+    <a href="/genre/31-electropop/">Electropop</a>
+  </div>
+  <div class="albumListScoreContainer">
+    <div class="scoreHeader">USER SCORE</div>
+    <div class="scoreValueContainer" title="83.9">
+      <div class="scoreValue">84</div>
+    </div>
+    <div class="scoreText">12,598 ratings</div>
+  </div>
+</div>
+"""
+
+# Fixture: one card from /releases/, captured 2026-04-30. Same
+# trimming policy.
+_RELEASE_BLOCK_HTML = """
+<div class="albumBlock five" data-type="ep">
+  <div class="image">
+    <a href="/album/1728324-illit-mamihlapinatapai.php">
+      <img src="https://cdn2.albumoftheyear.org/200x0/album/1728324-mamihlapinatapai_091400.jpg" alt="ILLIT - MAMIHLAPINATAPAI"/>
+    </a>
+  </div>
+  <a href="/artist/319705-illit/"><div class="artistTitle">ILLIT</div></a>
+  <a href="/album/1728324-illit-mamihlapinatapai.php"><div class="albumTitle">MAMIHLAPINATAPAI</div></a>
+  <div class="type">Apr 30 · EP</div>
+  <div class="ratingRowContainer">
+    <div class="ratingRow">
+      <div class="ratingBlock">
+        <div class="rating">63</div>
+        <div class="ratingBar yellow"><div class="yellow" style="width:63%;"></div></div>
+      </div>
+      <div class="ratingText">user score</div>
+      <div class="ratingText">(304)</div>
+    </div>
+  </div>
+</div>
+"""
+
+
+# --- top-of-year row parser -------------------------------------------------
+
+
+def test_parse_top_row_extracts_all_fields():
+    rows = _parse_album_list_rows(_RATING_ROW_HTML)
+    assert len(rows) == 1
+    a = rows[0]
+    assert a.rank == 1
+    assert a.artist == "Slayyyter"
+    assert a.title == "WOR$T GIRL IN AMERICA"
+    assert a.score == 84
+    assert a.rating_count == 12598
+    assert a.cover_url and "wort-girl-in-america" in a.cover_url
+    assert a.release_date == "March 27, 2026"
+    assert a.must_hear is True
+    assert a.aoty_url and a.aoty_url.startswith(
+        "https://www.albumoftheyear.org/album/"
+    )
+
+
+def test_parse_top_row_handles_missing_must_hear_flag():
+    """A row without the 'mustHear' class should still parse, just
+    with `must_hear=False`."""
+    html = _RATING_ROW_HTML.replace("albumListCover mustHear user", "albumListCover")
+    rows = _parse_album_list_rows(html)
+    assert len(rows) == 1
+    assert rows[0].must_hear is False
+
+
+def test_parse_top_row_handles_missing_score():
+    """Rows for very-recently-released albums sometimes have an
+    empty / non-numeric score block. Parser should return None
+    rather than raise."""
+    html = _RATING_ROW_HTML.replace(
+        '<div class="scoreValue">84</div>',
+        '<div class="scoreValue">N/A</div>',
+    )
+    rows = _parse_album_list_rows(html)
+    assert len(rows) == 1
+    assert rows[0].score is None
+
+
+def test_parse_top_row_skips_malformed_rows():
+    """A row that's missing the title anchor entirely (defensive
+    against future markup changes) should be silently skipped, not
+    crash the whole list."""
+    broken = "<div class='albumListRow'><div>nothing useful</div></div>"
+    rows = _parse_album_list_rows(broken)
+    assert rows == []
+
+
+# --- recent-releases card parser --------------------------------------------
+
+
+def test_parse_release_card_extracts_all_fields():
+    rows = _parse_album_block_cards(_RELEASE_BLOCK_HTML)
+    assert len(rows) == 1
+    a = rows[0]
+    assert a.artist == "ILLIT"
+    assert a.title == "MAMIHLAPINATAPAI"
+    assert a.score == 63
+    assert a.rating_count == 304
+    # The middle-dot in "Apr 30 · EP" is a UTF-8 encoded U+00B7.
+    # If the encoding fix in `_fetch` regresses, this character
+    # comes through as U+FFFD (the replacement marker) and the
+    # assertion below catches it.
+    assert "·" in (a.release_date or "")
+    assert a.cover_url and "mamihlapinatapai" in a.cover_url
+    assert a.must_hear is False  # /releases/ never sets this flag
+    assert a.rank is None
+
+
+def test_parse_release_card_treats_zero_score_as_none():
+    """Brand-new releases sometimes ship with a 0 in the rating
+    slot before AOTY has a real number. Surface that as `None` so
+    the UI doesn't render a misleading 0/100."""
+    html = _RELEASE_BLOCK_HTML.replace(
+        '<div class="rating">63</div>', '<div class="rating">0</div>'
+    )
+    rows = _parse_album_block_cards(html)
+    assert len(rows) == 1
+    assert rows[0].score is None
+
+
+def test_parse_release_card_handles_missing_cover():
+    """Unreleased albums sometimes have a `noCover` block instead
+    of an <img>. The parser should still emit the row with
+    `cover_url=None`."""
+    html = _RELEASE_BLOCK_HTML.replace(
+        '<img src="https://cdn2.albumoftheyear.org/200x0/album/1728324-mamihlapinatapai_091400.jpg" '
+        'alt="ILLIT - MAMIHLAPINATAPAI"/>',
+        '<div class="noCover"><i class="fa-light fa-lock"></i></div>',
+    )
+    rows = _parse_album_block_cards(html)
+    assert len(rows) == 1
+    assert rows[0].cover_url is None
+    assert rows[0].artist == "ILLIT"
+
+
+# --- the artist/title splitter ----------------------------------------------
+
+
+def test_split_artist_title_basic():
+    assert _split_artist_title("Slayyyter - WOR$T GIRL IN AMERICA") == (
+        "Slayyyter",
+        "WOR$T GIRL IN AMERICA",
+    )
+
+
+def test_split_artist_title_preserves_inner_hyphens():
+    """Splits on the first ' - ' so titles with their own hyphens
+    survive intact."""
+    assert _split_artist_title("Beck - Sea Change - Reissue") == (
+        "Beck",
+        "Sea Change - Reissue",
+    )
+
+
+def test_split_artist_title_missing_separator():
+    """If AOTY ever ships a title without the ' - ' separator,
+    return ('', combined) so the caller's empty-artist guard kicks
+    in and the row is skipped."""
+    assert _split_artist_title("just a title") == ("", "just a title")
+
+
+def test_split_artist_title_empty():
+    assert _split_artist_title("") == ("", "")

--- a/tests/test_aoty_resolver.py
+++ b/tests/test_aoty_resolver.py
@@ -1,0 +1,293 @@
+"""Tests for `app.aoty_resolver.resolve_listing`.
+
+The resolver's behavior matters more than its implementation: callers
+hand it a chart listing and expect every entry back, each decorated
+with a Tidal album dict or `None`. The cases worth pinning are the
+defensive paths (no listing, missing artist/title, search exception,
+serializer exception) and the cache contract (hit short-circuits the
+fan-out, miss writes through, None is never persisted).
+
+The fan-out itself uses a ThreadPoolExecutor of 3 workers per the
+rate-limit posture comment in the module — testing that requires real
+threads. Each test stubs the search / serializer / sleep with simple
+fakes, so the threading is incidental.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+import server
+from app import aoty_resolver, lastfm_disk_cache
+
+
+@pytest.fixture(autouse=True)
+def _isolated_disk_cache(tmp_path, monkeypatch):
+    """Per-test sqlite file. The resolver reads/writes through the
+    lastfm_disk_cache module, so a single redirect of `_db_path` is
+    enough — same pattern used by `test_lastfm_disk_cache`."""
+    monkeypatch.setattr(
+        lastfm_disk_cache, "_db_path", tmp_path / "lastfm_disk_cache.db"
+    )
+
+
+@pytest.fixture
+def stub_server(monkeypatch):
+    """Replace the symbols `resolve_listing` imports from `server`
+    with simple stand-ins. Callers can override individual fakes by
+    re-assigning attributes on the returned object."""
+
+    class _Stub:
+        searches: list[str] = []
+        # Default: the search returns a single album whose name + artist
+        # do NOT exact-match the requested artist/title — so the
+        # "exact match wins" branch isn't taken unless the test sets
+        # search_results explicitly.
+        search_results: dict = {"albums": [_FakeAlbum("Top Hit", "Some Artist")]}
+        serialize_call_count: int = 0
+        sleep_call_count: int = 0
+        explicit_pref: str = "explicit"
+
+        def search(self, query: str, limit: int = 5):
+            self.searches.append(query)
+            return self.search_results
+
+        def album_to_dict(self, album):
+            self.serialize_call_count += 1
+            return {"id": album.id, "name": album.name}
+
+        def filter_explicit_dupes(self, items, pref, *, kind):
+            return items
+
+        def tidal_jitter_sleep(self):
+            self.sleep_call_count += 1
+
+    stub = _Stub()
+    # Reset class-level state on every fixture instantiation so the
+    # mutable defaults don't leak between tests.
+    stub.searches = []
+    stub.serialize_call_count = 0
+    stub.sleep_call_count = 0
+    monkeypatch.setattr(server, "tidal", stub, raising=False)
+    monkeypatch.setattr(server, "album_to_dict", stub.album_to_dict)
+    monkeypatch.setattr(
+        server, "filter_explicit_dupes", stub.filter_explicit_dupes
+    )
+    monkeypatch.setattr(server, "tidal_jitter_sleep", stub.tidal_jitter_sleep)
+
+    class _SettingsStub:
+        explicit_content_preference = stub.explicit_pref
+
+    monkeypatch.setattr(server, "settings", _SettingsStub(), raising=False)
+    return stub
+
+
+class _FakeAlbum:
+    """Minimal stand-in for a Tidal Album object. Only exposes the
+    attributes `resolve_listing` reads via getattr."""
+
+    def __init__(self, name: str, artist: str, id_: str = "ID"):
+        self.id = id_
+        self.name = name
+        self.artists = [_FakeArtist(artist)]
+
+
+class _FakeArtist:
+    def __init__(self, name: str):
+        self.name = name
+
+
+# --- shape contract --------------------------------------------------------
+
+
+def test_empty_listing_returns_empty():
+    """No work to do, no Tidal calls, no exceptions."""
+    assert aoty_resolver.resolve_listing([]) == []
+
+
+def test_missing_artist_returns_tidal_album_none(stub_server):
+    """A listing entry without an artist string should pass through
+    with `tidal_album=None` rather than triggering a search for the
+    empty string."""
+    out = aoty_resolver.resolve_listing([{"artist": "", "title": "X"}])
+    assert len(out) == 1
+    assert out[0]["tidal_album"] is None
+    assert stub_server.searches == []
+
+
+def test_missing_title_returns_tidal_album_none(stub_server):
+    out = aoty_resolver.resolve_listing([{"artist": "X", "title": ""}])
+    assert len(out) == 1
+    assert out[0]["tidal_album"] is None
+    assert stub_server.searches == []
+
+
+def test_preserves_other_listing_fields(stub_server):
+    """Decoration is additive — original entry keys come back intact."""
+    entry = {
+        "artist": "X",
+        "title": "Y",
+        "score": 84,
+        "rank": 1,
+        "must_hear": True,
+    }
+    out = aoty_resolver.resolve_listing([entry])
+    assert out[0]["score"] == 84
+    assert out[0]["rank"] == 1
+    assert out[0]["must_hear"] is True
+
+
+# --- match preference ------------------------------------------------------
+
+
+def test_exact_artist_title_match_wins_over_top_hit(stub_server):
+    """The first result is Tidal's "top hit"; the second is an exact
+    case-insensitive match for the requested artist+title. The exact
+    match should win."""
+    stub_server.search_results = {
+        "albums": [
+            _FakeAlbum("Top Hit", "Some Artist", id_="TOP"),
+            _FakeAlbum("Wanted Title", "Wanted Artist", id_="EXACT"),
+        ]
+    }
+    out = aoty_resolver.resolve_listing(
+        [{"artist": "Wanted Artist", "title": "Wanted Title"}]
+    )
+    assert out[0]["tidal_album"]["id"] == "EXACT"
+
+
+def test_falls_back_to_top_hit_when_no_exact_match(stub_server):
+    """If no result exact-matches the requested artist+title, the
+    first (top-hit) result is used."""
+    stub_server.search_results = {
+        "albums": [
+            _FakeAlbum("Something Else", "Different", id_="TOP"),
+            _FakeAlbum("Other", "Yet Another", id_="OTHER"),
+        ]
+    }
+    out = aoty_resolver.resolve_listing(
+        [{"artist": "Wanted", "title": "Title"}]
+    )
+    assert out[0]["tidal_album"]["id"] == "TOP"
+
+
+def test_match_is_case_insensitive(stub_server):
+    """The exact-match check lowercases both sides — Tidal occasionally
+    returns differently-cased titles."""
+    stub_server.search_results = {
+        "albums": [
+            _FakeAlbum("WANTED TITLE", "wanted artist", id_="MATCH"),
+        ]
+    }
+    out = aoty_resolver.resolve_listing(
+        [{"artist": "Wanted Artist", "title": "Wanted Title"}]
+    )
+    assert out[0]["tidal_album"]["id"] == "MATCH"
+
+
+def test_empty_search_results_yields_none(stub_server):
+    """Tidal returned no albums for the query — the entry comes back
+    with `tidal_album=None` and the listing is preserved."""
+    stub_server.search_results = {"albums": []}
+    out = aoty_resolver.resolve_listing(
+        [{"artist": "X", "title": "Y", "rank": 7}]
+    )
+    assert out[0]["tidal_album"] is None
+    assert out[0]["rank"] == 7
+
+
+# --- cache contract --------------------------------------------------------
+
+
+def test_cache_hit_short_circuits_search(stub_server):
+    """A pre-populated cache entry means no Tidal search call and no
+    rate-limit sleep on the second pass."""
+    listing = [{"artist": "X", "title": "Y"}]
+    aoty_resolver.resolve_listing(listing)
+    first_search_count = len(stub_server.searches)
+    first_sleep_count = stub_server.sleep_call_count
+
+    # Second call with the same entry should hit the disk cache.
+    aoty_resolver.resolve_listing(listing)
+    assert len(stub_server.searches) == first_search_count
+    assert stub_server.sleep_call_count == first_sleep_count
+
+
+def test_cache_only_persists_successful_resolves(stub_server):
+    """A None resolution (Tidal returned no match) must NOT be cached
+    — caching None for 30 days would blank the album from the chart on
+    a single transient hiccup. So the second call should re-search."""
+    stub_server.search_results = {"albums": []}
+    listing = [{"artist": "X", "title": "Y"}]
+    aoty_resolver.resolve_listing(listing)
+    assert len(stub_server.searches) == 1
+
+    # Now Tidal "comes back" — the second call should retry the search
+    # rather than serving cached None.
+    stub_server.search_results = {
+        "albums": [_FakeAlbum("Y", "X", id_="HIT")]
+    }
+    out = aoty_resolver.resolve_listing(listing)
+    assert len(stub_server.searches) == 2
+    assert out[0]["tidal_album"]["id"] == "HIT"
+
+
+def test_cache_key_includes_explicit_preference(stub_server, monkeypatch):
+    """A user toggling explicit-content preference between requests
+    must not pull a stale cached resolution from the other branch.
+    Two resolves of the same album under two preferences should run
+    two searches."""
+    listing = [{"artist": "X", "title": "Y"}]
+
+    class ExplicitSettings:
+        explicit_content_preference = "explicit"
+
+    class CleanSettings:
+        explicit_content_preference = "clean"
+
+    monkeypatch.setattr(server, "settings", ExplicitSettings())
+    aoty_resolver.resolve_listing(listing)
+    monkeypatch.setattr(server, "settings", CleanSettings())
+    aoty_resolver.resolve_listing(listing)
+
+    assert len(stub_server.searches) == 2
+
+
+# --- defensive paths -------------------------------------------------------
+
+
+def test_search_exception_yields_none_and_does_not_cache(stub_server):
+    """A Tidal client exception (network, abuse-detection 429, etc.)
+    should surface as `tidal_album=None` and NOT poison the cache."""
+
+    def boom(*_a, **_kw):
+        raise RuntimeError("boom")
+
+    stub_server.search = boom
+    listing = [{"artist": "X", "title": "Y"}]
+    out = aoty_resolver.resolve_listing(listing)
+    assert out[0]["tidal_album"] is None
+
+    # Cache must be empty — a working Tidal on the next call should
+    # actually run the search again.
+    stub_server.search = lambda *_a, **_kw: {
+        "albums": [_FakeAlbum("Y", "X", id_="HIT")]
+    }
+    out = aoty_resolver.resolve_listing(listing)
+    assert out[0]["tidal_album"] is not None
+
+
+def test_serialize_exception_yields_none(stub_server):
+    """`album_to_dict` raising (e.g. an unexpected attribute on the
+    Tidal album object) must not propagate — the row comes back with
+    `tidal_album=None`."""
+
+    def boom(_a):
+        raise RuntimeError("serialize-boom")
+
+    with patch.object(server, "album_to_dict", boom):
+        out = aoty_resolver.resolve_listing(
+            [{"artist": "X", "title": "Y"}]
+        )
+    assert out[0]["tidal_album"] is None

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -22,6 +22,7 @@ import type {
   LastFmTopTrack,
   LastFmUserInfo,
   LastFmWeeklyScrobble,
+  AotyAlbum,
   LocalFile,
   LocalVideo,
   Lyrics,
@@ -325,6 +326,22 @@ export const api = {
           timestamp: track.timestamp ?? null,
         }),
       }),
+  },
+  aoty: {
+    /** Top-rated albums of the given year per AlbumOfTheYear, with
+     *  each entry decorated with a Tidal album dict when one exists.
+     *  Year defaults server-side to the current year. */
+    topOfYear: (opts?: { year?: number; limit?: number }) => {
+      const params = new URLSearchParams();
+      if (opts?.year !== undefined) params.set("year", String(opts.year));
+      if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
+      const qs = params.toString();
+      return req<AotyAlbum[]>(`/api/aoty/top-of-year${qs ? `?${qs}` : ""}`);
+    },
+    /** Recently-released albums per AOTY's /releases/ grid, with each
+     *  entry decorated with a Tidal album dict when one exists. */
+    recentReleases: (limit = 30) =>
+      req<AotyAlbum[]>(`/api/aoty/recent-releases?limit=${limit}`),
   },
   spotify: {
     /** Spotify's global play count for a recording identified by

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -389,6 +389,24 @@ export interface LastFmTopAlbum {
   image: string;
 }
 
+/** One row from an AlbumOfTheYear listing endpoint. The AOTY metadata
+ *  describes the album as AOTY presents it (rank, score, cover URL,
+ *  release date), and `tidal_album` is the resolved Tidal album dict
+ *  when AOTY's pick exists on Tidal — null when it doesn't, in which
+ *  case the row is shown but isn't directly playable. */
+export interface AotyAlbum {
+  title: string;
+  artist: string;
+  score: number | null;
+  rating_count: number | null;
+  cover_url: string | null;
+  release_date: string | null;
+  rank: number | null;
+  must_hear: boolean;
+  aoty_url: string | null;
+  tidal_album: Album | null;
+}
+
 export interface LastFmLovedTrack {
   name: string;
   artist: string;

--- a/web/src/components/AotyHomeSection.tsx
+++ b/web/src/components/AotyHomeSection.tsx
@@ -1,10 +1,10 @@
+import { useMemo } from "react";
 import { Link } from "react-router-dom";
 import { Music, Star } from "lucide-react";
 import type { AotyAlbum, Album } from "@/api/types";
-import type { OnDownload } from "@/api/download";
 import { useApi } from "@/hooks/useApi";
 import { api } from "@/api/client";
-import { SectionHeader } from "@/components/Grid";
+import { Grid, SectionHeader } from "@/components/Grid";
 import { GridSkeleton } from "@/components/Skeletons";
 import { PlayMediaButton } from "@/components/PlayMediaButton";
 import { imageProxy } from "@/lib/utils";
@@ -18,23 +18,21 @@ import { imageProxy } from "@/lib/utils";
  *
  * Entries without a resolved Tidal album are filtered out: the goal is
  * a discovery surface the user can play from, not a chart for its own
- * sake. AOTY's own page is still one click away via the section
- * subtitle on each entry.
+ * sake.
  */
-export function AotyHomeSection({ onDownload }: { onDownload: OnDownload }) {
-  const year = new Date().getFullYear();
+export function AotyHomeSection() {
+  // Memoised so the title doesn't recompute on every render. Won't
+  // tick over at midnight on Jan 1 without a remount, but the cost
+  // of that edge case is "wrong year in the title until next visit"
+  // which is fine.
+  const year = useMemo(() => new Date().getFullYear(), []);
   return (
     <div>
       <AotyRow
         title={`Top albums of ${year}`}
         fetch={() => api.aoty.topOfYear({ limit: 30 })}
-        onDownload={onDownload}
       />
-      <AotyRow
-        title="New releases"
-        fetch={() => api.aoty.recentReleases(24)}
-        onDownload={onDownload}
-      />
+      <AotyRow title="New releases" fetch={() => api.aoty.recentReleases(24)} />
     </div>
   );
 }
@@ -42,11 +40,9 @@ export function AotyHomeSection({ onDownload }: { onDownload: OnDownload }) {
 function AotyRow({
   title,
   fetch,
-  onDownload,
 }: {
   title: string;
   fetch: () => Promise<AotyAlbum[]>;
-  onDownload: OnDownload;
 }) {
   const { data, loading, error } = useApi(fetch, []);
 
@@ -70,15 +66,11 @@ function AotyRow({
   return (
     <div className="mb-2">
       <SectionHeader title={title} />
-      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
+      <Grid>
         {playable.map((entry) => (
-          <AotyCard
-            key={entry.tidal_album.id}
-            entry={entry}
-            onDownload={onDownload}
-          />
+          <AotyCard key={entry.tidal_album.id} entry={entry} />
         ))}
-      </div>
+      </Grid>
     </div>
   );
 }
@@ -89,13 +81,7 @@ function AotyRow({
  * when present, and a "must hear" star (top-right) when AOTY has
  * tagged the album that way.
  */
-function AotyCard({
-  entry,
-  onDownload: _onDownload,
-}: {
-  entry: AotyAlbum & { tidal_album: Album };
-  onDownload: OnDownload;
-}) {
+function AotyCard({ entry }: { entry: AotyAlbum & { tidal_album: Album } }) {
   const album = entry.tidal_album;
   const cover = imageProxy(album.cover);
   const artist = album.artists.map((a) => a.name).join(", ");
@@ -121,6 +107,7 @@ function AotyCard({
         {entry.score !== null && (
           <div
             className="absolute left-2 top-2 rounded bg-black/75 px-1.5 py-0.5 text-xs font-bold text-white shadow"
+            aria-label={`AOTY score: ${entry.score} out of 100`}
             title={`AOTY score: ${entry.score}/100`}
           >
             {entry.score}
@@ -129,6 +116,7 @@ function AotyCard({
         {entry.must_hear && (
           <div
             className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-full bg-amber-500 text-white shadow"
+            aria-label="AOTY must hear"
             title="AOTY must hear"
           >
             <Star className="h-3.5 w-3.5 fill-current" />

--- a/web/src/components/AotyHomeSection.tsx
+++ b/web/src/components/AotyHomeSection.tsx
@@ -1,0 +1,152 @@
+import { Link } from "react-router-dom";
+import { Music, Star } from "lucide-react";
+import type { AotyAlbum, Album } from "@/api/types";
+import type { OnDownload } from "@/api/download";
+import { useApi } from "@/hooks/useApi";
+import { api } from "@/api/client";
+import { SectionHeader } from "@/components/Grid";
+import { GridSkeleton } from "@/components/Skeletons";
+import { PlayMediaButton } from "@/components/PlayMediaButton";
+import { imageProxy } from "@/lib/utils";
+
+/**
+ * Two AOTY-backed rows on the Home page: the year's highest-user-rated
+ * albums and AOTY's recently-released grid. Each row fetches its own
+ * data so a slow / failed call to one doesn't block the other, and
+ * empty-or-errored rows render nothing at all (the section is purely
+ * additive — Home stays usable if AOTY is down).
+ *
+ * Entries without a resolved Tidal album are filtered out: the goal is
+ * a discovery surface the user can play from, not a chart for its own
+ * sake. AOTY's own page is still one click away via the section
+ * subtitle on each entry.
+ */
+export function AotyHomeSection({ onDownload }: { onDownload: OnDownload }) {
+  const year = new Date().getFullYear();
+  return (
+    <div>
+      <AotyRow
+        title={`Top albums of ${year}`}
+        fetch={() => api.aoty.topOfYear({ limit: 30 })}
+        onDownload={onDownload}
+      />
+      <AotyRow
+        title="New releases"
+        fetch={() => api.aoty.recentReleases(24)}
+        onDownload={onDownload}
+      />
+    </div>
+  );
+}
+
+function AotyRow({
+  title,
+  fetch,
+  onDownload,
+}: {
+  title: string;
+  fetch: () => Promise<AotyAlbum[]>;
+  onDownload: OnDownload;
+}) {
+  const { data, loading, error } = useApi(fetch, []);
+
+  // Silent failure mode — Home stays usable. The user sees an empty
+  // chart cycle, not a bright red error block.
+  if (error) return null;
+  if (loading) {
+    return (
+      <div className="mb-2">
+        <SectionHeader title={title} />
+        <GridSkeleton count={6} />
+      </div>
+    );
+  }
+
+  const playable = (data ?? []).filter(
+    (e): e is AotyAlbum & { tidal_album: Album } => e.tidal_album !== null,
+  );
+  if (playable.length === 0) return null;
+
+  return (
+    <div className="mb-2">
+      <SectionHeader title={title} />
+      <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
+        {playable.map((entry) => (
+          <AotyCard
+            key={entry.tidal_album.id}
+            entry={entry}
+            onDownload={onDownload}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * One AOTY-decorated album card. Visually a Tidal album card — cover,
+ * title, artist — with two small overlays: the AOTY score (top-left)
+ * when present, and a "must hear" star (top-right) when AOTY has
+ * tagged the album that way.
+ */
+function AotyCard({
+  entry,
+  onDownload: _onDownload,
+}: {
+  entry: AotyAlbum & { tidal_album: Album };
+  onDownload: OnDownload;
+}) {
+  const album = entry.tidal_album;
+  const cover = imageProxy(album.cover);
+  const artist = album.artists.map((a) => a.name).join(", ");
+
+  return (
+    <Link
+      to={`/album/${album.id}`}
+      className="group relative flex flex-col gap-3 rounded-lg bg-card p-4 transition-colors duration-200 ease-out hover:bg-accent"
+    >
+      <div className="relative aspect-square w-full overflow-hidden rounded-md bg-secondary">
+        {cover ? (
+          <img
+            src={cover}
+            alt={album.name}
+            loading="lazy"
+            className="h-full w-full object-cover transition-transform duration-300 ease-out group-hover:scale-105"
+          />
+        ) : (
+          <div className="flex h-full w-full items-center justify-center text-muted-foreground">
+            <Music className="h-10 w-10" />
+          </div>
+        )}
+        {entry.score !== null && (
+          <div
+            className="absolute left-2 top-2 rounded bg-black/75 px-1.5 py-0.5 text-xs font-bold text-white shadow"
+            title={`AOTY score: ${entry.score}/100`}
+          >
+            {entry.score}
+          </div>
+        )}
+        {entry.must_hear && (
+          <div
+            className="absolute right-2 top-2 flex h-6 w-6 items-center justify-center rounded-full bg-amber-500 text-white shadow"
+            title="AOTY must hear"
+          >
+            <Star className="h-3.5 w-3.5 fill-current" />
+          </div>
+        )}
+        <div className="absolute bottom-2 left-2 opacity-0 transition-all duration-200 ease-out group-hover:opacity-100 focus-within:opacity-100">
+          <PlayMediaButton kind="album" id={album.id} className="h-10 w-10" />
+        </div>
+      </div>
+      <div className="min-w-0">
+        <div className="truncate font-semibold">{album.name}</div>
+        <div className="mt-0.5 line-clamp-2 text-xs text-muted-foreground">
+          {artist}
+          {entry.rating_count !== null && (
+            <span> · {entry.rating_count.toLocaleString()} ratings</span>
+          )}
+        </div>
+      </div>
+    </Link>
+  );
+}

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -9,6 +9,7 @@ import { ViewMoreLink } from "@/components/Grid";
 import { PageView } from "@/components/PageView";
 import { ErrorView } from "@/components/ErrorView";
 import { GridSkeleton } from "@/components/Skeletons";
+import { AotyHomeSection } from "@/components/AotyHomeSection";
 import { LastfmConnectNudge } from "@/components/LastfmConnectNudge";
 import { CreditsDialog } from "@/components/CreditsDialog";
 import { DROPDOWN_MENU_PARTS, TrackMenuItems } from "@/components/TrackMenu";
@@ -652,6 +653,7 @@ export function Home({ onDownload }: { onDownload: OnDownload }) {
           onDownload={onDownload}
         />
       )}
+      <AotyHomeSection onDownload={onDownload} />
       {hoistedAlbums && (
         <PageView
           page={{ ...data, categories: [hoistedAlbums] }}

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -653,7 +653,7 @@ export function Home({ onDownload }: { onDownload: OnDownload }) {
           onDownload={onDownload}
         />
       )}
-      <AotyHomeSection onDownload={onDownload} />
+      <AotyHomeSection />
       {hoistedAlbums && (
         <PageView
           page={{ ...data, categories: [hoistedAlbums] }}


### PR DESCRIPTION
## Summary

Adds two new AOTY-backed rows to the Home page above Tidal's editorial blocks: **Top albums of {year}** and **New releases**. Lets the user replace some of the algorithmic Tidal recommendations with editorial / community-rated discovery, per the user's framing of the feature.

The data flow is layered so each cost lives where it's recoverable from:

- `app/aoty.py` — HTML scraper for `/ratings/user-highest-rated/{year}/` and `/releases/`. In-memory cache with per-key TTL (1h top-of-year, 30min recent). Fails silently to `[]` on HTTP / parse errors.
- `app/aoty_resolver.py` — fans each AOTY listing entry out to a Tidal album search at 3 workers + jittered sleeps (mirrors the rate-limit posture of the Last.fm Popular resolver). Per-album resolutions cached for 30 days in the SQLite-backed disk cache, so brand-new chart entries are the only thing that triggers fresh Tidal traffic across restarts. Only successful resolutions persist — a transient Tidal hiccup can't blank an album for a month.
- `server.py` — two thin route handlers (`/api/aoty/top-of-year`, `/api/aoty/recent-releases`) that glue the two together. No outer cache; the underlying caches already handle cost.
- `web/src/components/AotyHomeSection.tsx` — two side-by-side rows on Home. Each fetches independently, errors silently (Home stays usable when AOTY is down), and entries that don't resolve to Tidal are filtered out so every visible card is playable. Cards reuse the existing `<Grid>` and overlay the AOTY score / must-hear flag on a Tidal-styled cover.

Schema-wise this is purely additive — no migrations, no settings flags, no changes to existing endpoints.

## Test plan

- [x] `pytest tests/` — 489 passed / 2 skipped (was 476 before).
- [x] 11 inline-fixture tests for the two HTML parsers in `test_aoty_parser.py` covering the must-hear flag, missing-score rows, malformed rows, zero-score, missing-cover, UTF-8 middle-dot encoding.
- [x] 13 unit tests for the resolver in `test_aoty_resolver.py` covering the empty-listing short-circuit, missing-field guards, exact-match-wins-over-top-hit preference, the explicit-pref cache-key partition, the cache-only-on-success contract, and both exception paths. Stubs Tidal symbols and isolates the SQLite cache — no network.
- [x] `npx tsc -b --noEmit` clean.
- [x] `npm run lint` — 0 errors (56 pre-existing warnings, none new).
- [x] `npm test` — 36 vitest tests pass.
- [ ] Manual smoke: launch the app, confirm both rows render on Home, click a card opens the resolved Tidal album, AOTY-only entries are absent (filtered).
- [ ] Manual smoke: confirm Home still renders correctly when AOTY is unreachable (block the domain in hosts and verify the section is silently absent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)