### PR TITLE
CLAUDE.md: cross-device pause was never implemented, say so

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,14 +193,19 @@ If you need a high-signal line (mint failure, takeover received,
 state change), use the print pattern. If you need debug detail
 (per-frame trace, periodic heartbeat), use the logger.
 
-## Cross-device pause specifics
+## Cross-device pause — not implemented
 
-The realtime listener (`app/tidal_realtime.py`) is **always on** and
-spawns at server boot. It's gated under pytest via `_under_pytest()`
-in `server.py` so the test suite doesn't open a live WS to Tidal. If
-new tests need to exercise the listener, mock it directly — don't
-rely on starting it through the boot path.
+This section previously claimed Tideway has an always-on realtime
+listener at `app/tidal_realtime.py` that pauses local playback when
+another device on the same Tidal account starts playing. **That was
+aspirational documentation; the module never existed.** No
+`tidal_realtime.py`, no `_under_pytest()` helper, no
+`/api/realtime/status` endpoint, no WebSocket client to Tidal's
+realtime bus.
 
-Diagnostics: `GET /api/realtime/status` returns the listener's runtime
-state (running / connected / last_error / counters). Use it before
-debugging by log-grep.
+Building it for real means: a WebSocket client to Tidal's realtime
+endpoint, auth via the existing tidalapi session, reverse-engineering
+of the state-change message format, and wiring "another device
+started" to `PCMPlayer.pause()`. Comparable in scope to the Tidal
+Connect receiver work — undocumented protocol, ongoing maintenance.
+Out of scope until explicitly planned.


### PR DESCRIPTION
## What this PR does

Removes a misleading section of CLAUDE.md that described an `app/tidal_realtime.py` module that doesn't exist.

## What I found while triaging the cross-device-pause bug

The bug report said "this is supposedly already working but it is broken." Investigation: there's no `app/tidal_realtime.py` in the working tree or anywhere in git history. No `_under_pytest()` helper in server.py. No `/api/realtime/status` route. No WebSocket client code anywhere in the repo.

The CLAUDE.md section was added in [ca38682](https://github.com/J-M-PUNK/tideway/commit/ca38682) along with the rest of the dev-workflow docs — aspirational planning that shipped as if it described reality. The feature was never built.

## What this PR doesn't do

This is documentation-only — it doesn't implement the feature. The actual cross-device pause listener is a 1-2 week build (WebSocket client, protocol capture, state-change wiring) and is scoped separately for future planning.

## Why ship this

Documentation that lies about what exists is itself a bug. It misled the maintainer (me) into thinking there was a regression, and would mislead any future contributor reading CLAUDE.md to understand the codebase. Getting the docs honest is fast and unblocks correct triage when users report cross-device issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)