### PR TITLE
UI polish: search top-hit height + Home Custom Mixes spacing

### DIFF
--- a/web/src/components/TopHitCard.tsx
+++ b/web/src/components/TopHitCard.tsx
@@ -95,8 +95,15 @@ export function TopHitCard({
     </>
   );
 
+  // No `h-full` — the search hero is a 2-column grid where the right
+  // column (Songs list) is often much taller than the natural height
+  // of this card. Stretching the card to match leaves a big empty
+  // bottom region, especially on the artist branch where the subtitle
+  // line is intentionally suppressed. Letting the card size to its
+  // content matches the rhythm Spotify / Apple Music use, where the
+  // top-result and songs columns can have different heights.
   const cardClasses =
-    "group relative flex h-full flex-col gap-5 rounded-lg bg-card p-6 transition-colors duration-200 ease-out hover:bg-accent";
+    "group relative flex flex-col gap-5 rounded-lg bg-card p-6 transition-colors duration-200 ease-out hover:bg-accent";
 
   if (hit.kind === "track") {
     return (

--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -681,7 +681,20 @@ export function Home({ onDownload }: { onDownload: OnDownload }) {
           onDownload={onDownload}
         />
       ))}
-      <PageView page={filteredPage} onDownload={onDownload} forceSingleRow />
+      {/* mt-8 gives the priority rows (Custom Mixes is first) a
+           consistent breathing room above their first SectionHeader.
+           Without this, when `remainingCompact` is empty the rows
+           sit too close to the hoistedAlbums grid above (PageView's
+           inner `gap-8` only spaces *between* its own children, not
+           above its first one). 32px matches the inter-row gap so
+           the visual rhythm is consistent. */}
+      <div className="mt-8">
+        <PageView
+          page={filteredPage}
+          onDownload={onDownload}
+          forceSingleRow
+        />
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Two small visual fixes from the bug-tracker queue, bundled because they're both ~10-line CSS tweaks in the same area.

## Search top-hit card was too tall

The "Top Result" card on the Search page sat in a 2-column grid with the Songs column on the right. The card had `h-full`, so it stretched to match the row height that the much-taller Songs column established. The artist branch intentionally suppresses its subtitle (the kind chip is enough), so the artist top hit had less content than other kinds — and the stretched empty space below was very visible.

Drop `h-full` from `cardClasses` in [TopHitCard.tsx](web/src/components/TopHitCard.tsx). Card sizes to its content. Album / track / playlist top hits won't stretch either, but they have enough content (cover + name + subtitle + chip) that the visual rhythm stays fine — and this matches what Spotify / Apple Music do (their top-result and songs columns can have different heights).

## Home "Custom mixes" sat too close to the row above

Custom Mixes is the first row in the final `<PageView>` block on Home (priority-row ordering). PageView's internal `gap-8` only spaces *between* sibling rows, not above its first one — so when `remainingCompact` was empty, Custom Mixes butted right up against the hoisted-albums grid with no breathing room.

Wrap the final `<PageView>` in a `<div className="mt-8">` in [Home.tsx](web/src/pages/Home.tsx). 32px matches the inter-row gap so the visual rhythm stays consistent regardless of what content sits above.

## Test plan

- [x] `tsc --noEmit` clean
- [ ] Manual: search for an artist, confirm the top-hit card is no longer absurdly tall.
- [ ] Manual: open Home, confirm Custom Mixes has consistent spacing above it (check both with and without the "Suggested new songs" pill row populated, since that's what was inconsistent before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)