### PR TITLE
Player: skip button stays enabled on last track, stops playback

### DIFF
--- a/web/src/components/FullScreenPlayer.tsx
+++ b/web/src/components/FullScreenPlayer.tsx
@@ -43,7 +43,7 @@ export function FullScreenPlayer({
   onClose: () => void;
   onDownload: OnDownload;
 }) {
-  const { track, playing, loading, shuffle, repeat, hasNext, hasPrev } =
+  const { track, playing, loading, shuffle, repeat, hasPrev } =
     usePlayerMeta();
   const { currentTime, duration } = usePlayerTime();
   const actions = usePlayerActions();
@@ -223,7 +223,6 @@ export function FullScreenPlayer({
                 variant="ghost"
                 size="icon"
                 onClick={actions.next}
-                disabled={!hasNext && !shuffle && repeat === "off"}
                 className="h-10 w-10 hover:bg-white/10"
               >
                 <SkipForward className="h-5 w-5" fill="currentColor" />

--- a/web/src/components/NowPlaying.tsx
+++ b/web/src/components/NowPlaying.tsx
@@ -77,7 +77,6 @@ export function NowPlaying({
     volume,
     shuffle,
     repeat,
-    hasNext,
     hasPrev,
     queue,
     streamInfo,
@@ -272,7 +271,6 @@ export function NowPlaying({
               size="icon"
               className="h-8 w-8"
               onClick={actions.next}
-              disabled={!hasNext && !shuffle && repeat === "off"}
               title="Next"
             >
               <SkipForward className="h-4 w-4" fill="currentColor" />

--- a/web/src/hooks/usePlayer.ts
+++ b/web/src/hooks/usePlayer.ts
@@ -911,7 +911,21 @@ export function usePlayer() {
       : -1;
     const fromIdx = intendedIdx >= 0 ? intendedIdx : s.queueIndex;
     const n = pickNextIndex({ ...s, queueIndex: fromIdx });
-    if (n !== null) playAtIndex(n);
+    if (n !== null) {
+      playAtIndex(n);
+      return;
+    }
+    // End of queue with shuffle off + repeat off — explicit stop
+    // rather than silent no-op, so clicking Next on the last track
+    // of an album produces a predictable result instead of a
+    // button that pretends to do nothing. Matches Spotify / Apple
+    // Music behaviour, and lets the UI keep the Next button
+    // enabled (which a no-op `next` did not justify).
+    if (s.queue.length > 0) {
+      expectedTrackIdRef.current = null;
+      void api.player.stop().catch(() => {});
+      setState(INITIAL);
+    }
   }, [playAtIndex]);
 
   const prev = useCallback(() => {

--- a/web/src/pages/MiniPlayerPage.tsx
+++ b/web/src/pages/MiniPlayerPage.tsx
@@ -24,7 +24,7 @@ import { cn } from "@/lib/utils";
  * back to the main window.
  */
 export function MiniPlayerPage() {
-  const { track, playing, hasNext, hasPrev, streamInfo } = usePlayerMeta();
+  const { track, playing, hasPrev, streamInfo } = usePlayerMeta();
   const { currentTime, duration } = usePlayerTime();
   const actions = usePlayerActions();
 
@@ -84,10 +84,9 @@ export function MiniPlayerPage() {
           </button>
           <button
             onClick={actions.next}
-            disabled={!hasNext}
             title="Next"
             aria-label="Next"
-            className="flex h-8 w-8 items-center justify-center rounded-full text-muted-foreground hover:text-foreground disabled:opacity-30"
+            className="flex h-8 w-8 items-center justify-center rounded-full text-muted-foreground hover:text-foreground"
           >
             <SkipForward className="h-3.5 w-3.5" />
           </button>


### PR DESCRIPTION
## Summary

The Next button was disabled at the end of a non-shuffle, non-repeat queue:
- [NowPlaying.tsx](web/src/components/NowPlaying.tsx): `disabled={!hasNext && !shuffle && repeat === "off"}`
- [FullScreenPlayer.tsx](web/src/components/FullScreenPlayer.tsx): same
- [MiniPlayerPage.tsx](web/src/pages/MiniPlayerPage.tsx): `disabled={!hasNext}`

That's not what users expect on the last song of an album — the button is right there, the album just ended, and clicking it should produce a result. Spotify and Apple Music both keep the button live and land the user in stopped state.

## Two changes

- **[usePlayer.next()](web/src/hooks/usePlayer.ts:1037)** — when `pickNextIndex` returns null and the queue is non-empty, explicitly stop playback (clear `expectedTrackIdRef`, call `api.player.stop()`, reset state). Previously this branch was a silent no-op, which is why the `disabled` binding existed in the first place.
- **NowPlaying / FullScreenPlayer / MiniPlayer** — drop the `disabled` binding on the Next button. The button is now always live, and `next()` decides whether to advance or stop.

`hasNext` is no longer destructured by the three music players. `useVideoPlayer` / `VideoPlayerModal` copies are unchanged — video has different end-of-queue semantics worth preserving until separately considered.

## Test plan

- [x] `pytest tests/` — 465 passed, 2 skipped (no change)
- [x] `tsc --noEmit` clean
- [ ] Manual: play the last song of any album, click Next. Player should stop cleanly (not silently no-op, not disabled).
- [ ] Manual: enable shuffle on a multi-track queue. Click Next on a song. Should pick a random different song (no behavior change).
- [ ] Manual: enable Repeat All. Click Next on the last song. Should wrap to the first track (no behavior change).
- [ ] Manual: queue contains a single track, click Next. Should replay the track (matches Spotify; preexisting behavior unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)