### PR TITLE
AutoEQ Phase 4: A/B bypass + signal-path display

### DIFF
--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -246,6 +246,12 @@ class PCMPlayer:
         # SOS) so the stream-reopen path can recompile coefficients
         # at the new sample rate.
         self._eq_profile = None  # type: ignore[var-annotated]
+        # Phase 4 A/B bypass — momentary disable that preserves
+        # the active SOS / bands so flipping back is instant. The
+        # audio callback reads this each frame; toggling has the
+        # same ~immediate effect as a coefficient-clear without
+        # the cost of rebuilding when the user toggles back on.
+        self._eq_bypass: bool = False
 
         # Audio-callback diagnostics. Each pair is (count, last-print
         # time) for a different rate-limited stderr message:
@@ -982,6 +988,21 @@ class PCMPlayer:
                     self._eq.set_bands(list(bands), preamp_db=preamp)
                 else:
                     self._eq.clear()
+
+    def set_equalizer_bypass(self, bypassed: bool) -> None:
+        """Toggle the A/B bypass flag without touching the active
+        EQ configuration. The audio callback reads this each
+        frame, so the effect is on the next callback (~10 ms).
+        Used by the Phase 4 player-UI button + keyboard shortcut
+        for blink-test comparison."""
+        with self._lock:
+            self._eq_bypass = bool(bypassed)
+
+    def equalizer_bypass(self) -> bool:
+        """Read the current bypass flag — server uses it to expose
+        the value via /api/eq/state."""
+        with self._lock:
+            return self._eq_bypass
 
     def apply_equalizer_profile(self, profile) -> None:
         """Switch to AutoEQ profile mode and apply `profile`. The
@@ -1875,7 +1896,11 @@ class PCMPlayer:
         # pass-through is preserved at flat EQ + full volume + not
         # muted. Filtering requires float32; we round-trip through
         # float32 when the output dtype is int16/int32.
-        if self._eq is not None and self._eq.is_active():
+        if (
+            self._eq is not None
+            and self._eq.is_active()
+            and not self._eq_bypass
+        ):
             if outdata.dtype == np.float32:
                 self._eq.apply(outdata)
             else:

--- a/app/settings.py
+++ b/app/settings.py
@@ -101,6 +101,13 @@ class Settings:
     # eq_mode == "profile"; preserved across mode switches so
     # toggling profile/manual/profile keeps the user's pick.
     eq_active_profile_id: str = ""
+    # A/B bypass — momentarily disable the active EQ stage (manual
+    # OR profile) without losing the configuration. Phase 4 of the
+    # scope doc adds a player-UI button + keyboard shortcut for
+    # this so the user can compare correction-on vs correction-off
+    # without unsetting their pick. Persisted so the user can
+    # leave it bypassed and have that survive a relaunch.
+    eq_bypass: bool = False
     # Per-device AutoEQ profile mapping (Phase 3 of the scope doc).
     # Key = device fingerprint as `sounddevice` reports it; value =
     # profile_id, or None to explicitly skip mapping for that device

--- a/server.py
+++ b/server.py
@@ -4241,10 +4241,31 @@ def _native_player() -> PCMPlayer:
     if not _player_bootstrapped:
         _player_bootstrapped = True
         try:
-            if settings.eq_enabled and settings.eq_bands:
+            # Restore EQ — Phase 2 added profile mode, so prefer
+            # the profile path when one is selected; otherwise
+            # fall back to the manual bands path.
+            if (
+                settings.eq_enabled
+                and settings.eq_mode == "profile"
+                and settings.eq_active_profile_id
+            ):
+                try:
+                    from app.audio.autoeq.index import INDEX
+                    profile = INDEX.get(settings.eq_active_profile_id)
+                    if profile is not None:
+                        _pcm_player_singleton.apply_equalizer_profile(profile)
+                except Exception:
+                    log = logging.getLogger("autoeq.bootstrap")
+                    log.exception("autoeq profile restore failed")
+            elif settings.eq_enabled and settings.eq_bands:
                 _pcm_player_singleton.apply_equalizer(
                     settings.eq_bands, preamp=settings.eq_preamp
                 )
+            # Restore A/B bypass flag (Phase 4) — `apply_equalizer`
+            # / `apply_equalizer_profile` above don't touch it, so
+            # the persisted bypass value gets re-applied on top.
+            if settings.eq_bypass:
+                _pcm_player_singleton.set_equalizer_bypass(True)
             if settings.audio_output_device:
                 _pcm_player_singleton.set_output_device(
                     settings.audio_output_device
@@ -4841,12 +4862,35 @@ def autoeq_state() -> dict:
     return {
         "mode": settings.eq_mode,
         "enabled": settings.eq_enabled,
+        "bypass": settings.eq_bypass,
         "active_profile_id": settings.eq_active_profile_id,
         "active_profile": active_profile,
         "manual_bands": list(settings.eq_bands),
         "manual_preamp_db": settings.eq_preamp,
         "profile_catalog_size": INDEX.count(),
     }
+
+
+class _AutoEqBypassRequest(BaseModel):
+    bypass: bool
+
+
+@app.post("/api/eq/bypass")
+def autoeq_set_bypass(req: _AutoEqBypassRequest) -> dict:
+    """A/B bypass toggle. Disables the EQ stage without touching
+    the active configuration — toggling back is instant. The
+    state persists across restarts (so a user listening through
+    a baseline can leave it bypassed and have that survive a
+    relaunch)."""
+    _require_local_access()
+    settings.eq_bypass = bool(req.bypass)
+    save_settings(settings)
+    try:
+        _native_player().set_equalizer_bypass(settings.eq_bypass)
+    except Exception:
+        log = logging.getLogger("autoeq.bypass")
+        log.exception("set_equalizer_bypass failed")
+    return {"ok": True, "bypass": settings.eq_bypass}
 
 
 class _AutoEqLoadProfileRequest(BaseModel):
@@ -8136,6 +8180,7 @@ class SettingsPayload(BaseModel):
     download_rate_limit_mbps: Optional[int] = None
     eq_mode: Optional[str] = None
     eq_active_profile_id: Optional[str] = None
+    eq_bypass: Optional[bool] = None
     eq_device_mappings: Optional[dict] = None
     eq_fallback_when_unmapped: Optional[str] = None
 

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -967,6 +967,7 @@ export const api = {
       req<{
         mode: "off" | "manual" | "profile";
         enabled: boolean;
+        bypass: boolean;
         active_profile_id: string;
         active_profile: {
           id: string;
@@ -1007,6 +1008,13 @@ export const api = {
       req<{ ok: boolean; mode: string; enabled: boolean }>("/api/eq/mode", {
         method: "POST",
         body: JSON.stringify({ mode }),
+      }),
+    /** Phase 4 A/B bypass — momentary disable that preserves the
+     *  active profile / bands. Toggling back is instant. */
+    autoEqSetBypass: (bypass: boolean) =>
+      req<{ ok: boolean; bypass: boolean }>("/api/eq/bypass", {
+        method: "POST",
+        body: JSON.stringify({ bypass }),
       }),
     /** AutoEQ per-device profile mapping (Phase 3). Returns the
      *  list of seen output devices, each tagged with its mapped

--- a/web/src/components/FullScreenPlayer.tsx
+++ b/web/src/components/FullScreenPlayer.tsx
@@ -15,7 +15,8 @@ import {
   SkipForward,
 } from "lucide-react";
 import type { OnDownload } from "@/api/download";
-import type { Lyrics } from "@/api/types";
+import type { Lyrics, StreamInfo } from "@/api/types";
+import { useAutoEqState } from "@/hooks/useAutoEqState";
 import { useCoverColor } from "@/hooks/useCoverColor";
 import { useIsDownloaded } from "@/hooks/useDownloadedSet";
 import { useLyrics } from "@/hooks/useLyrics";
@@ -43,8 +44,16 @@ export function FullScreenPlayer({
   onClose: () => void;
   onDownload: OnDownload;
 }) {
-  const { track, playing, loading, shuffle, repeat, hasNext, hasPrev } =
-    usePlayerMeta();
+  const {
+    track,
+    playing,
+    loading,
+    shuffle,
+    repeat,
+    hasNext,
+    hasPrev,
+    streamInfo,
+  } = usePlayerMeta();
   const { currentTime, duration } = usePlayerTime();
   const actions = usePlayerActions();
 
@@ -147,6 +156,8 @@ export function FullScreenPlayer({
           )}
         </div>
       </div>
+
+      <SignalPathStrip open={open} streamInfo={streamInfo} />
 
       {/* Footer controls */}
       <div className="border-t border-white/10 bg-black/30 px-6 py-4 backdrop-blur-sm">
@@ -361,4 +372,91 @@ function useActiveLyric(lyrics: Lyrics | null, currentTime: number): number {
     }
     return idx;
   }, [lyrics, currentTime]);
+}
+
+/**
+ * One-line "what's actually happening to the audio" summary plus
+ * an A/B bypass button — Phase 4 of the AutoEQ scope. Reads
+ * stream codec / sample rate from the player snapshot and EQ
+ * mode / profile / bypass from the AutoEQ state endpoint.
+ *
+ * Hidden when the AutoEQ state endpoint isn't reachable (older
+ * server build) — the strip is purely informational and
+ * shouldn't take down the FullScreenPlayer if it can't load.
+ *
+ * Only fetches state while the player is open — no point
+ * polling the EQ state when the user can't see the strip.
+ */
+function SignalPathStrip({
+  open,
+  streamInfo,
+}: {
+  open: boolean;
+  streamInfo: StreamInfo | null;
+}) {
+  const { state, setBypass } = useAutoEqState(open);
+  if (state === null) return null;
+
+  const eqLabel =
+    state.mode === "off" || !state.enabled
+      ? "EQ off"
+      : state.mode === "profile" && state.active_profile
+        ? `${state.active_profile.brand} ${state.active_profile.model}`
+        : state.mode === "manual"
+          ? "Manual EQ"
+          : "EQ off";
+
+  // Only show the bypass button when an EQ is actually active —
+  // there's nothing to A/B compare when EQ is off / no profile.
+  const eqIsActive =
+    state.enabled &&
+    state.mode !== "off" &&
+    (state.mode === "manual" || state.active_profile !== null);
+
+  const formatLabel = streamInfo
+    ? `${streamInfo.codec || "?"}${
+        streamInfo.sample_rate_hz
+          ? ` ${(streamInfo.sample_rate_hz / 1000).toFixed(streamInfo.sample_rate_hz % 1000 === 0 ? 0 : 1)}kHz`
+          : ""
+      }${streamInfo.bit_depth ? ` / ${streamInfo.bit_depth}-bit` : ""}`
+    : null;
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-3 border-t border-white/5 bg-black/20 px-6 py-2 text-[11px] text-foreground/60">
+      <div className="flex flex-wrap items-center gap-2 truncate font-mono">
+        {formatLabel && (
+          <>
+            <span>{formatLabel}</span>
+            <span className="text-foreground/30">→</span>
+          </>
+        )}
+        <span
+          className={cn(
+            state.bypass
+              ? "text-foreground/40 line-through"
+              : eqIsActive
+                ? "text-foreground/90"
+                : "text-foreground/60",
+          )}
+        >
+          {eqLabel}
+        </span>
+      </div>
+      {eqIsActive && (
+        <button
+          type="button"
+          onClick={() => void setBypass(!state.bypass)}
+          className={cn(
+            "rounded px-2 py-0.5 text-[10px] font-bold uppercase tracking-wider transition-colors",
+            state.bypass
+              ? "bg-foreground/10 text-foreground/60 hover:bg-foreground/20"
+              : "bg-primary text-primary-foreground hover:bg-primary/80",
+          )}
+          title="Toggle EQ on / off for A/B comparison"
+        >
+          {state.bypass ? "EQ Bypassed" : "EQ On"}
+        </button>
+      )}
+    </div>
+  );
 }

--- a/web/src/hooks/useAutoEqState.ts
+++ b/web/src/hooks/useAutoEqState.ts
@@ -1,0 +1,72 @@
+import { useCallback, useEffect, useState } from "react";
+import { api } from "@/api/client";
+
+/**
+ * Fetches the current AutoEQ state (mode, active profile, bypass
+ * flag, manual bands) once on mount and provides a `refresh` so
+ * callers can re-pull after they mutate state via the API.
+ *
+ * Phase 4 intentionally doesn't add an SSE channel for EQ state —
+ * the user only changes EQ from one place (Settings) plus the
+ * Phase 4 A/B bypass button, and both call back to refresh
+ * directly. SSE would be the right answer if a future phase
+ * adds device-driven changes (auto-swap on output change) that
+ * the user needs to see reflected in the now-playing UI live —
+ * that's part of Phase 6 / 7.
+ */
+export type AutoEqState = {
+  mode: "off" | "manual" | "profile";
+  enabled: boolean;
+  bypass: boolean;
+  active_profile_id: string;
+  active_profile: {
+    id: string;
+    brand: string;
+    model: string;
+    source: string;
+    preamp_db: number;
+    band_count: number;
+  } | null;
+  manual_bands: number[];
+  manual_preamp_db: number | null;
+  profile_catalog_size: number;
+};
+
+export function useAutoEqState(enabled: boolean): {
+  state: AutoEqState | null;
+  refresh: () => Promise<void>;
+  setBypass: (bypass: boolean) => Promise<void>;
+} {
+  const [state, setState] = useState<AutoEqState | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!enabled) return;
+    try {
+      const s = await api.player.autoEqState();
+      setState(s);
+    } catch {
+      /* feature not available — keep null, callers hide */
+    }
+  }, [enabled]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const setBypass = useCallback(
+    async (bypass: boolean) => {
+      // Optimistic flip — the audio change is instant, no point
+      // making the UI wait for the round-trip.
+      setState((prev) => (prev ? { ...prev, bypass } : prev));
+      try {
+        await api.player.autoEqSetBypass(bypass);
+      } catch {
+        // Roll back on failure.
+        setState((prev) => (prev ? { ...prev, bypass: !bypass } : prev));
+      }
+    },
+    [],
+  );
+
+  return { state, refresh, setBypass };
+}


### PR DESCRIPTION
The "feature feels good" polish phase. Stacks on Phase 3 ([#86](https://github.com/J-M-PUNK/tideway/pull/86)).

## A/B bypass

Toggleable EQ disable that preserves the active configuration — flipping back is instant. Audio callback gates the existing `self._eq.apply()` call on `not self._eq_bypass`, so the effect hits the next callback (~10 ms). Persists across restart so a user listening through a baseline can leave it bypassed.

- New `eq_bypass: bool` setting + `POST /api/eq/bypass` endpoint.
- Restored from settings on startup.
- Optimistic UI updates with rollback on failure.

## Signal-path display

One-line read-only summary on the FullScreenPlayer between the cover/lyrics area and the footer transport controls. Shows the current chain in the form:

> `FLAC 24/96 → HD 600 (Sennheiser)`

with an EQ on/off button to the right. When EQ is bypassed, the EQ segment renders strikethrough so the bypass state is visually obvious. Hidden entirely when the AutoEQ state endpoint isn't reachable (older server build).

## Test plan

- [x] `pytest tests/` — 555 passed, 2 skipped (no regressions, no new tests; Phase 4 is mostly UI plumbing).
- [x] `tsc --noEmit` clean.
- [ ] Manual: open the FullScreenPlayer with an EQ profile active. Confirm the signal-path strip shows up between the cover/lyrics area and the transport controls.
- [ ] Manual: click the "EQ On" button. Confirm an audible difference (the strip's text shows strikethrough on the EQ segment + button text changes to "EQ Bypassed"). Click again to flip back.
- [ ] Manual: with EQ in "off" mode or no profile picked, confirm the bypass button doesn't render (nothing to A/B compare).
- [ ] Manual: bypass, then restart the app. Confirm the bypass state is preserved.

## Skipped scope

The scope doc mentions a window-scoped keyboard shortcut for the bypass (suggested `E`). Skipped because the existing global / window key handling has known landmines (see the existing media-key + Esc handling in FullScreenPlayer); adding a new shortcut without auditing collisions would be a regression risk. Worth doing as a follow-up after Phase 4 ships and we know the button placement is right.

## What's still ahead

- Phase 5: user tilt sliders (bass / treble / preamp offset).
- Phase 6: frequency-response graph.
- Phase 7: full ~5,000 profile catalog + update channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)