### PR TITLE
AOTY: revert top-of-year URL to user-highest-rated

### DIFF
--- a/app/aoty.py
+++ b/app/aoty.py
@@ -3,12 +3,14 @@
 Two surfaces:
 
   - `top_albums_of_year(year, limit)` reads
-    `/ratings/6-highest-rated/{year}/{page}/` — AOTY's canonical
-    "Best of {year}" ranking (the headline list, aggregated /
-    critic-blended). NOT `/ratings/user-highest-rated/{year}/`,
-    which is a separate user-only ranking with materially
-    different ordering. Stable list that turns over slowly
-    enough that an hour-level cache is comfortable.
+    `/ratings/user-highest-rated/{year}/{page}/` — AOTY's
+    user-rating-ordered "best of {year}" ranking. We previously
+    tried `/ratings/6-highest-rated/{year}/` thinking that was
+    AOTY's canonical aggregated/critic ranking, but that path
+    404s for year-scoped requests (likely an all-time-only ID).
+    The user-rated list is the only public year-scoped chart
+    AOTY exposes at a stable URL, so we use it. Stable enough
+    that an hour-level cache is comfortable.
 
   - `recent_releases(limit)` reads `/releases/this-week/` — the
     explicitly-this-week scope of AOTY's release grid. The
@@ -109,14 +111,15 @@ def top_albums_of_year(year: int, limit: int = 50) -> list[dict]:
 
     out: list[AotyAlbum] = []
     page = 1
-    # AOTY's pagination: /ratings/6-highest-rated/{year}/{page}/.
-    # `6-highest-rated` is AOTY's canonical aggregated ranking — the
-    # headline "Best of {year}" list users actually mean when they
-    # say "AOTY top albums." Distinct from `user-highest-rated`,
-    # which is the separate user-only score. Each page renders ~25
-    # rows. Walk pages until we hit `limit` or a page returns no rows.
+    # AOTY's pagination: /ratings/user-highest-rated/{year}/{page}/.
+    # `6-highest-rated` was tried first based on the assumption that
+    # the all-time aggregated list ID extended to year-scoped URLs
+    # — it doesn't, that path 404s. `user-highest-rated` is the only
+    # year-scoped chart AOTY exposes at a stable URL. Each page
+    # renders ~25 rows. Walk pages until we hit `limit` or a page
+    # returns no rows.
     while len(out) < limit and page <= 6:
-        path = f"/ratings/6-highest-rated/{year}/{page}/"
+        path = f"/ratings/user-highest-rated/{year}/{page}/"
         html = _fetch(urljoin(_BASE_URL, path))
         if html is None:
             break


### PR DESCRIPTION
## Summary

Fixes the empty Top Albums of 2026 section on Home in v1.4.1.

[#79](https://github.com/J-M-PUNK/tideway/pull/79) switched `top_albums_of_year` to `/ratings/6-highest-rated/{year}/`, asserting (incorrectly) that this was AOTY's canonical aggregated ranking. The URL 404s for year-scoped requests on the live site. Reverting to `/ratings/user-highest-rated/{year}/`, which is what v1.3.x and v1.4.0 used without complaints.

## Why the bug slipped review

[#79](https://github.com/J-M-PUNK/tideway/pull/79)'s parser tests passed because the fixtures used the same `albumListRow` CSS shape as the original URL. The URL itself was never live-verified before merge.

## Probed (all return 404 on live AOTY)

```
/ratings/6-highest-rated/2026/1/
/ratings/6-highest-rated/2025/1/
/ratings/6-highest-rated/all-time/1/
/ratings/highest-rated/2026/1/
/ratings/best/2026/1/
/ratings/critic-highest-rated/2026/1/
/ratings/aggregate-highest-rated/2026/1/
/lists/best-albums-of-2026/
```

`/ratings/user-highest-rated/{year}/` is the only year-scoped chart URL AOTY exposes publicly.

## Test plan

- [x] Live probe: `python -c "from app.aoty import top_albums_of_year; print(len(top_albums_of_year(2026, 10)))"` returns 10 albums.
- [x] `pytest tests/test_aoty_parser.py tests/test_aoty_resolver.py` — 24/24 pass (no fixture changes; the parser logic is unchanged, only the URL).
- [ ] Once shipped: confirm Home page Top Albums of 2026 row renders 25-30 cards on cold load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)