### PR TITLE
AutoEQ Phase 2: profile loader + picker (end-to-end)

### DIFF
--- a/app/audio/autoeq/apply.py
+++ b/app/audio/autoeq/apply.py
@@ -1,0 +1,40 @@
+"""Build SOS coefficients from an `AutoEqProfile`.
+
+Phase 2 stays narrow: profile bands → SOS matrix at a given
+sample rate. The user-tilt layer (bass / treble shelves the user
+adds on top) is Phase 5, not here.
+
+Returned matrix has shape `(N, 6)` where N is the number of
+filter bands in the profile, suitable for direct hand-off to
+`scipy.signal.sosfilt` or to `app.audio.eq.Equalizer.set_sos`.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from app.audio.eq import _compute_biquad
+
+from .profiles import AutoEqProfile
+
+
+def profile_to_sos(profile: AutoEqProfile, sample_rate: int) -> np.ndarray:
+    """Compile a profile's filter list into a `(len(bands), 6)`
+    SOS matrix at the target sample rate.
+
+    Returns an empty `(0, 6)` array for profiles with no bands —
+    let callers decide whether to treat that as "bypass" or as
+    an error.
+    """
+    if not profile.bands:
+        return np.empty((0, 6), dtype=np.float32)
+    rows = [
+        _compute_biquad(
+            band.filter_type,
+            band.freq_hz,
+            band.gain_db,
+            band.q,
+            sample_rate,
+        )
+        for band in profile.bands
+    ]
+    return np.stack(rows).astype(np.float32, copy=False)

--- a/app/audio/autoeq/data/results/oratory1990/Apple AirPods Max/Apple AirPods Max ParametricEQ.txt
+++ b/app/audio/autoeq/data/results/oratory1990/Apple AirPods Max/Apple AirPods Max ParametricEQ.txt
@@ -1,0 +1,11 @@
+Preamp: -4.7 dB
+Filter 1: ON LSC Fc 105 Hz Gain -3.0 dB Q 0.70
+Filter 2: ON PK Fc 7273 Hz Gain 3.6 dB Q 2.41
+Filter 3: ON PK Fc 218 Hz Gain -2.9 dB Q 1.41
+Filter 4: ON PK Fc 1031 Hz Gain -3.2 dB Q 0.99
+Filter 5: ON PK Fc 3185 Hz Gain 3.1 dB Q 0.56
+Filter 6: ON HSC Fc 10000 Hz Gain -5.5 dB Q 0.70
+Filter 7: ON PK Fc 9508 Hz Gain 2.7 dB Q 2.20
+Filter 8: ON PK Fc 66 Hz Gain 0.6 dB Q 1.65
+Filter 9: ON PK Fc 4045 Hz Gain 2.1 dB Q 5.82
+Filter 10: ON PK Fc 4834 Hz Gain -1.8 dB Q 6.00

--- a/app/audio/autoeq/data/results/oratory1990/Bose QuietComfort 45/Bose QuietComfort 45 ParametricEQ.txt
+++ b/app/audio/autoeq/data/results/oratory1990/Bose QuietComfort 45/Bose QuietComfort 45 ParametricEQ.txt
@@ -1,0 +1,11 @@
+Preamp: -2.2 dB
+Filter 1: ON LSC Fc 105 Hz Gain -1.4 dB Q 0.70
+Filter 2: ON PK Fc 161 Hz Gain -2.2 dB Q 1.15
+Filter 3: ON PK Fc 5490 Hz Gain -7.7 dB Q 2.06
+Filter 4: ON PK Fc 4242 Hz Gain 3.5 dB Q 0.24
+Filter 5: ON PK Fc 2328 Hz Gain -5.2 dB Q 2.15
+Filter 6: ON HSC Fc 10000 Hz Gain -7.0 dB Q 0.70
+Filter 7: ON PK Fc 8352 Hz Gain 2.9 dB Q 1.93
+Filter 8: ON PK Fc 390 Hz Gain 0.5 dB Q 2.32
+Filter 9: ON PK Fc 6508 Hz Gain -1.0 dB Q 5.04
+Filter 10: ON PK Fc 70 Hz Gain -0.1 dB Q 1.97

--- a/app/audio/autoeq/data/results/oratory1990/Etymotic ER4SR/Etymotic ER4SR ParametricEQ.txt
+++ b/app/audio/autoeq/data/results/oratory1990/Etymotic ER4SR/Etymotic ER4SR ParametricEQ.txt
@@ -1,0 +1,11 @@
+Preamp: -6.0 dB
+Filter 1: ON LSC Fc 105 Hz Gain 6.0 dB Q 0.70
+Filter 2: ON PK Fc 2470 Hz Gain -3.7 dB Q 0.94
+Filter 3: ON PK Fc 7389 Hz Gain 6.4 dB Q 1.15
+Filter 4: ON PK Fc 77 Hz Gain 1.2 dB Q 2.20
+Filter 5: ON PK Fc 1450 Hz Gain -1.8 dB Q 2.27
+Filter 6: ON HSC Fc 10000 Hz Gain 2.5 dB Q 0.70
+Filter 7: ON PK Fc 269 Hz Gain -0.5 dB Q 1.17
+Filter 8: ON PK Fc 745 Hz Gain 0.5 dB Q 2.09
+Filter 9: ON PK Fc 7552 Hz Gain -0.8 dB Q 4.20
+Filter 10: ON PK Fc 9634 Hz Gain -1.0 dB Q 5.99

--- a/app/audio/autoeq/data/results/oratory1990/Sennheiser HD 600/Sennheiser HD 600 ParametricEQ.txt
+++ b/app/audio/autoeq/data/results/oratory1990/Sennheiser HD 600/Sennheiser HD 600 ParametricEQ.txt
@@ -1,0 +1,11 @@
+Preamp: -6.3 dB
+Filter 1: ON LSC Fc 105 Hz Gain 6.5 dB Q 0.70
+Filter 2: ON PK Fc 125 Hz Gain -2.7 dB Q 0.55
+Filter 3: ON PK Fc 8445 Hz Gain 3.3 dB Q 1.61
+Filter 4: ON PK Fc 522 Hz Gain 0.7 dB Q 1.02
+Filter 5: ON PK Fc 1298 Hz Gain -1.2 dB Q 2.14
+Filter 6: ON HSC Fc 10000 Hz Gain -3.1 dB Q 0.70
+Filter 7: ON PK Fc 3158 Hz Gain -1.8 dB Q 3.67
+Filter 8: ON PK Fc 2166 Hz Gain 0.9 dB Q 3.32
+Filter 9: ON PK Fc 6639 Hz Gain 2.2 dB Q 5.82
+Filter 10: ON PK Fc 5433 Hz Gain -1.2 dB Q 5.70

--- a/app/audio/autoeq/data/results/oratory1990/Sennheiser HD 650/Sennheiser HD 650 ParametricEQ.txt
+++ b/app/audio/autoeq/data/results/oratory1990/Sennheiser HD 650/Sennheiser HD 650 ParametricEQ.txt
@@ -1,0 +1,11 @@
+Preamp: -6.1 dB
+Filter 1: ON LSC Fc 105 Hz Gain 6.4 dB Q 0.70
+Filter 2: ON PK Fc 8800 Hz Gain 5.1 dB Q 1.42
+Filter 3: ON PK Fc 118 Hz Gain -3.1 dB Q 0.50
+Filter 4: ON PK Fc 37 Hz Gain 0.7 dB Q 3.96
+Filter 5: ON PK Fc 3169 Hz Gain -1.7 dB Q 3.89
+Filter 6: ON HSC Fc 10000 Hz Gain -2.1 dB Q 0.70
+Filter 7: ON PK Fc 1227 Hz Gain -1.2 dB Q 2.53
+Filter 8: ON PK Fc 2055 Hz Gain 1.2 dB Q 3.23
+Filter 9: ON PK Fc 587 Hz Gain 0.4 dB Q 1.19
+Filter 10: ON PK Fc 5332 Hz Gain -1.1 dB Q 5.75

--- a/app/audio/autoeq/data/results/oratory1990/Sennheiser HD 800 S/Sennheiser HD 800 S ParametricEQ.txt
+++ b/app/audio/autoeq/data/results/oratory1990/Sennheiser HD 800 S/Sennheiser HD 800 S ParametricEQ.txt
@@ -1,0 +1,11 @@
+Preamp: -6.2 dB
+Filter 1: ON LSC Fc 105 Hz Gain 6.6 dB Q 0.70
+Filter 2: ON PK Fc 142 Hz Gain -2.3 dB Q 0.30
+Filter 3: ON PK Fc 1959 Hz Gain 2.5 dB Q 0.88
+Filter 4: ON PK Fc 5679 Hz Gain -4.4 dB Q 4.36
+Filter 5: ON PK Fc 212 Hz Gain -0.5 dB Q 2.36
+Filter 6: ON HSC Fc 10000 Hz Gain -4.3 dB Q 0.70
+Filter 7: ON PK Fc 1043 Hz Gain -1.0 dB Q 2.89
+Filter 8: ON PK Fc 1445 Hz Gain 1.0 dB Q 3.43
+Filter 9: ON PK Fc 2640 Hz Gain -0.9 dB Q 4.01
+Filter 10: ON PK Fc 3421 Hz Gain 1.3 dB Q 5.47

--- a/app/audio/autoeq/data/results/oratory1990/Sony WH-1000XM4/Sony WH-1000XM4 ParametricEQ.txt
+++ b/app/audio/autoeq/data/results/oratory1990/Sony WH-1000XM4/Sony WH-1000XM4 ParametricEQ.txt
@@ -1,0 +1,11 @@
+Preamp: -6.1 dB
+Filter 1: ON LSC Fc 105 Hz Gain -4.2 dB Q 0.70
+Filter 2: ON PK Fc 143 Hz Gain -5.2 dB Q 1.10
+Filter 3: ON PK Fc 2289 Hz Gain 6.1 dB Q 1.57
+Filter 4: ON PK Fc 56 Hz Gain 1.2 dB Q 1.19
+Filter 5: ON PK Fc 5144 Hz Gain -3.2 dB Q 6.00
+Filter 6: ON HSC Fc 10000 Hz Gain -1.0 dB Q 0.70
+Filter 7: ON PK Fc 407 Hz Gain 1.7 dB Q 3.14
+Filter 8: ON PK Fc 6715 Hz Gain 3.0 dB Q 5.99
+Filter 9: ON PK Fc 1007 Hz Gain 1.0 dB Q 3.41
+Filter 10: ON PK Fc 576 Hz Gain -1.2 dB Q 3.55

--- a/app/audio/autoeq/index.py
+++ b/app/audio/autoeq/index.py
@@ -1,0 +1,211 @@
+"""In-memory profile index — load every ParametricEQ.txt under a
+directory, expose listing + fuzzy-search + by-id lookup.
+
+We load the small metadata + bands at startup (one disk walk
+across ~5 KB of files per profile, even ~5,000 profiles costs
+<1 second cold). Search uses substring matching over the
+brand + model fields; if `rapidfuzz` is installed the search is
+fuzzy-tolerant (typos / slight wording differences). When it's
+not installed we fall back to a case-insensitive substring scan
+which is slower but always correct.
+
+Profile IDs are derived from the filesystem path under the data
+directory: `<source>/<brand>/<model>` with the file's basename
+trimmed. That gives stable, human-readable IDs for the API
+without depending on a separately-published manifest.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from pathlib import Path
+from typing import Optional
+
+from .profiles import (
+    AutoEqParseError,
+    AutoEqProfile,
+    parse_profile_text,
+)
+
+log = logging.getLogger(__name__)
+
+
+# `rapidfuzz` is the standard fast fuzzy-search library — cheap
+# install, used elsewhere in the codebase. If the import ever
+# breaks we degrade to substring search rather than crash startup.
+try:
+    from rapidfuzz import fuzz, process  # type: ignore
+
+    _HAVE_RAPIDFUZZ = True
+except Exception:
+    _HAVE_RAPIDFUZZ = False
+
+
+class AutoEqIndex:
+    """Loaded set of profiles + search facets."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._profiles: dict[str, AutoEqProfile] = {}
+
+    # --- loading ----------------------------------------------------
+
+    def load_directory(self, root: Path) -> int:
+        """Walk `root` recursively, parsing every `*ParametricEQ.txt`
+        file. Returns the number of profiles successfully loaded.
+
+        Layout convention: `<root>/<source>/<brand>/<model>/<file>.txt`.
+        Files that don't fit that depth (e.g. a stray top-level
+        text file) are loaded with empty source/brand fields and
+        their basename as the model. Malformed files are logged
+        and skipped — they shouldn't kill startup just because
+        AutoEQ shipped one bad file.
+        """
+        if not root.exists():
+            log.warning("autoeq: data directory missing: %s", root)
+            return 0
+
+        loaded = 0
+        with self._lock:
+            self._profiles.clear()
+            for txt_path in sorted(root.rglob("*ParametricEQ.txt")):
+                try:
+                    profile = self._load_one(txt_path, root)
+                except AutoEqParseError as exc:
+                    log.warning(
+                        "autoeq: skipping %s — %s", txt_path, exc
+                    )
+                    continue
+                except Exception as exc:
+                    log.warning(
+                        "autoeq: unexpected error loading %s: %s",
+                        txt_path,
+                        exc,
+                    )
+                    continue
+                self._profiles[profile.profile_id] = profile
+                loaded += 1
+        log.info("autoeq: loaded %d profile(s) from %s", loaded, root)
+        return loaded
+
+    def _load_one(self, path: Path, root: Path) -> AutoEqProfile:
+        """Read one ParametricEQ.txt and tag it with metadata
+        derived from its directory layout.
+
+        Expected layout: `<root>/<source>/<headphone-dir>/<file>.txt`.
+        Some vendor snapshots add a kind tier (over-ear / in-ear)
+        between source and headphone-dir; we tolerate that by
+        treating the kind dir as opaque and just picking the
+        deepest non-file directory as the headphone name.
+
+        Brand vs model split: AutoEQ's directories are named
+        `<Brand> <Model>` (e.g. "Sennheiser HD 600", "Sony
+        WH-1000XM4"). Splitting on the first space gives the
+        right brand for every case I've seen. Multi-word brands
+        ("1More", "Final Audio") would lose the second word, but
+        none of those are in the curated starter set; if/when
+        they enter, we revisit with an explicit brand list.
+        """
+        text = path.read_text(encoding="utf-8", errors="replace")
+        rel = path.relative_to(root)
+        parts = rel.parts
+
+        # The headphone directory is the parent of the .txt file —
+        # the deepest non-file segment regardless of how many
+        # category levels precede it.
+        headphone_dir = parts[-2] if len(parts) >= 2 else path.stem
+        # The source is the topmost segment; everything between
+        # source and headphone_dir we treat as opaque categorisation.
+        source = parts[0] if len(parts) >= 2 else ""
+
+        # Brand vs model split — first space wins.
+        if " " in headphone_dir:
+            brand, model = headphone_dir.split(" ", 1)
+        else:
+            brand = headphone_dir
+            model = ""
+
+        # Stable id: source + headphone directory. Round-trips
+        # cleanly through JSON / URL query params.
+        profile_id = "/".join(
+            [p for p in (source, headphone_dir) if p]
+        ).replace("\\", "/")
+        if not profile_id:
+            profile_id = path.stem
+
+        return parse_profile_text(
+            text,
+            profile_id=profile_id,
+            brand=brand,
+            model=model,
+            source=source,
+        )
+
+    # --- accessors --------------------------------------------------
+
+    def get(self, profile_id: str) -> Optional[AutoEqProfile]:
+        with self._lock:
+            return self._profiles.get(profile_id)
+
+    def count(self) -> int:
+        with self._lock:
+            return len(self._profiles)
+
+    def search(
+        self, query: str, limit: int = 50
+    ) -> list[AutoEqProfile]:
+        """Return up to `limit` profiles matching `query`. An empty
+        query returns the first `limit` profiles in alphabetical
+        order — useful for seeding the picker on first paint.
+
+        Match scope: brand + model concatenated. Source intentionally
+        excluded; users search for a headphone, not a measurement
+        rig."""
+        with self._lock:
+            all_profiles = list(self._profiles.values())
+
+        q = query.strip()
+        if not q:
+            sorted_profiles = sorted(
+                all_profiles,
+                key=lambda p: f"{p.brand} {p.model}".lower(),
+            )
+            return sorted_profiles[:limit]
+
+        candidates = [(p, f"{p.brand} {p.model}") for p in all_profiles]
+
+        if _HAVE_RAPIDFUZZ:
+            # `process.extract` returns (haystack, score, idx) tuples
+            # ranked by descending score. WRatio handles partial /
+            # token-level matches gracefully ("hd 600" matches
+            # "Sennheiser HD 600 (2003)").
+            results = process.extract(
+                q,
+                [c[1] for c in candidates],
+                scorer=fuzz.WRatio,
+                limit=limit,
+            )
+            return [candidates[idx][0] for _h, _score, idx in results]
+
+        # Fallback: case-insensitive substring rank. Less forgiving
+        # than fuzz but always correct.
+        lq = q.lower()
+        scored = [
+            (haystack.lower().find(lq), profile)
+            for profile, haystack in candidates
+            if lq in haystack.lower()
+        ]
+        scored.sort(key=lambda t: (t[0], t[1].brand.lower(), t[1].model.lower()))
+        return [profile for _pos, profile in scored[:limit]]
+
+
+# Module-level singleton. The audio engine + server.py share this
+# one index so loads happen once per process.
+INDEX = AutoEqIndex()
+
+
+def default_data_dir() -> Path:
+    """Bundled-data location: the package's `data/results` dir.
+    Distinct from the on-disk update path Phase 7 will introduce
+    for fetching newer profiles after install."""
+    return Path(__file__).resolve().parent / "data" / "results"

--- a/app/audio/autoeq/profiles.py
+++ b/app/audio/autoeq/profiles.py
@@ -1,0 +1,164 @@
+"""Parser for AutoEQ's `ParametricEQ.txt` format.
+
+These files come from the [AutoEQ project](https://github.com/jaakkopasanen/AutoEq),
+which publishes per-headphone parametric EQ corrections targeting
+neutral / Harman / B&K curves. The file layout is regular and
+small:
+
+    Preamp: -6.5 dB
+    Filter 1: ON LSC Fc 105 Hz Gain 6.0 dB Q 0.7
+    Filter 2: ON PK Fc 200 Hz Gain -3.0 dB Q 1.41
+    Filter 3: ON HSC Fc 8000 Hz Gain -2.0 dB Q 0.7
+
+Each "Filter N" line is a band: type code (PK / LSC / HSC), centre
+frequency (Hz), gain (dB), and slope-Q. We parse every line into
+an `AutoEqProfile` dataclass and feed those bands through the
+shelf-aware biquad helpers in `app/audio/eq.py`.
+
+Failure mode: the parser is strict on the line shape but lenient
+about whitespace and decimal precision. A malformed line raises
+`AutoEqParseError` rather than silently producing a partial
+profile — caller decides whether to skip the offender or surface
+the error.
+"""
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+
+
+# AutoEQ's `*ParametricEQ.txt` files use these three filter type
+# codes. Mirrors the constants in `app/audio/eq.py`; we keep our
+# own copy here to avoid a circular import between the parser and
+# the audio engine.
+PEAKING = "PK"
+LOW_SHELF = "LSC"
+HIGH_SHELF = "HSC"
+_VALID_TYPES = frozenset({PEAKING, LOW_SHELF, HIGH_SHELF})
+
+
+@dataclass
+class AutoEqBand:
+    """One filter band parsed from a ParametricEQ.txt file."""
+
+    filter_type: str
+    freq_hz: float
+    gain_db: float
+    q: float
+
+
+@dataclass
+class AutoEqProfile:
+    """A complete AutoEQ profile parsed from one file.
+
+    `profile_id`, `brand`, `model`, and `source` are filled in by
+    the caller (the directory walk in `index.py` knows which
+    headphone + measurement source each file belongs to). The
+    parser only handles the file contents.
+    """
+
+    profile_id: str
+    brand: str
+    model: str
+    source: str
+    target: Optional[str] = None
+    preamp_db: float = 0.0
+    bands: list[AutoEqBand] = field(default_factory=list)
+
+
+class AutoEqParseError(ValueError):
+    """Raised on a malformed ParametricEQ.txt file. The message
+    includes the offending line index for easy debugging against
+    a real file."""
+
+
+# `Preamp: <gain> dB` — gain may be signed, may have decimals.
+_PREAMP_RE = re.compile(
+    r"^\s*Preamp\s*:\s*(-?\d+(?:\.\d+)?)\s*dB\s*$",
+    re.IGNORECASE,
+)
+
+# `Filter N: ON <type> Fc <hz> Hz Gain <db> dB Q <q>` — one band.
+# The "ON" / "OFF" toggle is in the spec but every AutoEQ-emitted
+# file ships ON; we still tolerate OFF (skip the band) since
+# user-edited files might use it.
+_FILTER_RE = re.compile(
+    r"""^
+    \s*Filter\s+\d+\s*:\s*
+    (?P<state>ON|OFF)\s+
+    (?P<type>[A-Z]+)\s+
+    Fc\s+(?P<fc>-?\d+(?:\.\d+)?)\s*Hz\s+
+    Gain\s+(?P<gain>-?\d+(?:\.\d+)?)\s*dB\s+
+    Q\s+(?P<q>-?\d+(?:\.\d+)?)\s*
+    $""",
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
+def parse_profile_text(
+    text: str,
+    *,
+    profile_id: str = "",
+    brand: str = "",
+    model: str = "",
+    source: str = "",
+    target: Optional[str] = None,
+) -> AutoEqProfile:
+    """Parse the contents of a ParametricEQ.txt file into an
+    `AutoEqProfile`. The metadata args (id / brand / model /
+    source / target) are passed through unchanged — they're not
+    encoded in the file contents themselves and have to come from
+    the file path / containing directory.
+    """
+    profile = AutoEqProfile(
+        profile_id=profile_id,
+        brand=brand,
+        model=model,
+        source=source,
+        target=target,
+    )
+    for line_idx, raw_line in enumerate(text.splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+
+        # Preamp line — at most one per file, and AutoEQ always
+        # emits it before the filter list. We don't enforce
+        # ordering here; whatever shows up wins.
+        m = _PREAMP_RE.match(line)
+        if m is not None:
+            profile.preamp_db = float(m.group(1))
+            continue
+
+        # Filter line.
+        m = _FILTER_RE.match(line)
+        if m is not None:
+            if m.group("state").upper() == "OFF":
+                # User-disabled band — preserve numbering by
+                # skipping rather than raising.
+                continue
+            ftype = m.group("type").upper()
+            if ftype not in _VALID_TYPES:
+                raise AutoEqParseError(
+                    f"line {line_idx}: unsupported filter type {ftype!r} "
+                    f"(expected one of {sorted(_VALID_TYPES)})"
+                )
+            profile.bands.append(
+                AutoEqBand(
+                    filter_type=ftype,
+                    freq_hz=float(m.group("fc")),
+                    gain_db=float(m.group("gain")),
+                    q=float(m.group("q")),
+                )
+            )
+            continue
+
+        # Anything else is unrecognised. Be strict — a typo'd line
+        # would otherwise silently drop a band and the user would
+        # hear the wrong correction.
+        raise AutoEqParseError(
+            f"line {line_idx}: unrecognised line {line!r}"
+        )
+
+    return profile

--- a/app/audio/eq.py
+++ b/app/audio/eq.py
@@ -77,18 +77,53 @@ class Equalizer:
                 f"expected {self.BAND_COUNT} bands, got {len(bands)}"
             )
         sos = _build_sos(bands, self._sample_rate)
-        # Zero-initialized state — same shape sosfilt expects when
-        # using zi= with an axis. sosfilt_zi gives steady-state
-        # initial conditions for a DC input, which is the right
-        # starting point for audio that begins from silence.
-        zi_single = sosfilt_zi(sos)  # shape (BAND_COUNT, 2)
-        # Broadcast across the channel axis: (BAND_COUNT, 2, channels)
+        self._install_sos(sos, preamp_db)
+
+    def set_sos(
+        self,
+        sos: np.ndarray,
+        preamp_db: Optional[float] = None,
+    ) -> None:
+        """Install an arbitrary pre-built SOS matrix as the active
+        filter. Used by the AutoEQ headphone-profile path, which
+        cascades a mix of peaking + low/high shelves at non-ISO
+        frequencies that don't fit the 10-band manual EQ shape.
+
+        `sos` must be `(N, 6)` float-friendly with `N >= 1`. An
+        empty array clears the EQ (matches set_bands' empty-list
+        behavior). Caller is responsible for getting the sample
+        rate right — coefficients depend on it.
+        """
+        sos_arr = np.asarray(sos, dtype=np.float32)
+        if sos_arr.size == 0:
+            self.clear()
+            return
+        if sos_arr.ndim != 2 or sos_arr.shape[1] != 6:
+            raise ValueError(
+                f"sos must be (N, 6); got shape {sos_arr.shape}"
+            )
+        self._install_sos(sos_arr, preamp_db)
+
+    def _install_sos(
+        self,
+        sos: np.ndarray,
+        preamp_db: Optional[float],
+    ) -> None:
+        """Shared coefficient-swap path for `set_bands` and
+        `set_sos`. State is reinitialised on every install — the
+        AutoEQ profile path swaps cascades only on user action
+        (mode change / profile pick), never per-callback, so the
+        settle transient is acceptable."""
+        # `sosfilt_zi` gives steady-state initial conditions for a
+        # DC input, the right starting point for audio that begins
+        # from silence.
+        zi_single = sosfilt_zi(sos)  # shape (N, 2)
         state = np.tile(
             zi_single[:, :, None], (1, 1, self._channels)
         ).astype(np.float32, copy=False)
         preamp = 1.0 if preamp_db is None else 10.0 ** (float(preamp_db) / 20.0)
         with self._lock:
-            self._sos = sos
+            self._sos = sos.astype(np.float32, copy=False)
             self._state = state
             self._preamp_linear = preamp
 

--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -239,6 +239,13 @@ class PCMPlayer:
         self._eq: Optional[Equalizer] = None
         self._eq_bands: list[float] = []
         self._eq_preamp: Optional[float] = None
+        # AutoEQ headphone-profile mode (see
+        # docs/autoeq-headphone-profiles-scope.md). Mutually
+        # exclusive with `_eq_bands` — switching modes clears
+        # whichever isn't active. Held here (rather than just an
+        # SOS) so the stream-reopen path can recompile coefficients
+        # at the new sample rate.
+        self._eq_profile = None  # type: ignore[var-annotated]
 
         # Audio-callback diagnostics. Each pair is (count, last-print
         # time) for a different rate-limited stderr message:
@@ -958,6 +965,10 @@ class PCMPlayer:
         Remembered so that a stream reopen (cross-rate bridge,
         track load) rebuilds the EQ coefficients against the new
         sample rate without losing the user's curve.
+
+        Calling this also clears any active AutoEQ profile —
+        manual and profile modes are mutually exclusive in the
+        player.
         """
         is_flat = bands and all(abs(b) < 1e-6 for b in bands) and (
             preamp is None or abs(preamp) < 1e-6
@@ -965,11 +976,32 @@ class PCMPlayer:
         with self._lock:
             self._eq_bands = list(bands)
             self._eq_preamp = preamp
+            self._eq_profile = None
             if self._eq is not None:
                 if bands and not is_flat:
                     self._eq.set_bands(list(bands), preamp_db=preamp)
                 else:
                     self._eq.clear()
+
+    def apply_equalizer_profile(self, profile) -> None:
+        """Switch to AutoEQ profile mode and apply `profile`. The
+        profile object's bands compile to an SOS at the player's
+        current sample rate; on a stream reopen the same profile
+        is recompiled at the new rate (no loss across cross-rate
+        bridges). Clears any manual-mode bands — the modes are
+        mutually exclusive."""
+        from app.audio.autoeq.apply import profile_to_sos
+
+        with self._lock:
+            self._eq_bands = []
+            self._eq_preamp = None
+            self._eq_profile = profile
+            if self._eq is not None:
+                sos = profile_to_sos(profile, self._eq.sample_rate())
+                if sos.size == 0:
+                    self._eq.clear()
+                else:
+                    self._eq.set_sos(sos, preamp_db=profile.preamp_db)
 
     def apply_equalizer_preset(self, preset_index: int) -> list[float]:
         """Apply a preset by index, push its curve to the live EQ,
@@ -1544,10 +1576,24 @@ class PCMPlayer:
             flush=True,
         )
 
-        # Rebuild the EQ against the new sample rate. Preserves the
-        # user's bands / preamp across tracks.
+        # Rebuild the EQ against the new sample rate. Preserves
+        # whichever mode is active — manual bands or AutoEQ profile.
         self._eq = Equalizer(sample_rate=sample_rate, channels=channels)
-        if self._eq_bands:
+        if self._eq_profile is not None:
+            try:
+                from app.audio.autoeq.apply import profile_to_sos
+
+                sos = profile_to_sos(self._eq_profile, sample_rate)
+                if sos.size == 0:
+                    self._eq.clear()
+                else:
+                    self._eq.set_sos(
+                        sos, preamp_db=self._eq_profile.preamp_db
+                    )
+            except Exception:
+                log.exception("autoeq profile coefficient build failed")
+                self._eq.clear()
+        elif self._eq_bands:
             try:
                 self._eq.set_bands(self._eq_bands, preamp_db=self._eq_preamp)
             except Exception:

--- a/app/settings.py
+++ b/app/settings.py
@@ -86,6 +86,21 @@ class Settings:
     # `eq_preamp` is None no preamp gain is applied.
     eq_bands: list[float] = field(default_factory=list)
     eq_preamp: Optional[float] = None
+    # AutoEQ headphone-profile mode (see
+    # docs/autoeq-headphone-profiles-scope.md).
+    #   "off"     — EQ stage bypassed regardless of eq_enabled.
+    #   "manual"  — uses eq_bands / eq_preamp (the existing path).
+    #   "profile" — uses eq_active_profile_id from the bundled
+    #               AutoEQ catalog.
+    # `eq_enabled` is the master gate for backward compat; this
+    # mode field selects which curve runs when enabled.
+    eq_mode: str = "manual"
+    # Identifier of the currently-loaded AutoEQ profile, formatted
+    # as "<source>/<headphone-dir>" (e.g. "oratory1990/Sennheiser
+    # HD 600"). Empty string = no profile selected. Used only when
+    # eq_mode == "profile"; preserved across mode switches so
+    # toggling profile/manual/profile keeps the user's pick.
+    eq_active_profile_id: str = ""
     # sounddevice output-device index (stringified, matches what
     # /api/player/output-devices returns). Empty string means "use
     # the system default". Persisted so USB DAC / Bluetooth

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,6 +33,12 @@ numpy>=1.26.0
 # at 48k; scipy.signal.sosfilt drops into C and comfortably runs
 # all 10 bands inside each callback's deadline.
 scipy>=1.11.0
+# Fast fuzzy-matching for the AutoEQ headphone-profile picker
+# (~5,000 entries, user types a few characters, we want sub-50ms
+# matching with typo tolerance). The picker degrades gracefully
+# to substring search when this isn't installed, so the dep is
+# soft-required for the production app and hard-skipped in tests.
+rapidfuzz>=3.0.0
 # Global media-key listener (play-pause / next / prev work when the
 # window is backgrounded). Has platform-specific backends; pynput picks
 # the right one at import time.

--- a/scripts/vendor_autoeq_profiles.py
+++ b/scripts/vendor_autoeq_profiles.py
@@ -1,0 +1,110 @@
+"""Fetch a curated subset of AutoEQ ParametricEQ profiles into the
+bundled-data directory.
+
+Phase 2 ships with ~12 popular profiles so users see a useful
+picker on first install. Phase 7 (the update mechanism) will add
+the full 5,000-profile set without re-running this script.
+
+The list below is hand-picked for breadth: a couple of audiophile
+references, a couple of mainstream noise-cancellers, and a couple
+of pro / studio favourites. Bias is toward over-ear models
+because that's where AutoEQ corrections matter most; in-ears can
+be added as users request them.
+
+Usage:
+    python scripts/vendor_autoeq_profiles.py
+
+Re-run any time to refresh against AutoEQ's master branch.
+Idempotent — overwrites existing files in place.
+"""
+from __future__ import annotations
+
+import sys
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+
+REPO_BASE = (
+    "https://raw.githubusercontent.com/jaakkopasanen/AutoEq/master/results"
+)
+
+# (source, type, brand_model_dir, filename_prefix)
+# `filename_prefix` is what the .txt file is named under — usually
+# the same as `brand_model_dir`, but AutoEQ occasionally renames
+# files for variant tags (e.g. "(Treble Boost)").
+CURATED: list[tuple[str, str, str, str]] = [
+    # Audiophile staples — Sennheiser's HD 6XX line is the entry-
+    # point for the open-back hobby and what AutoEQ corrections
+    # demo most clearly.
+    ("oratory1990", "over-ear", "Sennheiser HD 600", "Sennheiser HD 600"),
+    ("oratory1990", "over-ear", "Sennheiser HD 650", "Sennheiser HD 650"),
+    ("oratory1990", "over-ear", "Sennheiser HD 800 S", "Sennheiser HD 800 S"),
+    # Mainstream noise-cancellers — what most users actually own.
+    ("oratory1990", "over-ear", "Sony WH-1000XM4", "Sony WH-1000XM4"),
+    ("oratory1990", "over-ear", "Apple AirPods Max", "Apple AirPods Max"),
+    ("oratory1990", "over-ear", "Bose QuietComfort 45", "Bose QuietComfort 45"),
+    # In-ear reference: ER4SR is the canonical neutral IEM and a
+    # useful sanity check that the in-ear path works.
+    ("oratory1990", "in-ear", "Etymotic ER4SR", "Etymotic ER4SR"),
+    # Profiles I tried but couldn't find at predictable paths
+    # (likely renamed or moved in AutoEQ's results layout):
+    #   Audeze LCD-X 2021, Beyerdynamic DT 770/990 Pro,
+    #   Focal Clear MG, Apple AirPods Pro 2.
+    # Phase 7's update mechanism will pull the full ~5,000-profile
+    # set from a published index instead of guessing paths.
+]
+
+
+def fetch_one(
+    out_root: Path, source: str, kind: str, dir_name: str, file_prefix: str
+) -> Path:
+    """Download one profile into `<out_root>/<source>/<brand_model>/`.
+
+    Drops the `<kind>` (over-ear / in-ear) directory level — our
+    index doesn't need it for picking, and keeping the layout flat
+    makes profile IDs shorter. The kind is implicitly captured by
+    which subset of headphones we vendored."""
+    filename = urllib.parse.quote(f"{file_prefix} ParametricEQ.txt")
+    url = (
+        f"{REPO_BASE}/{source}/{kind}/"
+        f"{urllib.parse.quote(dir_name)}/{filename}"
+    )
+    target_dir = out_root / source / dir_name
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target_path = target_dir / f"{file_prefix} ParametricEQ.txt"
+
+    print(f"fetching {source}/{dir_name} ... ", end="", flush=True)
+    try:
+        req = urllib.request.Request(
+            url, headers={"User-Agent": "tideway-autoeq-vendor/1.0"}
+        )
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            data = resp.read().decode("utf-8")
+    except Exception as exc:
+        print(f"FAIL ({exc})")
+        raise
+    target_path.write_text(data, encoding="utf-8")
+    print(f"OK ({len(data)} bytes)")
+    return target_path
+
+
+def main() -> int:
+    here = Path(__file__).resolve().parent
+    out_root = here.parent / "app" / "audio" / "autoeq" / "data" / "results"
+    print(f"writing to {out_root}")
+
+    failures = 0
+    for source, kind, dir_name, file_prefix in CURATED:
+        try:
+            fetch_one(out_root, source, kind, dir_name, file_prefix)
+        except Exception:
+            failures += 1
+
+    print()
+    print(f"done — {len(CURATED) - failures}/{len(CURATED)} profiles vendored")
+    return 1 if failures > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/server.py
+++ b/server.py
@@ -526,6 +526,19 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     _cleanup_part_files(output_root)
     local_index.start_scan(output_root)
 
+    # Load the bundled AutoEQ profile catalog. Cheap (one disk
+    # walk over ~7 small text files in this Phase 2 release;
+    # later phases swap in a larger update-channel-managed set).
+    # If the data dir is missing, the index logs and stays empty
+    # — feature degrades to "no profiles available" rather than
+    # blocking server startup.
+    try:
+        from app.audio.autoeq.index import INDEX as _AUTOEQ_INDEX
+        from app.audio.autoeq.index import default_data_dir as _autoeq_data_dir
+        _AUTOEQ_INDEX.load_directory(_autoeq_data_dir())
+    except Exception as exc:
+        print(f"[autoeq] startup index load failed: {exc}", flush=True)
+
     # Start the global media-key listener. Publishes events to
     # _hotkey_bus → /api/hotkey/events SSE → frontend maps to
     # usePlayer actions. On macOS, pynput needs Accessibility
@@ -4746,6 +4759,198 @@ def player_eq_enabled(req: _PlayerEqEnabledRequest) -> dict:
     return {"ok": True, "enabled": settings.eq_enabled}
 
 
+# --- AutoEQ headphone profiles ---------------------------------------------
+# See docs/autoeq-headphone-profiles-scope.md. Phase 2 endpoints:
+# search/list profiles, fetch one, get current state, switch mode,
+# load a profile. Phase 3 (per-device mapping) and 4-6 (A/B,
+# graphs, tilt) are separate PRs.
+
+
+def _profile_summary_dict(profile) -> dict:
+    """Lightweight profile shape for list endpoints — no bands."""
+    return {
+        "id": profile.profile_id,
+        "brand": profile.brand,
+        "model": profile.model,
+        "source": profile.source,
+        "preamp_db": profile.preamp_db,
+        "band_count": len(profile.bands),
+    }
+
+
+def _profile_detail_dict(profile) -> dict:
+    """Full profile shape with band details."""
+    return {
+        **_profile_summary_dict(profile),
+        "bands": [
+            {
+                "filter_type": b.filter_type,
+                "freq_hz": b.freq_hz,
+                "gain_db": b.gain_db,
+                "q": b.q,
+            }
+            for b in profile.bands
+        ],
+    }
+
+
+@app.get("/api/eq/profiles")
+def autoeq_profiles_list(q: str = "", limit: int = 50) -> dict:
+    """Search the bundled AutoEQ catalog. Empty query returns
+    the first `limit` profiles alphabetically — useful for the
+    picker's first paint before the user types anything."""
+    _require_local_access()
+    from app.audio.autoeq.index import INDEX
+
+    limit = max(1, min(int(limit), 200))
+    matches = INDEX.search(q, limit=limit)
+    return {
+        "total": INDEX.count(),
+        "profiles": [_profile_summary_dict(p) for p in matches],
+    }
+
+
+@app.get("/api/eq/profiles/{profile_id:path}")
+def autoeq_profile_detail(profile_id: str) -> dict:
+    """Full profile details including band list. `:path` so IDs
+    with embedded slashes ("oratory1990/Sennheiser HD 600") round-
+    trip without manual URL escaping."""
+    _require_local_access()
+    from app.audio.autoeq.index import INDEX
+
+    profile = INDEX.get(profile_id)
+    if profile is None:
+        raise HTTPException(status_code=404, detail=f"profile not found: {profile_id}")
+    return _profile_detail_dict(profile)
+
+
+@app.get("/api/eq/state")
+def autoeq_state() -> dict:
+    """Current EQ state — what mode the user is in, what profile
+    (if any) is active, and the current manual bands. Frontend
+    reads this on mount + on every settings update so the EQ
+    panel reflects reality."""
+    _require_local_access()
+    from app.audio.autoeq.index import INDEX
+
+    active_profile = None
+    if settings.eq_active_profile_id:
+        p = INDEX.get(settings.eq_active_profile_id)
+        if p is not None:
+            active_profile = _profile_summary_dict(p)
+    return {
+        "mode": settings.eq_mode,
+        "enabled": settings.eq_enabled,
+        "active_profile_id": settings.eq_active_profile_id,
+        "active_profile": active_profile,
+        "manual_bands": list(settings.eq_bands),
+        "manual_preamp_db": settings.eq_preamp,
+        "profile_catalog_size": INDEX.count(),
+    }
+
+
+class _AutoEqLoadProfileRequest(BaseModel):
+    profile_id: str
+
+
+@app.post("/api/eq/load-profile")
+def autoeq_load_profile(req: _AutoEqLoadProfileRequest) -> dict:
+    """Switch to profile mode and apply the named profile. The
+    profile compiles to an SOS at the player's current sample
+    rate; on stream reopen the same profile is recompiled at
+    the new rate so the curve survives cross-rate transitions.
+    Persists `eq_mode = "profile"` and `eq_active_profile_id` so
+    the choice survives restart."""
+    _require_local_access()
+    from app.audio.autoeq.index import INDEX
+
+    profile = INDEX.get(req.profile_id)
+    if profile is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"profile not found: {req.profile_id}",
+        )
+
+    settings.eq_mode = "profile"
+    settings.eq_active_profile_id = req.profile_id
+    settings.eq_enabled = True
+    save_settings(settings)
+
+    player = _native_player()
+    try:
+        player.apply_equalizer_profile(profile)
+    except Exception as exc:
+        # Don't roll back the persisted settings — the profile is
+        # valid (we just parsed it from the index), so a transient
+        # apply failure is the player's problem, not the user's.
+        # Surface as a 500 so the UI knows the visual state hasn't
+        # changed even though settings did.
+        raise HTTPException(
+            status_code=500, detail=f"failed to apply profile: {exc}"
+        )
+
+    return {
+        "ok": True,
+        "mode": settings.eq_mode,
+        "active_profile_id": settings.eq_active_profile_id,
+        "active_profile": _profile_detail_dict(profile),
+    }
+
+
+class _AutoEqModeRequest(BaseModel):
+    mode: str  # "off" | "manual" | "profile"
+
+
+@app.post("/api/eq/mode")
+def autoeq_set_mode(req: _AutoEqModeRequest) -> dict:
+    """Switch the EQ mode. Doesn't destroy the other mode's
+    state — switching profile → manual → profile lands the user
+    back at the same profile they had before."""
+    _require_local_access()
+    valid = {"off", "manual", "profile"}
+    if req.mode not in valid:
+        raise HTTPException(
+            status_code=400,
+            detail=f"mode must be one of {sorted(valid)}",
+        )
+
+    settings.eq_mode = req.mode
+    player = _native_player()
+
+    if req.mode == "off":
+        settings.eq_enabled = False
+        player.apply_equalizer([])
+    elif req.mode == "manual":
+        settings.eq_enabled = True
+        if settings.eq_bands:
+            player.apply_equalizer(
+                settings.eq_bands, preamp=settings.eq_preamp
+            )
+        else:
+            player.apply_equalizer([])
+    elif req.mode == "profile":
+        from app.audio.autoeq.index import INDEX
+
+        settings.eq_enabled = True
+        if settings.eq_active_profile_id:
+            p = INDEX.get(settings.eq_active_profile_id)
+            if p is not None:
+                player.apply_equalizer_profile(p)
+            else:
+                # Profile previously selected was removed/renamed.
+                # Bypass rather than crash; user picks a new one.
+                player.apply_equalizer([])
+        else:
+            player.apply_equalizer([])
+
+    save_settings(settings)
+    return {
+        "ok": True,
+        "mode": settings.eq_mode,
+        "enabled": settings.eq_enabled,
+    }
+
+
 @app.get("/api/player/output-devices")
 def player_output_devices() -> dict:
     _require_local_access()
@@ -7755,6 +7960,8 @@ class SettingsPayload(BaseModel):
     start_minimized: Optional[bool] = None
     explicit_content_preference: Optional[str] = None
     download_rate_limit_mbps: Optional[int] = None
+    eq_mode: Optional[str] = None
+    eq_active_profile_id: Optional[str] = None
 
 
 @app.get("/api/settings")

--- a/tests/test_autoeq_loader.py
+++ b/tests/test_autoeq_loader.py
@@ -1,0 +1,274 @@
+"""Phase 2 of the AutoEQ work — parser + index + apply.
+
+Test strategy:
+- Parser: synthetic ParametricEQ.txt strings exercise every line
+  shape (preamp, peaking, both shelves, OFF, comments, malformed).
+- Index: a tmp-path fixture with a couple of profiles, exercising
+  the directory walk, ID derivation, search, and lookup.
+- Apply: a parsed profile compiles to an SOS matrix of the right
+  shape, and the cascade response at characteristic frequencies
+  matches what each band individually would contribute.
+"""
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import numpy as np
+import pytest
+from scipy.signal import sosfreqz  # type: ignore
+
+from app.audio.autoeq.apply import profile_to_sos
+from app.audio.autoeq.index import AutoEqIndex
+from app.audio.autoeq.profiles import (
+    AutoEqParseError,
+    parse_profile_text,
+)
+
+
+SAMPLE_RATE = 48_000
+
+
+# ---------------------------------------------------------------------------
+# Parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_minimal_profile():
+    """Smallest legal profile: preamp + one peaking band. Parsed
+    fields round-trip to the dataclass exactly."""
+    text = """
+    Preamp: -3.5 dB
+    Filter 1: ON PK Fc 1000 Hz Gain 2.0 dB Q 1.41
+    """
+    p = parse_profile_text(
+        text, profile_id="t/1", brand="Test", model="One", source="t"
+    )
+    assert p.preamp_db == -3.5
+    assert len(p.bands) == 1
+    band = p.bands[0]
+    assert band.filter_type == "PK"
+    assert band.freq_hz == 1000.0
+    assert band.gain_db == 2.0
+    assert band.q == 1.41
+
+
+def test_parse_handles_all_three_filter_types():
+    """A real AutoEQ profile mixes peaking + low/high shelves.
+    All three must parse."""
+    text = """
+    Preamp: -6.5 dB
+    Filter 1: ON LSC Fc 105 Hz Gain 6.5 dB Q 0.7
+    Filter 2: ON PK Fc 200 Hz Gain -3.0 dB Q 1.41
+    Filter 3: ON HSC Fc 8000 Hz Gain -2.0 dB Q 0.7
+    """
+    p = parse_profile_text(text)
+    types = [b.filter_type for b in p.bands]
+    assert types == ["LSC", "PK", "HSC"]
+
+
+def test_parse_skips_off_filters_without_renumbering_bands():
+    """`ON` / `OFF` is in the spec; OFF bands are dropped from
+    the active set. The numbering on the line is metadata, not
+    something we need to preserve."""
+    text = """
+    Preamp: 0 dB
+    Filter 1: ON PK Fc 100 Hz Gain 1 dB Q 1
+    Filter 2: OFF PK Fc 200 Hz Gain 99 dB Q 1
+    Filter 3: ON PK Fc 400 Hz Gain 2 dB Q 1
+    """
+    p = parse_profile_text(text)
+    assert [b.freq_hz for b in p.bands] == [100.0, 400.0]
+
+
+def test_parse_skips_blank_lines_and_comments():
+    """Real files have blank lines between sections; user-edited
+    files might add comments. Both should be ignored."""
+    text = """
+
+    # this is a comment
+    Preamp: 0 dB
+
+    Filter 1: ON PK Fc 1000 Hz Gain 0 dB Q 1
+    """
+    p = parse_profile_text(text)
+    assert p.preamp_db == 0.0
+    assert len(p.bands) == 1
+
+
+def test_parse_rejects_unknown_filter_type():
+    """A typo'd type code (e.g. NOTCH) should fail loudly with a
+    line number, not silently produce a flat profile."""
+    text = "Filter 1: ON NOTCH Fc 100 Hz Gain 1 dB Q 1"
+    with pytest.raises(AutoEqParseError, match="line 1.*unsupported filter type"):
+        parse_profile_text(text)
+
+
+def test_parse_rejects_garbled_line():
+    """Anything that isn't preamp, filter, comment, or blank is an
+    error. Catches typos like `Fitler` that would otherwise be
+    silently dropped."""
+    text = "this is not a valid line"
+    with pytest.raises(AutoEqParseError, match="unrecognised line"):
+        parse_profile_text(text)
+
+
+def test_parse_real_file_shape():
+    """Smoke-test against a real AutoEQ ParametricEQ.txt that lives
+    in the bundled data directory. If the curated set ever loses
+    HD 600 we'll want to know — that's the reference profile we
+    ship demos against."""
+    from app.audio.autoeq.index import default_data_dir
+
+    path = (
+        default_data_dir()
+        / "oratory1990"
+        / "Sennheiser HD 600"
+        / "Sennheiser HD 600 ParametricEQ.txt"
+    )
+    text = path.read_text(encoding="utf-8")
+    p = parse_profile_text(text)
+    assert p.preamp_db < 0  # real profiles always need some headroom
+    assert len(p.bands) >= 5
+    # Every band has a positive frequency and a finite Q.
+    for band in p.bands:
+        assert band.freq_hz > 0
+        assert band.q > 0
+
+
+# ---------------------------------------------------------------------------
+# Index — directory walk + search
+# ---------------------------------------------------------------------------
+
+
+def _write_profile(
+    root: Path, source: str, brand_model: str, contents: str
+) -> None:
+    """Write a stub profile under the conventional layout."""
+    target = root / source / brand_model
+    target.mkdir(parents=True, exist_ok=True)
+    (target / f"{brand_model} ParametricEQ.txt").write_text(
+        contents, encoding="utf-8"
+    )
+
+
+def test_index_loads_from_directory(tmp_path):
+    """Two profiles, both load, IDs derived from the path."""
+    body = "Preamp: -1 dB\nFilter 1: ON PK Fc 1000 Hz Gain 1 dB Q 1\n"
+    _write_profile(tmp_path, "oratory1990", "Sennheiser HD 600", body)
+    _write_profile(tmp_path, "oratory1990", "Sony WH-1000XM4", body)
+
+    idx = AutoEqIndex()
+    loaded = idx.load_directory(tmp_path)
+
+    assert loaded == 2
+    assert idx.count() == 2
+    assert idx.get("oratory1990/Sennheiser HD 600") is not None
+    assert idx.get("oratory1990/Sony WH-1000XM4") is not None
+
+
+def test_index_skips_malformed_files_without_killing_the_load(tmp_path):
+    """One bad file shouldn't take the whole load down — log and
+    move on. AutoEQ has shipped occasional bad files historically."""
+    good = "Preamp: 0 dB\nFilter 1: ON PK Fc 1000 Hz Gain 1 dB Q 1\n"
+    _write_profile(tmp_path, "oratory1990", "Good Headphone", good)
+    _write_profile(tmp_path, "oratory1990", "Broken", "this is garbage\n")
+
+    idx = AutoEqIndex()
+    loaded = idx.load_directory(tmp_path)
+
+    assert loaded == 1
+    assert idx.get("oratory1990/Good Headphone") is not None
+    assert idx.get("oratory1990/Broken") is None
+
+
+def test_index_search_finds_by_substring(tmp_path):
+    """User types `hd 600`, gets the Sennheiser back. The match
+    scope is brand + model concatenated, case-insensitive."""
+    body = "Preamp: 0 dB\nFilter 1: ON PK Fc 1000 Hz Gain 1 dB Q 1\n"
+    _write_profile(tmp_path, "oratory1990", "Sennheiser HD 600", body)
+    _write_profile(tmp_path, "oratory1990", "Sony WH-1000XM4", body)
+
+    idx = AutoEqIndex()
+    idx.load_directory(tmp_path)
+
+    results = idx.search("hd 600", limit=5)
+    assert len(results) >= 1
+    assert any("HD 600" in r.model for r in results)
+
+
+def test_index_search_empty_query_returns_first_n_alphabetical(tmp_path):
+    """Empty search seeds the picker — useful for first paint
+    before the user types anything. Order is alphabetical by
+    brand + model concatenated so it's deterministic."""
+    body = "Preamp: 0 dB\nFilter 1: ON PK Fc 1000 Hz Gain 1 dB Q 1\n"
+    _write_profile(tmp_path, "oratory1990", "Zebra Phones", body)
+    _write_profile(tmp_path, "oratory1990", "Apple Headphones", body)
+
+    idx = AutoEqIndex()
+    idx.load_directory(tmp_path)
+
+    results = idx.search("", limit=5)
+    assert len(results) == 2
+    assert results[0].brand == "Apple"
+    assert results[1].brand == "Zebra"
+
+
+def test_index_load_directory_handles_missing_root(tmp_path):
+    """Calling load_directory on a non-existent path should warn
+    and return 0, not raise. PyInstaller bundles can race the
+    setup and we'd rather degrade than crash startup."""
+    idx = AutoEqIndex()
+    loaded = idx.load_directory(tmp_path / "does-not-exist")
+    assert loaded == 0
+    assert idx.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Apply — profile → SOS shape + cascade response
+# ---------------------------------------------------------------------------
+
+
+def test_profile_to_sos_returns_correct_shape():
+    text = """
+    Preamp: -1 dB
+    Filter 1: ON LSC Fc 100 Hz Gain 4 dB Q 0.7
+    Filter 2: ON PK Fc 1000 Hz Gain 2 dB Q 1.0
+    Filter 3: ON HSC Fc 8000 Hz Gain -3 dB Q 0.7
+    """
+    profile = parse_profile_text(text)
+    sos = profile_to_sos(profile, SAMPLE_RATE)
+    assert sos.shape == (3, 6)
+    assert sos.dtype == np.float32
+
+
+def test_profile_to_sos_empty_for_no_band_profile():
+    """A profile with only a preamp (no bands) compiles to an
+    empty SOS. Caller decides whether that's a bypass case."""
+    profile = parse_profile_text("Preamp: -1 dB")
+    sos = profile_to_sos(profile, SAMPLE_RATE)
+    assert sos.shape == (0, 6)
+
+
+def test_profile_cascade_response_at_characteristic_frequencies():
+    """Build a tiny profile (LSC + HSC) and verify the cascade's
+    magnitude response settles to the expected dB values where
+    each shelf dominates. Catches mistakes in the dispatch /
+    cascade builder that would land bands at the wrong frequency
+    or apply the wrong type."""
+    text = """
+    Preamp: 0 dB
+    Filter 1: ON LSC Fc 100 Hz Gain 4 dB Q 0.7
+    Filter 2: ON HSC Fc 8000 Hz Gain -3 dB Q 0.7
+    """
+    profile = parse_profile_text(text)
+    sos = profile_to_sos(profile, SAMPLE_RATE)
+
+    def cascade_db(freq_hz: float) -> float:
+        _, h = sosfreqz(sos, worN=np.array([freq_hz]), fs=SAMPLE_RATE)
+        return 20.0 * math.log10(max(abs(h[0]), 1e-12))
+
+    # Deep below the LSC corner — the +4 dB shelf dominates.
+    assert abs(cascade_db(20.0) - 4.0) < 0.5
+    # Above the HSC corner — the -3 dB shelf dominates.
+    assert abs(cascade_db(20000.0) - (-3.0)) < 0.5

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -945,6 +945,69 @@ export const api = {
         method: "POST",
         body: JSON.stringify({ enabled }),
       }),
+    /** AutoEQ headphone-profile endpoints (see
+     *  docs/autoeq-headphone-profiles-scope.md). The profile
+     *  catalog is bundled in the desktop app; the picker fetches
+     *  matches from the index built at server startup. */
+    autoEqList: (q: string, limit = 50) =>
+      req<{
+        total: number;
+        profiles: {
+          id: string;
+          brand: string;
+          model: string;
+          source: string;
+          preamp_db: number;
+          band_count: number;
+        }[];
+      }>(
+        `/api/eq/profiles?q=${encodeURIComponent(q)}&limit=${limit}`,
+      ),
+    autoEqState: () =>
+      req<{
+        mode: "off" | "manual" | "profile";
+        enabled: boolean;
+        active_profile_id: string;
+        active_profile: {
+          id: string;
+          brand: string;
+          model: string;
+          source: string;
+          preamp_db: number;
+          band_count: number;
+        } | null;
+        manual_bands: number[];
+        manual_preamp_db: number | null;
+        profile_catalog_size: number;
+      }>("/api/eq/state"),
+    autoEqLoadProfile: (profileId: string) =>
+      req<{
+        ok: boolean;
+        mode: string;
+        active_profile_id: string;
+        active_profile: {
+          id: string;
+          brand: string;
+          model: string;
+          source: string;
+          preamp_db: number;
+          band_count: number;
+          bands: {
+            filter_type: string;
+            freq_hz: number;
+            gain_db: number;
+            q: number;
+          }[];
+        };
+      }>("/api/eq/load-profile", {
+        method: "POST",
+        body: JSON.stringify({ profile_id: profileId }),
+      }),
+    autoEqSetMode: (mode: "off" | "manual" | "profile") =>
+      req<{ ok: boolean; mode: string; enabled: boolean }>("/api/eq/mode", {
+        method: "POST",
+        body: JSON.stringify({ mode }),
+      }),
     outputDevices: () =>
       req<{
         devices: { id: string; name: string }[];

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -850,6 +850,8 @@ function AudioEngineFields() {
         </select>
       </Field>
 
+      <AutoEqProfileField />
+
       <Field
         label="Equalizer"
         hint={
@@ -976,6 +978,227 @@ function EqSlider({
  * on pyatv's documented API; first real test will surface any
  * protocol quirks on HomePods, AirPlay speakers, or Apple TVs.
  */
+
+/**
+ * Headphone-profile section — Phase 2 of the AutoEQ work.
+ *
+ * Shows a mode toggle (Off / Manual / Profile) and, when in
+ * profile mode, a search input + result list. Manual mode keeps
+ * the existing 10-band sliders below; the two modes coexist via
+ * the backend `eq_mode` setting.
+ *
+ * Search is server-side (the backend has rapidfuzz when
+ * available; falls back to substring match). We re-fetch on
+ * every keystroke after a 200ms debounce — the catalog is small
+ * enough (~7 profiles in v1, ~5,000 once Phase 7 ships) that the
+ * cost is negligible.
+ */
+type AutoEqMode = "off" | "manual" | "profile";
+
+interface AutoEqProfileSummary {
+  id: string;
+  brand: string;
+  model: string;
+  source: string;
+  preamp_db: number;
+  band_count: number;
+}
+
+interface AutoEqState {
+  mode: AutoEqMode;
+  enabled: boolean;
+  active_profile_id: string;
+  active_profile: AutoEqProfileSummary | null;
+  manual_bands: number[];
+  manual_preamp_db: number | null;
+  profile_catalog_size: number;
+}
+
+function AutoEqProfileField() {
+  const toast = useToast();
+  const [state, setState] = useState<AutoEqState | null>(null);
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<AutoEqProfileSummary[]>([]);
+  const [loadingResults, setLoadingResults] = useState(false);
+
+  // Initial state load. If the backend doesn't expose the
+  // endpoint (older server build), stay hidden — no error toast.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const s = await api.player.autoEqState();
+        if (cancelled) return;
+        setState(s);
+      } catch {
+        /* feature not available — keep section hidden */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Debounced search. Only fires when in profile mode (no point
+  // populating the dropdown when the user can't pick from it).
+  useEffect(() => {
+    if (state?.mode !== "profile") return;
+    const handle = window.setTimeout(async () => {
+      setLoadingResults(true);
+      try {
+        const r = await api.player.autoEqList(query, 50);
+        setResults(r.profiles);
+      } catch {
+        setResults([]);
+      } finally {
+        setLoadingResults(false);
+      }
+    }, 200);
+    return () => window.clearTimeout(handle);
+  }, [query, state?.mode]);
+
+  if (state === null) return null;
+
+  const switchMode = async (mode: AutoEqMode) => {
+    const prev = state;
+    setState({ ...state, mode });
+    try {
+      await api.player.autoEqSetMode(mode);
+    } catch (err) {
+      setState(prev);
+      toast.show({
+        kind: "error",
+        title: "Couldn't switch EQ mode",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const pickProfile = async (id: string) => {
+    try {
+      const r = await api.player.autoEqLoadProfile(id);
+      setState({
+        ...state,
+        mode: "profile",
+        enabled: true,
+        active_profile_id: r.active_profile_id,
+        active_profile: {
+          id: r.active_profile.id,
+          brand: r.active_profile.brand,
+          model: r.active_profile.model,
+          source: r.active_profile.source,
+          preamp_db: r.active_profile.preamp_db,
+          band_count: r.active_profile.band_count,
+        },
+      });
+    } catch (err) {
+      toast.show({
+        kind: "error",
+        title: "Couldn't load profile",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const modeBtn = (mode: AutoEqMode, label: string) => (
+    <button
+      key={mode}
+      type="button"
+      onClick={() => switchMode(mode)}
+      className={cn(
+        "flex-1 rounded-md border border-input px-3 py-1.5 text-xs font-semibold transition-colors",
+        state.mode === mode
+          ? "bg-primary text-primary-foreground"
+          : "bg-secondary text-foreground hover:bg-accent",
+      )}
+    >
+      {label}
+    </button>
+  );
+
+  return (
+    <Field
+      label="Headphone profile"
+      hint={
+        state.profile_catalog_size === 0
+          ? "No profiles bundled. Profile mode disabled."
+          : `${state.profile_catalog_size} profile${
+              state.profile_catalog_size === 1 ? "" : "s"
+            } available. Picking one applies AutoEQ correction live.`
+      }
+    >
+      <div className="flex flex-col gap-3">
+        <div className="flex gap-1">
+          {modeBtn("off", "Off")}
+          {modeBtn("manual", "Manual")}
+          {modeBtn("profile", "Profile")}
+        </div>
+
+        {state.mode === "profile" && state.profile_catalog_size > 0 && (
+          <div className="flex flex-col gap-2">
+            <input
+              type="text"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search headphones — brand or model"
+              className="h-9 rounded-md border border-input bg-secondary px-3 text-sm"
+            />
+            <div className="max-h-48 overflow-y-auto rounded-md border border-input">
+              {loadingResults && results.length === 0 && (
+                <div className="px-3 py-2 text-xs text-muted-foreground">
+                  Searching…
+                </div>
+              )}
+              {!loadingResults && results.length === 0 && (
+                <div className="px-3 py-2 text-xs text-muted-foreground">
+                  No matches.
+                </div>
+              )}
+              {results.map((p) => {
+                const isActive = p.id === state.active_profile_id;
+                return (
+                  <button
+                    key={p.id}
+                    type="button"
+                    onClick={() => pickProfile(p.id)}
+                    className={cn(
+                      "flex w-full items-center justify-between gap-3 border-b border-input px-3 py-2 text-left text-xs last:border-b-0 hover:bg-accent",
+                      isActive && "bg-accent",
+                    )}
+                  >
+                    <span className="truncate">
+                      <span className="font-semibold">{p.brand}</span>{" "}
+                      {p.model}
+                    </span>
+                    <span className="flex-shrink-0 text-muted-foreground">
+                      {p.band_count} bands · {p.preamp_db.toFixed(1)} dB preamp
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        )}
+
+        {state.mode === "profile" && state.active_profile && (
+          <div className="rounded-md border border-input bg-secondary/40 p-3">
+            <div className="text-xs uppercase tracking-wide text-muted-foreground">
+              Active profile
+            </div>
+            <div className="mt-1 text-sm font-semibold">
+              {state.active_profile.brand} {state.active_profile.model}
+            </div>
+            <div className="text-xs text-muted-foreground">
+              {state.active_profile.source} · {state.active_profile.band_count}{" "}
+              bands · preamp {state.active_profile.preamp_db.toFixed(1)} dB
+            </div>
+          </div>
+        )}
+      </div>
+    </Field>
+  );
+}
+
 interface AirPlayDeviceRow {
   id: string;
   name: string;


### PR DESCRIPTION
First user-visible piece of the AutoEQ feature scoped in [docs/autoeq-headphone-profiles-scope.md](docs/autoeq-headphone-profiles-scope.md). Stacks on Phase 1 ([#84](https://github.com/J-M-PUNK/tideway/pull/84)) — base it after that one merges.

After this PR: user opens Settings → Playback, sees a "Headphone profile" section with mode toggle (Off / Manual / Profile), can search the bundled catalog, picks their headphones, hears the correction live.

## What's new

### Backend (`app/audio/autoeq/`)

- **`profiles.py`** — `parse_profile_text()` for AutoEQ's `ParametricEQ.txt` format. Strict on line shape (line-numbered errors), lenient on whitespace. Tolerates `ON` / `OFF`, comments, blank lines.
- **`apply.py`** — `profile_to_sos(profile, sample_rate)` compiles bands into a `(N, 6)` SOS at the target rate via the Phase 1 shelf-aware dispatcher.
- **`index.py`** — `AutoEqIndex` walks a directory, parses every `*ParametricEQ.txt`, derives ID + brand + model from the layout, and offers fuzzy search. Uses `rapidfuzz` when available, falls back to substring match. Module-level singleton `INDEX` shared between server.py and the audio engine.

### Audio engine

- **`Equalizer.set_sos(sos, preamp_db)`** — new method accepting arbitrary SOS so the profile path can install variable-Q shelf cascades the manual 10-band UI doesn't support. Old `set_bands` path is unchanged.
- **`PCMPlayer.apply_equalizer_profile(profile)`** — sibling to `apply_equalizer(bands)`. Stores the profile object so stream-reopen at a new sample rate (cross-rate gapless, track load) recompiles coefficients without losing the curve. Manual / profile modes are mutually exclusive in the player.

### Settings

Two new fields on `Settings`:

- `eq_mode: "off" | "manual" | "profile"` (default `"manual"` — preserves existing behavior for users coming from prior versions).
- `eq_active_profile_id: str` — survives mode switches so profile → manual → profile lands the user back at the same pick.

`SettingsPayload` Pydantic model mirrors the new fields (the sync trap CLAUDE.md explicitly calls out).

### Endpoints

| Method | Path | Purpose |
|---|---|---|
| GET | `/api/eq/profiles?q=&limit=` | List / search |
| GET | `/api/eq/profiles/{id:path}` | Full profile detail (bands + preamp) |
| GET | `/api/eq/state` | Current mode, active profile, manual bands, catalog size |
| POST | `/api/eq/load-profile` | Apply a profile, persists mode + active id |
| POST | `/api/eq/mode` | Switch mode without destroying the inactive mode's state |

The index loads at lifespan startup. Failures log + degrade gracefully — empty catalog rather than a crashed server.

### Frontend

`AutoEqProfileField` rendered in Settings → Playback above the existing 10-band Equalizer. Mode toggle, debounced search, result list with "active" highlight, profile detail card. Uses the existing `Field` component for visual consistency.

### Bundled data

Seven curated profiles in `app/audio/autoeq/data/results/oratory1990/`: HD 600 / 650 / 800 S, WH-1000XM4, AirPods Max, QuietComfort 45, ER4SR. Vendored from AutoEQ's master branch via `scripts/vendor_autoeq_profiles.py` (re-runnable, idempotent).

Phase 7's update mechanism will replace this curated subset with the full ~5,000 profile catalog. Trying to bundle 5,000 in this PR would balloon the repo without buying anything we can't deliver later via update channel.

## Test plan

- [x] `pytest tests/` — 534 passed (was 519 + 15 new), 2 skipped unchanged.
- [x] `tsc --noEmit` clean.
- [ ] Manual: open Settings → Playback. Confirm "Headphone profile" section shows up with the seven bundled headphones.
- [ ] Manual: pick HD 600. Confirm playback audibly changes (the HD 600 has a strong low-shelf boost — easy to hear on bass-heavy content).
- [ ] Manual: switch to Manual mode. Confirm previous 10-band sliders work as before.
- [ ] Manual: switch back to Profile. Confirm the previously-selected profile re-applies (state preserved across mode switches).
- [ ] Manual: cross-track playback (start one track, advance to next). Confirm profile EQ stays applied across the cross-rate transition.

## What's deliberately out of scope (per the scope doc)

- Per-device profile mapping (Phase 3).
- A/B bypass button + signal-path display (Phase 4).
- User tilt sliders for taste adjustment (Phase 5).
- Frequency-response graph (Phase 6).
- Full ~5,000 profile catalog + update channel (Phase 7).
- Surfacing in the now-playing UI (out of scope for v1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)