### PR TITLE
Add release-signing-guard workflow

### DIFF
--- a/.github/workflows/release-signing-guard.yml
+++ b/.github/workflows/release-signing-guard.yml
@@ -1,0 +1,107 @@
+name: Release Signing Guard
+
+# Fires the moment a GitHub release is published. Verifies that
+# every installer asset (.dmg, .exe, .AppImage) has a paired
+# `.minisig` sidecar. If any are missing, the release is auto-
+# rolled-back to draft and an issue is opened tagging the
+# missing artifacts.
+#
+# Why: every Tideway install >= v1.4.0 verifies a minisign
+# signature on the auto-update download before launching the
+# installer binary. Publishing a release without `.minisig`
+# files turns "Install now" into a hard error for every user.
+# `scripts/sign-release.sh` is the manual step that produces
+# the sidecars (CLAUDE.md step 8 of the release flow), and it
+# requires a signing key that lives offline — so the failure
+# mode is "human or AI driving the deploy forgets to run it,
+# clicks Publish anyway, every user's auto-update breaks".
+#
+# This workflow is the safety net. It runs on the GitHub side
+# the second a release flips from draft to published, so the
+# bad state lasts seconds, not "until the maintainer next
+# checks the release page".
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write   # gh release edit --draft=true
+  issues: write     # gh issue create
+
+jobs:
+  verify-signatures:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: List release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+        run: |
+          gh release view "$TAG" --json assets --jq '.assets[].name' > assets.txt
+          echo "Assets on $TAG:"
+          cat assets.txt
+
+      - name: Check for missing .minisig sidecars
+        id: check
+        run: |
+          set +e
+          python scripts/check_release_signatures.py assets.txt > missing.txt
+          rc=$?
+          set -e
+          echo "missing_count=$(wc -l < missing.txt)" >> "$GITHUB_OUTPUT"
+          echo "exit_code=$rc" >> "$GITHUB_OUTPUT"
+          if [ "$rc" -ne 0 ]; then
+            echo "Missing .minisig sidecars for:"
+            cat missing.txt
+          fi
+
+      - name: Roll back to draft if any sidecars are missing
+        if: steps.check.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.release.tag_name }}
+          RELEASE_URL: ${{ github.event.release.html_url }}
+        run: |
+          set -euo pipefail
+          gh release edit "$TAG" --draft=true
+          echo "Release $TAG flipped back to draft."
+
+          # Build the issue body. We list every missing artifact
+          # so the maintainer doesn't have to re-derive what
+          # `sign-release.sh` is supposed to produce.
+          {
+            echo "## Release \`$TAG\` was auto-rolled-back to draft"
+            echo
+            echo "The release was published without minisign signatures on:"
+            while IFS= read -r name; do
+              [ -z "$name" ] && continue
+              echo "- \`$name\`"
+            done < missing.txt
+            echo
+            echo "Every Tideway install >= v1.4.0 verifies a \`.minisig\` sidecar"
+            echo "before launching the installer the auto-updater downloaded."
+            echo "Publishing without them turns the \"Install now\" button into"
+            echo "an error for every user."
+            echo
+            echo "**To fix:**"
+            echo
+            echo "1. From the machine that holds the minisign signing key, run:"
+            echo "   \`\`\`"
+            echo "   scripts/sign-release.sh $TAG"
+            echo "   \`\`\`"
+            echo "2. Re-publish:"
+            echo "   \`\`\`"
+            echo "   gh release edit $TAG --draft=false"
+            echo "   \`\`\`"
+            echo
+            echo "See $RELEASE_URL."
+            echo
+            echo "_Filed automatically by \`.github/workflows/release-signing-guard.yml\`._"
+          } > issue-body.md
+
+          gh issue create \
+            --title "Release $TAG published without signatures — rolled back to draft" \
+            --body-file issue-body.md

--- a/scripts/check_release_signatures.py
+++ b/scripts/check_release_signatures.py
@@ -1,0 +1,77 @@
+"""Find installer assets on a GitHub release that are missing
+their minisign sidecar.
+
+Used by `.github/workflows/release-signing-guard.yml` to catch the
+case where someone published a release before running
+`scripts/sign-release.sh`. Every Tideway install >= v1.4.0 verifies
+a `.minisig` sidecar before launching the installer the auto-
+updater downloaded; without the sidecar, the install click is a
+hard error for every user. The guard auto-rolls a missing-sidecar
+release back to draft so the failure window is seconds, not
+"whenever the maintainer next checks the release page".
+
+The detection logic lives here (and not inline in the workflow
+YAML) so it's testable from `tests/test_check_release_signatures.py`
+without spinning up GitHub.
+
+Usage:
+    python scripts/check_release_signatures.py <asset-list-file>
+
+The asset-list-file is one filename per line — typically the
+output of `gh release view <tag> --json assets --jq
+'.assets[].name'`. Exits 0 if every installer has a paired
+sidecar, 1 if any are missing (and prints the missing names to
+stdout, one per line, for the workflow to consume).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+
+# Asset filename suffixes we treat as "installer artifacts that
+# the auto-updater will hand to a user". Anything matching one of
+# these MUST have a `<name>.minisig` sidecar in the same release.
+INSTALLER_SUFFIXES: tuple[str, ...] = (".dmg", ".exe", ".AppImage")
+
+
+def find_missing_minisig(asset_names: list[str]) -> list[str]:
+    """Return the installer asset names that lack a `.minisig`
+    sidecar in `asset_names`.
+
+    `asset_names` is the flat list of every asset filename on a
+    GitHub release. Order doesn't matter. The check is exact-name:
+    `Foo-1.0.dmg` is satisfied iff `Foo-1.0.dmg.minisig` is also
+    in the list.
+    """
+    names = set(asset_names)
+    missing: list[str] = []
+    for name in asset_names:
+        if not name.endswith(INSTALLER_SUFFIXES):
+            continue
+        if f"{name}.minisig" not in names:
+            missing.append(name)
+    return missing
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            "usage: check_release_signatures.py <asset-list-file>",
+            file=sys.stderr,
+        )
+        return 2
+    path = Path(argv[1])
+    asset_names = [
+        line.strip() for line in path.read_text().splitlines() if line.strip()
+    ]
+    missing = find_missing_minisig(asset_names)
+    if not missing:
+        return 0
+    for name in missing:
+        print(name)
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/test_check_release_signatures.py
+++ b/tests/test_check_release_signatures.py
@@ -1,0 +1,127 @@
+"""Tests for the release-signing-guard helper.
+
+The bug the guard catches: a maintainer (or an AI driving the
+deploy) tags a release, lets CI build the installers, and clicks
+Publish without first running `scripts/sign-release.sh`. Every
+v1.4.0+ install then refuses the auto-update because the .minisig
+sidecar is missing. The guard's detection logic lives in
+`find_missing_minisig`; these tests pin its behavior down so a
+future refactor can't quietly break the production safety net.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from check_release_signatures import find_missing_minisig  # noqa: E402
+
+
+# A fully-signed v1.4.0-ish release as the canonical positive case.
+SIGNED_RELEASE = [
+    "Tideway-1.4.0.dmg",
+    "Tideway-1.4.0.dmg.minisig",
+    "Tideway-setup-1.4.0.exe",
+    "Tideway-setup-1.4.0.exe.minisig",
+    "Tideway-setup-1.4.0-arm64.exe",
+    "Tideway-setup-1.4.0-arm64.exe.minisig",
+    "Tideway-1.4.0-x86_64.AppImage",
+    "Tideway-1.4.0-x86_64.AppImage.minisig",
+]
+
+
+def test_fully_signed_release_returns_empty():
+    assert find_missing_minisig(SIGNED_RELEASE) == []
+
+
+def test_unsigned_release_flags_every_installer():
+    """The exact failure mode v1.4.1 hit: workflow built four
+    installers, sign-release.sh never ran, Publish was clicked."""
+    assets = [
+        "Tideway-1.4.1.dmg",
+        "Tideway-setup-1.4.1.exe",
+        "Tideway-setup-1.4.1-arm64.exe",
+        "Tideway-1.4.1-x86_64.AppImage",
+    ]
+    missing = find_missing_minisig(assets)
+    assert sorted(missing) == sorted(assets)
+
+
+def test_partial_signing_flags_only_the_unsigned():
+    """If the maintainer signed three of four installers (e.g.
+    minisign passphrase fatigue, machine fell asleep mid-script),
+    the guard should flag exactly the one that was missed —
+    not pass because "most" of them are signed."""
+    assets = [
+        "Tideway-1.4.0.dmg",
+        "Tideway-1.4.0.dmg.minisig",
+        "Tideway-setup-1.4.0.exe",
+        "Tideway-setup-1.4.0.exe.minisig",
+        "Tideway-setup-1.4.0-arm64.exe",
+        "Tideway-1.4.0-x86_64.AppImage",
+        "Tideway-1.4.0-x86_64.AppImage.minisig",
+    ]
+    assert find_missing_minisig(assets) == ["Tideway-setup-1.4.0-arm64.exe"]
+
+
+def test_minisig_alone_is_not_an_installer():
+    """A `.minisig` file in the asset list without the matching
+    installer is weird, but it's not what the guard cares about
+    — the guard checks installers, not orphan sidecars. So no
+    false positive here."""
+    assets = ["Tideway-1.4.0.dmg.minisig"]
+    assert find_missing_minisig(assets) == []
+
+
+def test_non_installer_assets_are_ignored():
+    """Future releases may attach checksums, SBOMs, source
+    tarballs etc. — the guard must not demand .minisig sidecars
+    for those, only for the binaries the auto-updater downloads."""
+    assets = [
+        "Tideway-1.4.0.dmg",
+        "Tideway-1.4.0.dmg.minisig",
+        "checksums.txt",
+        "SBOM.spdx.json",
+        "source.tar.gz",
+    ]
+    assert find_missing_minisig(assets) == []
+
+
+def test_empty_release_returns_empty():
+    """A release with zero assets (workflow failed mid-upload, or
+    the maintainer is staging assets manually) has nothing for
+    the guard to verify. Don't false-positive into rolling back
+    an empty release."""
+    assert find_missing_minisig([]) == []
+
+
+def test_appimage_capitalisation_matches_actual_artifact_name():
+    """`appimagetool` emits `.AppImage` (mixed case). The matcher
+    treats the suffix exactly — no lowercasing — so the .minisig
+    sidecar lookup is case-sensitive too. Pinning this in case
+    a "let's lowercase everything" refactor accidentally breaks
+    the AppImage detection."""
+    assets = ["Tideway-1.4.0-x86_64.AppImage"]
+    assert find_missing_minisig(assets) == ["Tideway-1.4.0-x86_64.AppImage"]
+    assets_signed = [
+        "Tideway-1.4.0-x86_64.AppImage",
+        "Tideway-1.4.0-x86_64.AppImage.minisig",
+    ]
+    assert find_missing_minisig(assets_signed) == []
+
+
+def test_arm64_dmg_naming_handled():
+    """Forward-compat: PR #92 introduces `-arm64.dmg` and
+    `-x64.dmg` arch-tagged DMG names. Each needs its own
+    .minisig — the guard treats them as independent installer
+    artifacts (because that's what they are)."""
+    assets = [
+        "Tideway-1.5.0-arm64.dmg",
+        "Tideway-1.5.0-arm64.dmg.minisig",
+        "Tideway-1.5.0-x64.dmg",
+        # Intel .minisig deliberately missing
+    ]
+    assert find_missing_minisig(assets) == ["Tideway-1.5.0-x64.dmg"]


### PR DESCRIPTION
## Summary

- Auto-rolls a published release back to draft if any installer asset (`.dmg`, `.exe`, `.AppImage`) is missing its `.minisig` sidecar; files an issue tagging the missing artifacts so the maintainer can re-run `sign-release.sh` and republish.
- v1.4.1 just hit this exact failure mode: the deploy reached publish without `sign-release.sh` running, the auto-updater on the maintainer's own install immediately broke, and the release had to be flipped back to draft manually. This workflow makes that rollback automatic.
- Belt-and-suspenders next to [CLAUDE.md](CLAUDE.md) step 8, which already documents the manual signing step. The workflow exists for when the human/AI driving the deploy skips it anyway.

## Files

- `scripts/check_release_signatures.py` — pure detection logic, testable without GitHub.
- `tests/test_check_release_signatures.py` — 8 cases: fully-signed, fully-unsigned, partial-sign, AppImage casing, PR #92's arch-tagged DMG naming, orphan/non-installer asset edge cases.
- `.github/workflows/release-signing-guard.yml` — triggers on `release.published`, runs the check, flips to draft + opens issue if any sidecar is missing.

## Note on rollout

The workflow only fires for releases published **after** it lands on `main`. To validate it against v1.4.1:
1. Merge this into `deploy/v1.4.1` with `--no-ff`.
2. Fast-forward `main` to `deploy/v1.4.1` so the workflow exists on the default branch.
3. Sign v1.4.1 with `sign-release.sh` and click Publish — the guard runs, sees signatures present, no-ops. Validates the happy path on the very deploy it was built for.

## Test plan

- [x] `pytest tests/test_check_release_signatures.py` — 8/8 pass locally.
- [ ] Once landed on main, validate happy-path on v1.4.1 publish (signatures present → guard no-ops).
- [ ] (Optional) Manually publish a throwaway draft without signatures to confirm the rollback + issue-creation path fires correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)