### PR TITLE
Downloader: prefetch next segment + default rate cap 20 → 10 MB/s

### DIFF
--- a/app/downloader.py
+++ b/app/downloader.py
@@ -8,6 +8,7 @@ import tempfile
 import threading
 import time
 import uuid
+from concurrent.futures import Future, ThreadPoolExecutor
 from dataclasses import dataclass
 from enum import Enum
 from pathlib import Path
@@ -1048,45 +1049,96 @@ class Downloader:
                 _apply_aggregate_rate(rate_mbps)
                 limiter = _RateLimiter(rate_mbps * 1_000_000) if rate_mbps > 0 else None
 
-                with open(tmp_path, "wb") as f:
-                    # Write the first URL we already opened.
-                    got = 0
-                    for chunk in first_resp.iter_content(chunk_size=65536):
-                        if not chunk:
-                            continue
-                        self._check_cancel(item.item_id)
-                        f.write(chunk)
-                        got += len(chunk)
-                        bytes_total += len(chunk)
-                        _AGGREGATE_LIMITER.consume(len(chunk))
-                        if limiter is not None:
-                            limiter.consume(len(chunk))
-                        inner = (got / first_len) if first_len else 0.5
-                        _bump(0, inner)
-                    first_resp_cm.__exit__(None, None, None)
-                    first_resp_cm = None
+                # Single-segment prefetch: while we stream segment K's
+                # body under the rate limiter, a worker thread runs the
+                # HTTP request for K+1 (handshake, request send, TTFB,
+                # response headers). When K finishes, K+1 is already
+                # connection-open and ready for body streaming — saves
+                # ~one RTT per segment of overlap. Worker only opens
+                # the connection; the body is still streamed in this
+                # thread under `_AGGREGATE_LIMITER` + per-track
+                # `limiter`, so the network throughput cap is unchanged
+                # (same bytes-per-second to the CDN).
+                #
+                # max_workers=1 because we only ever need one segment
+                # in flight beyond the current one. Multiple parallel
+                # in-flight requests per track would double the
+                # concurrent-stream signal and is intentionally avoided.
+                #
+                # `_open` here is just `SESSION.get(...)` returning a
+                # streaming Response; named for symmetry with the loop.
+                def _open(url: str):
+                    return SESSION.get(url, stream=True, timeout=60)
 
-                    # Then every remaining URL concatenated into the
-                    # same file — for DASH hi-res these are per-segment
-                    # binary chunks that form a valid FLAC once joined.
-                    for i, url in enumerate(urls[1:], start=1):
-                        self._check_cancel(item.item_id)
-                        with SESSION.get(url, stream=True, timeout=60) as resp:
-                            resp.raise_for_status()
-                            seg_len = int(resp.headers.get("Content-Length", 0))
-                            seg_got = 0
-                            for chunk in resp.iter_content(chunk_size=65536):
-                                if not chunk:
-                                    continue
-                                self._check_cancel(item.item_id)
-                                f.write(chunk)
-                                seg_got += len(chunk)
-                                bytes_total += len(chunk)
-                                _AGGREGATE_LIMITER.consume(len(chunk))
-                                if limiter is not None:
-                                    limiter.consume(len(chunk))
-                                inner = (seg_got / seg_len) if seg_len else 0.5
-                                _bump(i, inner)
+                next_resp_future: Optional[Future] = None
+                with ThreadPoolExecutor(
+                    max_workers=1,
+                    thread_name_prefix="dl-prefetch",
+                ) as prefetch_pool:
+                    # Kick off the prefetch for url[1] before we start
+                    # streaming url[0]. The first segment's stream and
+                    # the second segment's connection-open run in
+                    # parallel.
+                    if len(urls) > 1:
+                        next_resp_future = prefetch_pool.submit(_open, urls[1])
+
+                    with open(tmp_path, "wb") as f:
+                        # Write the first URL we already opened.
+                        got = 0
+                        for chunk in first_resp.iter_content(chunk_size=65536):
+                            if not chunk:
+                                continue
+                            self._check_cancel(item.item_id)
+                            f.write(chunk)
+                            got += len(chunk)
+                            bytes_total += len(chunk)
+                            _AGGREGATE_LIMITER.consume(len(chunk))
+                            if limiter is not None:
+                                limiter.consume(len(chunk))
+                            inner = (got / first_len) if first_len else 0.5
+                            _bump(0, inner)
+                        first_resp_cm.__exit__(None, None, None)
+                        first_resp_cm = None
+
+                        # Then every remaining URL concatenated into the
+                        # same file — for DASH hi-res these are per-segment
+                        # binary chunks that form a valid FLAC once joined.
+                        for i, url in enumerate(urls[1:], start=1):
+                            self._check_cancel(item.item_id)
+                            # Pre-fetched response for this segment was
+                            # opened by the worker. result() blocks until
+                            # the worker has the response object (request
+                            # sent + headers received). If the prefetch
+                            # raised, that exception propagates here and
+                            # fails the download cleanly via the outer
+                            # try/except.
+                            assert next_resp_future is not None
+                            resp = next_resp_future.result()
+                            # Kick off the next prefetch immediately so it
+                            # overlaps with this segment's body streaming.
+                            next_resp_future = (
+                                prefetch_pool.submit(_open, urls[i + 1])
+                                if i + 1 < len(urls)
+                                else None
+                            )
+                            try:
+                                resp.raise_for_status()
+                                seg_len = int(resp.headers.get("Content-Length", 0))
+                                seg_got = 0
+                                for chunk in resp.iter_content(chunk_size=65536):
+                                    if not chunk:
+                                        continue
+                                    self._check_cancel(item.item_id)
+                                    f.write(chunk)
+                                    seg_got += len(chunk)
+                                    bytes_total += len(chunk)
+                                    _AGGREGATE_LIMITER.consume(len(chunk))
+                                    if limiter is not None:
+                                        limiter.consume(len(chunk))
+                                    inner = (seg_got / seg_len) if seg_len else 0.5
+                                    _bump(i, inner)
+                            finally:
+                                resp.close()
             finally:
                 if first_resp_cm is not None:
                     try:

--- a/app/settings.py
+++ b/app/settings.py
@@ -49,12 +49,14 @@ class Settings:
     # Tidal's per-account rate-limit. Users with stable accounts can
     # raise this in Settings; the slider goes up to 10.
     concurrent_downloads: int = 1
-    # Per-track download rate cap in MB/s. 0 = unlimited. Default 20
-    # MB/s — fast enough that a Max-quality 4-minute track finishes in
-    # ~2 seconds on a normal connection, slow enough that the CDN sees
-    # a steady streaming-shaped fetch instead of a "scrape as fast as
-    # possible" pattern that would attract anti-abuse attention.
-    download_rate_limit_mbps: int = 20
+    # Per-track download rate cap in MB/s. 0 = unlimited. Default 10
+    # MB/s — fast enough that a Max-quality 4-minute track finishes
+    # in a few seconds on a normal connection, but well clear of the
+    # "saturate fiber, obviously not listening" pattern that the
+    # previous 20 MB/s default could produce on fast connections.
+    # Existing users keep their previously-saved value; this only
+    # affects fresh installs and explicit "reset to defaults".
+    download_rate_limit_mbps: int = 10
     # When True, the UI hides everything that needs a live Tidal session
     # (search, editorial, favorites, streaming fallback) and the server
     # stops requiring auth on the handful of endpoints that only touch

--- a/tests/test_settings_endpoint.py
+++ b/tests/test_settings_endpoint.py
@@ -137,14 +137,16 @@ def test_default_concurrent_downloads_is_one():
     assert Settings().concurrent_downloads == 1
 
 
-def test_default_download_rate_limit_is_20_mbps():
-    """20 MB/s is the new default — fast enough to feel instant on a
-    healthy connection, slow enough to look like steady streaming
-    rather than a bulk scrape. Pin the value because it's the kind
-    of setting that's tempting to "just bump" in a refactor."""
+def test_default_download_rate_limit_is_10_mbps():
+    """10 MB/s default — lowered from 20 to keep fresh-install
+    behavior visibly clear of the "saturate fiber" pattern that
+    20 MB/s could produce on fast connections, while still being
+    fast enough to feel near-instant for typical track downloads.
+    Pin the value because it's the kind of setting that's tempting
+    to "just bump" in a refactor."""
     from app.settings import Settings
 
-    assert Settings().download_rate_limit_mbps == 20
+    assert Settings().download_rate_limit_mbps == 10
 
 
 def test_put_multiple_fields_in_one_request(client):


### PR DESCRIPTION
Two changes shipping together because they're a coherent package: the prefetch buys back per-track wall-clock that the lower rate cap could otherwise feel like a regression on, and the lower cap nudges fresh-install behavior toward less aggressive default network usage.

## Prefetch / single-segment overlap

DASH hi-res FLAC tracks arrive as ~50-100 segments. Each segment was fetched sequentially in [downloader.py:1072](app/downloader.py:1072), paying one RTT for request + TTFB before the body streams. Across a hi-res track that's a meaningful tax on per-track wall-clock — pure round-trip latency, not bandwidth.

Add a tiny `ThreadPoolExecutor(max_workers=1)` per track that pre-opens the connection for segment K+1 while segment K is streaming. The worker only runs `SESSION.get(stream=True)` — sends the request, reads response headers, returns the `Response` object. Body bytes still stream in the main thread under the existing rate limiter, so network throughput is unchanged.

`max_workers=1` because more in-flight prefetches would multiply the concurrent-stream signal we deliberately avoid (see `concurrent_downloads: 1` default). One pre-opened segment is overlap; two would be parallel scraping.

Estimated win: ~25-30% per-track wall-clock on hi-res FLAC at the new 10 MB/s cap. Larger gains on uncapped settings.

## Default rate cap 20 → 10 MB/s

20 MB/s = 160 Mbps, which on a fiber connection saturates the link during downloads. Cleanest "this user is bulk-downloading, not listening" pattern an observer (Tidal CDN, ISP traffic shaping) could ask for. 10 MB/s = 80 Mbps stays fast enough for the user-facing case (4-minute hi-res track finishes in seconds) while stepping back from saturation.

The actual safety win is unmeasurable — Tidal's anomaly detection weights are opaque and probably care more about total volume + concurrent-stream count than per-second peak. But conservative defaults are the right ethical posture for a tool already in TOS-gray-area territory; users who want faster can raise the slider explicitly.

**Existing users keep their previously-saved value.** This only affects fresh installs and explicit "reset to defaults."

## Test plan

- [x] `pytest tests/` — 507 passed, 2 skipped
- [x] One existing test was pinned to `== 20`; updated to `== 10` and reworded the docstring
- [ ] Manual: download a multi-segment hi-res FLAC track. Confirm it works end-to-end (prefetch doesn't break the multi-segment concatenation).
- [ ] Manual: cancel mid-segment, confirm cancellation completes within ~1s (in-flight prefetch is just headers, not body).
- [ ] Manual: slow-network simulation (throttle to 5 Mbps), confirm rate-limit semantics still apply (downloads pace correctly, no burst-then-idle pattern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)