### PR TITLE
Spotify enrichment: don't poison cache on transient failure

### DIFF
--- a/web/src/hooks/useSpotifyEnrichment.ts
+++ b/web/src/hooks/useSpotifyEnrichment.ts
@@ -68,14 +68,24 @@ export function useSpotifyTrackPlaycount(
     if (!key || !spotifyEnabled) return;
     const off = subscribe(playcountSubs, key, () => force((n) => n + 1));
     if (!playcountCache.has(key) && !playcountInflight.has(key)) {
+      // Successful resolution: cache the result (including a server-
+      // authoritative null for "Spotify doesn't know this track").
+      // Failure (timeout / network blip / 5xx): do NOT cache. Caching
+      // a null sentinel from a transient failure poisons the entry
+      // for the rest of the session — every subsequent read sees it
+      // as "Spotify said null" and never retries. Letting the cache
+      // stay empty means the next render re-fires the request, which
+      // is the right cold-load recovery.
       const p = api.spotify
         .trackPlaycount(key)
-        .then((r) => r.playcount)
-        .catch(() => null)
-        .then((val) => {
-          playcountCache.set(key, val);
+        .then((r) => {
+          playcountCache.set(key, r.playcount);
           notify(playcountSubs, key);
-          return val;
+          return r.playcount;
+        })
+        .catch(() => {
+          notify(playcountSubs, key);
+          return null;
         })
         .finally(() => playcountInflight.delete(key));
       playcountInflight.set(key, p);
@@ -108,28 +118,34 @@ export function useSpotifyArtistStats(
       return;
     const off = subscribe(statsSubs, key, () => force((n) => n + 1));
     if (!statsCache.has(key) && !statsInflight.has(key)) {
+      // Cache only on success. A transient failure used to write
+      // {monthly_listeners: null, ...} into the cache, which then
+      // looked indistinguishable from "Spotify said null" on every
+      // subsequent read for the rest of the session — that was the
+      // root cause of the cold-load "monthly listeners missing"
+      // report. Leaving the cache empty on failure lets the next
+      // render re-fire the request.
       const p = api.spotify
         .artistStats(tidalArtistId, tidalArtistName || "", cleanedIsrcs)
-        .then(
-          (r): ArtistStats => ({
+        .then((r): ArtistStats => {
+          const val: ArtistStats = {
             monthly_listeners: r.monthly_listeners,
             followers: r.followers,
             world_rank: r.world_rank,
             top_cities: r.top_cities,
-          }),
-        )
-        .catch(
-          (): ArtistStats => ({
+          };
+          statsCache.set(key, val);
+          notify(statsSubs, key);
+          return val;
+        })
+        .catch((): ArtistStats => {
+          notify(statsSubs, key);
+          return {
             monthly_listeners: null,
             followers: null,
             world_rank: null,
             top_cities: [],
-          }),
-        )
-        .then((val) => {
-          statsCache.set(key, val);
-          notify(statsSubs, key);
-          return val;
+          };
         })
         .finally(() => statsInflight.delete(key));
       statsInflight.set(key, p);
@@ -172,13 +188,19 @@ export function useSpotifyAlbumTotalPlays(
     if (!key || !spotifyEnabled) return;
     const off = subscribe(albumPlaysSubs, key, () => force((n) => n + 1));
     if (!albumPlaysCache.has(key) && !albumPlaysInflight.has(key)) {
+      // Same failure-cache rule as the other Spotify enrichment
+      // hooks — only cache on success so a transient failure doesn't
+      // stick zeroes for the rest of the session.
       const p = api.spotify
         .albumTotalPlays(key.split(","))
-        .catch(() => ({ total_plays: 0, resolved: 0, total: 0 }))
         .then((val) => {
           albumPlaysCache.set(key, val);
           notify(albumPlaysSubs, key);
           return val;
+        })
+        .catch(() => {
+          notify(albumPlaysSubs, key);
+          return { total_plays: 0, resolved: 0, total: 0 };
         })
         .finally(() => albumPlaysInflight.delete(key));
       albumPlaysInflight.set(key, p);


### PR DESCRIPTION
## Summary

Fixes the user-reported "monthly listeners are now not showing on artists on a cold load." Root cause is in the per-page failure-caching behaviour of the three Spotify enrichment hooks, not in the server-side resolver.

## What was happening

All three hooks (`useSpotifyTrackPlaycount`, `useSpotifyArtistStats`, `useSpotifyAlbumTotalPlays`) had the same broken shape:

```ts
.catch(() => null)           // or {monthly_listeners: null, ...}
.then((val) => {
  cache.set(key, val);       // poisons cache on transient failure
  ...
})
```

If the very first request failed — timeout, 5xx, network blip — the catch returned a null sentinel and the next `.then` unconditionally wrote it to the module-level cache. From then on, `cache.has(key)` was true, and every subsequent read returned the sentinel forever, until the user restarted the app.

This is exactly the cold-load failure mode in the bug report: the first time the user opens an artist page, the request hadn't quite landed (15s default timeout), the cache got poisoned, and the page was stuck rendering "no monthly listeners" for that artist for the rest of the session.

## Fix

Move the cache write into the success branch only. On failure, the catch still returns a sentinel for *this* render so the hook return type stays clean — but it doesn't write anything to the cache. The next render re-fires the request. Server-authoritative nulls (when Spotify legitimately doesn't know a track) still get cached because they come from the success path; only transient failures fall through.

## What this PR does NOT fix

The bug report also mentioned "stream numbers are also often incorrect" — that's a different problem in the server-side ISRC → Spotify-track resolver picking the wrong recording for a given ISRC. It needs real-world data comparison (Tideway's number vs spotify.com's number for the same track) to investigate, and is intentionally left as a separate follow-up rather than guessing at a fix without data.

## Test plan

- [x] `tsc --noEmit` clean
- [x] Existing `useSpotifyEnrichment.test.ts` still passes
- [ ] Manual: open an artist page on a cold app session. Throttle network to "Slow 3G" in dev tools so the first request times out. Confirm monthly listeners populates within ~30s of opening (not stuck blank forever)
- [ ] Manual: open an artist Spotify legitimately has no overview for. Confirm "no monthly listeners" stays stable across renders (still cached as null from the success path; not retrying on every render)

🤖 Generated with [Claude Code](https://claude.com/claude-code)