### PR TITLE
Fix prettier failure in Home.tsx

### DIFF
--- a/web/src/pages/Home.tsx
+++ b/web/src/pages/Home.tsx
@@ -689,11 +689,7 @@ export function Home({ onDownload }: { onDownload: OnDownload }) {
            above its first one). 32px matches the inter-row gap so
            the visual rhythm is consistent. */}
       <div className="mt-8">
-        <PageView
-          page={filteredPage}
-          onDownload={onDownload}
-          forceSingleRow
-        />
+        <PageView page={filteredPage} onDownload={onDownload} forceSingleRow />
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary

- The PageView JSX block at the bottom of [Home.tsx](web/src/pages/Home.tsx) fits on one line; prettier wanted it collapsed and #81's merge into deploy/v1.4.1 left it expanded.
- CI's `format:check` job has been failing on main since the v1.4.1 deploy because of this single JSX block. v1.4.1's release artifacts are unaffected (this is formatting only) but main is red.

## Test plan

- [x] `prettier --write src/pages/Home.tsx` produces only this one diff.
- [ ] CI `Tests / frontend` passes after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)