### PR TITLE
AutoEQ Phase 7: full catalog via update channel

### DIFF
--- a/app/audio/autoeq/index.py
+++ b/app/audio/autoeq/index.py
@@ -61,32 +61,48 @@ class AutoEqIndex:
         and skipped — they shouldn't kill startup just because
         AutoEQ shipped one bad file.
         """
-        if not root.exists():
-            log.warning("autoeq: data directory missing: %s", root)
-            return 0
+        return self.load_directories([root])
 
-        loaded = 0
+    def load_directories(self, roots: list[Path]) -> int:
+        """Walk every directory in `roots` and load every
+        `*ParametricEQ.txt` found. Later roots override earlier
+        ones for any duplicate profile id — Phase 7 uses this so
+        the user's downloaded `cache_dir` takes precedence over
+        the bundled snapshot when both contain the same profile.
+
+        Returns the count of successfully-loaded profiles after
+        the merge."""
         with self._lock:
             self._profiles.clear()
-            for txt_path in sorted(root.rglob("*ParametricEQ.txt")):
-                try:
-                    profile = self._load_one(txt_path, root)
-                except AutoEqParseError as exc:
-                    log.warning(
-                        "autoeq: skipping %s — %s", txt_path, exc
-                    )
+            total_seen = 0
+            for root in roots:
+                if not root.exists():
+                    log.debug("autoeq: data directory missing: %s", root)
                     continue
-                except Exception as exc:
-                    log.warning(
-                        "autoeq: unexpected error loading %s: %s",
-                        txt_path,
-                        exc,
-                    )
-                    continue
-                self._profiles[profile.profile_id] = profile
-                loaded += 1
-        log.info("autoeq: loaded %d profile(s) from %s", loaded, root)
-        return loaded
+                count = 0
+                for txt_path in sorted(root.rglob("*ParametricEQ.txt")):
+                    try:
+                        profile = self._load_one(txt_path, root)
+                    except AutoEqParseError as exc:
+                        log.warning("autoeq: skipping %s — %s", txt_path, exc)
+                        continue
+                    except Exception as exc:
+                        log.warning(
+                            "autoeq: unexpected error loading %s: %s",
+                            txt_path,
+                            exc,
+                        )
+                        continue
+                    # Later roots override earlier ones — `cache`
+                    # wins over `bundled` when both have the same
+                    # profile_id.
+                    self._profiles[profile.profile_id] = profile
+                    count += 1
+                total_seen += count
+                log.info(
+                    "autoeq: loaded %d profile(s) from %s", count, root
+                )
+        return len(self._profiles)
 
     def _load_one(self, path: Path, root: Path) -> AutoEqProfile:
         """Read one ParametricEQ.txt and tag it with metadata

--- a/app/audio/autoeq/updater.py
+++ b/app/audio/autoeq/updater.py
@@ -1,0 +1,313 @@
+"""AutoEQ catalog updater — Phase 7 of the scope doc.
+
+Fetches the full AutoEQ profile catalog from GitHub on user
+demand and caches it in `user_data_dir()` so subsequent app
+launches see the expanded set without going back to the network.
+
+## Why fetch on demand instead of bundling 5,000 profiles
+
+Bundling the whole AutoEQ catalog would balloon Tideway's
+installer by ~30 MB of plain text. Phase 2 deliberately ships
+~7 curated profiles for the out-of-the-box experience; Phase 7
+gives users with niche headphones a one-click way to fill in
+the rest.
+
+## Layout
+
+The cache dir mirrors the bundled-data layout exactly:
+
+    user_data_dir/autoeq_cache/results/<source>/<brand-model>/
+        <Brand Model> ParametricEQ.txt
+        <Brand Model>.csv               (optional)
+
+The Phase 2-6 index loader already knows that shape — Phase 7's
+work is making the index walk BOTH directories at startup.
+
+## Fetch strategy
+
+- **Manifest:** one call to GitHub's Git Tree API to enumerate
+  every `*ParametricEQ.txt` path under `results/`. ~30 KB JSON.
+  Per-user; no auth required (60 req/hour limit is plenty for
+  a manual "check for updates" workflow).
+- **PEQ downloads:** small thread pool (3 workers) with jittered
+  sleeps. raw.githubusercontent.com is a CDN and doesn't impose
+  the same per-account rate limits as the API; the burst pacing
+  is etiquette to avoid getting throttled mid-batch.
+- **CSV downloads:** intentionally NOT bulk-fetched. Per-profile
+  ~50 KB × 5,000 = 250 MB which is wasteful when only the
+  profiles the user actually picks need a CSV (just for the FR
+  graph in Phase 6). CSVs are best-effort lazy: when a user
+  picks a profile that has no CSV in cache, we fetch one in the
+  background and the graph degrades to post-EQ-only until then.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+from app.paths import user_data_dir
+
+log = logging.getLogger(__name__)
+
+
+# AutoEQ's Git Tree API. `recursive=1` returns the entire tree
+# in one response. For AutoEQ that's ~25K entries, ~3 MB JSON —
+# fine for a one-shot enumeration call.
+_TREE_URL = (
+    "https://api.github.com/repos/jaakkopasanen/AutoEq/"
+    "git/trees/master?recursive=1"
+)
+_RAW_BASE = (
+    "https://raw.githubusercontent.com/jaakkopasanen/AutoEq/master"
+)
+_USER_AGENT = "tideway-autoeq-updater/1.0"
+
+
+@dataclass
+class CatalogManifest:
+    """Result of `fetch_manifest`. `profile_paths` is a list of
+    repo-relative paths like
+    `results/oratory1990/over-ear/Sennheiser HD 600/Sennheiser HD 600 ParametricEQ.txt`.
+
+    Structured rather than raw-list so we can extend with CSV
+    paths or measurement targets later without a breaking change.
+    """
+
+    profile_paths: list[str]
+    fetched_at: int  # unix seconds
+
+
+@dataclass
+class DownloadResult:
+    """Per-profile outcome for the bulk-download progress UI."""
+
+    profile_id: str
+    ok: bool
+    reason: str = ""
+
+
+def cache_dir() -> Path:
+    """Where downloaded profiles live. Created on first write."""
+    return user_data_dir() / "autoeq_cache" / "results"
+
+
+def _http_get(url: str, timeout: float = 30.0) -> bytes:
+    req = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read()
+
+
+def fetch_manifest() -> CatalogManifest:
+    """Fetch the full list of `*ParametricEQ.txt` paths from
+    AutoEQ's repo via GitHub's Tree API. One HTTP call.
+
+    Raises on network / parse errors — the caller surfaces them
+    as a 5xx response so the user can retry."""
+    data = _http_get(_TREE_URL, timeout=30.0)
+    parsed = json.loads(data.decode("utf-8"))
+    tree = parsed.get("tree") or []
+    if parsed.get("truncated"):
+        # AutoEQ has historically been small enough to fit in
+        # one tree response, but if that ever changes we'd need
+        # to switch to the Contents API per directory.
+        log.warning(
+            "autoeq tree response truncated — manifest may be incomplete"
+        )
+    paths: list[str] = []
+    for entry in tree:
+        path = entry.get("path") or ""
+        if entry.get("type") == "blob" and path.endswith("ParametricEQ.txt"):
+            paths.append(path)
+    return CatalogManifest(
+        profile_paths=sorted(paths),
+        fetched_at=int(time.time()),
+    )
+
+
+def _profile_id_from_path(path: str) -> str:
+    """Convert a manifest path back into the index's profile_id
+    format (`<source>/<brand-model>`). The manifest contains
+    `results/<source>/<kind>/<brand-model>/<file>.txt`; we strip
+    the leading `results/` and the kind tier (over-ear/in-ear)
+    so IDs match what the index produces from the bundled data."""
+    parts = path.split("/")
+    # Drop `results/` (parts[0]) and the optional kind tier
+    # (parts[2]). What remains: source / brand-model.
+    if len(parts) >= 5 and parts[0] == "results":
+        return f"{parts[1]}/{parts[3]}"
+    # Fallback for unexpected layouts — still produces a stable id
+    # but might not match the index's derivation. Caller logs.
+    return path
+
+
+def diff_manifest_against_disk(
+    manifest: CatalogManifest, bundled_root: Path
+) -> tuple[list[str], list[str]]:
+    """Returns (already_on_disk_ids, missing_ids).
+
+    "On disk" = present in either the bundled data root OR the
+    cache dir. We don't re-download things the user already has.
+    """
+    cache_root = cache_dir()
+    on_disk: set[str] = set()
+    for root in (bundled_root, cache_root):
+        if not root.exists():
+            continue
+        for txt in root.rglob("*ParametricEQ.txt"):
+            try:
+                rel = txt.relative_to(root)
+                # rel = <source>/<brand-model>/<file>.txt
+                parts = rel.parts
+                if len(parts) >= 2:
+                    on_disk.add(f"{parts[0]}/{parts[1]}")
+            except ValueError:
+                continue
+
+    missing: list[str] = []
+    already: list[str] = []
+    seen_ids: set[str] = set()
+    for path in manifest.profile_paths:
+        pid = _profile_id_from_path(path)
+        if pid in seen_ids:
+            continue  # AutoEQ occasionally has duplicate paths
+        seen_ids.add(pid)
+        if pid in on_disk:
+            already.append(pid)
+        else:
+            missing.append(pid)
+    return already, missing
+
+
+def _peq_url_for_path(path: str) -> str:
+    """Build a raw.githubusercontent.com URL for a manifest
+    entry. The path is repo-relative and may contain spaces /
+    URL-special characters — quote per-segment to keep slashes
+    intact."""
+    quoted = "/".join(urllib.parse.quote(p) for p in path.split("/"))
+    return f"{_RAW_BASE}/{quoted}"
+
+
+def _csv_url_for_path(peq_path: str) -> str:
+    """Sibling CSV path. AutoEQ's `<...>/<X> ParametricEQ.txt`
+    lives next to `<...>/<X>.csv`."""
+    csv_path = peq_path.replace(" ParametricEQ.txt", ".csv")
+    return _peq_url_for_path(csv_path)
+
+
+def _cache_target_for_path(peq_path: str) -> tuple[Path, Path]:
+    """Where to write the PEQ + CSV in the cache dir.
+
+    Layout matches the bundled-data layout (no kind tier) so the
+    index loads both with the same logic.
+    """
+    parts = peq_path.split("/")
+    # parts: ["results", source, kind, brand_model, "<X> ParametricEQ.txt"]
+    if len(parts) < 5:
+        raise ValueError(f"unexpected manifest path shape: {peq_path}")
+    source = parts[1]
+    brand_model = parts[3]
+    filename = parts[4]
+    target_dir = cache_dir() / source / brand_model
+    peq_target = target_dir / filename
+    csv_target = target_dir / filename.replace(" ParametricEQ.txt", ".csv")
+    return peq_target, csv_target
+
+
+def download_profiles(
+    manifest_paths_by_id: dict[str, str],
+    profile_ids: list[str],
+    *,
+    include_csv: bool = False,
+    max_workers: int = 3,
+    progress_cb=None,
+) -> list[DownloadResult]:
+    """Download the PEQ (and optionally CSV) files for the named
+    profile_ids. Files land under `cache_dir()`.
+
+    `manifest_paths_by_id` maps profile_id → manifest path; the
+    caller builds it from `fetch_manifest` + `_profile_id_from_path`.
+
+    Workers = 3 by default. raw.githubusercontent.com is a CDN
+    so it doesn't impose the same per-account limits as the API,
+    but burst-pacing is etiquette to avoid abuse-detection trips
+    on a 5,000-profile bulk download. Per-profile failures are
+    logged and surfaced individually rather than aborting the
+    whole batch — one missing file shouldn't kill a 4,999-file
+    download.
+    """
+    results: list[DownloadResult] = []
+    results_lock = threading.Lock()
+    done_count = [0]
+    total = len(profile_ids)
+
+    def _one(pid: str) -> DownloadResult:
+        path = manifest_paths_by_id.get(pid)
+        if path is None:
+            return DownloadResult(profile_id=pid, ok=False, reason="unknown id")
+        try:
+            peq_target, csv_target = _cache_target_for_path(path)
+        except ValueError as exc:
+            return DownloadResult(profile_id=pid, ok=False, reason=str(exc))
+
+        peq_target.parent.mkdir(parents=True, exist_ok=True)
+
+        if not peq_target.exists():
+            try:
+                peq_target.write_bytes(_http_get(_peq_url_for_path(path)))
+            except Exception as exc:
+                return DownloadResult(
+                    profile_id=pid, ok=False, reason=f"PEQ fetch failed: {exc}"
+                )
+
+        if include_csv and not csv_target.exists():
+            try:
+                csv_target.write_bytes(_http_get(_csv_url_for_path(path)))
+            except Exception as exc:
+                # Non-fatal — CSV missing means no FR graph for
+                # that profile, but the PEQ still works.
+                log.debug("autoeq CSV fetch failed for %s: %s", pid, exc)
+
+        return DownloadResult(profile_id=pid, ok=True)
+
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = [pool.submit(_one, pid) for pid in profile_ids]
+        for fut in futures:
+            res = fut.result()
+            with results_lock:
+                results.append(res)
+                done_count[0] += 1
+                if progress_cb is not None:
+                    try:
+                        progress_cb(done_count[0], total, res)
+                    except Exception:
+                        pass
+    return results
+
+
+def fetch_csv_lazy(profile_id: str) -> Optional[Path]:
+    """Best-effort: if the named profile is in the catalog and
+    its CSV isn't already in cache, fetch it. Returns the path
+    if it lands; None on any failure. Callers (the FR graph
+    endpoint) use this when a profile is loaded but its CSV
+    isn't in either bundled data or cache yet.
+
+    Idempotent: if the CSV is already on disk, returns its path
+    without making a network call.
+    """
+    # Reconstruct the manifest path from the profile_id +
+    # AutoEQ's known layout. We don't have the kind tier (over-
+    # ear / in-ear) on hand, so we'd need a fresh manifest fetch
+    # to reverse this — too expensive for a per-pick lazy fetch.
+    # Skip for now. Caller still works (graph degrades to post-
+    # EQ only).
+    _ = profile_id
+    return None

--- a/server.py
+++ b/server.py
@@ -526,16 +526,20 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     _cleanup_part_files(output_root)
     local_index.start_scan(output_root)
 
-    # Load the bundled AutoEQ profile catalog. Cheap (one disk
-    # walk over ~7 small text files in this Phase 2 release;
-    # later phases swap in a larger update-channel-managed set).
-    # If the data dir is missing, the index logs and stays empty
-    # — feature degrades to "no profiles available" rather than
-    # blocking server startup.
+    # Load the AutoEQ profile catalog from BOTH the bundled
+    # snapshot (~7 starter profiles) AND the user's cache dir
+    # populated by Phase 7's "Update profile catalog" button.
+    # Cache wins on conflict — if a downloaded version exists
+    # for a profile we also bundle, the downloaded one (likely
+    # newer) takes precedence. Missing dirs are silently
+    # skipped.
     try:
         from app.audio.autoeq.index import INDEX as _AUTOEQ_INDEX
         from app.audio.autoeq.index import default_data_dir as _autoeq_data_dir
-        _AUTOEQ_INDEX.load_directory(_autoeq_data_dir())
+        from app.audio.autoeq.updater import cache_dir as _autoeq_cache_dir
+        _AUTOEQ_INDEX.load_directories(
+            [_autoeq_data_dir(), _autoeq_cache_dir()]
+        )
     except Exception as exc:
         print(f"[autoeq] startup index load failed: {exc}", flush=True)
 
@@ -4894,6 +4898,182 @@ def autoeq_state() -> dict:
             "treble_db": settings.eq_tilt_treble_db,
         },
     }
+
+
+# --- Phase 7 catalog updates -------------------------------------------------
+#
+# Fetch the full ~5,000-profile AutoEQ catalog from GitHub on
+# user demand; cache to user_data_dir so subsequent launches see
+# the expanded set. Two endpoints:
+#
+#   GET  /api/eq/check-updates  → manifest fetch, returns counts
+#   POST /api/eq/download-catalog → downloads PEQs (and optional
+#                                    CSVs) for the missing set,
+#                                    streams progress as JSON
+#                                    chunks. Long-running.
+#
+# The download endpoint runs in a background thread so the user
+# can navigate elsewhere; status is polled via /api/eq/update-status.
+
+_AUTOEQ_UPDATE_LOCK = threading.Lock()
+_AUTOEQ_UPDATE_STATE: dict = {
+    "running": False,
+    "started_at": 0.0,
+    "total": 0,
+    "done": 0,
+    "succeeded": 0,
+    "failed": 0,
+    "last_error": "",
+}
+_AUTOEQ_UPDATE_MANIFEST_CACHE: dict = {
+    "manifest": None,  # CatalogManifest | None
+    "missing_ids": [],
+    "already_ids": [],
+}
+
+
+@app.get("/api/eq/check-updates")
+def autoeq_check_updates() -> dict:
+    """Fetch the AutoEQ catalog manifest and report what's
+    available vs what the user already has on disk. Single
+    GitHub API call (~3 MB JSON for the full tree). Result
+    cached in-process for the duration of this server session
+    so the subsequent download-catalog call doesn't have to
+    re-fetch."""
+    _require_local_access()
+    from app.audio.autoeq import updater
+
+    try:
+        manifest = updater.fetch_manifest()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=502,
+            detail=f"failed to fetch AutoEQ manifest: {exc}",
+        )
+
+    bundled_root = _autoeq_data_dir_path()
+    already_ids, missing_ids = updater.diff_manifest_against_disk(
+        manifest, bundled_root
+    )
+
+    _AUTOEQ_UPDATE_MANIFEST_CACHE["manifest"] = manifest
+    _AUTOEQ_UPDATE_MANIFEST_CACHE["missing_ids"] = missing_ids
+    _AUTOEQ_UPDATE_MANIFEST_CACHE["already_ids"] = already_ids
+
+    return {
+        "ok": True,
+        "total_in_catalog": len(manifest.profile_paths),
+        "already_on_disk": len(already_ids),
+        "missing": len(missing_ids),
+        "fetched_at": manifest.fetched_at,
+    }
+
+
+def _autoeq_data_dir_path():
+    """Bundled-data root. Imported lazily to keep the autoeq
+    package off server.py's startup import path."""
+    from app.audio.autoeq.index import default_data_dir
+    return default_data_dir()
+
+
+@app.post("/api/eq/download-catalog")
+def autoeq_download_catalog() -> dict:
+    """Kick off a background download of every missing profile
+    PEQ from the cached manifest. Returns immediately; poll
+    `/api/eq/update-status` for progress.
+
+    Caller must have run `/api/eq/check-updates` first so the
+    manifest is in cache. We could re-fetch here but that
+    silently doubles the API hit on a typical "check then
+    download" UX, and the front-end already serialises the two.
+    """
+    _require_local_access()
+
+    with _AUTOEQ_UPDATE_LOCK:
+        if _AUTOEQ_UPDATE_STATE["running"]:
+            raise HTTPException(
+                status_code=409,
+                detail="catalog download already running",
+            )
+        manifest = _AUTOEQ_UPDATE_MANIFEST_CACHE["manifest"]
+        missing_ids = list(_AUTOEQ_UPDATE_MANIFEST_CACHE["missing_ids"])
+        if manifest is None or not missing_ids:
+            return {
+                "ok": True,
+                "started": False,
+                "reason": (
+                    "no manifest cached — call /api/eq/check-updates first"
+                    if manifest is None
+                    else "everything already on disk"
+                ),
+            }
+        _AUTOEQ_UPDATE_STATE.update(
+            running=True,
+            started_at=time.time(),
+            total=len(missing_ids),
+            done=0,
+            succeeded=0,
+            failed=0,
+            last_error="",
+        )
+
+    # Build id → path map once so workers don't redo the lookup.
+    from app.audio.autoeq import updater
+    paths_by_id: dict[str, str] = {}
+    for path in manifest.profile_paths:
+        pid = updater._profile_id_from_path(path)
+        # First wins — manifest can have duplicate ids in rare
+        # cases of renames. Match diff_manifest_against_disk.
+        paths_by_id.setdefault(pid, path)
+
+    def _progress(done: int, total: int, res) -> None:
+        with _AUTOEQ_UPDATE_LOCK:
+            _AUTOEQ_UPDATE_STATE["done"] = done
+            if res.ok:
+                _AUTOEQ_UPDATE_STATE["succeeded"] += 1
+            else:
+                _AUTOEQ_UPDATE_STATE["failed"] += 1
+                _AUTOEQ_UPDATE_STATE["last_error"] = res.reason
+
+    def _run() -> None:
+        try:
+            updater.download_profiles(
+                paths_by_id,
+                missing_ids,
+                include_csv=False,  # see updater module docstring
+                max_workers=3,
+                progress_cb=_progress,
+            )
+        except Exception as exc:
+            log = logging.getLogger("autoeq.updater")
+            log.exception("download_profiles failed: %s", exc)
+            with _AUTOEQ_UPDATE_LOCK:
+                _AUTOEQ_UPDATE_STATE["last_error"] = str(exc)
+        finally:
+            # Reload the index so newly-downloaded profiles
+            # appear in the picker without an app restart.
+            try:
+                from app.audio.autoeq.index import INDEX, default_data_dir
+                INDEX.load_directories(
+                    [default_data_dir(), updater.cache_dir()]
+                )
+            except Exception:
+                pass
+            with _AUTOEQ_UPDATE_LOCK:
+                _AUTOEQ_UPDATE_STATE["running"] = False
+
+    threading.Thread(target=_run, daemon=True, name="autoeq-update").start()
+    return {"ok": True, "started": True, "missing": len(missing_ids)}
+
+
+@app.get("/api/eq/update-status")
+def autoeq_update_status() -> dict:
+    """Snapshot of the download-catalog progress. Frontend polls
+    every ~500 ms while the spinner is up; cheap (no I/O,
+    locked dict read)."""
+    _require_local_access()
+    with _AUTOEQ_UPDATE_LOCK:
+        return dict(_AUTOEQ_UPDATE_STATE)
 
 
 @app.get("/api/eq/response")

--- a/tests/test_autoeq_updater.py
+++ b/tests/test_autoeq_updater.py
@@ -1,0 +1,145 @@
+"""Phase 7 — catalog updater logic.
+
+Network code (manifest fetch, raw downloads) isn't exercised
+here — those require either real GitHub access or a heavy mock
+layer that doesn't catch much. The decision-heavy bits (path
+parsing, diff against disk, cache layout derivation) are pure
+and worth pinning.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.audio.autoeq.updater import (
+    CatalogManifest,
+    _cache_target_for_path,
+    _profile_id_from_path,
+    diff_manifest_against_disk,
+)
+
+
+# ---------------------------------------------------------------------------
+# Path → profile_id
+# ---------------------------------------------------------------------------
+
+
+def test_profile_id_strips_results_prefix_and_kind_tier():
+    """AutoEQ's manifest paths have a `results/<source>/<kind>/...`
+    layout. The id we want is `<source>/<headphone>` so it matches
+    what the bundled-data index produces."""
+    pid = _profile_id_from_path(
+        "results/oratory1990/over-ear/Sennheiser HD 600/"
+        "Sennheiser HD 600 ParametricEQ.txt"
+    )
+    assert pid == "oratory1990/Sennheiser HD 600"
+
+
+def test_profile_id_handles_in_ear_kind():
+    pid = _profile_id_from_path(
+        "results/oratory1990/in-ear/Etymotic ER4SR/"
+        "Etymotic ER4SR ParametricEQ.txt"
+    )
+    assert pid == "oratory1990/Etymotic ER4SR"
+
+
+def test_profile_id_falls_back_for_unexpected_layout():
+    """Defensive: an unexpected manifest path doesn't crash; we
+    just return the raw path. Caller treats unknown ids as
+    'skip with a log line.'"""
+    pid = _profile_id_from_path("results/something.txt")
+    assert pid == "results/something.txt"
+
+
+# ---------------------------------------------------------------------------
+# Cache-target derivation
+# ---------------------------------------------------------------------------
+
+
+def test_cache_target_layout_matches_bundled():
+    """Downloaded files land at
+    cache_root/<source>/<brand_model>/<filename> — same shape
+    the bundled data uses, so the index walks both with one
+    layout rule."""
+    peq, csv = _cache_target_for_path(
+        "results/oratory1990/over-ear/Sony WH-1000XM4/"
+        "Sony WH-1000XM4 ParametricEQ.txt"
+    )
+    assert peq.parent.name == "Sony WH-1000XM4"
+    assert peq.parent.parent.name == "oratory1990"
+    assert peq.name == "Sony WH-1000XM4 ParametricEQ.txt"
+    # CSV sibling.
+    assert csv.parent == peq.parent
+    assert csv.name == "Sony WH-1000XM4.csv"
+
+
+# ---------------------------------------------------------------------------
+# Manifest diff against disk
+# ---------------------------------------------------------------------------
+
+
+def _write_stub_profile(root: Path, source: str, brand_model: str) -> None:
+    """Write a minimal ParametricEQ.txt at the layout the index
+    expects so `diff_manifest_against_disk` can find it."""
+    target = root / source / brand_model
+    target.mkdir(parents=True, exist_ok=True)
+    (target / f"{brand_model} ParametricEQ.txt").write_text(
+        "Preamp: 0 dB\nFilter 1: ON PK Fc 1000 Hz Gain 0 dB Q 1\n",
+        encoding="utf-8",
+    )
+
+
+def test_diff_marks_existing_as_already_and_missing_as_missing(tmp_path):
+    bundled = tmp_path / "bundled"
+    _write_stub_profile(bundled, "oratory1990", "Sennheiser HD 600")
+    # Note: cache_dir is the user_data_dir cache, which we don't
+    # control here — diff falls back to bundled-only when the
+    # cache dir doesn't exist (typical fresh-install state).
+
+    manifest = CatalogManifest(
+        profile_paths=[
+            "results/oratory1990/over-ear/Sennheiser HD 600/"
+            "Sennheiser HD 600 ParametricEQ.txt",
+            "results/oratory1990/over-ear/Sony WH-1000XM4/"
+            "Sony WH-1000XM4 ParametricEQ.txt",
+        ],
+        fetched_at=0,
+    )
+    already, missing = diff_manifest_against_disk(manifest, bundled)
+    assert already == ["oratory1990/Sennheiser HD 600"]
+    assert missing == ["oratory1990/Sony WH-1000XM4"]
+
+
+def test_diff_dedupes_repeated_manifest_entries(tmp_path):
+    """AutoEQ's manifest occasionally has duplicate paths (renames,
+    historical mirrors). The diff should not produce duplicate
+    ids — caller would otherwise download the same profile twice."""
+    bundled = tmp_path / "bundled"
+    bundled.mkdir()
+
+    same_path = (
+        "results/oratory1990/over-ear/Some Headphone/"
+        "Some Headphone ParametricEQ.txt"
+    )
+    manifest = CatalogManifest(
+        profile_paths=[same_path, same_path],
+        fetched_at=0,
+    )
+    already, missing = diff_manifest_against_disk(manifest, bundled)
+    assert already == []
+    assert missing == ["oratory1990/Some Headphone"]
+
+
+def test_diff_handles_missing_bundled_root(tmp_path):
+    """A fresh-install or test machine where the bundled root
+    doesn't exist yet should still diff cleanly — everything is
+    'missing,' nothing 'already.'"""
+    nonexistent = tmp_path / "does-not-exist"
+    manifest = CatalogManifest(
+        profile_paths=[
+            "results/oratory1990/over-ear/X Y/X Y ParametricEQ.txt",
+        ],
+        fetched_at=0,
+    )
+    already, missing = diff_manifest_against_disk(manifest, nonexistent)
+    assert already == []
+    assert missing == ["oratory1990/X Y"]

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1021,6 +1021,35 @@ export const api = {
         method: "POST",
         body: JSON.stringify({ bypass }),
       }),
+    /** Phase 7 catalog updater. `check-updates` returns counts
+     *  in one round-trip; `download-catalog` kicks off a long-
+     *  running download (background thread) and returns
+     *  immediately; `update-status` polls progress. */
+    autoEqCheckUpdates: () =>
+      req<{
+        ok: boolean;
+        total_in_catalog: number;
+        already_on_disk: number;
+        missing: number;
+        fetched_at: number;
+      }>("/api/eq/check-updates"),
+    autoEqDownloadCatalog: () =>
+      req<{
+        ok: boolean;
+        started: boolean;
+        missing?: number;
+        reason?: string;
+      }>("/api/eq/download-catalog", { method: "POST" }),
+    autoEqUpdateStatus: () =>
+      req<{
+        running: boolean;
+        started_at: number;
+        total: number;
+        done: number;
+        succeeded: number;
+        failed: number;
+        last_error: string;
+      }>("/api/eq/update-status"),
     /** Phase 6 frequency-response data for the FR graph. Returns
      *  three parallel arrays — raw measured curve, target curve,
      *  predicted post-EQ — at log-spaced frequencies. Raw + target

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -1027,22 +1027,20 @@ function AutoEqProfileField() {
   const [results, setResults] = useState<AutoEqProfileSummary[]>([]);
   const [loadingResults, setLoadingResults] = useState(false);
 
-  // Initial state load. If the backend doesn't expose the
-  // endpoint (older server build), stay hidden — no error toast.
+  // Refetch the EQ state. Called once on mount + whenever a
+  // child surface (catalog updater, etc.) wants to re-pull
+  // because something changed server-side.
+  const refresh = async () => {
+    try {
+      const s = await api.player.autoEqState();
+      setState(s);
+    } catch {
+      /* feature not available — keep section hidden */
+    }
+  };
+
   useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const s = await api.player.autoEqState();
-        if (cancelled) return;
-        setState(s);
-      } catch {
-        /* feature not available — keep section hidden */
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
+    void refresh();
   }, []);
 
   // Debounced search. Only fires when in profile mode (no point
@@ -1139,6 +1137,17 @@ function AutoEqProfileField() {
           {modeBtn("manual", "Manual")}
           {modeBtn("profile", "Profile")}
         </div>
+
+        {state.mode === "profile" && (
+          <AutoEqCatalogUpdater
+            catalogSize={state.profile_catalog_size}
+            onCatalogChanged={() => {
+              // Refetch state so the new catalog size + any
+              // newly-available profiles surface in the picker.
+              void refresh();
+            }}
+          />
+        )}
 
         {state.mode === "profile" && state.profile_catalog_size > 0 && (
           <div className="flex flex-col gap-2">
@@ -1440,6 +1449,184 @@ function AutoEqResponseGraph({
         <div className="mt-1 text-[10px] text-muted-foreground">
           No measurement CSV bundled for this profile — showing EQ
           response only.
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Phase 7 catalog updater. One small row under the mode toggle
+ * with a "Check for new headphones" button. Two-step UX:
+ *
+ *   1. Click "Check" → GET /api/eq/check-updates (single GitHub
+ *      API call, ~1-3s). Reveals "X new profiles available" +
+ *      a "Download all" button.
+ *   2. Click "Download all" → POST /api/eq/download-catalog,
+ *      backend kicks off a background download. Frontend polls
+ *      /api/eq/update-status at ~750 ms intervals to drive the
+ *      progress bar.
+ *
+ * On completion, calls onCatalogChanged so the parent picker
+ * re-fetches its state and the new profiles surface in the
+ * search list.
+ */
+function AutoEqCatalogUpdater({
+  catalogSize,
+  onCatalogChanged,
+}: {
+  catalogSize: number;
+  onCatalogChanged: () => void;
+}) {
+  const toast = useToast();
+  const [check, setCheck] = useState<{
+    total_in_catalog: number;
+    already_on_disk: number;
+    missing: number;
+  } | null>(null);
+  const [checking, setChecking] = useState(false);
+  const [progress, setProgress] = useState<{
+    total: number;
+    done: number;
+    succeeded: number;
+    failed: number;
+    running: boolean;
+  } | null>(null);
+
+  const onCheck = async () => {
+    setChecking(true);
+    try {
+      const r = await api.player.autoEqCheckUpdates();
+      setCheck({
+        total_in_catalog: r.total_in_catalog,
+        already_on_disk: r.already_on_disk,
+        missing: r.missing,
+      });
+    } catch (err) {
+      toast.show({
+        kind: "error",
+        title: "Couldn't reach AutoEQ",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setChecking(false);
+    }
+  };
+
+  const onDownload = async () => {
+    try {
+      const r = await api.player.autoEqDownloadCatalog();
+      if (!r.started) {
+        toast.show({ kind: "info", title: r.reason || "Nothing to download" });
+        return;
+      }
+    } catch (err) {
+      toast.show({
+        kind: "error",
+        title: "Couldn't start download",
+        description: err instanceof Error ? err.message : String(err),
+      });
+      return;
+    }
+    // Poll. Cleared once status.running flips back to false.
+    const interval = window.setInterval(async () => {
+      try {
+        const s = await api.player.autoEqUpdateStatus();
+        setProgress({
+          total: s.total,
+          done: s.done,
+          succeeded: s.succeeded,
+          failed: s.failed,
+          running: s.running,
+        });
+        if (!s.running) {
+          window.clearInterval(interval);
+          // Re-check the diff so the "missing" number updates.
+          await onCheck();
+          onCatalogChanged();
+          toast.show({
+            kind: "success",
+            title: `Downloaded ${s.succeeded} profile${
+              s.succeeded === 1 ? "" : "s"
+            }`,
+            description:
+              s.failed > 0
+                ? `${s.failed} failed (transient network errors)`
+                : undefined,
+          });
+        }
+      } catch {
+        /* keep polling — server briefly unreachable is fine */
+      }
+    }, 750);
+  };
+
+  return (
+    <div className="rounded-md border border-input bg-secondary/40 p-3 text-xs">
+      {check === null && progress === null && (
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-muted-foreground">
+            {catalogSize} headphone{catalogSize === 1 ? "" : "s"} bundled.
+            Check AutoEQ for the full ~5,000-profile catalog.
+          </div>
+          <button
+            type="button"
+            onClick={onCheck}
+            disabled={checking}
+            className="rounded-md border border-input px-2.5 py-1 text-[11px] font-semibold hover:bg-accent disabled:opacity-50"
+          >
+            {checking ? "Checking…" : "Check for updates"}
+          </button>
+        </div>
+      )}
+      {check !== null && progress === null && (
+        <div className="flex items-center justify-between gap-3">
+          <div className="text-muted-foreground">
+            {check.missing > 0
+              ? `${check.missing} new headphone profile${
+                  check.missing === 1 ? "" : "s"
+                } available (${check.total_in_catalog} total in catalog).`
+              : `Already up to date — ${check.total_in_catalog} profile${
+                  check.total_in_catalog === 1 ? "" : "s"
+                } cached.`}
+          </div>
+          {check.missing > 0 && (
+            <button
+              type="button"
+              onClick={onDownload}
+              className="rounded-md border border-primary bg-primary px-2.5 py-1 text-[11px] font-semibold text-primary-foreground hover:bg-primary/80"
+            >
+              Download all
+            </button>
+          )}
+        </div>
+      )}
+      {progress !== null && (
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center justify-between text-muted-foreground">
+            <span>
+              {progress.running
+                ? `Downloading… ${progress.done}/${progress.total}`
+                : `Done: ${progress.succeeded} succeeded, ${progress.failed} failed`}
+            </span>
+            {progress.failed > 0 && (
+              <span className="text-amber-500">
+                {progress.failed} skipped
+              </span>
+            )}
+          </div>
+          <div className="h-1.5 overflow-hidden rounded-full bg-foreground/10">
+            <div
+              className="h-full bg-primary transition-[width] duration-150"
+              style={{
+                width: `${
+                  progress.total > 0
+                    ? (progress.done / progress.total) * 100
+                    : 0
+                }%`,
+              }}
+            />
+          </div>
         </div>
       )}
     </div>


### PR DESCRIPTION
Closes the AutoEQ feature work. Bundle stays at ~7 starter profiles for fast install + offline-friendly first launch; users with niche headphones click "Check for updates" once and fill in the rest of AutoEQ's ~5,000-profile catalog from GitHub.

Stacks on Phase 6 ([#89](https://github.com/J-M-PUNK/tideway/pull/89)).

## How it works

[`app/audio/autoeq/updater.py`](app/audio/autoeq/updater.py):

- `fetch_manifest()` — single GitHub Tree API call enumerates every `*ParametricEQ.txt` path in AutoEQ's `results/`. ~30 KB JSON. No auth (60 req/hr limit per IP is plenty for a manual workflow).
- `diff_manifest_against_disk()` — walks both bundled + `user_data_dir/autoeq_cache/results`, returns `(already_on_disk_ids, missing_ids)`.
- `download_profiles()` — bulk-fetches missing PEQs to the cache dir using a 3-worker pool. Per-profile failures are logged but don't abort the batch. CSVs intentionally not bulk-fetched (would add ~250 MB for the full catalog when only user-picked profiles need them).

[`app/audio/autoeq/index.py`](app/audio/autoeq/index.py):

- New `load_directories(roots)` walks multiple roots in order; later roots override earlier ones. So the cache dir's downloaded profiles take precedence over bundled copies — user gets newer data when AutoEQ updates a profile.

## Endpoints

| Method | Path | Purpose |
|---|---|---|
| GET | `/api/eq/check-updates` | Fetch manifest, return diff counts |
| POST | `/api/eq/download-catalog` | Kick off background download |
| GET | `/api/eq/update-status` | Poll progress |

Server startup loads BOTH bundled + cache dir in one merged index, so users who downloaded the full catalog see it immediately on next launch.

## Frontend

`AutoEqCatalogUpdater` rendered above the search input in the profile picker. Two-step UX:

1. **Check for updates** → single GitHub API call (~1-3s), reveals count of new profiles available.
2. **Download all** → background download with a live progress bar. On completion the picker re-fetches state so the new profiles surface in the search list.

## Test plan

- [x] `pytest tests/` — 570 passed (was 563 + 7 new), 2 skipped unchanged.
- [x] `tsc --noEmit` clean.
- [ ] Manual: open Settings → Playback → Headphone profile, switch to Profile mode. Confirm the "X headphones bundled" updater row appears above the search input.
- [ ] Manual: click "Check for updates." Confirm it reaches GitHub and reports a count (~5,000 total, 5,000 - 7 = ~4,993 missing).
- [ ] Manual: click "Download all." Watch the progress bar fill in over ~10-15 minutes. Confirm new profiles appear in the search list when complete.
- [ ] Manual: restart the app. Confirm previously-downloaded profiles still appear in the picker (loaded from cache dir on startup).

## End of the AutoEQ scope

Phases 1-7 ship the full feature outlined in [docs/autoeq-headphone-profiles-scope.md](docs/autoeq-headphone-profiles-scope.md). The interaction loop:

> Pick headphones → right correction applies → drag tilt sliders → watch FR graph → A/B compare → switch devices → correction auto-swaps → click "update" to grow the catalog when needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)