### PR TITLE
macOS universal2 DMG: one Mac download for both Apple Silicon and Intel

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,13 +22,38 @@ env:
 
 jobs:
   # -------------------------------------------------------------------
-  # macOS .app bundle. Produces Tideway-macOS.zip containing
-  # the .app — users drag it to /Applications. Unsigned / unnotarized
-  # so first-launch shows Gatekeeper's "cannot be verified" warning;
-  # README tells them to right-click → Open.
+  # macOS .app bundle (per-arch). Matrix-builds an arm64 slice on
+  # macos-14 and an x86_64 slice on macos-13, in parallel. Each runner
+  # produces a single-arch .app; they're tarred (to preserve symlinks
+  # that GitHub's zip-based artifacts would otherwise dereference) and
+  # uploaded as intermediate artifacts. The downstream
+  # merge-macos-universal job lipo-fuses them into one universal2 .app
+  # which is what actually ships in the release.
+  #
+  # Why pinning macos-13 for the x64 build:
+  #
+  #   GitHub's macos-13 runner is the last x64-native macOS image
+  #   (macos-14 and macos-15 are arm64-only). Building x64 on an arm64
+  #   runner via Rosetta is technically possible but the Python wheels
+  #   come back arm64 anyway because pip resolves against the host
+  #   arch, not the target. Native x64 runner = native x64 wheels.
+  #
+  # First-launch on the resulting universal DMG still shows
+  # Gatekeeper's "cannot be verified" warning (build is unsigned /
+  # unnotarized); README covers right-click → Open.
   # -------------------------------------------------------------------
   build-macos:
-    runs-on: macos-14
+    strategy:
+      # fail-fast: false lets the other arch finish even if one fails
+      # — useful when investigating per-arch wheel issues.
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-14
+          - arch: x64
+            runner: macos-13
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -63,7 +88,9 @@ jobs:
         # regression. PyInstaller's static analysis routinely misses
         # native libs that get loaded via ctypes / CFFI at runtime,
         # and curl-cffi falling back to plain requests would silently
-        # drop our TLS-fingerprint match.
+        # drop our TLS-fingerprint match. Runs per-arch so a wheel
+        # missing on just one arch shows up here, before the lipo
+        # merge muddies the diagnostic.
         #
         # tls_client used to be checked here too — we deliberately
         # stopped bundling it in v0.4.11 because its Go-CGO DLL was
@@ -80,22 +107,100 @@ jobs:
           for pat in "${required_globs[@]}"; do
             count=$(find "$APP_DIR" -path "$pat" 2>/dev/null | wc -l | tr -d ' ')
             if [ "$count" -eq 0 ]; then
-              echo "::error ::Missing native library matching $pat in macOS bundle"
+              echo "::error ::Missing native library matching $pat in macOS bundle (${{ matrix.arch }})"
               echo "PyInstaller didn't pick up a runtime-loaded dylib."
               echo "Check the collect_all() list in Tideway-mac.spec."
               exit 1
             fi
-            echo "OK: found $count file(s) matching $pat"
+            echo "OK: found $count file(s) matching $pat (${{ matrix.arch }})"
           done
 
-      - name: Build DMG
-        # DMG is the canonical macOS install format — Finder mounts
-        # the image, shows the drag-to-Applications window, users
-        # eject when done. ZIP technically works but fails the
-        # Mac-native install expectation, so we ship only the DMG.
-        # Name matches the auto-updater's convention:
-        # Tideway-<version>.dmg.
-        run: bash scripts/build_dmg.sh
+      - name: Tar the .app for the merge job
+        # tar instead of upload-artifact-with-bare-directory, because
+        # GitHub Actions zips the artifact contents and zip dereferences
+        # symlinks. Mach-O bundles can have symlinks (Frameworks, dylib
+        # alias names) that would break if dereferenced, so we tar
+        # first and ship the tarball as the artifact's payload.
+        run: |
+          cd dist
+          tar -cf "Tideway-${{ matrix.arch }}.app.tar" Tideway.app
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: Tideway-macOS-${{ matrix.arch }}-app
+          path: dist/Tideway-${{ matrix.arch }}.app.tar
+          if-no-files-found: error
+
+  # -------------------------------------------------------------------
+  # Lipo-merge the two arch-specific .app bundles into one universal2
+  # .app and package the result as the single Tideway-<version>.dmg
+  # release asset. Runs on macos-14 because lipo is macOS-only and
+  # the build is fast enough that runner choice doesn't matter.
+  #
+  # The result is a single DMG that runs natively on both Apple
+  # Silicon and Intel Macs — same model Discord, Slack, Zoom, and
+  # 1Password ship on the Mac, and it's how we get to "one download
+  # link per OS" without making the user know what CPU they have.
+  # -------------------------------------------------------------------
+  merge-macos-universal:
+    needs: build-macos
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: Tideway-macOS-arm64-app
+          path: in/arm64
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: Tideway-macOS-x64-app
+          path: in/x64
+
+      - name: Untar arch-specific .app bundles
+        run: |
+          set -euo pipefail
+          tar -xf in/arm64/Tideway-arm64.app.tar -C in/arm64
+          tar -xf in/x64/Tideway-x64.app.tar -C in/x64
+          ls -la in/arm64 in/x64
+
+      - name: Lipo-merge into universal2 .app
+        run: |
+          mkdir -p merged
+          bash scripts/lipo_merge_macos.sh \
+            in/arm64/Tideway.app \
+            in/x64/Tideway.app \
+            merged/Tideway.app
+
+      - name: Verify merged .app is universal2
+        # Double-check the main executable now reports both arm64 and
+        # x86_64. If lipo merge silently dropped a slice, the binary
+        # would still launch on ONE arch and break on the other; this
+        # check fails the build before users get a half-working DMG.
+        run: |
+          set -e
+          MAIN_EXE="merged/Tideway.app/Contents/MacOS/Tideway"
+          if [ ! -f "$MAIN_EXE" ]; then
+            echo "::error ::merged main executable missing at $MAIN_EXE"
+            exit 1
+          fi
+          archs=$(lipo -archs "$MAIN_EXE")
+          echo "Main executable architectures: $archs"
+          if ! echo "$archs" | grep -q "arm64"; then
+            echo "::error ::merged main executable has no arm64 slice (got: $archs)"
+            exit 1
+          fi
+          if ! echo "$archs" | grep -q "x86_64"; then
+            echo "::error ::merged main executable has no x86_64 slice (got: $archs)"
+            exit 1
+          fi
+          echo "OK: main executable is universal2"
+
+      - name: Build DMG from merged .app
+        run: bash scripts/build_dmg.sh merged/Tideway.app
 
       - uses: actions/upload-artifact@v7
         with:
@@ -376,7 +481,7 @@ jobs:
   # artifacts but doesn't create a release.
   # -------------------------------------------------------------------
   publish:
-    needs: [build-macos, build-windows, build-windows-arm64, build-linux]
+    needs: [merge-macos-universal, build-windows, build-windows-arm64, build-linux]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,16 @@ jobs:
   #   come back arm64 anyway because pip resolves against the host
   #   arch, not the target. Native x64 runner = native x64 wheels.
   #
+  # FUTURE: GitHub retires macOS runner images on roughly a yearly
+  # cadence (macos-12 is already gone). When macos-13 follows, this
+  # workflow breaks until we have another way to produce native x64
+  # Python wheels. Options at that point: build x64 wheels on a
+  # self-hosted runner, switch to cross-arch builds with cibuildwheel
+  # if Python's universal2 story has improved, or accept arm64-only
+  # and document Rosetta 2 as the Intel Mac fallback (regresses the
+  # bit-perfect audio path on Intel — the original reason this whole
+  # workflow exists).
+  #
   # First-launch on the resulting universal DMG still shows
   # Gatekeeper's "cannot be verified" warning (build is unsigned /
   # unnotarized); README covers right-click → Open.
@@ -176,28 +186,68 @@ jobs:
             merged/Tideway.app
 
       - name: Verify merged .app is universal2
-        # Double-check the main executable now reports both arm64 and
-        # x86_64. If lipo merge silently dropped a slice, the binary
-        # would still launch on ONE arch and break on the other; this
-        # check fails the build before users get a half-working DMG.
+        # Confirm the merge actually produced fat binaries for the
+        # main executable AND for the runtime-loaded native libraries
+        # the app needs to function. Checking just the main exe isn't
+        # enough — the lipo merge script's fallback path (when a wheel
+        # is single-arch in only one matrix runner's bundle) is to
+        # keep the file as-is and emit a warning. Without this check
+        # a curl-cffi or sounddevice dylib could end up arm64-only in
+        # the merged bundle and the app would launch on Intel but
+        # crash on the first network request or first audio callback.
+        #
+        # Patterns must match Mach-O binaries that exist after the
+        # merge. Glob is anchored to Contents/ rather than the bundle
+        # root so PyInstaller's varying internal layout (Frameworks/
+        # vs Contents/Resources/ etc.) doesn't trip the check.
         run: |
           set -e
-          MAIN_EXE="merged/Tideway.app/Contents/MacOS/Tideway"
-          if [ ! -f "$MAIN_EXE" ]; then
-            echo "::error ::merged main executable missing at $MAIN_EXE"
-            exit 1
+          BUNDLE="merged/Tideway.app"
+
+          require_universal() {
+            local label="$1"; local file="$2"
+            if [ ! -f "$file" ]; then
+              echo "::error ::$label not found at $file"
+              return 1
+            fi
+            local archs
+            archs=$(lipo -archs "$file" 2>/dev/null || true)
+            echo "  $label: $archs"
+            if ! echo "$archs" | grep -q "arm64"; then
+              echo "::error ::$label is missing arm64 slice (got: $archs)"
+              return 1
+            fi
+            if ! echo "$archs" | grep -q "x86_64"; then
+              echo "::error ::$label is missing x86_64 slice (got: $archs)"
+              return 1
+            fi
+            return 0
+          }
+
+          require_universal "main exe" "$BUNDLE/Contents/MacOS/Tideway"
+
+          # Walk the runtime-loaded native libs we care about. Each
+          # pattern must produce at least one match; each match must
+          # be universal2. Patterns mirror the per-arch verify step
+          # above so a wheel bundle change shows up in BOTH places.
+          checked_any=0
+          for pat in \
+              "$BUNDLE/Contents/*/curl_cffi/_wrapper*.so" \
+              "$BUNDLE/Contents/*/sounddevice*.so" \
+              "$BUNDLE/Contents/*/_sounddevice_data/portaudio-binaries/libportaudio.dylib"
+          do
+            for f in $pat; do
+              [ -e "$f" ] || continue
+              checked_any=1
+              require_universal "$(basename "$f")" "$f"
+            done
+          done
+
+          if [ "$checked_any" -eq 0 ]; then
+            echo "::warning ::merged-bundle dylib check matched no files; the verify-step glob may be stale"
           fi
-          archs=$(lipo -archs "$MAIN_EXE")
-          echo "Main executable architectures: $archs"
-          if ! echo "$archs" | grep -q "arm64"; then
-            echo "::error ::merged main executable has no arm64 slice (got: $archs)"
-            exit 1
-          fi
-          if ! echo "$archs" | grep -q "x86_64"; then
-            echo "::error ::merged main executable has no x86_64 slice (got: $archs)"
-            exit 1
-          fi
-          echo "OK: main executable is universal2"
+
+          echo "OK: merged bundle is universal2"
 
       - name: Build DMG from merged .app
         run: bash scripts/build_dmg.sh merged/Tideway.app

--- a/README.md
+++ b/README.md
@@ -407,9 +407,17 @@ scripts/build_dmg.sh
 ```
 
 The DMG lands at `dist/Tideway-<version>.dmg`. Users drag the
-`.app` into Applications and launch. The CI builds on macOS 14
-(Apple Silicon), so the DMG produced by the release workflow is
-arm64. Intel Mac builds aren't part of the release pipeline today.
+`.app` into Applications and launch. A local build like this
+produces a single-architecture `.app` matching the host (arm64 on
+Apple Silicon, x86_64 on Intel) — fine for development.
+
+The release pipeline builds **both** architectures in parallel
+(`macos-14` runner for arm64, `macos-13` runner for x86_64), then
+lipo-merges them into one universal2 `.app` packaged as a single
+`Tideway-<version>.dmg`. The merge step is
+`scripts/lipo_merge_macos.sh`; it walks the bundle and fuses every
+Mach-O file into a fat binary so the same DMG runs natively on
+both Apple Silicon and Intel Macs.
 
 ### Windows
 
@@ -450,7 +458,7 @@ can replace the bundle.
 The release asset names must match these patterns:
 
 ```
-Tideway-<version>.dmg                       (macOS, Apple Silicon)
+Tideway-<version>.dmg                       (macOS, universal2: arm64 + x86_64)
 Tideway-setup-<version>.exe                 (Windows x64)
 Tideway-setup-<version>-arm64.exe           (Windows ARM64)
 Tideway-<version>-x86_64.AppImage           (Linux x86_64)

--- a/scripts/build_dmg.sh
+++ b/scripts/build_dmg.sh
@@ -1,9 +1,19 @@
 #!/usr/bin/env bash
-# Build a distributable DMG from the PyInstaller .app output.
+# Build a distributable DMG from a pre-built .app bundle.
 #
 # Prereqs:
-#   - pyinstaller Tideway-mac.spec has produced dist/Tideway.app
-#   - hdiutil (ships with macOS)
+#   - The .app bundle exists at the path given as the first argument
+#     (defaults to dist/Tideway.app when called with no arguments —
+#     matches the local single-arch dev workflow).
+#   - hdiutil (ships with macOS).
+#
+# Usage:
+#   scripts/build_dmg.sh                       # uses dist/Tideway.app
+#   scripts/build_dmg.sh path/to/Tideway.app   # explicit path (used by
+#                                              # the universal-binary
+#                                              # merge job in CI, where
+#                                              # the merged .app lives
+#                                              # outside dist/)
 #
 # Output:
 #   dist/Tideway-<version>.dmg
@@ -17,12 +27,13 @@ REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 cd "$REPO_ROOT"
 
 APP_NAME="Tideway"
-APP_PATH="dist/${APP_NAME}.app"
+APP_PATH="${1:-dist/${APP_NAME}.app}"
 VERSION_FILE="VERSION"
 
 if [[ ! -d "$APP_PATH" ]]; then
-  echo "ERROR: $APP_PATH not found. Run pyinstaller first:" >&2
+  echo "ERROR: $APP_PATH not found. Either run pyinstaller first:" >&2
   echo "  .venv/bin/pyinstaller Tideway-mac.spec --noconfirm" >&2
+  echo "or pass a path to an existing .app bundle as the first argument." >&2
   exit 1
 fi
 

--- a/scripts/lipo_merge_macos.sh
+++ b/scripts/lipo_merge_macos.sh
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+# Fuse two single-architecture macOS .app bundles into one universal2
+# .app bundle. Reads an arm64 .app and an x86_64 .app, produces an
+# output .app whose Mach-O binaries are universal (both archs in one
+# file) and whose non-binary resources come from the arm64 source
+# verbatim.
+#
+# Why this exists:
+#
+#   PyInstaller produces single-arch .app bundles. If we ship just
+#   one, half our user base (Apple Silicon or Intel, depending which
+#   we picked) gets a broken-on-launch app. The two-DMG approach
+#   forces users to pick by architecture, which is a UX regression
+#   relative to what every other modern Mac app does.
+#
+#   The standard fix is a "universal2" .app: every Mach-O binary
+#   inside is fat (contains both arm64 and x86_64 slices), so macOS
+#   loads the right slice automatically based on the host CPU.
+#   Apple's official path to universal2 is `--target-arch universal2`
+#   at build time, but that requires Python and every C-extension
+#   wheel to be universal2 themselves — rarely the case in practice.
+#   Building each arch separately and lipo-merging the results is
+#   the standard workaround.
+#
+# Usage:
+#
+#   scripts/lipo_merge_macos.sh <arm64_app> <x64_app> <output_app>
+#
+# All three paths are .app bundle directories. The output bundle is
+# created fresh (existing one at that path is removed first).
+#
+# Algorithm:
+#
+#   1. Copy arm64 .app to the output path. Most files in the bundle
+#      (Info.plist, JS bundles, icons, fonts, frozen Python bytecode)
+#      are arch-independent — they survive verbatim.
+#   2. Walk every regular file in the output bundle. For each one,
+#      run `file -b` to check the type:
+#        - If "Mach-O" (executable, dylib, shared object): find the
+#          matching path in the x64 bundle. Run lipo to extract
+#          arm64 and x86_64 slices and combine them into a fat
+#          binary that replaces the arm64-only original.
+#        - If not Mach-O: skip. The arm64 copy is byte-identical to
+#          what the x64 build would have produced for resources.
+#   3. Walk the x64 bundle for any Mach-O files that DON'T exist in
+#      the output. Those are arch-specific dependencies one wheel
+#      pulled in but the other didn't. Copy them in as-is — they're
+#      single-arch but at least they exist (better than missing).
+#
+# Edge cases:
+#
+#   - A Mach-O file already universal in one source (e.g. the
+#     arm64 wheel happened to include a fat binary). lipo -thin
+#     extracts the right slice; if no slice exists for the requested
+#     arch, fall back to copying the existing fat binary unchanged.
+#   - Symlinks inside the bundle (Frameworks/Versions/A pattern).
+#     `cp -R` preserves them, and we skip non-regular files
+#     during the walk.
+
+set -euo pipefail
+
+if [ "$#" -ne 3 ]; then
+    echo "usage: $0 <arm64_app> <x64_app> <output_app>" >&2
+    exit 2
+fi
+
+ARM64_APP="$1"
+X64_APP="$2"
+OUTPUT_APP="$3"
+
+if [ ! -d "$ARM64_APP" ]; then
+    echo "ERROR: arm64 .app not found: $ARM64_APP" >&2
+    exit 1
+fi
+if [ ! -d "$X64_APP" ]; then
+    echo "ERROR: x64 .app not found: $X64_APP" >&2
+    exit 1
+fi
+
+if ! command -v lipo >/dev/null 2>&1; then
+    echo "ERROR: lipo not in PATH (this script must run on macOS)" >&2
+    exit 1
+fi
+
+echo "lipo-merging:"
+echo "  arm64:  $ARM64_APP"
+echo "  x86_64: $X64_APP"
+echo "  output: $OUTPUT_APP"
+
+# Start fresh. Removing first means a half-completed previous run
+# can't leave stale Mach-O binaries lurking in the output.
+rm -rf "$OUTPUT_APP"
+# `cp -R` preserves symlinks, which matters for framework bundles
+# that use the Versions/A + Versions/Current symlink pattern.
+cp -R "$ARM64_APP" "$OUTPUT_APP"
+
+merged_count=0
+skipped_count=0
+arm_only_count=0
+x64_only_count=0
+
+# Phase 1: walk the output bundle (which is the arm64 copy), merge
+# each Mach-O with its x64 sibling.
+while IFS= read -r -d '' arm_file; do
+    rel="${arm_file#"$OUTPUT_APP"/}"
+    x64_file="$X64_APP/$rel"
+
+    # `file -b` strips the filename prefix from the output; just
+    # check whether the type description starts with "Mach-O".
+    file_type="$(file -b "$arm_file" 2>/dev/null || true)"
+    case "$file_type" in
+        "Mach-O "*) ;;
+        *)
+            skipped_count=$((skipped_count + 1))
+            continue
+            ;;
+    esac
+
+    if [ ! -f "$x64_file" ]; then
+        # Mach-O exists in arm64 but not in x64. Keep the arm64
+        # version untouched; the universal app will be missing x86_64
+        # support for this specific binary, which is the best we can
+        # do without inventing a slice. Surface a warning so a build
+        # producing a lot of these doesn't go unnoticed.
+        echo "  WARN: $rel exists in arm64 only; keeping arm64-thin copy"
+        arm_only_count=$((arm_only_count + 1))
+        continue
+    fi
+
+    # Extract each arch's slice. `lipo -thin` is a no-op for an
+    # already-thin file of that arch, and extracts the slice from a
+    # universal binary if the input is fat. If the slice doesn't
+    # exist (e.g. a binary that's arm64-only and somehow ended up in
+    # the x64 build's path), fall back to copying the input file —
+    # better to ship something than to fail the merge.
+    arm_thin="$(mktemp -t lipo-arm)"
+    x64_thin="$(mktemp -t lipo-x64)"
+    if ! lipo "$arm_file" -thin arm64 -output "$arm_thin" 2>/dev/null; then
+        cp "$arm_file" "$arm_thin"
+    fi
+    if ! lipo "$x64_file" -thin x86_64 -output "$x64_thin" 2>/dev/null; then
+        cp "$x64_file" "$x64_thin"
+    fi
+
+    # `lipo -create` builds a fat binary from the inputs. Output
+    # back into the bundle, replacing the arm64-only original.
+    if lipo -create "$arm_thin" "$x64_thin" -output "$arm_file" 2>/dev/null; then
+        merged_count=$((merged_count + 1))
+    else
+        # Failed to combine. Most common cause: both inputs already
+        # universal with overlapping archs. Try lipo on the originals
+        # directly with -replace; if that also fails, keep the arm64
+        # copy and warn.
+        if ! lipo -create "$arm_file" "$x64_file" -output "$arm_file.merged" 2>/dev/null; then
+            echo "  WARN: lipo failed to merge $rel; keeping arm64 copy"
+        else
+            mv "$arm_file.merged" "$arm_file"
+            merged_count=$((merged_count + 1))
+        fi
+    fi
+    rm -f "$arm_thin" "$x64_thin"
+done < <(find "$OUTPUT_APP" -type f -print0)
+
+# Phase 2: catch x64-only Mach-O files. These are dylibs pulled in
+# by the x64 wheel of some dependency but not the arm64 wheel (or
+# vice versa). Copy them in single-arch — the universal app will
+# only have x86_64 support for these, but that's better than the
+# binary being missing entirely on Intel hosts.
+while IFS= read -r -d '' x64_file; do
+    rel="${x64_file#"$X64_APP"/}"
+    out_file="$OUTPUT_APP/$rel"
+
+    [ -e "$out_file" ] && continue
+
+    file_type="$(file -b "$x64_file" 2>/dev/null || true)"
+    case "$file_type" in
+        "Mach-O "*) ;;
+        *) continue ;;
+    esac
+
+    echo "  WARN: $rel exists in x64 only; copying x86_64-thin into output"
+    mkdir -p "$(dirname "$out_file")"
+    cp "$x64_file" "$out_file"
+    x64_only_count=$((x64_only_count + 1))
+done < <(find "$X64_APP" -type f -print0)
+
+echo ""
+echo "lipo merge complete:"
+echo "  $merged_count Mach-O files fused (arm64 + x86_64 -> universal2)"
+echo "  $skipped_count non-Mach-O files copied unchanged"
+[ "$arm_only_count" -gt 0 ] && echo "  $arm_only_count Mach-O files kept arm64-only (no x64 match)"
+[ "$x64_only_count" -gt 0 ] && echo "  $x64_only_count Mach-O files added x64-only (no arm64 match)"
+
+# Quick sanity check on the main executable. If lipo says the
+# bundle's binary now reports both archs, the merge worked end-to-end.
+APP_NAME="$(basename "$OUTPUT_APP" .app)"
+MAIN_EXE="$OUTPUT_APP/Contents/MacOS/$APP_NAME"
+if [ -f "$MAIN_EXE" ]; then
+    echo ""
+    echo "Main executable architectures:"
+    lipo -archs "$MAIN_EXE" | sed 's/^/  /'
+fi

--- a/scripts/lipo_merge_macos.sh
+++ b/scripts/lipo_merge_macos.sh
@@ -127,6 +127,20 @@ while IFS= read -r -d '' arm_file; do
         continue
     fi
 
+    # Fast path: both files already report the same set of archs
+    # (typical when a wheel ships a universal2 dylib that both
+    # matrix runners pulled identically). Re-running lipo on these
+    # would fail with "duplicate architecture", and the result we
+    # want is the arm64-copy that's already in place. Detect and
+    # short-circuit so the merged_count accounting and the warn
+    # line below stay accurate.
+    arm_archs="$(lipo -archs "$arm_file" 2>/dev/null || true)"
+    x64_archs="$(lipo -archs "$x64_file" 2>/dev/null || true)"
+    if [ -n "$arm_archs" ] && [ "$arm_archs" = "$x64_archs" ]; then
+        merged_count=$((merged_count + 1))
+        continue
+    fi
+
     # Extract each arch's slice. `lipo -thin` is a no-op for an
     # already-thin file of that arch, and extracts the slice from a
     # universal binary if the input is fat. If the slice doesn't
@@ -147,16 +161,11 @@ while IFS= read -r -d '' arm_file; do
     if lipo -create "$arm_thin" "$x64_thin" -output "$arm_file" 2>/dev/null; then
         merged_count=$((merged_count + 1))
     else
-        # Failed to combine. Most common cause: both inputs already
-        # universal with overlapping archs. Try lipo on the originals
-        # directly with -replace; if that also fails, keep the arm64
-        # copy and warn.
-        if ! lipo -create "$arm_file" "$x64_file" -output "$arm_file.merged" 2>/dev/null; then
-            echo "  WARN: lipo failed to merge $rel; keeping arm64 copy"
-        else
-            mv "$arm_file.merged" "$arm_file"
-            merged_count=$((merged_count + 1))
-        fi
+        # Lipo refused both inputs even after slicing. Real cause is
+        # almost always a malformed Mach-O on one side; keep the
+        # arm64 copy intact and surface a warning the verify step
+        # downstream can correlate against.
+        echo "  WARN: lipo failed to merge $rel (arm:$arm_archs x64:$x64_archs); keeping arm64 copy"
     fi
     rm -f "$arm_thin" "$x64_thin"
 done < <(find "$OUTPUT_APP" -type f -print0)


### PR DESCRIPTION
## Summary

Replaces the arm64-only macOS build with a universal2 DMG that runs natively on both Apple Silicon and Intel Macs. Same file, no architecture picker on the Releases page, matches how Discord / Slack / Zoom / 1Password ship.

Implements **Path A** from `private/features/universal-installer-hardware-detection.md`. Closes [#92](https://github.com/J-M-PUNK/zideway/pull/92), which took the multi-DMG-with-arch-suffix approach (Path B in the same doc).

## What changed

- **`build-macos`** is now a matrix job over `[arm64 (macos-14), x64 (macos-13)]`, `fail-fast: false`. Each matrix runner does the existing PyInstaller flow and uploads its arch-specific `.app` as a tarball intermediate artifact. Tar instead of a bare directory because GitHub Actions zip-packs artifacts and zip silently dereferences symlinks that Mach-O bundles depend on.
- **New `merge-macos-universal` job** runs on macos-14, downloads both arch tarballs, calls `scripts/lipo_merge_macos.sh` to fuse them, runs a `lipo -archs` sanity check on the merged main executable, then packages via `scripts/build_dmg.sh`. Uploads the single `Tideway-<version>.dmg` as the `Tideway-macOS` artifact the publish job already expects.
- **`scripts/lipo_merge_macos.sh`** (new) walks every file in the arm64 .app, runs `file -b` to identify Mach-O binaries, and uses `lipo -thin` + `lipo -create` to fuse each one with its x64 sibling. Non-Mach-O resources survive verbatim from the arm64 copy. Files that exist in only one arch's bundle are warned and either kept or copied single-arch rather than failing the whole merge.
- **`scripts/build_dmg.sh`** now accepts an explicit `.app` path as its first argument so the merge job can point it at the merged bundle outside `dist/`. Default behaviour (no argument) is unchanged for the local single-arch dev workflow.
- **`README.md`** updated to describe the universal2 build and reflect the asset name comment.

## Why Path A over Path B

Path B (separate Intel + ARM64 DMGs) was 95% done in #92 and would have shipped tonight. The reason to throw it away anyway: the user-facing goal is "one download link per OS," and Path B doesn't deliver that — Intel users still need to pick the right DMG. Once Path A ships, the auto-updater asset-matching code can stay simple (one extension, no arch detection), the README has one Mac line, and the Releases page has 4 assets per release instead of 5.

The cost is a doubled-size Mac DMG (both archs in one binary). For Tideway-scale that's fine — task doc explicitly accepted this trade-off.

## Test plan

- [x] `bash scripts/lipo_merge_macos.sh` smoke test against `/usr/bin/file` (a real universal binary) thinned to per-arch sources, then re-merged. Output reports `Mach-O universal binary with 2 architectures: [x86_64] [arm64]`. Confirms the lipo logic produces actual fat binaries, not just renamed thin ones.
- [x] `pytest tests/` — clean.
- [x] `cd web && npx tsc -b --noEmit` — clean.
- [x] `cd web && npm run lint:all` — 0 errors.
- [x] `cd web && npm test` — 36 passed.
- [x] YAML parses, job topology verified: matrix `build-macos` → `merge-macos-universal` → `publish`.
- [ ] Reviewer: tag a test release on this branch (or workflow_dispatch with a tag input) and confirm both Mac runners produce a `.app` tarball that the merge job successfully fuses. The CI's `lipo -archs` step on the main executable will fail-loud if the merge silently drops a slice.
- [ ] Reviewer (after merge): on a real Apple Silicon Mac, install the universal DMG, launch, audio plays. Same on a real Intel Mac. The auto-updater pulls a universal DMG → `_match_release_asset` is unchanged so existing 1.4.x installs upgrade as normal.

## Out of scope

- Windows ARM64 universal binary. The doc explicitly says no — Windows ARM64 runs x64 binaries via Prism transparently and the audience for a native ARM Windows build is small. The existing per-arch Windows installers stay as-is.
- Linux universal anything. The AppImage already targets the lowest-glibc-we-care-about and is portable across distros within that constraint.
- Code signing / notarization. Different problem, different fix (Apple Developer ID + `xcrun notarytool`). The existing Gatekeeper "right-click → Open" workaround still applies.