### PR TITLE
Fix SearchSuggestions: move ref writes out of render body

### DIFF
--- a/web/src/components/SearchSuggestions.tsx
+++ b/web/src/components/SearchSuggestions.tsx
@@ -151,12 +151,17 @@ export function SearchSuggestions({
   // Keyboard handling lives at the document level so the user can
   // type / arrow-key without the input losing focus. Refs hold the
   // latest activate / onCloseRequested so the listener doesn't have
-  // to re-attach on every render — handy when the parent recreates
-  // the close callback inline (NavBar does).
+  // to re-attach on every render, which matters because NavBar
+  // recreates the close callback inline. The ref writes go in their
+  // own effect rather than the render body so we only update them
+  // for committed renders, not for renders concurrent React may
+  // start and discard.
   const activateRef = useRef(activate);
   const closeRef = useRef(onCloseRequested);
-  activateRef.current = activate;
-  closeRef.current = onCloseRequested;
+  useEffect(() => {
+    activateRef.current = activate;
+    closeRef.current = onCloseRequested;
+  });
 
   useEffect(() => {
     if (!open) return;


### PR DESCRIPTION
## Summary

The keyboard handling in [SearchSuggestions.tsx](web/src/components/SearchSuggestions.tsx) holds `activate` and `onCloseRequested` in refs so the document-level keydown listener does not re-attach every time the parent recreates those callbacks (NavBar does). The refs were being updated with bare assignments at the top of the component:

```tsx
activateRef.current = activate;
closeRef.current = onCloseRequested;
```

Writing to refs during render is unsafe under concurrent rendering. React 18 can start a render, mutate the ref, then abandon the work (higher-priority update, Suspense, StrictMode double-invoke); the mutation already happened, so the ref reflects a render that never committed.

This PR moves the writes into their own `useEffect` with no deps array. Effects only run for committed renders, so the refs always match what the user actually sees.

The same fix silences the `react-hooks/refs-during-render` rule that ships in eslint-plugin-react-hooks v7, in case we ever take that bump.

**No user-visible behavior change today.** The codebase doesn't currently wrap SearchSuggestions in Suspense, and the keydown listener is stable enough that a one-render lag wouldn't visibly misbehave. This is preventive.

## Test plan

- [x] Preflight green locally (pytest 494 / vitest 36, tsc + lint clean).
- [ ] Open NavBar's search dropdown, type to filter, hit Escape — should still close.
- [ ] Type in the search box, ArrowDown to highlight a suggestion, Enter — should still navigate to the result.
- [ ] Open the dropdown and check it doesn't pile on document-level listeners (devtools "Event Listeners" tab on the document, look for `keydown` count staying at 1 across re-renders).