### PR TITLE
Ship Mac Intel installer alongside Apple Silicon

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,32 @@ env:
 
 jobs:
   # -------------------------------------------------------------------
-  # macOS .app bundle. Produces Tideway-macOS.zip containing
-  # the .app — users drag it to /Applications. Unsigned / unnotarized
-  # so first-launch shows Gatekeeper's "cannot be verified" warning;
-  # README tells them to right-click → Open.
+  # macOS DMG build, run twice — once on Apple Silicon (macos-14
+  # is arm64-native) and once on Intel (macos-13). Each runner
+  # uses host-arch Python + PyInstaller, so the DMG that comes
+  # out matches the runner's architecture. build_dmg.sh tags the
+  # output filename with the arch suffix, so both DMGs can sit
+  # in the release alongside each other.
+  #
+  # Without the Intel job, an Apple Silicon-only build forces
+  # Intel Mac users into Rosetta 2 (which works for most things
+  # but breaks bit-perfect audio) or just leaves them with a
+  # download that won't launch.
   # -------------------------------------------------------------------
   build-macos:
-    runs-on: macos-14
+    strategy:
+      # `fail-fast: false` so an Intel-runner deprecation doesn't
+      # take down the arm64 build alongside it. Each architecture
+      # ships independently.
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runs-on: macos-14
+          - arch: x64
+            runs-on: macos-13
+    name: build-macos (${{ matrix.arch }})
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -93,13 +112,16 @@ jobs:
         # the image, shows the drag-to-Applications window, users
         # eject when done. ZIP technically works but fails the
         # Mac-native install expectation, so we ship only the DMG.
-        # Name matches the auto-updater's convention:
-        # Tideway-<version>.dmg.
+        # build_dmg.sh tags the output with the host arch:
+        # Tideway-<version>-arm64.dmg / Tideway-<version>-x64.dmg.
         run: bash scripts/build_dmg.sh
 
       - uses: actions/upload-artifact@v7
         with:
-          name: Tideway-macOS
+          # Per-arch artifact name so the matrix legs don't collide
+          # in the artifact storage. The release-publish job
+          # downloads both via a wildcard.
+          name: Tideway-macOS-${{ matrix.arch }}
           path: dist/Tideway-*.dmg
           if-no-files-found: error
 
@@ -398,7 +420,13 @@ jobs:
 
       - uses: actions/download-artifact@v8
         with:
-          name: Tideway-macOS
+          # Both Mac legs (arm64 + x64) upload under
+          # `Tideway-macOS-<arch>` artifact names. Glob via
+          # `pattern` + `merge-multiple` so one download step
+          # picks up both DMGs into the same flat `artifacts/`
+          # directory the existing release glob expects.
+          pattern: Tideway-macOS-*
+          merge-multiple: true
           path: artifacts
       - uses: actions/download-artifact@v8
         with:

--- a/README.md
+++ b/README.md
@@ -159,8 +159,16 @@ but never expected.
 Grab the latest from the Releases page for whichever fork of this
 repo you are installing from.
 
-On macOS, download `Tideway-<version>.dmg`, double-click it, and
-drag the `Tideway` app into `/Applications`.
+On macOS, download the DMG matching your CPU, double-click it,
+and drag the `Tideway` app into `/Applications`:
+
+- **Apple Silicon** (M1 / M2 / M3 / M4): `Tideway-<version>-arm64.dmg`
+- **Intel**: `Tideway-<version>-x64.dmg`
+
+The app's auto-updater picks the right one for you on subsequent
+releases — this only matters for the first install. Not sure
+which you have? Apple → About This Mac. "Apple silicon" or
+"Apple M…" = arm64; "Intel" = x64.
 
 On Windows, download `Tideway-setup-<version>.exe` and run it. The
 installer drops the app under your user profile, registers a Start
@@ -406,10 +414,12 @@ npm --prefix web run build
 scripts/build_dmg.sh
 ```
 
-The DMG lands at `dist/Tideway-<version>.dmg`. Users drag the
-`.app` into Applications and launch. The CI builds on macOS 14
-(Apple Silicon), so the DMG produced by the release workflow is
-arm64. Intel Mac builds aren't part of the release pipeline today.
+The DMG lands at `dist/Tideway-<version>-<arch>.dmg`, where
+`<arch>` is `arm64` on Apple Silicon and `x64` on Intel — the
+build script picks the suffix from `uname -m`. Users drag the
+`.app` into Applications and launch. The release pipeline builds
+both: arm64 on macOS 14 and x64 on macOS 13, so the auto-updater
+hands each user the matching DMG.
 
 ### Windows
 
@@ -450,7 +460,8 @@ can replace the bundle.
 The release asset names must match these patterns:
 
 ```
-Tideway-<version>.dmg                       (macOS, Apple Silicon)
+Tideway-<version>-arm64.dmg                 (macOS, Apple Silicon)
+Tideway-<version>-x64.dmg                   (macOS, Intel)
 Tideway-setup-<version>.exe                 (Windows x64)
 Tideway-setup-<version>-arm64.exe           (Windows ARM64)
 Tideway-<version>-x86_64.AppImage           (Linux x86_64)

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -40,7 +40,23 @@ trap 'rm -rf "$STAGING"' EXIT
 cp -R "$APP_PATH" "$STAGING/${APP_NAME}.app"
 ln -s /Applications "$STAGING/Applications"
 
-DMG_OUT="dist/${APP_NAME}-${VERSION}.dmg"
+# Tag the DMG with the host architecture so `Tideway-<v>-arm64.dmg`
+# and `Tideway-<v>-x64.dmg` can coexist as separate release assets.
+# The auto-updater (server.py:_match_release_asset) picks the right
+# one based on the running Mac's CPU. Without arch tagging, Intel
+# Mac users would download the arm64 binary and get a "PowerPC?
+# this won't run" failure on first launch.
+HOST_ARCH="$(uname -m)"
+case "$HOST_ARCH" in
+  arm64)  ARCH_SUFFIX="arm64" ;;
+  x86_64) ARCH_SUFFIX="x64"   ;;
+  *)
+    echo "ERROR: unrecognised mac architecture: $HOST_ARCH" >&2
+    exit 1
+    ;;
+esac
+
+DMG_OUT="dist/${APP_NAME}-${VERSION}-${ARCH_SUFFIX}.dmg"
 rm -f "$DMG_OUT"
 
 # `hdiutil create -srcfolder ... -format UDZO` produces a compressed,

--- a/server.py
+++ b/server.py
@@ -1351,17 +1351,18 @@ def _match_release_asset(release_data: dict) -> Optional[str]:
 
     Naming convention (matches scripts/build_dmg.sh, the Inno Setup
     script, and scripts/build_appimage.sh):
-      - macOS:           Tideway-<version>.dmg
-      - Windows x64:     Tideway-setup-<version>.exe
-      - Windows ARM64:   Tideway-setup-<version>-arm64.exe
-      - Linux x86_64:    Tideway-<version>-x86_64.AppImage
+      - macOS Apple Silicon: Tideway-<version>-arm64.dmg
+      - macOS Intel:         Tideway-<version>-x64.dmg
+      - Windows x64:         Tideway-setup-<version>.exe
+      - Windows ARM64:       Tideway-setup-<version>-arm64.exe
+      - Linux x86_64:        Tideway-<version>-x86_64.AppImage
 
-    On Windows we pick the asset matching the host CPU rather than the
-    process arch. platform.machine() reflects the underlying CPU even
-    when we're running as an emulated x64 process on an ARM64 host
-    (Prism exposes PROCESSOR_ARCHITEW6432=ARM64), so an ARM64 user who
-    accidentally installed the x64 build will still be offered the
-    correct ARM64 installer on the next update.
+    On Windows AND macOS we pick the asset matching the host CPU
+    rather than the process arch. platform.machine() reflects the
+    underlying CPU even when we're running as an emulated x64
+    process on an ARM64 host, so an ARM64 user who accidentally
+    installed the x64 build will still be offered the correct
+    ARM64 installer on the next update.
 
     Linux is currently x86_64-only — ARM Linux (Raspberry Pi etc.)
     isn't built and falls through to None until someone asks. Old
@@ -1369,16 +1370,34 @@ def _match_release_asset(release_data: dict) -> Optional[str]:
     either, so a Linux user pinned to a pre-AppImage release simply
     sees "no installer available" until a newer release lands.
     """
-    want_arm64 = False
+    # `arch_suffix` is the architecture marker we expect at the
+    # tail of the asset filename (before the extension). Empty
+    # string means "no arch suffix" — used by the Windows x64
+    # build's unsuffixed naming for back-compat.
+    arch_suffix = ""
     if sys.platform == "darwin":
         suffix = ".dmg"
+        host = platform.machine().lower()
+        if host in ("arm64", "aarch64"):
+            arch_suffix = "-arm64"
+        elif host in ("x86_64", "amd64", "i386"):
+            arch_suffix = "-x64"
+        else:
+            # Unknown Mac architecture — try an unsuffixed match
+            # for back-compat with releases predating the
+            # arch-tagged DMGs (≤v1.4.0). The strict / fallback
+            # logic below handles this gracefully.
+            arch_suffix = ""
     elif sys.platform.startswith("win"):
         suffix = ".exe"
-        want_arm64 = platform.machine().lower() in ("arm64", "aarch64")
+        if platform.machine().lower() in ("arm64", "aarch64"):
+            arch_suffix = "-arm64"
+        # Windows x64 ships unsuffixed (Tideway-setup-<v>.exe);
+        # leave arch_suffix as "" for the strict-match path.
     elif sys.platform.startswith("linux"):
         # Only x86_64 ships today. An aarch64 Linux host gets None
-        # rather than a wrong-arch download — same defensive shape as
-        # the Windows fallback below, just lacking a graceful
+        # rather than a wrong-arch download — same defensive shape
+        # as the platform fallback below, just lacking a graceful
         # "any matching ext" branch because there's nothing to fall
         # back to (no aarch64 AppImage exists yet).
         if platform.machine().lower() not in ("x86_64", "amd64"):
@@ -1388,7 +1407,7 @@ def _match_release_asset(release_data: dict) -> Optional[str]:
         return None
 
     assets = release_data.get("assets") or []
-    candidates: list[tuple[bool, str]] = []
+    candidates: list[tuple[str, str]] = []  # (asset_arch_tag, url)
     for a in assets:
         name = (a.get("name") or "").lower()
         if not (name.endswith(suffix) and name.startswith("tideway")):
@@ -1396,17 +1415,32 @@ def _match_release_asset(release_data: dict) -> Optional[str]:
         url = a.get("browser_download_url")
         if not url:
             continue
-        is_arm64 = name.endswith("-arm64" + suffix)
-        candidates.append((is_arm64, url))
+        # Detect the asset's arch tag — `-arm64`, `-x64`, or empty
+        # (= no tag, the back-compat naming for Windows x64 and
+        # for Mac releases ≤v1.4.0).
+        stem_lower = name[: -len(suffix)]
+        if stem_lower.endswith("-arm64"):
+            asset_arch = "-arm64"
+        elif stem_lower.endswith("-x64"):
+            asset_arch = "-x64"
+        else:
+            asset_arch = ""
+        candidates.append((asset_arch, url))
 
-    # Strict pass: only an asset with the matching arch suffix.
-    for is_arm64, url in candidates:
-        if is_arm64 == want_arm64:
+    # Strict pass: only an asset with the matching arch tag.
+    for asset_arch, url in candidates:
+        if asset_arch == arch_suffix:
             return url
-    # Fallback: any matching extension. Lets older releases that
-    # predate the ARM64 build still expose their single x64 asset to
-    # ARM64 hosts (the install will fail at runtime, but that is the
-    # pre-fix status quo and not a regression).
+    # Fallback: prefer an unsuffixed asset before settling for any
+    # matching extension. Older Mac releases (≤v1.4.0) had a
+    # single unsuffixed DMG that was actually arm64 — Apple
+    # Silicon users running an Intel-host installer should still
+    # get pointed at it for back-compat. Intel Mac users get the
+    # same unsuffixed download, which won't run, but that's the
+    # pre-fix status quo (not a regression).
+    for asset_arch, url in candidates:
+        if asset_arch == "":
+            return url
     if candidates:
         return candidates[0][1]
     return None

--- a/tests/test_update_asset_match.py
+++ b/tests/test_update_asset_match.py
@@ -86,16 +86,84 @@ def test_x64_host_does_not_pick_arm64_only_release(force_windows, monkeypatch):
     )
 
 
-def test_macos_picks_dmg_ignoring_arch(force_macos, monkeypatch):
-    """macOS doesn't yet ship per-arch DMGs, so the matcher should
-    return the .dmg unconditionally and ignore the Windows assets."""
+def test_macos_apple_silicon_picks_arm64_dmg(force_macos, monkeypatch):
+    """Apple Silicon Macs should be offered the arm64 DMG when both
+    are present. Critical for the bit-perfect audio path — running
+    an x64 binary under Rosetta 2 changes ALSA / CoreAudio behaviour
+    in subtle ways that compromise the engine's invariants."""
     _set_machine(monkeypatch, "arm64")
     rel = _release(
-        "Tideway-1.0.0.dmg",
-        "Tideway-setup-1.0.0.exe",
-        "Tideway-setup-1.0.0-arm64.exe",
+        "Tideway-1.5.0-arm64.dmg",
+        "Tideway-1.5.0-x64.dmg",
+        "Tideway-setup-1.5.0.exe",
     )
-    assert server._match_release_asset(rel) == "https://example/Tideway-1.0.0.dmg"
+    assert (
+        server._match_release_asset(rel)
+        == "https://example/Tideway-1.5.0-arm64.dmg"
+    )
+
+
+def test_macos_intel_picks_x64_dmg(force_macos, monkeypatch):
+    """The whole reason this PR exists: Intel Mac users were
+    silently getting served the arm64 DMG and hitting "this
+    application is damaged" or worse. The x64-tagged DMG must
+    win for Intel hosts."""
+    _set_machine(monkeypatch, "x86_64")
+    rel = _release(
+        "Tideway-1.5.0-arm64.dmg",
+        "Tideway-1.5.0-x64.dmg",
+    )
+    assert (
+        server._match_release_asset(rel)
+        == "https://example/Tideway-1.5.0-x64.dmg"
+    )
+
+
+def test_macos_apple_silicon_falls_back_to_unsuffixed_dmg(force_macos, monkeypatch):
+    """Releases predating this PR (≤v1.4.0) shipped a single
+    unsuffixed `Tideway-<v>.dmg` that was actually arm64. Apple
+    Silicon users running the auto-updater against one of those
+    older releases (e.g. browsing back through the release log)
+    should still get pointed at it."""
+    _set_machine(monkeypatch, "arm64")
+    rel = _release("Tideway-1.4.0.dmg")
+    assert (
+        server._match_release_asset(rel)
+        == "https://example/Tideway-1.4.0.dmg"
+    )
+
+
+def test_macos_intel_falls_back_to_unsuffixed_dmg_on_old_release(
+    force_macos, monkeypatch
+):
+    """An Intel Mac user updating against a pre-PR release gets
+    handed the unsuffixed (=arm64) DMG as a fallback. It won't
+    actually run on Intel — but that's the pre-fix status quo,
+    not a regression. The new arch-tagged releases will give
+    them a working install going forward."""
+    _set_machine(monkeypatch, "x86_64")
+    rel = _release("Tideway-1.4.0.dmg")
+    assert (
+        server._match_release_asset(rel)
+        == "https://example/Tideway-1.4.0.dmg"
+    )
+
+
+def test_macos_picks_dmg_ignoring_windows_and_linux_assets(force_macos, monkeypatch):
+    """Sanity: with all four platforms' assets in the release,
+    the matcher only looks at .dmg files."""
+    _set_machine(monkeypatch, "arm64")
+    rel = _release(
+        "Tideway-1.5.0-arm64.dmg",
+        "Tideway-1.5.0-x64.dmg",
+        "Tideway-setup-1.5.0.exe",
+        "Tideway-setup-1.5.0-arm64.exe",
+        "Tideway-1.5.0-x86_64.AppImage",
+    )
+    assert (
+        server._match_release_asset(rel)
+        == "https://example/Tideway-1.5.0-arm64.dmg"
+    )
 
 
 def test_no_matching_asset_returns_none(force_windows, monkeypatch):


### PR DESCRIPTION
## Summary

- The macOS release pipeline today builds an arm64-only DMG; Intel Mac users get either a launch failure or Rosetta 2 (which breaks the bit-perfect audio path).
- Add a parallel macos-13 (Intel) runner to the build matrix and tag DMGs with `-arm64` / `-x64` so both can ship in the same release.
- Teach the auto-updater to pick the right DMG for the host CPU, with back-compat fallback for older unsuffixed releases.

## Changes

- `scripts/build_dmg.sh`: detect host arch via `uname -m`, name DMG `Tideway-<v>-arm64.dmg` or `Tideway-<v>-x64.dmg`.
- `.github/workflows/release.yml`: `build-macos` becomes a matrix job (arm64 on macos-14, x64 on macos-13, `fail-fast: false`). Per-arch artifact names; publish job globs `Tideway-macOS-*` with `merge-multiple: true`.
- `server.py:_match_release_asset`: add Mac CPU arch detection. Strict match → unsuffixed fallback (≤v1.4.0 back-compat) → any matching extension.
- `tests/test_update_asset_match.py`: 5 new tests covering Apple Silicon match, Intel match, both fallbacks, and the cross-platform sanity case. 16 tests pass.
- `README.md`: install + release-asset sections reflect the new naming.

## Naming convention (after this PR)

```
Tideway-<v>-arm64.dmg            (macOS, Apple Silicon)
Tideway-<v>-x64.dmg              (macOS, Intel)
Tideway-setup-<v>.exe            (Windows x64)
Tideway-setup-<v>-arm64.exe      (Windows ARM64)
Tideway-<v>-x86_64.AppImage      (Linux x86_64)
```

## Test plan

- [ ] Tag a release on this branch and confirm both Mac runners produce a DMG.
- [ ] Download the x64 DMG on an Intel Mac (or Rosetta-1 host) and confirm it mounts + launches.
- [ ] Confirm auto-updater on an Apple Silicon machine still picks `-arm64.dmg`.
- [ ] Confirm auto-updater on an Intel machine picks `-x64.dmg`.
- [ ] Run pytest locally — `tests/test_update_asset_match.py` covers the matcher logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)