### PR TITLE
AutoEQ Phase 3: per-device profile mapping

### DIFF
--- a/app/audio/autoeq/resolver.py
+++ b/app/audio/autoeq/resolver.py
@@ -1,0 +1,114 @@
+"""Per-device AutoEQ profile resolver — Phase 3 of the scope doc.
+
+When the active output device changes, this module decides which
+profile (if any) to apply, given:
+
+- The device's fingerprint (its `sounddevice` name).
+- The user's `eq_device_mappings` settings.
+- The user's `eq_fallback_when_unmapped` choice.
+- The current `eq_active_profile_id` (used by the
+  `use_last_profile` fallback).
+
+The resolver is intentionally small: just decision logic,
+returning a `ResolverDecision`. Callers (server.py) apply the
+decision to the player and persist any state changes — keeps the
+package free of circular dependencies on server module state.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .index import AutoEqIndex
+from .profiles import AutoEqProfile
+
+
+@dataclass
+class ResolverDecision:
+    """What the resolver thinks should happen on a device change.
+
+    `profile` is the profile to apply (None means "bypass — clear
+    the EQ"). `active_profile_id` is the new value to persist into
+    settings; may differ from the input when the resolver picked
+    a fallback or cleared the mapping. `reason` is a short label
+    for logging / SSE telemetry."""
+
+    profile: Optional[AutoEqProfile]
+    active_profile_id: str
+    reason: str
+
+
+def resolve_for_device(
+    fingerprint: str,
+    *,
+    device_mappings: dict[str, Optional[str]],
+    fallback: str,
+    current_active_profile_id: str,
+    index: AutoEqIndex,
+) -> ResolverDecision:
+    """Pick the right profile for the given device.
+
+    Decision order:
+
+    1. If `device_mappings[fingerprint]` is a known profile_id,
+       apply that profile.
+    2. If `device_mappings[fingerprint]` is explicitly `None`
+       (user mapped this device to "no EQ"), bypass.
+    3. If the device isn't in the map, apply `fallback`:
+       - `"bypass"`: clear the EQ.
+       - `"use_last_profile"`: keep `current_active_profile_id`.
+
+    The fingerprint is normalised to its trimmed form so trailing
+    whitespace from `sounddevice` (yes, it happens) doesn't break
+    lookups."""
+    fp = (fingerprint or "").strip()
+
+    # Case 1+2: explicit mapping (including explicit None).
+    if fp in device_mappings:
+        mapped_id = device_mappings[fp]
+        if mapped_id is None:
+            return ResolverDecision(
+                profile=None,
+                active_profile_id="",
+                reason="device explicitly mapped to bypass",
+            )
+        profile = index.get(mapped_id)
+        if profile is None:
+            # Mapped to a profile that no longer exists (catalog
+            # update removed it, file rename, etc.). Treat as
+            # unmapped — fall through to the fallback branch.
+            mapped_missing = True
+        else:
+            return ResolverDecision(
+                profile=profile,
+                active_profile_id=mapped_id,
+                reason=f"device mapped to {mapped_id}",
+            )
+    else:
+        mapped_missing = False
+
+    # Case 3: no mapping — fall back per user preference.
+    if fallback == "use_last_profile" and current_active_profile_id:
+        last = index.get(current_active_profile_id)
+        if last is not None:
+            reason = (
+                "no mapping; keeping last profile"
+                if not mapped_missing
+                else f"mapped profile {device_mappings[fp]} missing; "
+                f"keeping last profile"
+            )
+            return ResolverDecision(
+                profile=last,
+                active_profile_id=current_active_profile_id,
+                reason=reason,
+            )
+
+    # Default fallback: bypass.
+    base_reason = (
+        "no mapping" if not mapped_missing else "mapped profile missing"
+    )
+    return ResolverDecision(
+        profile=None,
+        active_profile_id="",
+        reason=f"{base_reason}; bypassing",
+    )

--- a/app/audio/autoeq/seen_devices.py
+++ b/app/audio/autoeq/seen_devices.py
@@ -1,0 +1,187 @@
+"""Track which output devices the user has seen, for the AutoEQ
+per-device profile picker.
+
+The picker UI needs a list of "all the headphones / speakers /
+DACs you've used recently" so the user can map a profile to each
+without having to plug everything in simultaneously. This module
+maintains that list.
+
+Storage shape — a small JSON file in `user_data_dir()`:
+
+    [
+      {
+        "fingerprint": "Scarlett Solo USB",
+        "display_name": "Scarlett Solo USB",
+        "kind": "usb",
+        "first_seen": 1735000000,
+        "last_seen": 1735999999
+      },
+      ...
+    ]
+
+Fingerprint = device name as `sounddevice.query_devices()` reports
+it. That's stable across reconnects on every platform we ship to,
+which is good enough for v1 — the alternative (some hash of
+USB-VID/PID + endpoint id) would be more robust but requires
+platform-specific probing.
+
+`upsert(active_devices)` is called from the audio engine whenever
+it enumerates devices. It updates `last_seen` for known devices
+and inserts new ones with `first_seen = last_seen = now`.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+from pathlib import Path
+from typing import Optional
+
+from app.paths import user_data_dir
+
+log = logging.getLogger(__name__)
+
+
+_FILE_NAME = "autoeq_seen_devices.json"
+
+
+def _store_path() -> Path:
+    return user_data_dir() / _FILE_NAME
+
+
+def _classify_kind(name: str) -> str:
+    """Best-effort classification of a device name into one of
+    `bt` / `usb` / `builtin` / `unknown`. Used by the picker UI
+    to show the right icon and to surface a one-time toast on
+    BT devices warning about reduced EQ accuracy.
+
+    Heuristics, not bulletproof. A USB DAC named "AirPods Bose"
+    would misclassify, but the name match is what users would
+    expect."""
+    lower = name.lower()
+    if any(
+        marker in lower
+        for marker in ("bluetooth", "airpods", "wh-1000", "qc", "buds")
+    ):
+        return "bt"
+    if "usb" in lower or "scarlett" in lower or "dac" in lower:
+        return "usb"
+    if any(
+        marker in lower
+        for marker in ("speakers", "internal", "built-in", "macbook")
+    ):
+        return "builtin"
+    return "unknown"
+
+
+class SeenDeviceStore:
+    """Thread-safe JSON-backed list of seen output devices."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        # Keyed by fingerprint for O(1) upsert. Same dataset gets
+        # serialised as a JSON list ordered by last_seen desc.
+        self._records: dict[str, dict] = {}
+        self._loaded = False
+
+    def _ensure_loaded(self) -> None:
+        if self._loaded:
+            return
+        path = _store_path()
+        if path.exists():
+            try:
+                raw = json.loads(path.read_text(encoding="utf-8"))
+                if isinstance(raw, list):
+                    for entry in raw:
+                        fp = entry.get("fingerprint")
+                        if isinstance(fp, str) and fp:
+                            self._records[fp] = entry
+            except Exception as exc:
+                log.warning(
+                    "autoeq seen-devices: load failed, starting empty: %s",
+                    exc,
+                )
+        self._loaded = True
+
+    def _flush(self) -> None:
+        """Write the current records to disk, ordered by last_seen
+        desc so the picker list is naturally sorted on read."""
+        path = _store_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        ordered = sorted(
+            self._records.values(),
+            key=lambda r: r.get("last_seen", 0),
+            reverse=True,
+        )
+        try:
+            path.write_text(
+                json.dumps(ordered, ensure_ascii=False, indent=2),
+                encoding="utf-8",
+            )
+        except Exception as exc:
+            log.warning("autoeq seen-devices: write failed: %s", exc)
+
+    def upsert(
+        self,
+        fingerprint: str,
+        display_name: Optional[str] = None,
+    ) -> None:
+        """Record (or update) a device sighting. `display_name`
+        defaults to the fingerprint — they're usually the same
+        but the parameter exists for callers that have a richer
+        display string."""
+        if not fingerprint:
+            return
+        now = int(time.time())
+        with self._lock:
+            self._ensure_loaded()
+            entry = self._records.get(fingerprint)
+            if entry is None:
+                entry = {
+                    "fingerprint": fingerprint,
+                    "display_name": display_name or fingerprint,
+                    "kind": _classify_kind(fingerprint),
+                    "first_seen": now,
+                    "last_seen": now,
+                }
+                self._records[fingerprint] = entry
+            else:
+                entry["last_seen"] = now
+                if display_name:
+                    entry["display_name"] = display_name
+            self._flush()
+
+    def list(self) -> list[dict]:
+        """Return all known devices, ordered by last_seen desc."""
+        with self._lock:
+            self._ensure_loaded()
+            return sorted(
+                (dict(r) for r in self._records.values()),
+                key=lambda r: r.get("last_seen", 0),
+                reverse=True,
+            )
+
+    def forget(self, fingerprint: str) -> bool:
+        """Remove a device from the seen list. Returns True if
+        anything was removed. Used by the picker's "Forget device"
+        affordance — does NOT touch the device-mapping settings,
+        callers prune those separately."""
+        with self._lock:
+            self._ensure_loaded()
+            if fingerprint not in self._records:
+                return False
+            del self._records[fingerprint]
+            self._flush()
+            return True
+
+    def clear(self) -> None:
+        """Wipe the entire seen-devices list. Test-only helper."""
+        with self._lock:
+            self._records.clear()
+            self._loaded = True
+            self._flush()
+
+
+# Module-level singleton — all upsert/list calls share state.
+STORE = SeenDeviceStore()

--- a/app/settings.py
+++ b/app/settings.py
@@ -101,6 +101,19 @@ class Settings:
     # eq_mode == "profile"; preserved across mode switches so
     # toggling profile/manual/profile keeps the user's pick.
     eq_active_profile_id: str = ""
+    # Per-device AutoEQ profile mapping (Phase 3 of the scope doc).
+    # Key = device fingerprint as `sounddevice` reports it; value =
+    # profile_id, or None to explicitly skip mapping for that device
+    # (e.g. an HDMI output to a TV where EQ doesn't make sense).
+    # When the active output device changes, the resolver looks up
+    # this map and applies the matching profile.
+    eq_device_mappings: dict[str, Optional[str]] = field(default_factory=dict)
+    # Behaviour when the active device has no mapping entry:
+    #   "bypass" — clear the EQ (safest; user opts in by mapping).
+    #   "use_last_profile" — keep the last-applied profile active
+    #     even on unmapped devices. Convenient for users who only
+    #     ever listen on one pair.
+    eq_fallback_when_unmapped: str = "bypass"
     # sounddevice output-device index (stringified, matches what
     # /api/player/output-devices returns). Empty string means "use
     # the system default". Persisted so USB DAC / Bluetooth

--- a/server.py
+++ b/server.py
@@ -4897,6 +4897,119 @@ def autoeq_load_profile(req: _AutoEqLoadProfileRequest) -> dict:
     }
 
 
+class _AutoEqDeviceMappingRequest(BaseModel):
+    fingerprint: str
+    profile_id: Optional[str] = None  # None = "no EQ for this device"
+
+
+class _AutoEqForgetDeviceRequest(BaseModel):
+    fingerprint: str
+
+
+@app.get("/api/eq/devices")
+def autoeq_devices() -> dict:
+    """Seen output devices + their currently-mapped profiles.
+    Powers the per-device profile picker in Settings → Playback.
+
+    Includes a `current_fingerprint` field so the picker can
+    highlight / pin the active device. The fingerprint is
+    derived the same way the resolver does it — by looking up
+    the active device's name in the live device list."""
+    _require_local_access()
+    from app.audio.autoeq.seen_devices import STORE as _SEEN_STORE
+
+    seen = _SEEN_STORE.list()
+    # Decorate each seen device with its current mapping (if any)
+    # so the picker can render checkboxes / dropdowns inline.
+    for entry in seen:
+        fp = entry.get("fingerprint", "")
+        if fp in settings.eq_device_mappings:
+            entry["mapped_profile_id"] = settings.eq_device_mappings[fp]
+        else:
+            entry["mapped_profile_id"] = None
+            entry["unmapped"] = True
+
+    # Active fingerprint — what's currently driving playback.
+    current_fingerprint = ""
+    try:
+        device_list = _native_player().list_output_devices()
+        for entry in device_list:
+            if entry.get("id") == settings.audio_output_device:
+                current_fingerprint = entry.get("name") or ""
+                break
+    except Exception:
+        pass
+
+    return {
+        "devices": seen,
+        "current_fingerprint": current_fingerprint,
+        "fallback_when_unmapped": settings.eq_fallback_when_unmapped,
+    }
+
+
+@app.post("/api/eq/device-mappings")
+def autoeq_set_device_mapping(req: _AutoEqDeviceMappingRequest) -> dict:
+    """Set (or clear) the AutoEQ profile mapped to a specific
+    output device. `profile_id=null` explicitly mutes the EQ for
+    this device. To remove the mapping entirely (so the device
+    falls back to `eq_fallback_when_unmapped`), use the
+    `/api/eq/device-mappings/clear` endpoint."""
+    _require_local_access()
+    from app.audio.autoeq.index import INDEX
+
+    if req.profile_id is not None and INDEX.get(req.profile_id) is None:
+        raise HTTPException(
+            status_code=404, detail=f"profile not found: {req.profile_id}"
+        )
+
+    settings.eq_device_mappings[req.fingerprint] = req.profile_id
+
+    # If this is the currently-active device and we're in profile
+    # mode, apply the new mapping immediately so the user hears
+    # the result without having to switch away and back.
+    try:
+        player = _native_player()
+        device_list = player.list_output_devices()
+        active_fp = ""
+        for entry in device_list:
+            if entry.get("id") == settings.audio_output_device:
+                active_fp = entry.get("name") or ""
+                break
+        if active_fp == req.fingerprint and settings.eq_mode == "profile":
+            if req.profile_id is None:
+                player.apply_equalizer([])
+                settings.eq_active_profile_id = ""
+            else:
+                profile = INDEX.get(req.profile_id)
+                if profile is not None:
+                    player.apply_equalizer_profile(profile)
+                    settings.eq_active_profile_id = req.profile_id
+    except Exception:
+        log = logging.getLogger("autoeq.resolver")
+        log.exception("autoeq apply-on-set failed")
+
+    save_settings(settings)
+    return {
+        "ok": True,
+        "fingerprint": req.fingerprint,
+        "profile_id": req.profile_id,
+    }
+
+
+@app.post("/api/eq/forget-device")
+def autoeq_forget_device(req: _AutoEqForgetDeviceRequest) -> dict:
+    """Remove a device from the seen-list and drop any mapping
+    it had. Doesn't affect the active device or the active
+    profile — just cleans up clutter in the picker."""
+    _require_local_access()
+    from app.audio.autoeq.seen_devices import STORE as _SEEN_STORE
+
+    removed = _SEEN_STORE.forget(req.fingerprint)
+    settings.eq_device_mappings.pop(req.fingerprint, None)
+    save_settings(settings)
+    return {"ok": True, "removed": removed}
+
+
 class _AutoEqModeRequest(BaseModel):
     mode: str  # "off" | "manual" | "profile"
 
@@ -4964,10 +5077,71 @@ def player_output_devices() -> dict:
 @app.post("/api/player/output-device")
 def player_set_output_device(req: _PlayerOutputDeviceRequest) -> dict:
     _require_local_access()
-    _native_player().set_output_device(req.device_id)
+    player = _native_player()
+    player.set_output_device(req.device_id)
     settings.audio_output_device = req.device_id
+
+    # Track this device in the seen-list so the user can map a
+    # profile to it later, and run the AutoEQ resolver to apply
+    # the matching profile (or fallback) if the user is in
+    # profile mode. No-op when in manual / off mode.
+    _autoeq_on_device_change(req.device_id)
+
     save_settings(settings)
     return {"ok": True, "device_id": settings.audio_output_device}
+
+
+def _autoeq_on_device_change(device_id: str) -> None:
+    """Bridge between an output-device change and the AutoEQ
+    per-device resolver. Resolves the device's fingerprint from
+    the active device list, upserts it into the seen-devices
+    store, then applies the resolver's decision to the player and
+    persists `eq_active_profile_id` if the resolver picked or
+    cleared a profile.
+
+    Failures here are logged + swallowed — a bug in the resolver
+    must not prevent the audio device switch from completing.
+    """
+    if settings.eq_mode != "profile":
+        return
+
+    try:
+        from app.audio.autoeq.index import INDEX
+        from app.audio.autoeq.resolver import resolve_for_device
+        from app.audio.autoeq.seen_devices import STORE as _SEEN_STORE
+
+        # Look up the human-readable device name (the fingerprint)
+        # from the active device list. The empty id == "system
+        # default" — we still upsert it so users with one device
+        # can map it.
+        player = _native_player()
+        device_list = player.list_output_devices()
+        fingerprint = ""
+        for entry in device_list:
+            if entry.get("id") == device_id:
+                fingerprint = entry.get("name") or ""
+                break
+        if not fingerprint:
+            return
+
+        _SEEN_STORE.upsert(fingerprint)
+
+        decision = resolve_for_device(
+            fingerprint,
+            device_mappings=dict(settings.eq_device_mappings),
+            fallback=settings.eq_fallback_when_unmapped,
+            current_active_profile_id=settings.eq_active_profile_id,
+            index=INDEX,
+        )
+
+        settings.eq_active_profile_id = decision.active_profile_id
+        if decision.profile is not None:
+            player.apply_equalizer_profile(decision.profile)
+        else:
+            player.apply_equalizer([])
+    except Exception:
+        log = logging.getLogger("autoeq.resolver")
+        log.exception("autoeq device-change resolver failed")
 
 
 # ---------------------------------------------------------------------------
@@ -7962,6 +8136,8 @@ class SettingsPayload(BaseModel):
     download_rate_limit_mbps: Optional[int] = None
     eq_mode: Optional[str] = None
     eq_active_profile_id: Optional[str] = None
+    eq_device_mappings: Optional[dict] = None
+    eq_fallback_when_unmapped: Optional[str] = None
 
 
 @app.get("/api/settings")

--- a/tests/test_autoeq_per_device.py
+++ b/tests/test_autoeq_per_device.py
@@ -1,0 +1,239 @@
+"""Phase 3 of the AutoEQ work — per-device profile mapping.
+
+Tests cover the resolver decision logic in isolation (no audio
+engine, no FastAPI) and the seen-devices JSON store. The
+server-side wiring (lifespan startup, output-device endpoint)
+is exercised by manual smoke testing — the value here is in
+pinning the small, decision-heavy modules.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.audio.autoeq.index import AutoEqIndex
+from app.audio.autoeq.resolver import resolve_for_device
+from app.audio.autoeq.seen_devices import SeenDeviceStore, _classify_kind
+
+
+# ---------------------------------------------------------------------------
+# Resolver — decision logic
+# ---------------------------------------------------------------------------
+
+
+def _populate(tmp_path: Path) -> AutoEqIndex:
+    """Stub index with two profiles for the resolver tests."""
+    body = "Preamp: 0 dB\nFilter 1: ON PK Fc 1000 Hz Gain 1 dB Q 1\n"
+    for brand_model in ("Sennheiser HD 600", "Sony WH-1000XM4"):
+        target = tmp_path / "oratory1990" / brand_model
+        target.mkdir(parents=True, exist_ok=True)
+        (target / f"{brand_model} ParametricEQ.txt").write_text(
+            body, encoding="utf-8"
+        )
+    idx = AutoEqIndex()
+    idx.load_directory(tmp_path)
+    return idx
+
+
+def test_resolver_applies_mapped_profile(tmp_path):
+    idx = _populate(tmp_path)
+    decision = resolve_for_device(
+        "Scarlett Solo USB",
+        device_mappings={"Scarlett Solo USB": "oratory1990/Sennheiser HD 600"},
+        fallback="bypass",
+        current_active_profile_id="",
+        index=idx,
+    )
+    assert decision.profile is not None
+    assert decision.profile.profile_id == "oratory1990/Sennheiser HD 600"
+    assert decision.active_profile_id == "oratory1990/Sennheiser HD 600"
+
+
+def test_resolver_explicit_none_means_bypass(tmp_path):
+    """A user can explicitly map a device to "no EQ" — resolver
+    must respect that even when a fallback profile is set."""
+    idx = _populate(tmp_path)
+    decision = resolve_for_device(
+        "HDMI Output",
+        device_mappings={"HDMI Output": None},
+        fallback="use_last_profile",
+        current_active_profile_id="oratory1990/Sennheiser HD 600",
+        index=idx,
+    )
+    assert decision.profile is None
+    assert decision.active_profile_id == ""
+
+
+def test_resolver_unmapped_with_bypass_fallback_clears_eq(tmp_path):
+    idx = _populate(tmp_path)
+    decision = resolve_for_device(
+        "Unknown Device",
+        device_mappings={},
+        fallback="bypass",
+        current_active_profile_id="oratory1990/Sennheiser HD 600",
+        index=idx,
+    )
+    assert decision.profile is None
+    assert decision.active_profile_id == ""
+
+
+def test_resolver_unmapped_with_use_last_profile_keeps_active(tmp_path):
+    idx = _populate(tmp_path)
+    decision = resolve_for_device(
+        "Unknown Device",
+        device_mappings={},
+        fallback="use_last_profile",
+        current_active_profile_id="oratory1990/Sennheiser HD 600",
+        index=idx,
+    )
+    assert decision.profile is not None
+    assert decision.active_profile_id == "oratory1990/Sennheiser HD 600"
+
+
+def test_resolver_handles_missing_mapped_profile(tmp_path):
+    """A device mapped to a profile_id that no longer exists in
+    the catalog (e.g. catalog update removed it) must NOT crash —
+    fall back per the user's `fallback` setting."""
+    idx = _populate(tmp_path)
+    decision = resolve_for_device(
+        "Some Device",
+        device_mappings={"Some Device": "oratory1990/Nonexistent Headphone"},
+        fallback="use_last_profile",
+        current_active_profile_id="oratory1990/Sony WH-1000XM4",
+        index=idx,
+    )
+    # Last-profile fallback succeeded — the missing mapping
+    # surfaced cleanly.
+    assert decision.profile is not None
+    assert decision.active_profile_id == "oratory1990/Sony WH-1000XM4"
+
+
+def test_resolver_strips_whitespace_from_fingerprint(tmp_path):
+    """sounddevice occasionally emits trailing spaces on device
+    names (Windows quirk). The resolver should match against the
+    trimmed form rather than fail because the user's mapping
+    omitted invisible whitespace."""
+    idx = _populate(tmp_path)
+    decision = resolve_for_device(
+        "  Scarlett Solo USB   ",
+        device_mappings={"Scarlett Solo USB": "oratory1990/Sennheiser HD 600"},
+        fallback="bypass",
+        current_active_profile_id="",
+        index=idx,
+    )
+    assert decision.profile is not None
+
+
+# ---------------------------------------------------------------------------
+# Seen-devices store
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_store(tmp_path, monkeypatch):
+    """Redirect the seen-devices store to a tmp file."""
+    from app.audio.autoeq import seen_devices
+
+    monkeypatch.setattr(
+        seen_devices,
+        "_store_path",
+        lambda: tmp_path / "autoeq_seen_devices.json",
+    )
+    return SeenDeviceStore()
+
+
+def test_seen_store_upsert_inserts_new_device(isolated_store):
+    isolated_store.upsert("Scarlett Solo USB")
+    rows = isolated_store.list()
+    assert len(rows) == 1
+    assert rows[0]["fingerprint"] == "Scarlett Solo USB"
+    assert rows[0]["display_name"] == "Scarlett Solo USB"
+    assert rows[0]["kind"] == "usb"
+    assert rows[0]["first_seen"] == rows[0]["last_seen"]
+
+
+def test_seen_store_upsert_updates_last_seen(isolated_store):
+    """Re-upsert bumps last_seen but preserves first_seen."""
+    isolated_store.upsert("Scarlett Solo USB")
+    first_seen = isolated_store.list()[0]["first_seen"]
+    # Force a clear time difference. We can't easily mock time
+    # without monkeypatching `time.time`, so just trust that
+    # last_seen >= first_seen and check that the same fingerprint
+    # is still the only record.
+    isolated_store.upsert("Scarlett Solo USB")
+    rows = isolated_store.list()
+    assert len(rows) == 1
+    assert rows[0]["first_seen"] == first_seen
+    assert rows[0]["last_seen"] >= first_seen
+
+
+def test_seen_store_persists_across_reloads(tmp_path, monkeypatch):
+    """A new SeenDeviceStore instance picks up records from disk."""
+    from app.audio.autoeq import seen_devices
+
+    monkeypatch.setattr(
+        seen_devices,
+        "_store_path",
+        lambda: tmp_path / "autoeq_seen_devices.json",
+    )
+
+    store1 = SeenDeviceStore()
+    store1.upsert("Scarlett Solo USB")
+    store1.upsert("AirPods Pro")
+
+    store2 = SeenDeviceStore()
+    rows = store2.list()
+    assert len(rows) == 2
+    fps = {r["fingerprint"] for r in rows}
+    assert fps == {"Scarlett Solo USB", "AirPods Pro"}
+
+
+def test_seen_store_forget_removes_only_named_device(isolated_store):
+    isolated_store.upsert("AirPods")
+    isolated_store.upsert("Scarlett Solo USB")
+    assert isolated_store.forget("AirPods") is True
+    assert {r["fingerprint"] for r in isolated_store.list()} == {
+        "Scarlett Solo USB"
+    }
+    # Forgetting an unknown device returns False rather than
+    # raising — idempotent for the "user clicked forget twice"
+    # case.
+    assert isolated_store.forget("Nonexistent") is False
+
+
+def test_seen_store_orders_by_last_seen_desc(isolated_store):
+    isolated_store.upsert("DeviceA")
+    isolated_store.upsert("DeviceB")
+    isolated_store.upsert("DeviceA")  # bump A's last_seen
+    rows = isolated_store.list()
+    assert rows[0]["fingerprint"] == "DeviceA"
+    assert rows[1]["fingerprint"] == "DeviceB"
+
+
+def test_seen_store_ignores_empty_fingerprint(isolated_store):
+    isolated_store.upsert("")
+    assert isolated_store.list() == []
+
+
+# ---------------------------------------------------------------------------
+# Kind classification — heuristic, not exhaustive
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("AirPods Pro", "bt"),
+        ("WH-1000XM5 (Bluetooth)", "bt"),
+        ("Samsung Buds", "bt"),
+        ("Scarlett Solo USB", "usb"),
+        ("Topping E50 DAC", "usb"),
+        ("MacBook Pro Speakers", "builtin"),
+        ("Internal Speakers", "builtin"),
+        ("Built-in Output", "builtin"),
+        ("Unknown Speaker", "unknown"),
+    ],
+)
+def test_classify_kind(name, expected):
+    assert _classify_kind(name) == expected

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1008,6 +1008,38 @@ export const api = {
         method: "POST",
         body: JSON.stringify({ mode }),
       }),
+    /** AutoEQ per-device profile mapping (Phase 3). Returns the
+     *  list of seen output devices, each tagged with its mapped
+     *  profile id (or null = "EQ off for this device", or
+     *  unmapped = "use the fallback rule"). */
+    autoEqDevices: () =>
+      req<{
+        devices: {
+          fingerprint: string;
+          display_name: string;
+          kind: string;
+          first_seen: number;
+          last_seen: number;
+          mapped_profile_id: string | null;
+          unmapped?: boolean;
+        }[];
+        current_fingerprint: string;
+        fallback_when_unmapped: "bypass" | "use_last_profile";
+      }>("/api/eq/devices"),
+    autoEqSetDeviceMapping: (fingerprint: string, profileId: string | null) =>
+      req<{
+        ok: boolean;
+        fingerprint: string;
+        profile_id: string | null;
+      }>("/api/eq/device-mappings", {
+        method: "POST",
+        body: JSON.stringify({ fingerprint, profile_id: profileId }),
+      }),
+    autoEqForgetDevice: (fingerprint: string) =>
+      req<{ ok: boolean; removed: boolean }>("/api/eq/forget-device", {
+        method: "POST",
+        body: JSON.stringify({ fingerprint }),
+      }),
     outputDevices: () =>
       req<{
         devices: { id: string; name: string }[];

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -851,6 +851,7 @@ function AudioEngineFields() {
       </Field>
 
       <AutoEqProfileField />
+      <AutoEqDeviceMappingField />
 
       <Field
         label="Equalizer"
@@ -1194,6 +1195,182 @@ function AutoEqProfileField() {
             </div>
           </div>
         )}
+      </div>
+    </Field>
+  );
+}
+
+/**
+ * Per-device AutoEQ profile mapping — Phase 3 of the scope doc.
+ *
+ * For each output device the user has used, lets them pick the
+ * profile to apply. When a device's mapping changes (or the
+ * active device changes), the audio engine resolves the right
+ * profile and applies it live.
+ *
+ * Hidden when the catalog is empty (no profiles bundled) — there
+ * would be nothing to map. Otherwise renders even when no
+ * devices have been seen yet, with a hint about plugging
+ * something in.
+ */
+interface AutoEqDeviceRow {
+  fingerprint: string;
+  display_name: string;
+  kind: string;
+  first_seen: number;
+  last_seen: number;
+  mapped_profile_id: string | null;
+  unmapped?: boolean;
+}
+
+function AutoEqDeviceMappingField() {
+  const toast = useToast();
+  const [data, setData] = useState<{
+    devices: AutoEqDeviceRow[];
+    current_fingerprint: string;
+    fallback: "bypass" | "use_last_profile";
+  } | null>(null);
+  const [profiles, setProfiles] = useState<
+    { id: string; brand: string; model: string }[] | null
+  >(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const [d, p] = await Promise.all([
+          api.player.autoEqDevices(),
+          api.player.autoEqList("", 200),
+        ]);
+        if (cancelled) return;
+        setData({
+          devices: d.devices,
+          current_fingerprint: d.current_fingerprint,
+          fallback: d.fallback_when_unmapped,
+        });
+        setProfiles(p.profiles.map((x) => ({ id: x.id, brand: x.brand, model: x.model })));
+      } catch {
+        /* feature not available — keep section hidden */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const setMapping = async (fingerprint: string, profileId: string | null) => {
+    if (!data) return;
+    const prev = data;
+    setData({
+      ...data,
+      devices: data.devices.map((d) =>
+        d.fingerprint === fingerprint
+          ? { ...d, mapped_profile_id: profileId, unmapped: false }
+          : d,
+      ),
+    });
+    try {
+      await api.player.autoEqSetDeviceMapping(fingerprint, profileId);
+    } catch (err) {
+      setData(prev);
+      toast.show({
+        kind: "error",
+        title: "Couldn't set device profile",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const forget = async (fingerprint: string) => {
+    if (!data) return;
+    const prev = data;
+    setData({
+      ...data,
+      devices: data.devices.filter((d) => d.fingerprint !== fingerprint),
+    });
+    try {
+      await api.player.autoEqForgetDevice(fingerprint);
+    } catch (err) {
+      setData(prev);
+      toast.show({
+        kind: "error",
+        title: "Couldn't forget device",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  if (data === null || profiles === null) return null;
+  if (profiles.length === 0) return null;
+
+  return (
+    <Field
+      label="Output device profiles"
+      hint={
+        data.devices.length === 0
+          ? "Once you've used an output device, it'll show up here so you can map a profile to it."
+          : "Each output device can have its own AutoEQ profile. Tideway switches automatically when you change devices."
+      }
+    >
+      <div className="flex flex-col gap-2">
+        {data.devices.map((d) => {
+          const isActive = d.fingerprint === data.current_fingerprint;
+          const value = d.unmapped
+            ? "__unmapped__"
+            : d.mapped_profile_id ?? "__none__";
+          return (
+            <div
+              key={d.fingerprint}
+              className={cn(
+                "flex flex-wrap items-center gap-2 rounded-md border border-input bg-secondary/40 px-3 py-2 text-xs",
+                isActive && "border-primary bg-primary/10",
+              )}
+            >
+              <div className="flex min-w-0 flex-1 flex-col">
+                <span className="truncate font-semibold">
+                  {d.display_name}
+                  {isActive && (
+                    <span className="ml-2 rounded bg-primary px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wide text-primary-foreground">
+                      Active
+                    </span>
+                  )}
+                </span>
+                <span className="text-muted-foreground">
+                  {d.kind === "unknown" ? "device" : d.kind}
+                </span>
+              </div>
+              <select
+                value={value}
+                onChange={(e) => {
+                  const v = e.target.value;
+                  if (v === "__unmapped__") return; // can't pick unmapped
+                  setMapping(
+                    d.fingerprint,
+                    v === "__none__" ? null : v,
+                  );
+                }}
+                className="h-8 rounded-md border border-input bg-background px-2"
+              >
+                <option value="__unmapped__" disabled>
+                  Use fallback
+                </option>
+                <option value="__none__">No EQ for this device</option>
+                {profiles.map((p) => (
+                  <option key={p.id} value={p.id}>
+                    {p.brand} {p.model}
+                  </option>
+                ))}
+              </select>
+              <button
+                type="button"
+                onClick={() => forget(d.fingerprint)}
+                className="rounded-md border border-input px-2 py-1 text-[11px] text-muted-foreground hover:bg-accent"
+              >
+                Forget
+              </button>
+            </div>
+          );
+        })}
       </div>
     </Field>
   );


### PR DESCRIPTION
The headline AutoEQ feature: plug in your IEMs, EQ swaps to the IEM profile. Switch to your DAC + open-backs, EQ swaps again. Completes the v1 marketable core (Phases 1+2+3) per [docs/autoeq-headphone-profiles-scope.md](docs/autoeq-headphone-profiles-scope.md).

Stacks on Phase 2 ([#85](https://github.com/J-M-PUNK/tideway/pull/85)).

## What's new

### Backend

- **`app/audio/autoeq/seen_devices.py`** — JSON-backed store of output devices the user has used. Keyed by fingerprint (`sounddevice` device name), with first/last-seen timestamps + a heuristic `kind` field (bt / usb / builtin / unknown). Persisted in `user_data_dir/autoeq_seen_devices.json`.
- **`app/audio/autoeq/resolver.py`** — pure decision logic mapping `(fingerprint, mappings, fallback)` → which profile to apply. Handles the explicit-None ("no EQ for this device") case, the missing-profile case (catalog removed it), and the two fallback strategies (`bypass` / `use_last_profile`).
- Hooked into `POST /api/player/output-device` so a device switch triggers an upsert + resolve. No-op when the user isn't in profile mode.

### Settings

Two new fields:

- `eq_device_mappings: dict[str, str | None]` — fingerprint → profile_id. `None` means "EQ off for this device" explicitly.
- `eq_fallback_when_unmapped: str = "bypass"` — what to do for devices the user hasn't mapped yet (`"bypass"` or `"use_last_profile"`).

`SettingsPayload` Pydantic model mirrors both (the sync trap CLAUDE.md flags).

### Endpoints

| Method | Path | Purpose |
|---|---|---|
| GET | `/api/eq/devices` | Seen devices + mappings + active fingerprint |
| POST | `/api/eq/device-mappings` | Set/clear a device's mapping (applies live) |
| POST | `/api/eq/forget-device` | Drop from seen-list + remove mapping |

### Frontend

`AutoEqDeviceMappingField` rendered in Settings → Playback below the Phase 2 picker. Lists every seen device with a profile dropdown; the currently-active device gets an "Active" badge. Forget button cleans up clutter for devices the user no longer uses.

## Test plan

- [x] `pytest tests/` — 555 passed (was 534 + 21 new), 2 skipped unchanged.
- [x] `tsc --noEmit` clean.
- [ ] Manual: Play music. Confirm the active output device shows up in the new "Output device profiles" section with an "Active" badge.
- [ ] Manual: Map the active device to one of the bundled profiles. Audible change should be immediate.
- [ ] Manual: Switch to a different output device (System Settings or app picker). The mapped profile should swap automatically.
- [ ] Manual: Map a device explicitly to "No EQ for this device." Confirm switching to it bypasses the EQ.
- [ ] Manual: With `fallback_when_unmapped` = bypass (default), switch to an unmapped device. EQ should bypass.

## What's still ahead

- Phase 4: A/B bypass button + signal-path display.
- Phase 5: user tilt sliders (bass / treble / preamp offset).
- Phase 6: frequency-response graph.
- Phase 7: full ~5,000 profile catalog + update channel.

Phases 1+2+3 together are the marketable v1 — pick a headphone, hear correction, automatic per-device. The polish phases are additive on top.

🤖 Generated with [Claude Code](https://claude.com/claude-code)