### PR TITLE
AutoEQ Phase 5: user-tilt sliders (bass / treble / preamp offset)

### DIFF
--- a/app/audio/autoeq/apply.py
+++ b/app/audio/autoeq/apply.py
@@ -1,20 +1,74 @@
-"""Build SOS coefficients from an `AutoEqProfile`.
+"""Build SOS coefficients from an `AutoEqProfile`, optionally
+augmented with the Phase 5 user-tilt shelves.
 
-Phase 2 stays narrow: profile bands → SOS matrix at a given
-sample rate. The user-tilt layer (bass / treble shelves the user
-adds on top) is Phase 5, not here.
+The cascade structure:
 
-Returned matrix has shape `(N, 6)` where N is the number of
-filter bands in the profile, suitable for direct hand-off to
-`scipy.signal.sosfilt` or to `app.audio.eq.Equalizer.set_sos`.
+    Master preamp = profile.preamp_db + tilt.preamp_offset_db
+    SOS rows:
+      [profile band 1]
+      [profile band 2]
+      ...
+      [profile band N]
+      [low-shelf @ 80 Hz with tilt.bass_db]    (only when nonzero)
+      [high-shelf @ 8 kHz with tilt.treble_db] (only when nonzero)
+
+Tilt shelves are positioned AFTER the profile bands so the
+profile correction lands on a clean signal first; the tilt is a
+taste-layer adjustment on top. Phase 6's FR graph will visualise
+this composition cleanly.
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import numpy as np
 
-from app.audio.eq import _compute_biquad
+from app.audio.eq import (
+    _compute_biquad,
+    _high_shelf_biquad,
+    _low_shelf_biquad,
+)
 
 from .profiles import AutoEqProfile
+
+
+# Phase 5 tilt-shelf parameters. Pinned constants, not per-user
+# adjustable — the user picks the gain, not where the shelf
+# corner lives. Values match common "warmth / brightness" tilt
+# controls in audiophile EQs (PEACE, foobar2000's PEQ).
+TILT_BASS_FREQ_HZ = 80.0
+TILT_BASS_Q = 0.7
+TILT_TREBLE_FREQ_HZ = 8000.0
+TILT_TREBLE_Q = 0.7
+
+# A nudge below this in dB is treated as zero — avoids appending
+# a no-op biquad to the cascade for sub-noise-floor slider
+# positions.
+_TILT_EPS_DB = 0.05
+
+
+@dataclass
+class TiltConfig:
+    """User taste-layer adjustments stacked on top of the profile.
+
+    All three values default to 0.0 = "no tilt" — equivalent to
+    not having Phase 5 at all. Backwards-compatible with the
+    Phase 2-4 code paths via the default.
+
+    Sliders in the UI use a -12..+12 dB range; the dataclass
+    doesn't clamp because that's a presentation concern.
+    """
+
+    preamp_offset_db: float = 0.0
+    bass_db: float = 0.0
+    treble_db: float = 0.0
+
+    def is_flat(self) -> bool:
+        return (
+            abs(self.preamp_offset_db) < _TILT_EPS_DB
+            and abs(self.bass_db) < _TILT_EPS_DB
+            and abs(self.treble_db) < _TILT_EPS_DB
+        )
 
 
 def profile_to_sos(profile: AutoEqProfile, sample_rate: int) -> np.ndarray:
@@ -24,6 +78,11 @@ def profile_to_sos(profile: AutoEqProfile, sample_rate: int) -> np.ndarray:
     Returns an empty `(0, 6)` array for profiles with no bands —
     let callers decide whether to treat that as "bypass" or as
     an error.
+
+    This is the Phase 2 entry point. Phase 5 callers that need
+    tilt shelves use `cascade_with_tilt` instead; this function
+    stays unchanged so older callers + tests still see the same
+    contract.
     """
     if not profile.bands:
         return np.empty((0, 6), dtype=np.float32)
@@ -38,3 +97,51 @@ def profile_to_sos(profile: AutoEqProfile, sample_rate: int) -> np.ndarray:
         for band in profile.bands
     ]
     return np.stack(rows).astype(np.float32, copy=False)
+
+
+def cascade_with_tilt(
+    profile: AutoEqProfile,
+    sample_rate: int,
+    tilt: TiltConfig,
+) -> tuple[np.ndarray, float]:
+    """Build the full Phase 5 cascade — profile bands + tilt
+    shelves — and return `(sos, total_preamp_db)`.
+
+    `total_preamp_db` is `profile.preamp_db + tilt.preamp_offset_db`.
+    Caller installs both via `Equalizer.set_sos(sos, preamp_db=...)`.
+
+    A flat tilt produces the same SOS as `profile_to_sos` (no
+    extra biquads appended), so the audio path is identical to
+    Phase 2-4 behavior when the user hasn't moved any tilt
+    sliders.
+    """
+    rows: list[np.ndarray] = [
+        _compute_biquad(
+            band.filter_type,
+            band.freq_hz,
+            band.gain_db,
+            band.q,
+            sample_rate,
+        )
+        for band in profile.bands
+    ]
+    if abs(tilt.bass_db) >= _TILT_EPS_DB:
+        rows.append(
+            _low_shelf_biquad(
+                TILT_BASS_FREQ_HZ, tilt.bass_db, TILT_BASS_Q, sample_rate
+            )
+        )
+    if abs(tilt.treble_db) >= _TILT_EPS_DB:
+        rows.append(
+            _high_shelf_biquad(
+                TILT_TREBLE_FREQ_HZ,
+                tilt.treble_db,
+                TILT_TREBLE_Q,
+                sample_rate,
+            )
+        )
+    if not rows:
+        return np.empty((0, 6), dtype=np.float32), 0.0
+    sos = np.stack(rows).astype(np.float32, copy=False)
+    total_preamp = profile.preamp_db + tilt.preamp_offset_db
+    return sos, total_preamp

--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -252,6 +252,12 @@ class PCMPlayer:
         # same ~immediate effect as a coefficient-clear without
         # the cost of rebuilding when the user toggles back on.
         self._eq_bypass: bool = False
+        # Phase 5 user-tilt — bass / treble shelves + preamp
+        # offset stacked on top of the active profile. Held as a
+        # separate config so changing tilt without re-picking the
+        # profile is one rebuild. None = no tilt set yet (treat
+        # as flat); a TiltConfig with all-zero gains is also flat.
+        self._eq_tilt = None  # type: ignore[var-annotated]
 
         # Audio-callback diagnostics. Each pair is (count, last-print
         # time) for a different rate-limited stderr message:
@@ -1010,19 +1016,56 @@ class PCMPlayer:
         current sample rate; on a stream reopen the same profile
         is recompiled at the new rate (no loss across cross-rate
         bridges). Clears any manual-mode bands — the modes are
-        mutually exclusive."""
-        from app.audio.autoeq.apply import profile_to_sos
+        mutually exclusive.
+
+        Phase 5: if a user-tilt is active, the cascade includes
+        the tilt shelves + preamp offset. Picking a new profile
+        keeps the tilt setting (taste preference travels with
+        the user, not the headphone)."""
+        from app.audio.autoeq.apply import (
+            TiltConfig,
+            cascade_with_tilt,
+        )
 
         with self._lock:
             self._eq_bands = []
             self._eq_preamp = None
             self._eq_profile = profile
+            tilt = self._eq_tilt or TiltConfig()
             if self._eq is not None:
-                sos = profile_to_sos(profile, self._eq.sample_rate())
+                sos, preamp_db = cascade_with_tilt(
+                    profile, self._eq.sample_rate(), tilt
+                )
                 if sos.size == 0:
                     self._eq.clear()
                 else:
-                    self._eq.set_sos(sos, preamp_db=profile.preamp_db)
+                    self._eq.set_sos(sos, preamp_db=preamp_db)
+
+    def apply_equalizer_tilt(self, tilt) -> None:
+        """Update the user-tilt and rebuild the active cascade if
+        a profile is loaded. No-op when no profile is active —
+        tilt is a stack-on-top thing, not a standalone EQ.
+
+        `tilt` is `TiltConfig | None`; passing None clears tilt
+        back to flat. The profile + sample rate stay the same;
+        only the trailing tilt shelves + preamp offset change."""
+        from app.audio.autoeq.apply import (
+            TiltConfig,
+            cascade_with_tilt,
+        )
+
+        with self._lock:
+            self._eq_tilt = tilt
+            effective = tilt if tilt is not None else TiltConfig()
+            if self._eq_profile is None or self._eq is None:
+                return
+            sos, preamp_db = cascade_with_tilt(
+                self._eq_profile, self._eq.sample_rate(), effective
+            )
+            if sos.size == 0:
+                self._eq.clear()
+            else:
+                self._eq.set_sos(sos, preamp_db=preamp_db)
 
     def apply_equalizer_preset(self, preset_index: int) -> list[float]:
         """Apply a preset by index, push its curve to the live EQ,
@@ -1602,15 +1645,19 @@ class PCMPlayer:
         self._eq = Equalizer(sample_rate=sample_rate, channels=channels)
         if self._eq_profile is not None:
             try:
-                from app.audio.autoeq.apply import profile_to_sos
+                from app.audio.autoeq.apply import (
+                    TiltConfig,
+                    cascade_with_tilt,
+                )
 
-                sos = profile_to_sos(self._eq_profile, sample_rate)
+                tilt = self._eq_tilt or TiltConfig()
+                sos, preamp_db = cascade_with_tilt(
+                    self._eq_profile, sample_rate, tilt
+                )
                 if sos.size == 0:
                     self._eq.clear()
                 else:
-                    self._eq.set_sos(
-                        sos, preamp_db=self._eq_profile.preamp_db
-                    )
+                    self._eq.set_sos(sos, preamp_db=preamp_db)
             except Exception:
                 log.exception("autoeq profile coefficient build failed")
                 self._eq.clear()

--- a/app/settings.py
+++ b/app/settings.py
@@ -121,6 +121,14 @@ class Settings:
     #     even on unmapped devices. Convenient for users who only
     #     ever listen on one pair.
     eq_fallback_when_unmapped: str = "bypass"
+    # Phase 5 user-tilt: shelves stacked after the profile bands +
+    # a master preamp offset. User-global (not per-device) — these
+    # are taste preferences that travel with the listener, not
+    # headphone-specific corrections. Range -12..+12 dB enforced
+    # at the API layer; raw floats persisted here.
+    eq_tilt_preamp_offset_db: float = 0.0
+    eq_tilt_bass_db: float = 0.0
+    eq_tilt_treble_db: float = 0.0
     # sounddevice output-device index (stringified, matches what
     # /api/player/output-devices returns). Empty string means "use
     # the system default". Persisted so USB DAC / Bluetooth

--- a/server.py
+++ b/server.py
@@ -4266,6 +4266,26 @@ def _native_player() -> PCMPlayer:
             # the persisted bypass value gets re-applied on top.
             if settings.eq_bypass:
                 _pcm_player_singleton.set_equalizer_bypass(True)
+            # Restore Phase 5 tilt. Setting it after the profile
+            # restore means the cascade rebuild includes the tilt
+            # shelves on the very first stream — user doesn't
+            # have to nudge a slider to "wake it up."
+            if (
+                settings.eq_tilt_preamp_offset_db
+                or settings.eq_tilt_bass_db
+                or settings.eq_tilt_treble_db
+            ):
+                try:
+                    from app.audio.autoeq.apply import TiltConfig
+                    tilt = TiltConfig(
+                        preamp_offset_db=settings.eq_tilt_preamp_offset_db,
+                        bass_db=settings.eq_tilt_bass_db,
+                        treble_db=settings.eq_tilt_treble_db,
+                    )
+                    _pcm_player_singleton.apply_equalizer_tilt(tilt)
+                except Exception:
+                    log = logging.getLogger("autoeq.bootstrap")
+                    log.exception("autoeq tilt restore failed")
             if settings.audio_output_device:
                 _pcm_player_singleton.set_output_device(
                     settings.audio_output_device
@@ -4868,6 +4888,71 @@ def autoeq_state() -> dict:
         "manual_bands": list(settings.eq_bands),
         "manual_preamp_db": settings.eq_preamp,
         "profile_catalog_size": INDEX.count(),
+        "tilt": {
+            "preamp_offset_db": settings.eq_tilt_preamp_offset_db,
+            "bass_db": settings.eq_tilt_bass_db,
+            "treble_db": settings.eq_tilt_treble_db,
+        },
+    }
+
+
+class _AutoEqTiltRequest(BaseModel):
+    preamp_offset_db: Optional[float] = None
+    bass_db: Optional[float] = None
+    treble_db: Optional[float] = None
+
+
+_TILT_RANGE_DB = 12.0  # ±12 dB matches the slider in the UI.
+
+
+@app.post("/api/eq/tilt")
+def autoeq_set_tilt(req: _AutoEqTiltRequest) -> dict:
+    """Update one or more tilt parameters. Each is optional —
+    omitting a field leaves its current setting unchanged, so
+    the slider's onChange handler can ship a single field at a
+    time without round-tripping the others.
+
+    Values are clamped to ±12 dB. Tilt only audibly affects
+    playback when in profile mode with a profile loaded; in
+    manual / off mode the values still persist (so they're
+    there when the user switches back to profile mode) but the
+    audio path doesn't run them."""
+    _require_local_access()
+
+    def _clamp(v: float) -> float:
+        return max(-_TILT_RANGE_DB, min(_TILT_RANGE_DB, float(v)))
+
+    if req.preamp_offset_db is not None:
+        settings.eq_tilt_preamp_offset_db = _clamp(req.preamp_offset_db)
+    if req.bass_db is not None:
+        settings.eq_tilt_bass_db = _clamp(req.bass_db)
+    if req.treble_db is not None:
+        settings.eq_tilt_treble_db = _clamp(req.treble_db)
+    save_settings(settings)
+
+    # Rebuild the active cascade so the tilt change is audible
+    # immediately. No-op when not in profile mode (player does
+    # the gate internally).
+    try:
+        from app.audio.autoeq.apply import TiltConfig
+
+        tilt = TiltConfig(
+            preamp_offset_db=settings.eq_tilt_preamp_offset_db,
+            bass_db=settings.eq_tilt_bass_db,
+            treble_db=settings.eq_tilt_treble_db,
+        )
+        _native_player().apply_equalizer_tilt(tilt)
+    except Exception:
+        log = logging.getLogger("autoeq.tilt")
+        log.exception("apply_equalizer_tilt failed")
+
+    return {
+        "ok": True,
+        "tilt": {
+            "preamp_offset_db": settings.eq_tilt_preamp_offset_db,
+            "bass_db": settings.eq_tilt_bass_db,
+            "treble_db": settings.eq_tilt_treble_db,
+        },
     }
 
 
@@ -8183,6 +8268,9 @@ class SettingsPayload(BaseModel):
     eq_bypass: Optional[bool] = None
     eq_device_mappings: Optional[dict] = None
     eq_fallback_when_unmapped: Optional[str] = None
+    eq_tilt_preamp_offset_db: Optional[float] = None
+    eq_tilt_bass_db: Optional[float] = None
+    eq_tilt_treble_db: Optional[float] = None
 
 
 @app.get("/api/settings")

--- a/tests/test_autoeq_loader.py
+++ b/tests/test_autoeq_loader.py
@@ -250,6 +250,74 @@ def test_profile_to_sos_empty_for_no_band_profile():
     assert sos.shape == (0, 6)
 
 
+def test_cascade_with_flat_tilt_matches_profile_to_sos():
+    """A TiltConfig with all zeros should produce the same SOS as
+    `profile_to_sos`. Phase 5 guarantee: zero-tilt audio path is
+    identical to Phase 2-4 behavior, so users who never touch the
+    tilt sliders aren't running through extra biquads."""
+    from app.audio.autoeq.apply import TiltConfig, cascade_with_tilt
+
+    text = """
+    Preamp: -1 dB
+    Filter 1: ON LSC Fc 100 Hz Gain 4 dB Q 0.7
+    Filter 2: ON PK Fc 1000 Hz Gain 2 dB Q 1.0
+    """
+    profile = parse_profile_text(text)
+    sos_old = profile_to_sos(profile, SAMPLE_RATE)
+    sos_new, preamp = cascade_with_tilt(profile, SAMPLE_RATE, TiltConfig())
+    np.testing.assert_array_equal(sos_old, sos_new)
+    assert preamp == pytest.approx(profile.preamp_db)
+
+
+def test_cascade_with_tilt_appends_shelves_when_nonzero():
+    """A non-flat tilt adds extra biquads to the cascade. Shape
+    grows by 1 per nonzero shelf (preamp offset doesn't add a
+    biquad — it only adjusts the master preamp)."""
+    from app.audio.autoeq.apply import TiltConfig, cascade_with_tilt
+
+    text = """
+    Preamp: -1 dB
+    Filter 1: ON PK Fc 1000 Hz Gain 1 dB Q 1.0
+    """
+    profile = parse_profile_text(text)
+    # Bass only.
+    sos, preamp = cascade_with_tilt(
+        profile, SAMPLE_RATE, TiltConfig(bass_db=4.0)
+    )
+    assert sos.shape == (2, 6)
+    assert preamp == pytest.approx(profile.preamp_db)
+    # Bass + treble.
+    sos, _ = cascade_with_tilt(
+        profile, SAMPLE_RATE, TiltConfig(bass_db=4.0, treble_db=-3.0)
+    )
+    assert sos.shape == (3, 6)
+    # Preamp offset rolled into total — no shelf biquads added.
+    sos, preamp = cascade_with_tilt(
+        profile, SAMPLE_RATE, TiltConfig(preamp_offset_db=-2.0)
+    )
+    assert sos.shape == (1, 6)
+    assert preamp == pytest.approx(profile.preamp_db + (-2.0))
+
+
+def test_cascade_tilt_response_settles_to_expected_db():
+    """Apply a +6 dB bass tilt over a flat-ish profile and verify
+    the cascade's response below the shelf corner is ~+6 dB."""
+    from app.audio.autoeq.apply import TiltConfig, cascade_with_tilt
+
+    text = "Preamp: 0 dB\nFilter 1: ON PK Fc 1000 Hz Gain 0 dB Q 1.0"
+    profile = parse_profile_text(text)
+    sos, _ = cascade_with_tilt(
+        profile, SAMPLE_RATE, TiltConfig(bass_db=6.0)
+    )
+
+    def cascade_db(freq_hz: float) -> float:
+        _, h = sosfreqz(sos, worN=np.array([freq_hz]), fs=SAMPLE_RATE)
+        return 20.0 * math.log10(max(abs(h[0]), 1e-12))
+
+    # Well below the 80 Hz tilt corner — bass shelf dominates.
+    assert abs(cascade_db(20.0) - 6.0) < 0.5
+
+
 def test_profile_cascade_response_at_characteristic_frequencies():
     """Build a tiny profile (LSC + HSC) and verify the cascade's
     magnitude response settles to the expected dB values where

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -980,6 +980,11 @@ export const api = {
         manual_bands: number[];
         manual_preamp_db: number | null;
         profile_catalog_size: number;
+        tilt: {
+          preamp_offset_db: number;
+          bass_db: number;
+          treble_db: number;
+        };
       }>("/api/eq/state"),
     autoEqLoadProfile: (profileId: string) =>
       req<{
@@ -1015,6 +1020,25 @@ export const api = {
       req<{ ok: boolean; bypass: boolean }>("/api/eq/bypass", {
         method: "POST",
         body: JSON.stringify({ bypass }),
+      }),
+    /** Phase 5 user-tilt — bass / treble shelves + preamp offset
+     *  stacked on top of the profile. Each field is optional;
+     *  omitting one leaves it unchanged on the server. */
+    autoEqSetTilt: (tilt: {
+      preamp_offset_db?: number;
+      bass_db?: number;
+      treble_db?: number;
+    }) =>
+      req<{
+        ok: boolean;
+        tilt: {
+          preamp_offset_db: number;
+          bass_db: number;
+          treble_db: number;
+        };
+      }>("/api/eq/tilt", {
+        method: "POST",
+        body: JSON.stringify(tilt),
       }),
     /** AutoEQ per-device profile mapping (Phase 3). Returns the
      *  list of seen output devices, each tagged with its mapped

--- a/web/src/hooks/useAutoEqState.ts
+++ b/web/src/hooks/useAutoEqState.ts
@@ -30,6 +30,11 @@ export type AutoEqState = {
   manual_bands: number[];
   manual_preamp_db: number | null;
   profile_catalog_size: number;
+  tilt: {
+    preamp_offset_db: number;
+    bass_db: number;
+    treble_db: number;
+  };
 };
 
 export function useAutoEqState(enabled: boolean): {

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1013,6 +1013,11 @@ interface AutoEqState {
   manual_bands: number[];
   manual_preamp_db: number | null;
   profile_catalog_size: number;
+  tilt: {
+    preamp_offset_db: number;
+    bass_db: number;
+    treble_db: number;
+  };
 }
 
 function AutoEqProfileField() {
@@ -1195,8 +1200,162 @@ function AutoEqProfileField() {
             </div>
           </div>
         )}
+
+        {state.mode === "profile" && state.active_profile && (
+          <AutoEqTiltSliders
+            initial={state.tilt}
+            onChange={(t) =>
+              setState((prev) => (prev ? { ...prev, tilt: t } : prev))
+            }
+          />
+        )}
       </div>
     </Field>
+  );
+}
+
+/**
+ * Tilt sliders below the active profile card. Three sliders
+ * (-12..+12 dB): preamp offset, bass, treble. Live local state
+ * for smooth dragging; commits to the server on slider release
+ * via api.player.autoEqSetTilt. A reset button zeros everything.
+ *
+ * Tilt is user-global, not per-device — taste preference travels
+ * with the listener. The backend persists in `eq_tilt_*` settings
+ * fields so a relaunch keeps the user's curve.
+ */
+function AutoEqTiltSliders({
+  initial,
+  onChange,
+}: {
+  initial: { preamp_offset_db: number; bass_db: number; treble_db: number };
+  onChange: (next: {
+    preamp_offset_db: number;
+    bass_db: number;
+    treble_db: number;
+  }) => void;
+}) {
+  const toast = useToast();
+  const [local, setLocal] = useState(initial);
+
+  // Re-sync from props when the parent state refreshes (e.g.
+  // after picking a different profile, the server still returns
+  // the same tilt values but the parent re-renders us).
+  useEffect(() => {
+    setLocal(initial);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initial.preamp_offset_db, initial.bass_db, initial.treble_db]);
+
+  const commit = async (
+    field: "preamp_offset_db" | "bass_db" | "treble_db",
+    value: number,
+  ) => {
+    const next = { ...local, [field]: value };
+    setLocal(next);
+    onChange(next);
+    try {
+      await api.player.autoEqSetTilt({ [field]: value });
+    } catch (err) {
+      toast.show({
+        kind: "error",
+        title: "Couldn't update tilt",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  const reset = async () => {
+    const zero = { preamp_offset_db: 0, bass_db: 0, treble_db: 0 };
+    setLocal(zero);
+    onChange(zero);
+    try {
+      await api.player.autoEqSetTilt(zero);
+    } catch (err) {
+      toast.show({
+        kind: "error",
+        title: "Couldn't reset tilt",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  return (
+    <div className="rounded-md border border-input bg-secondary/40 p-3">
+      <div className="mb-2 flex items-center justify-between">
+        <div className="text-xs uppercase tracking-wide text-muted-foreground">
+          Tilt
+        </div>
+        <button
+          type="button"
+          onClick={reset}
+          className="rounded-md border border-input px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-accent"
+        >
+          Reset
+        </button>
+      </div>
+      <div className="flex flex-col gap-2">
+        <TiltSlider
+          label="Preamp offset"
+          value={local.preamp_offset_db}
+          onChange={(v) =>
+            setLocal((prev) => ({ ...prev, preamp_offset_db: v }))
+          }
+          onCommit={(v) => commit("preamp_offset_db", v)}
+        />
+        <TiltSlider
+          label="Bass (80 Hz shelf)"
+          value={local.bass_db}
+          onChange={(v) => setLocal((prev) => ({ ...prev, bass_db: v }))}
+          onCommit={(v) => commit("bass_db", v)}
+        />
+        <TiltSlider
+          label="Treble (8 kHz shelf)"
+          value={local.treble_db}
+          onChange={(v) => setLocal((prev) => ({ ...prev, treble_db: v }))}
+          onCommit={(v) => commit("treble_db", v)}
+        />
+      </div>
+    </div>
+  );
+}
+
+function TiltSlider({
+  label,
+  value,
+  onChange,
+  onCommit,
+}: {
+  label: string;
+  value: number;
+  onChange: (v: number) => void;
+  onCommit: (v: number) => void;
+}) {
+  return (
+    <label className="flex items-center gap-3 text-xs">
+      <span className="w-32 flex-shrink-0 text-muted-foreground">{label}</span>
+      <input
+        type="range"
+        min={-12}
+        max={12}
+        step={0.5}
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        onMouseUp={(e) =>
+          onCommit(parseFloat((e.target as HTMLInputElement).value))
+        }
+        onTouchEnd={(e) =>
+          onCommit(parseFloat((e.target as HTMLInputElement).value))
+        }
+        onKeyUp={(e) =>
+          onCommit(parseFloat((e.target as HTMLInputElement).value))
+        }
+        className="flex-1 cursor-pointer accent-primary"
+      />
+      <span className="w-12 flex-shrink-0 text-right tabular-nums">
+        {value > 0 ? "+" : ""}
+        {value.toFixed(1)} dB
+      </span>
+    </label>
   );
 }
 


### PR DESCRIPTION
The "I love this profile but want more bass" feature. Three sliders below the active profile card that stack on top of the profile bands without overwriting them — a taste layer. Stacks on Phase 4 ([#87](https://github.com/J-M-PUNK/tideway/pull/87)).

## Cascade structure

> Profile bands → low-shelf @ 80 Hz (if bass tilt nonzero) → high-shelf @ 8 kHz (if treble tilt nonzero) → master preamp adjusted by `profile.preamp_db + tilt.preamp_offset_db`

A **flat tilt produces the exact same SOS as Phase 2's `profile_to_sos`**, so users who never touch the tilt sliders aren't running through extra biquads. New `cascade_with_tilt` returns `(sos, total_preamp_db)` so the caller installs both atomically.

Tilt shelf parameters are pinned (80 Hz / 8 kHz, Q=0.7) — the user picks the gain, not where the shelf corner lives. Matches common audiophile EQ "warmth / brightness" controls (PEACE / foobar2000's PEQ).

## Backend

- `app/audio/autoeq/apply.py` — `TiltConfig` dataclass + new `cascade_with_tilt(profile, sample_rate, tilt)` builder. Phase 2's `profile_to_sos` stays unchanged for compat.
- `PCMPlayer._eq_tilt` field + `apply_equalizer_tilt(tilt)` method. `apply_equalizer_profile` now uses the active tilt on the cascade rebuild. Stream-reopen at a new sample rate recompiles with both profile + tilt — no taste loss across cross-rate transitions.
- Three new persisted settings: `eq_tilt_preamp_offset_db`, `eq_tilt_bass_db`, `eq_tilt_treble_db`. `SettingsPayload` mirrors all three.
- `POST /api/eq/tilt` accepts any combination of the three fields (each optional; omitted = unchanged), clamps to ±12 dB, persists, and rebuilds the cascade live. Tilt also added to `GET /api/eq/state` and restored on bootstrap.

## Frontend

`AutoEqTiltSliders` rendered below the active-profile card in the Phase 2 picker. Three sliders (−12..+12 dB, 0.5 step) with labels, live values, and a Reset button. Local state for smooth dragging; commits on slider release. Optimistic state mirror so the UI feels instant; toast on commit failure.

## Test plan

- [x] `pytest tests/` — 558 passed (was 555 + 3 new), 2 skipped unchanged.
- [x] `tsc --noEmit` clean.
- [ ] Manual: load a profile, drag the bass slider — bass should swell live.
- [ ] Manual: drag preamp offset down to −6 dB — overall level should drop.
- [ ] Manual: hit Reset — sliders snap to 0, profile-only sound returns.
- [ ] Manual: switch profiles while tilt is non-zero — tilt should persist (taste layer travels with the user).
- [ ] Manual: cross-track playback (advance to a track at a different sample rate) — tilt curve should survive the rebuild.
- [ ] Manual: change tilt, restart app — tilt should restore on next launch.

## Skipped scope

The scope doc mentions a headroom-clip warning when total cascade gain at any frequency exceeds 0 dB. Not in this PR — it's a defensive UX nicety that can sit on top of the Phase 6 FR graph (which already computes the full response curve we'd warn against). Easier to add then than to compute the response twice.

## What's left

- Phase 6: frequency-response graph.
- Phase 7: full ~5,000 profile catalog + update channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)