### PR TITLE
Add UPnP/DLNA renderer output for network audio devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,13 @@ same limitation Tidal desktop and foobar2000 have.
 
 A 10 band parametric equalizer is available with presets and a
 preamp. The output device picker lists every USB DAC, Bluetooth
-sink, and builtin option the OS exposes, and you can switch mid
-playback. Global media keys for play, pause, next, and previous
+sink, and builtin option the OS exposes, plus Chromecast targets,
+Tidal Connect renderers, and UPnP/DLNA devices discovered on the
+LAN. You can switch between any of them mid playback. The DLNA
+path covers WiiM, newer Bluesound, Cambridge, NAD, most network
+AVRs, and a long tail of cheaper Hi-Fi network bridges. See
+[docs/dlna-renderer.md](docs/dlna-renderer.md) for the DLNA-side
+details. Global media keys for play, pause, next, and previous
 work even when the window is minimized. A tray icon keeps playback
 running when you close the window, and there is an opt-in desktop
 notification on every track change.
@@ -345,29 +350,21 @@ either a Dolby-capable renderer on the OS side or a receiver on
 the other end of HDMI, which most setups do not have. If any of
 that changes, we can revisit.
 
-**Network audio output.** Tidal Connect, Chromecast, and AirPlay
-are all ways of casting a stream from a desktop app to a network
-streamer, DAC, or smart speaker. Their status here:
+**Network audio output is mostly there, with caveats.**
+Chromecast, Tidal Connect, and UPnP/DLNA all ship in the output
+device picker. AirPlay is still coming: the code is written, the
+PCM tap on the audio engine feeds a live FLAC stream out to a
+paired receiver, but the feature is off in the current build
+because we haven't tested it against real hardware yet.
 
-- **AirPlay** is coming soon. The code is written and wired into
-  the Settings page, and the PCM tap on the audio engine already
-  feeds a live FLAC stream out to a paired receiver. The feature
-  is off in the current build because we have not tested it
-  against real hardware yet. It will enable in a future release
-  once that testing is done.
-- **Chromecast** is not implemented today. Possibly coming later.
-- **Tidal Connect** is not planned. Pairing with Tidal's own
-  protocol requires the partner authorization that immersive
-  audio does, and that is the same reason the Atmos / 360 tiers
-  are excluded.
-
-Audio in the shipping build goes to whichever output device the
-host OS exposes, which is any wired DAC, Bluetooth sink, or
-builtin speaker you can select from the Settings output-device
-picker. Network streamers that only accept Tidal Connect or
-Chromecast will not receive audio from this app yet. If your
-streamer also shows up as a Bluetooth device or a USB DAC, you
-can use that path instead.
+The DLNA path in particular has not been bench-tested against
+real renderers. The unit tests cover the SOAP wrappers, session
+lifecycle, and audio plumbing, but device-side behaviour (does
+your specific WiiM accept the FLAC stream, does pause respond
+fast, does the device cleanly disconnect when you switch) is
+unverified. If you hit a renderer that misbehaves, please file a
+GitHub issue with the device's manufacturer and model and any
+log output from the diagnostic panel.
 
 **Play reporting to Tidal Recently Played is best effort.** Every
 play fires a `playback_session` event at Tidal's event producer

--- a/app/audio/avtransport.py
+++ b/app/audio/avtransport.py
@@ -1,0 +1,278 @@
+"""UPnP AVTransport + RenderingControl SOAP wrappers.
+
+The DLNA MediaRenderer profile that WiiM, Bluesound, Cambridge,
+LG / Samsung TVs, and almost every cheap network streamer
+implements is a small set of SOAP actions over two UPnP services:
+
+  AVTransport:1
+    SetAVTransportURI: point the device at our HTTP stream URL
+    Play / Pause / Stop: transport control
+    Seek: relative time offset within the stream
+    GetTransportInfo: current state (PLAYING, PAUSED_PLAYBACK, ...)
+    GetPositionInfo: RelTime, TrackDuration
+
+  RenderingControl:1 (optional, not all renderers expose):
+    SetVolume / GetVolume / SetMute / GetMute
+
+The SOAP machinery lives in `app/audio/openhome.py` despite the
+file name. That module's `invoke()`, `_build_soap_envelope`, and
+`OpenHomeService` predate this work but are generic UPnP-SOAP
+helpers. They don't depend on anything OpenHome-specific. We
+import them directly here rather than duplicate the envelope
+encoder, and don't rename the openhome module because the existing
+controllers (Playlist, Volume, Time, Info) ARE OpenHome-specific
+and that's the right name for them.
+
+This file is the AVTransport-flavored equivalent: thin typed
+wrappers around `invoke()` so the manager can call
+`controller.play()` instead of building SOAP args inline. Argument
+serialization (InstanceID="0", duration formatting, etc.) is
+encapsulated here so the manager stays focused on session
+lifecycle and audio plumbing.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from app.audio.openhome import (
+    OpenHomeDevice,
+    OpenHomeService,
+    invoke,
+)
+
+log = logging.getLogger(__name__)
+
+
+# UPnP-A/V service-type URNs. Versions vary across devices (some
+# older Sonos hardware advertises AVTransport:1, newer devices may
+# expose :2 or :3 as well). We match the prefix and accept any
+# version. The actions we use exist in every published version.
+_AVTRANSPORT_PREFIX = "urn:schemas-upnp-org:service:AVTransport:"
+_RENDERING_CONTROL_PREFIX = "urn:schemas-upnp-org:service:RenderingControl:"
+
+# AVTransport's SetAVTransportURI / Play / Pause / Stop all take an
+# InstanceID. The spec lets a single device own multiple transport
+# instances (think a multi-zone amp), but every consumer renderer
+# we'll see treats InstanceID="0" as the only instance. Hardcoding
+# "0" everywhere is fine. If we ever target multi-zone gear it
+# becomes a per-session attribute.
+_INSTANCE_ID = "0"
+
+
+def _find_service(
+    device: OpenHomeDevice, prefix: str,
+) -> Optional[OpenHomeService]:
+    """Return the first service on `device` whose service_type
+    starts with `prefix`. Lets us match any version of the service
+    URN without forcing the caller to know which the device
+    advertises."""
+    for svc in device.services:
+        if svc.service_type.startswith(prefix):
+            return svc
+    return None
+
+
+# ---------------------------------------------------------------------
+# AVTransport
+# ---------------------------------------------------------------------
+
+
+class AVTransportController:
+    """Thin wrapper over the AVTransport service. One instance per
+    active DLNA session; manager builds it after `fetch_device()`.
+
+    Methods raise the same `OpenHomeSOAPError` / `RuntimeError` that
+    `invoke()` raises. The manager treats both as "device rejected
+    the action" and tears down the session.
+    """
+
+    def __init__(self, service: OpenHomeService) -> None:
+        self._service = service
+
+    @classmethod
+    def from_device(
+        cls, device: OpenHomeDevice,
+    ) -> Optional["AVTransportController"]:
+        """Build a controller from a parsed device, or return None
+        if the device doesn't advertise AVTransport. In that case
+        we can't drive playback against it through this protocol,
+        and the manager should reject the connect."""
+        svc = _find_service(device, _AVTRANSPORT_PREFIX)
+        if svc is None:
+            return None
+        return cls(svc)
+
+    @property
+    def service_type(self) -> str:
+        return self._service.service_type
+
+    def set_av_transport_uri(self, uri: str, didl_metadata: str) -> None:
+        """Point the device at a stream URL.
+
+        `uri` is the full http://host:port/path our embedded stream
+        server exposes. `didl_metadata` is a DIDL-Lite XML document
+        describing the track (built by `openhome.build_didl_lite`);
+        many devices will refuse SetAVTransportURI without one, or
+        accept it but show "Unknown Track" on their display.
+
+        After this call the device is in TRANSITIONING or STOPPED;
+        a subsequent `play()` is what actually starts the pull.
+        """
+        invoke(
+            self._service,
+            "SetAVTransportURI",
+            {
+                "InstanceID": _INSTANCE_ID,
+                "CurrentURI": uri,
+                "CurrentURIMetaData": didl_metadata,
+            },
+        )
+
+    def play(self, speed: str = "1") -> None:
+        """Begin (or resume) playback. Speed="1" is normal forward;
+        the spec allows "2", "1/2", etc. but no consumer renderer
+        actually honors them, so we don't expose the parameter."""
+        invoke(
+            self._service,
+            "Play",
+            {"InstanceID": _INSTANCE_ID, "Speed": speed},
+        )
+
+    def pause(self) -> None:
+        """Pause playback. Some renderers reject Pause from the
+        STOPPED state with UPnP error 701 (Transition Not
+        Available); the manager catches that and turns it into a
+        no-op. Pause from PLAYING moves to PAUSED_PLAYBACK."""
+        invoke(self._service, "Pause", {"InstanceID": _INSTANCE_ID})
+
+    def stop(self) -> None:
+        """Stop playback. Tears down the active stream resource on
+        most renderers; the device drops its HTTP connection to our
+        embedded server, which is how the encoder feeds drain
+        cleanly when a session ends."""
+        invoke(self._service, "Stop", {"InstanceID": _INSTANCE_ID})
+
+    def seek(self, position_s: int) -> None:
+        """Seek to an absolute offset within the current track,
+        formatted as REL_TIME (HH:MM:SS).
+
+        AVTransport's seek modes vary by device; REL_TIME is the
+        only one universally supported across the renderers we
+        care about. ABS_TIME is technically what we want (offset
+        from start of stream) but devices often map both modes to
+        the same internal clock, and REL_TIME is more widely
+        accepted in practice."""
+        h = max(0, position_s) // 3600
+        m = (max(0, position_s) % 3600) // 60
+        s = max(0, position_s) % 60
+        invoke(
+            self._service,
+            "Seek",
+            {
+                "InstanceID": _INSTANCE_ID,
+                "Unit": "REL_TIME",
+                "Target": f"{h:02d}:{m:02d}:{s:02d}",
+            },
+        )
+
+    def get_transport_info(self) -> dict[str, str]:
+        """Return the current transport state as a dict with at
+        least `CurrentTransportState` (PLAYING / PAUSED_PLAYBACK /
+        STOPPED / TRANSITIONING / NO_MEDIA_PRESENT). Other fields
+        the device may include (CurrentTransportStatus,
+        CurrentSpeed) pass through."""
+        return invoke(
+            self._service,
+            "GetTransportInfo",
+            {"InstanceID": _INSTANCE_ID},
+        )
+
+    def get_position_info(self) -> dict[str, str]:
+        """Return current position as a dict. Useful keys:
+        `RelTime` (HH:MM:SS), `TrackDuration` (HH:MM:SS), `Track`
+        (queue index, usually "1"). Devices that don't track
+        position internally return "00:00:00" or "NOT_IMPLEMENTED";
+        the manager treats both as "position unknown."""
+        return invoke(
+            self._service,
+            "GetPositionInfo",
+            {"InstanceID": _INSTANCE_ID},
+        )
+
+
+# ---------------------------------------------------------------------
+# RenderingControl (volume / mute)
+# ---------------------------------------------------------------------
+
+
+class RenderingControlController:
+    """Optional wrapper around RenderingControl. Many renderers
+    expose this; some don't, and a few only honor SetMute (no
+    volume). Manager builds an instance lazily, or None if the
+    device doesn't expose the service. In the None case
+    volume/mute become no-ops at the session level.
+    """
+
+    def __init__(self, service: OpenHomeService) -> None:
+        self._service = service
+
+    @classmethod
+    def from_device(
+        cls, device: OpenHomeDevice,
+    ) -> Optional["RenderingControlController"]:
+        svc = _find_service(device, _RENDERING_CONTROL_PREFIX)
+        if svc is None:
+            return None
+        return cls(svc)
+
+    @property
+    def service_type(self) -> str:
+        return self._service.service_type
+
+    def set_volume(self, level_percent: int) -> None:
+        """Set master-channel volume to a 0-100 percentage. The
+        UPnP spec says the value is "in the device's native
+        range" but Channel="Master" with a 0-100 value is what
+        every consumer renderer accepts; the spec's "absolute
+        units" model is mostly theoretical."""
+        clamped = max(0, min(100, int(level_percent)))
+        invoke(
+            self._service,
+            "SetVolume",
+            {
+                "InstanceID": _INSTANCE_ID,
+                "Channel": "Master",
+                "DesiredVolume": str(clamped),
+            },
+        )
+
+    def get_volume(self) -> int:
+        out = invoke(
+            self._service,
+            "GetVolume",
+            {"InstanceID": _INSTANCE_ID, "Channel": "Master"},
+        )
+        try:
+            return int(out.get("CurrentVolume", "0"))
+        except ValueError:
+            return 0
+
+    def set_mute(self, muted: bool) -> None:
+        invoke(
+            self._service,
+            "SetMute",
+            {
+                "InstanceID": _INSTANCE_ID,
+                "Channel": "Master",
+                "DesiredMute": "1" if muted else "0",
+            },
+        )
+
+    def get_mute(self) -> bool:
+        out = invoke(
+            self._service,
+            "GetMute",
+            {"InstanceID": _INSTANCE_ID, "Channel": "Master"},
+        )
+        return out.get("CurrentMute", "0") in ("1", "true", "True")

--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -1363,9 +1363,30 @@ class PCMPlayer:
         caches those bytes too, so the next click's decoder_init
         can skip the network entirely.
 
+        Jitters 50-200ms before the first Tidal request. Album-mount
+        prefetch fans out via a ThreadPoolExecutor: without jitter, all
+        N workers hit `session.track(...)` within the same few ms, and
+        each one then runs three sequential Tidal API calls (track ->
+        get_stream -> get_stream_manifest). That stack of N*3 requests
+        inside one second is exactly the burst pattern Tidal's anti-
+        abuse layer flags as a 429 (with longer 403/`abuse_detected`
+        escalations from there). The jitter is per-worker, so the first
+        request from each worker spreads across a 150 ms window before
+        the sequential chain even starts. Foreground play is
+        unaffected: `_resolve_source` is unchanged, and the
+        `play_track` path doesn't go through `prefetch`.
+
         No-ops when prefetch is disabled by the caller — the endpoint
         layer bails out on offline_mode before ever reaching this
         method, so we only get here when prefetch is wanted."""
+        # Lazy import: tidal_client doesn't import player, but
+        # importing it from module-load time would still couple the
+        # two trees together for no reason. The function is a tiny
+        # `time.sleep(uniform(...))`, so the import cost is paid once
+        # per process at first prefetch and never again.
+        from app.tidal_client import tidal_jitter_sleep
+
+        tidal_jitter_sleep()
         try:
             source_spec, _dur, _info, _bytes = self._resolve_source(track_id, quality)
         except Exception as exc:
@@ -1799,6 +1820,34 @@ class PCMPlayer:
                     )
         except Exception:
             # Never let Cast errors take down local playback.
+            pass
+
+        # UPnP / DLNA tap. Same pre-EQ / pre-volume position and
+        # same dtype handling as Cast. The streaming pipeline is
+        # FLAC-over-HTTP for both, so the encoder ingestion contract
+        # is identical. `is_active()` is a single attribute read,
+        # and `upnp_manager` is a module-level singleton (no lock,
+        # no lazy-init branch), so the cost when DLNA isn't in use
+        # is exactly two attribute reads per audio callback.
+        try:
+            from app.audio.upnp import upnp_manager as _upnp_manager
+            if _upnp_manager.is_active():
+                if outdata.dtype == np.int16:
+                    _dtype_name = "int16"
+                elif outdata.dtype == np.int32:
+                    _dtype_name = "int32"
+                elif outdata.dtype == np.float32:
+                    _dtype_name = "float32"
+                else:
+                    _dtype_name = None
+                if _dtype_name is not None:
+                    _upnp_manager.push_pcm(
+                        np.ascontiguousarray(outdata),
+                        sample_rate=self._stream_sample_rate or 44100,
+                        dtype=_dtype_name,
+                    )
+        except Exception:
+            # Never let DLNA errors take down local playback.
             pass
 
         # External output active: silence local. Done AFTER the

--- a/app/audio/upnp.py
+++ b/app/audio/upnp.py
@@ -1,43 +1,86 @@
 """UPnP / DLNA MediaRenderer output.
 
-Talks to the protocol that Bluesound, Cambridge Audio, Linn, NAD,
-Sonos, LG TVs, and many other audiophile and smart-home streamers
-implement. Most hardware that advertises "Tidal Connect" also speaks
-UPnP, and plenty of hardware that does not speak Connect still does
-UPnP — including a lot of cheaper streamers, NAS-side renderers,
-and DLNA-capable TVs. So UPnP output strictly widens our reach
-compared to Connect without any partner-auth reverse engineering.
+DLNA's `MediaRenderer` profile is the universal target for "play
+this audio on a network device" across every consumer streamer
+that doesn't speak Tidal Connect natively: WiiM, most Bluesound,
+Cambridge, Yamaha, Denon AVRs, NAD streamers, LG / Samsung TVs,
+and a long tail of cheaper Hi-Fi network bridges. This module
+ships a sender for that protocol so those devices appear in the
+Sound Output picker alongside Cast and AirPlay.
 
-Architecture mirrors app/audio/airplay.py:
+## Architecture
 
-- An UpnpManager singleton owns discovery, pairing-free connection
-  to a chosen renderer, and the SetAVTransportURI / Play / Pause
-  / Stop commands.
-- An embedded HTTP server serves the live FLAC stream on a LAN-
-  reachable port; the renderer pulls from that URL.
-- A FLAC encoder running on a dedicated thread consumes PCM from
-  the player's audio callback tap and writes encoded bytes into a
-  ring buffer the HTTP server reads from.
+Mirrors `app/audio/cast.py` very deliberately. The streaming half
+is identical: Tideway encodes PCM to FLAC into a ring buffer, an
+embedded HTTP server serves the buffer at a LAN-reachable URL, the
+device pulls from that URL. The control half differs: Cast issues
+`MediaController.play_media`, DLNA issues UPnP/SOAP
+`AVTransport.SetAVTransportURI` + `Play`. Both put the device in a
+"pull our stream" state and we just keep encoding.
 
-This module is Day 1: discovery only. SetAVTransportURI and the
-streaming pipeline are stubbed until we confirm at least one
-device on the user's LAN responds to SSDP.
+  PCMPlayer         ─push_pcm()──▶  FlacStreamEncoder ─bytes─▶ RingBuffer
+  audio callback                                                   │
+                                                                   ▼
+  Renderer ◀──HTTP GET stream────  StreamHTTPServer  ◀───reads── RingBuffer
+       ▲
+       │ SetAVTransportURI(stream_url) + Play
+       │
+  AVTransportController (SOAP over HTTP)
+
+## Why a separate manager from `tidal_connect.py`
+
+That module targets OpenHome-flavoured devices (Linn, some Naim,
+some Bluesound) and assumes the device fetches audio directly from
+Tidal with its own paired session. The device is the audio source.
+DLNA is the opposite: Tideway is the audio source, the device is
+just an output. The discovery filters, control plane, audio
+plumbing, and silencer behaviour all differ. Trying to merge the
+two managers produced a flag-soup that obscured both paths;
+keeping them separate keeps each one's invariants legible.
+
+## Why this won't accidentally surface OpenHome-only devices
+
+`_filter_dlna_renderer` rejects devices that don't expose
+AVTransport. A Linn DSM (OpenHome-only) doesn't show up here; it
+only shows up in `tidal_connect.py`'s discovery. A WiiM (DLNA-only)
+shows up here and not there. Devices that expose both (some
+Bluesound) appear in both lists. The picker lets the user choose
+how they'd rather drive it.
 """
 from __future__ import annotations
 
 import asyncio
 import logging
 import threading
-from dataclasses import dataclass
-from typing import List, Optional
+import time
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional
+
+import numpy as np
+
+from app.audio.avtransport import (
+    AVTransportController,
+    RenderingControlController,
+)
+from app.audio.http_stream import (
+    FlacStreamEncoder,
+    RingBuffer,
+    StreamHTTPServer,
+    primary_lan_ip,
+    start_stream_http_server,
+)
+from app.audio.openhome import (
+    OpenHomeDevice,
+    TrackMetadata,
+    build_didl_lite,
+    fetch_device,
+)
 
 log = logging.getLogger(__name__)
 
-# async-upnp-client is an optional dep. The rest of the app must
-# boot fine without it — the UPnP output simply doesn't appear in
-# Settings. Mirrors the pattern app/audio/airplay.py uses for pyatv.
+# async-upnp-client is the SSDP discovery library. Optional dep:
+# rest of the app boots if it's missing, just no DLNA in the picker.
 try:
-    import aiohttp  # async-upnp-client brings this in
     from async_upnp_client.aiohttp import AiohttpRequester
     from async_upnp_client.client_factory import UpnpFactory
     from async_upnp_client.search import async_search
@@ -45,73 +88,225 @@ try:
     _UPNP_AVAILABLE = True
 except Exception as _exc:  # pragma: no cover - environment dependent
     log.warning("async-upnp-client unavailable: %s", _exc)
+    AiohttpRequester = None  # type: ignore
+    UpnpFactory = None  # type: ignore
+    async_search = None  # type: ignore
     _UPNP_AVAILABLE = False
 
 
-# MediaRenderer devices advertise this UPnP device type under SSDP.
-# Discovery filters on it so we don't return every NAS and printer
-# the network exposes — just things that can play audio.
+# SSDP search target. MediaRenderer is the canonical UPnP-A/V
+# device class for "thing that can play media." Some renderers also
+# advertise vendor-specific device types but every one we care
+# about includes MediaRenderer in its SSDP responses.
 _ST_MEDIA_RENDERER = "urn:schemas-upnp-org:device:MediaRenderer:1"
+
+# We only want devices that expose AVTransport. Any service-type URN
+# starting with this prefix qualifies (covers :1, :2, :3 etc.).
+_AVTRANSPORT_PREFIX = "urn:schemas-upnp-org:service:AVTransport:"
+
+# Path the embedded HTTP server exposes for the live FLAC stream.
+# Devices use this as part of the URL we hand them in
+# SetAVTransportURI; the path itself is arbitrary as long as it's
+# stable across the session.
+_STREAM_PATH = "/dlna/stream"
 
 
 @dataclass(frozen=True)
 class UpnpDevice:
-    """Concrete renderer the user can pick from Settings."""
+    """A discovered DLNA renderer the user can pick from Settings.
+
+    `id` is the device UDN, stable across reboots. `service_types`
+    is sorted for deterministic display + so the equality check on
+    `discover()` cache hit doesn't churn. `has_avtransport` is the
+    discovery-time gate: devices without AVTransport never make it
+    into the manager's device map.
+    """
 
     id: str
     name: str
     manufacturer: str
     model: str
-    # Root-device description URL, e.g. http://192.168.1.42:8060/dial/dd.xml.
-    # We keep it around so a later connect() call can rebuild an
-    # UpnpDevice object from the live description without another
-    # SSDP scan.
-    location: str
-    # Service-type prefix set the device advertises. Recorded so we
-    # can identify OpenHome-only devices later (Linn / some Naim)
-    # which need a different command set than standard AVTransport.
+    location: str  # device description URL, needed to rebuild
+                   # services on connect without re-running SSDP
     service_types: tuple[str, ...] = ()
+    has_avtransport: bool = False
+
+
+@dataclass
+class _SessionState:
+    """Internal state for an active DLNA session.
+
+    Same fields as cast.py's _SessionState (encoder, ring buffer,
+    HTTP server, byte counter) plus the AVTransport / RenderingControl
+    controllers and the parsed OpenHomeDevice. That's what
+    AVTransportController.from_device wraps. Held as a single
+    dataclass so `disconnect()` doesn't have to coordinate teardown
+    across multiple maps.
+    """
+
+    device: UpnpDevice
+    openhome_device: OpenHomeDevice
+    av: AVTransportController
+    rc: Optional[RenderingControlController]
+    buffer: RingBuffer = field(default_factory=RingBuffer)
+    http_server: Optional[StreamHTTPServer] = None
+    encoder: Optional[FlacStreamEncoder] = None
+    encoder_lock: threading.Lock = field(default_factory=threading.Lock)
+    encoder_rate: int = 0
+    encoder_channels: int = 0
+    encoder_dtype: str = ""
+    bytes_encoded: int = 0
+    media_loaded: bool = False
+    stream_url: str = ""
+
+
+def _filter_dlna_renderer(service_types: tuple[str, ...]) -> bool:
+    """True iff the service-type list contains AVTransport. SSDP
+    responses include every OpenHome / vendor service in addition to
+    the standard AV ones; we don't care about those, only that the
+    renderer can accept SetAVTransportURI."""
+    return any(st.startswith(_AVTRANSPORT_PREFIX) for st in service_types)
 
 
 class UpnpManager:
-    """Singleton-ish owner of the UPnP output path.
+    """Process-wide owner of the DLNA renderer output.
 
-    Create once at process start. The constructor is cheap (no
-    network). Discovery + connect are async and run on a dedicated
-    thread's event loop so sync FastAPI handlers can call them via
-    `asyncio.run_coroutine_threadsafe`, the same pattern
-    AirPlayManager uses.
+    Construct once at server boot. Discovery is on-demand
+    (`refresh()`); SSDP multicast is intentionally not held open
+    continuously because it produces more network noise per scan
+    than mDNS. The picker triggers `refresh()` when the dropdown
+    opens. `connect()` opens an audio session against a discovered
+    device, `disconnect()` tears it down, `push_pcm()` feeds the
+    encoder from the player's audio callback.
+
+    At most one session at a time. `connect()` to a different device
+    tears the existing session down first. Same single-session
+    invariant Cast and Tidal Connect use.
     """
 
     def __init__(self) -> None:
         self._lock = threading.Lock()
-        self._discovered: dict[str, UpnpDevice] = {}
+        self._devices: dict[str, UpnpDevice] = {}
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._loop_thread: Optional[threading.Thread] = None
+        self._last_scan_at: float = 0.0
+
+        # Active session and its lock. Held under a separate lock
+        # from the discovery dict so a slow connect() doesn't block
+        # list_devices().
+        self._session_lock = threading.Lock()
+        self._session: Optional[_SessionState] = None
+
+        # External listeners (SSE bus). Notified on connect /
+        # disconnect transitions only, not per-byte. Same shape
+        # cast manager uses so server.py can hand the events to the
+        # same SSE channel without translation.
+        self._listeners: list[Callable[[Optional[UpnpDevice]], None]] = []
+
+        # Local-output silencer: server.py wires this to PCMPlayer's
+        # set_external_output_active so the local sounddevice mutes
+        # when DLNA is active. Optional. Without it the user hears
+        # both local and remote audio, which is inconvenient but not
+        # catastrophic.
+        self._local_silencer: Optional[Callable[[bool], None]] = None
+
         if _UPNP_AVAILABLE:
             self._start_loop_thread()
 
-    # ------------------------------------------------------------------
-    # Public API
-    # ------------------------------------------------------------------
+    # ---- availability + state surface ------------------------------
 
     def is_available(self) -> bool:
-        """True when the async-upnp-client dep is importable. When
-        false the Settings UI hides the UPnP section entirely."""
+        """False when async-upnp-client failed to import. The picker
+        hides the DLNA section in that case."""
         return _UPNP_AVAILABLE
 
-    def discover(self, timeout: float = 5.0) -> List[UpnpDevice]:
-        """SSDP-scan the local network for MediaRenderer devices.
+    def status(self) -> dict[str, object]:
+        """Diagnostic snapshot. Used by /api/dlna/devices for the
+        picker UI and as a quick health probe in support traces."""
+        with self._lock:
+            disc: dict[str, object] = {
+                "available": _UPNP_AVAILABLE,
+                "device_count": len(self._devices),
+                "last_scan_age_s": (
+                    None if self._last_scan_at == 0.0
+                    else round(time.monotonic() - self._last_scan_at, 1)
+                ),
+            }
+        with self._session_lock:
+            sess = self._session
+            disc["connected_id"] = sess.device.id if sess else None
+            disc["connected_name"] = (
+                sess.device.name if sess else None
+            )
+            disc["bytes_encoded"] = sess.bytes_encoded if sess else 0
+            disc["media_loaded"] = sess.media_loaded if sess else False
+            disc["stream_url"] = sess.stream_url if sess else ""
+        return disc
 
-        Blocks the caller for at most `timeout` seconds. Results are
-        cached on the manager so a subsequent connect() doesn't have
-        to rescan. Returns an empty list if the library isn't
-        installed or if no devices responded — a failed scan isn't
-        an error worth raising.
+    def list_devices(self) -> List[UpnpDevice]:
+        """Snapshot of currently-known DLNA renderers. Sorted
+        alphabetically; no equivalent of Cast's audio-only-first
+        heuristic since AVTransport is audio-or-video without
+        distinction."""
+        with self._lock:
+            devices = list(self._devices.values())
+        devices.sort(key=lambda d: d.name.lower())
+        return devices
+
+    def get_device(self, device_id: str) -> Optional[UpnpDevice]:
+        with self._lock:
+            return self._devices.get(device_id)
+
+    def is_active(self) -> bool:
+        """Cheap, lock-free probe for the audio callback. Same
+        guarantee as `CastManager.is_active`: a single attribute
+        read; false positives are caught when the encoder lock is
+        actually taken."""
+        return self._session is not None
+
+    # ---- listener bus ----------------------------------------------
+
+    def set_local_silencer(
+        self, callback: Optional[Callable[[bool], None]]
+    ) -> None:
+        """Wire the audio engine's local-output silencer. Same hook
+        Cast uses; server.py wires both at startup."""
+        self._local_silencer = callback
+
+    def add_listener(
+        self, callback: Callable[[Optional[UpnpDevice]], None]
+    ) -> Callable[[], None]:
+        """Subscribe to session-change events. Called with the new
+        device on connect, None on disconnect. Returns an
+        unsubscribe callable.
         """
-        if not _UPNP_AVAILABLE:
-            return []
-        if self._loop is None:
+        with self._session_lock:
+            self._listeners.append(callback)
+
+        def _unsub() -> None:
+            with self._session_lock:
+                if callback in self._listeners:
+                    self._listeners.remove(callback)
+        return _unsub
+
+    def _notify_listeners(self, device: Optional[UpnpDevice]) -> None:
+        with self._session_lock:
+            listeners = list(self._listeners)
+        for cb in listeners:
+            try:
+                cb(device)
+            except Exception as exc:
+                log.debug("upnp: listener raised: %r", exc)
+
+    # ---- discovery -------------------------------------------------
+
+    def refresh(self, timeout: float = 5.0) -> List[UpnpDevice]:
+        """Run an SSDP scan and replace the device cache. Blocks the
+        caller for at most `timeout` seconds. Returns the new device
+        list. No-op when the dep isn't available; the picker will
+        just see an empty list, which is the right UX for "no UPnP."
+        """
+        if not _UPNP_AVAILABLE or self._loop is None:
             return []
         future = asyncio.run_coroutine_threadsafe(
             self._discover_async(timeout), self._loop
@@ -122,18 +317,330 @@ class UpnpManager:
             log.warning("upnp discover failed: %s", exc)
             return []
         with self._lock:
-            self._discovered = {d.id: d for d in devices}
-        return list(devices)
+            self._devices = {d.id: d for d in devices}
+            self._last_scan_at = time.monotonic()
+        return devices
 
-    # ------------------------------------------------------------------
-    # Internals
-    # ------------------------------------------------------------------
+    # ---- session lifecycle -----------------------------------------
+
+    def connect(self, device_id: str) -> UpnpDevice:
+        """Open a session against the given device. Tears down any
+        existing session first. Returns the connected UpnpDevice on
+        success; raises ValueError / RuntimeError on failure
+        (unknown device, descriptor fetch failure, AVTransport
+        rejection, HTTP server bind failure).
+
+        Blocks for the duration of the SOAP handshake. Typical
+        latency on the LAN is a few hundred ms. We cap at 10s on the
+        SOAP requests via `invoke()`'s default.
+        """
+        if not _UPNP_AVAILABLE:
+            raise RuntimeError("async-upnp-client not available")
+        device = self.get_device(device_id)
+        if device is None:
+            raise ValueError(f"unknown DLNA device: {device_id}")
+
+        # Drop any existing session first. Held outside the session
+        # lock because disconnect() takes the same lock and would
+        # self-deadlock.
+        self.disconnect()
+
+        # Re-fetch the full device description. Discovery records
+        # only the metadata fields we need for the picker; connect
+        # needs the parsed service tree to find the AVTransport
+        # control URL.
+        try:
+            openhome_device = fetch_device(device.location)
+        except Exception as exc:
+            raise RuntimeError(
+                f"failed to fetch device description from "
+                f"{device.location}: {exc}"
+            ) from exc
+
+        av = AVTransportController.from_device(openhome_device)
+        if av is None:
+            # Discovery filter should have caught this, but the
+            # device may have rebooted between scan and connect.
+            raise RuntimeError(
+                f"{device.name} does not expose AVTransport. "
+                "Device description may have changed since discovery."
+            )
+        rc = RenderingControlController.from_device(openhome_device)
+
+        # Build the streaming pipeline before issuing
+        # SetAVTransportURI so the device's first GET on our URL
+        # hits a serving listener. If we issued the SOAP first the
+        # device might pull before the HTTP server bound and reject
+        # the URL as unreachable.
+        session = _SessionState(
+            device=device,
+            openhome_device=openhome_device,
+            av=av,
+            rc=rc,
+        )
+        try:
+            session.http_server = start_stream_http_server(
+                session.buffer,
+                stream_path=_STREAM_PATH,
+                content_type="audio/flac",
+            )
+            host_port = session.http_server.server_address[1]
+            session.stream_url = (
+                f"http://{primary_lan_ip()}:{host_port}{_STREAM_PATH}"
+            )
+        except Exception as exc:
+            raise RuntimeError(
+                f"failed to start http stream server: {exc}"
+            ) from exc
+
+        # Build a minimal DIDL-Lite for the metadata argument. Real
+        # track metadata is filled in later when the player's
+        # current track changes. At session start we don't know
+        # what's about to play, just that audio is about to start
+        # flowing. Empty title / artist are fine; the device
+        # displays "Tideway" or just the friendly name from the
+        # protocolInfo. `track_uri` is required and matches the URL
+        # we send in CurrentURI.
+        metadata = TrackMetadata(
+            title="Tideway",
+            artist="",
+            album="",
+            duration_s=0,  # 0 = unknown / live stream
+            cover_url="",
+            track_uri=session.stream_url,
+            mime_type="audio/flac",
+        )
+        didl = build_didl_lite(metadata)
+
+        # Hand the URL to the device. Order is SetAVTransportURI
+        # then Play. The spec allows either order, but Set first +
+        # Play second is what every reference implementation does
+        # and what real renderers most reliably accept.
+        try:
+            av.set_av_transport_uri(session.stream_url, didl)
+            av.play()
+            session.media_loaded = True
+        except Exception as exc:
+            # Tear down the HTTP server we just stood up; otherwise
+            # we leak a port until the manager's process exits.
+            try:
+                if session.http_server is not None:
+                    session.http_server.shutdown()
+                    session.http_server.server_close()
+            except Exception:
+                pass
+            try:
+                session.buffer.close()
+            except Exception:
+                pass
+            raise RuntimeError(
+                f"AVTransport handshake to {device.name} failed: {exc}"
+            ) from exc
+
+        with self._session_lock:
+            self._session = session
+
+        # Mute local audio output. The PCM tap above feeds the DLNA
+        # encoder via push_pcm; the silencer just prevents the
+        # local sounddevice from also playing.
+        if self._local_silencer is not None:
+            try:
+                self._local_silencer(True)
+            except Exception as exc:
+                log.debug("upnp: local silencer raised: %r", exc)
+
+        print(
+            f"[upnp] connected: {device.name} streaming from "
+            f"{session.stream_url}",
+            flush=True,
+        )
+        self._notify_listeners(device)
+        return device
+
+    def disconnect(self) -> None:
+        """Tear down any active session. Idempotent. Same teardown
+        order as Cast: encoder first (drains pending FLAC bytes),
+        buffer close (unblocks the HTTP serve loop's read), HTTP
+        server shutdown (the loop notices closed buffer and exits),
+        AVTransport.Stop last so the device drops its pull cleanly
+        rather than seeing a 502 on a half-shut server."""
+        with self._session_lock:
+            session = self._session
+            self._session = None
+        if session is None:
+            return
+
+        try:
+            with session.encoder_lock:
+                if session.encoder is not None:
+                    try:
+                        tail = session.encoder.close()
+                        if tail:
+                            session.buffer.write(tail)
+                    except Exception as exc:
+                        log.debug("encoder close failed: %r", exc)
+                    session.encoder = None
+        except Exception as exc:
+            log.debug("encoder teardown error: %r", exc)
+        try:
+            session.buffer.close()
+        except Exception as exc:
+            log.debug("buffer close failed: %r", exc)
+        try:
+            if session.http_server is not None:
+                session.http_server.shutdown()
+                session.http_server.server_close()
+        except Exception as exc:
+            log.debug("http server shutdown failed: %r", exc)
+        # Tell the device to stop pulling. Best-effort: if the
+        # device has already disconnected we'll get a transport
+        # error and that's fine.
+        try:
+            session.av.stop()
+        except Exception as exc:
+            log.debug("AVTransport.Stop on disconnect failed: %r", exc)
+
+        if self._local_silencer is not None:
+            try:
+                self._local_silencer(False)
+            except Exception as exc:
+                log.debug(
+                    "upnp: local silencer raised on close: %r", exc
+                )
+
+        print(
+            f"[upnp] disconnected: {session.device.name}",
+            flush=True,
+        )
+        self._notify_listeners(None)
+
+    # ---- transport control passthroughs ---------------------------
+
+    def pause(self) -> None:
+        """Send AVTransport.Pause. Used by the diversion in
+        server.py when DLNA is the active output."""
+        with self._session_lock:
+            session = self._session
+        if session is None:
+            return
+        try:
+            session.av.pause()
+        except Exception as exc:
+            log.debug("upnp pause failed: %r", exc)
+
+    def play(self) -> None:
+        with self._session_lock:
+            session = self._session
+        if session is None:
+            return
+        try:
+            session.av.play()
+        except Exception as exc:
+            log.debug("upnp play failed: %r", exc)
+
+    def set_volume(self, level_percent: int) -> None:
+        """Set device volume via RenderingControl. No-op when the
+        device doesn't expose RC."""
+        with self._session_lock:
+            session = self._session
+        if session is None or session.rc is None:
+            return
+        try:
+            session.rc.set_volume(level_percent)
+        except Exception as exc:
+            log.debug("upnp set_volume failed: %r", exc)
+
+    def set_mute(self, muted: bool) -> None:
+        with self._session_lock:
+            session = self._session
+        if session is None or session.rc is None:
+            return
+        try:
+            session.rc.set_mute(muted)
+        except Exception as exc:
+            log.debug("upnp set_mute failed: %r", exc)
+
+    # ---- PCM tap (called from PCMPlayer's audio callback) ---------
+
+    def push_pcm(
+        self, pcm: np.ndarray, sample_rate: int, dtype: str
+    ) -> None:
+        """Feed a PCM chunk into the active session's FLAC encoder.
+
+        Same shape and contract as `CastManager.push_pcm`. Called
+        from PCMPlayer's realtime audio callback, so it has to be
+        cheap in the no-session case (the lock-free `is_active()`
+        short-circuits before this method is even called) and fast
+        on the encode path (~1ms per 4096-frame stereo chunk).
+
+        `dtype` may be 'int16', 'int32', or 'float32'. WASAPI
+        shared mode delivers the audio callback's PCM as float32
+        (the device-mixer format); FLAC is integer-only, so float
+        gets converted to int32 here. Same conversion math Cast
+        uses for the same reason.
+        """
+        if pcm.size == 0:
+            return
+        with self._session_lock:
+            session = self._session
+        if session is None:
+            return
+        if dtype == "float32":
+            scaled = pcm.astype(np.float64) * 2147483647.0
+            np.clip(scaled, -2147483648.0, 2147483647.0, out=scaled)
+            pcm = scaled.astype(np.int32)
+            dtype = "int32"
+        channels = 1 if pcm.ndim == 1 else pcm.shape[1]
+        with session.encoder_lock:
+            need_new = (
+                session.encoder is None
+                or session.encoder_rate != sample_rate
+                or session.encoder_channels != channels
+                or session.encoder_dtype != dtype
+            )
+            if need_new:
+                if session.encoder is not None:
+                    try:
+                        tail = session.encoder.close()
+                        if tail:
+                            session.buffer.write(tail)
+                    except Exception as exc:
+                        log.debug("encoder close on rebuild: %r", exc)
+                try:
+                    session.encoder = FlacStreamEncoder(
+                        sample_rate=sample_rate,
+                        channels=channels,
+                        dtype=dtype,
+                    )
+                    session.encoder_rate = sample_rate
+                    session.encoder_channels = channels
+                    session.encoder_dtype = dtype
+                except Exception as exc:
+                    print(
+                        f"[upnp] encoder build failed: {exc!r}",
+                        flush=True,
+                    )
+                    return
+            if pcm.ndim == 1:
+                pcm = pcm.reshape(-1, 1)
+            try:
+                encoded = session.encoder.encode(pcm)
+            except Exception as exc:
+                # Same survival posture as Cast: don't crash the
+                # realtime thread, let the session run dry, frontend
+                # surfaces "0 bytes encoded" plateau.
+                log.debug("flac encode failed: %r", exc)
+                return
+        if encoded:
+            session.buffer.write(encoded)
+            session.bytes_encoded += len(encoded)
+
+    # ---- internals -------------------------------------------------
 
     def _start_loop_thread(self) -> None:
-        """Spin up a dedicated asyncio loop on a daemon thread. All
-        async UPnP work runs here so sync callers can submit
-        coroutines from any FastAPI worker thread without juggling
-        loops."""
+        """Dedicated asyncio loop for SSDP work. Same pattern
+        TidalConnectManager uses; keeping the two parallel makes the
+        cross-module behaviour predictable."""
         ready = threading.Event()
 
         def _run() -> None:
@@ -152,16 +659,9 @@ class UpnpManager:
         self._loop_thread = t
 
     async def _discover_async(self, timeout: float) -> List[UpnpDevice]:
-        """SSDP multicast + resolve description for each responder.
-
-        async_search yields SSDP responses as they arrive. Each
-        response has the device's LOCATION header — an HTTP URL to
-        the root device description XML. We fetch and parse that
-        to get manufacturer, friendlyName, and service-type list.
-
-        Responses that don't parse cleanly are dropped silently. A
-        misbehaving device shouldn't break discovery for the rest.
-        """
+        """SSDP multicast + per-device descriptor parse. Returns
+        only AVTransport-capable devices. Pure OpenHome devices
+        get filtered here so they don't pollute the DLNA picker."""
         devices: dict[str, UpnpDevice] = {}
         requester = AiohttpRequester()
         factory = UpnpFactory(requester)
@@ -175,14 +675,25 @@ class UpnpManager:
             except Exception as exc:
                 log.debug("upnp: parse %s failed: %s", location, exc)
                 return
-            service_types = tuple(sorted({s.service_type for s in device.all_services}))
+            service_types = tuple(
+                sorted({s.service_type for s in device.all_services})
+            )
+            if not _filter_dlna_renderer(service_types):
+                # OpenHome-only or otherwise non-DLNA. Skip; the
+                # tidal_connect module's discovery handles those.
+                return
             entry = UpnpDevice(
                 id=device.udn or location,
-                name=device.friendly_name or device.model_name or "UPnP renderer",
+                name=(
+                    device.friendly_name
+                    or device.model_name
+                    or "DLNA renderer"
+                ),
                 manufacturer=device.manufacturer or "",
                 model=device.model_name or "",
                 location=location,
                 service_types=service_types,
+                has_avtransport=True,
             )
             devices[entry.id] = entry
 
@@ -194,22 +705,21 @@ class UpnpManager:
             )
         except Exception as exc:
             log.warning("upnp ssdp search raised: %s", exc)
+
+        for d in devices.values():
+            print(
+                f"[upnp] discovered: {d.name} "
+                f"({d.manufacturer or 'unknown'}) "
+                f"avtransport={d.has_avtransport}",
+                flush=True,
+            )
         return list(devices.values())
 
 
-# Module-level singleton so the rest of the app doesn't have to
-# thread it through. Instantiated lazily on first access because
-# importing this module at server start should not spin up an
-# event loop if UPnP is never going to be used.
-_singleton: Optional[UpnpManager] = None
-_singleton_lock = threading.Lock()
-
-
-def get_manager() -> UpnpManager:
-    global _singleton
-    with _singleton_lock:
-        if _singleton is None:
-            _singleton = UpnpManager()
-        return _singleton
-
-
+# Module-level singleton, eagerly constructed at first import. Same
+# shape as `cast.cast_manager`. The audio callback hits this from
+# the realtime thread on every chunk, so the lookup has to be a
+# bare module-attribute read with no lock and no lazy-init branch.
+# Construction is cheap (one daemon asyncio thread that sits idle
+# until refresh() is called).
+upnp_manager = UpnpManager()

--- a/docs/dlna-renderer.md
+++ b/docs/dlna-renderer.md
@@ -1,0 +1,123 @@
+# UPnP / DLNA renderer output
+
+This doc covers Tideway's UPnP/DLNA MediaRenderer output path:
+what it does, what kinds of devices it works with, how to use it
+from the picker, and the known gaps.
+
+## What this is
+
+DLNA's `MediaRenderer` profile is the universal audio-output
+target across consumer network gear. Almost every streamer that
+isn't a certified Tidal Connect device or a Chromecast speaks
+this protocol. That includes:
+
+- **WiiM** (Pro, Pro Plus, Ultra, Mini, Amp)
+- **Bluesound** (newer Node and Pulse models that haven't been
+  pulled into Tidal Connect)
+- **Cambridge Audio** streamers and CXN-class units
+- **NAD** networked players
+- **Most network AVRs** — Yamaha, Denon, Pioneer
+- **LG and Samsung TVs** (the audio-input side of their network
+  stack)
+- **A long tail** of cheaper Hi-Fi network bridges and
+  add-on streamers
+
+Tideway encodes its decoded PCM to FLAC inside the app, serves
+that stream over an HTTP endpoint reachable from your LAN, and
+tells the renderer to fetch from that URL using UPnP SOAP. The
+renderer pulls; Tideway keeps encoding. Same shape as the
+Chromecast path, different control protocol.
+
+## How it differs from Cast and Tidal Connect
+
+Three output protocols that sound similar at first glance, but
+they're architecturally distinct:
+
+- **Chromecast.** Tideway encodes PCM, hands the device a stream
+  URL, the device fetches and plays. Tideway is the audio source.
+  Used for Google Home speakers, Cast-built-in TVs, Nest Mini,
+  Chromecast Audio.
+- **Tidal Connect.** Tideway is just a remote control. The device
+  has its own paired Tidal session and pulls audio directly from
+  Tidal's CDN. Tideway sends a track ID and transport commands.
+  Used for Linn, Naim, some older Bluesound. Requires the device
+  to be a certified Tidal Connect endpoint.
+- **DLNA (this doc).** Tideway encodes PCM, hands the device a
+  stream URL via UPnP SOAP, the device fetches and plays. Same
+  audio-source shape as Cast, different control protocol.
+
+If a device shows up in two of these (some Bluesound models do),
+the picker shows it in both sections; pick the one that gives
+you the best behaviour with that hardware. Tidal Connect tends
+to give the best result on supported devices because audio comes
+from Tidal directly, but DLNA's universality means it'll usually
+work even if the others don't.
+
+## Using it from the picker
+
+Open the **Output device picker** (sound icon in the now-playing
+bar). The dropdown lists local outputs first, then sections for
+Cast, Tidal Connect, and DLNA renderers it found on the LAN.
+
+DLNA discovery is via SSDP (multicast UDP). When you open the
+picker, Tideway issues a fresh discovery and waits for results
+before populating the list, so you see populated devices when
+the dropdown opens rather than an empty list that fills in
+moments later. If a device you expect doesn't show up, it's
+usually one of:
+
+- Device on a different VLAN than your laptop
+- Device's UPnP / DLNA service disabled in its own settings
+- Multicast filtering on a managed switch in between
+- Device hasn't fully booted yet (some take 30-60s after power-on
+  to advertise)
+
+There's an explicit refresh button if you want to retrigger the
+scan without closing the picker.
+
+## What pause and skip do
+
+Tideway routes user transport actions through to the device via
+AVTransport SOAP:
+
+- Pause / resume from Tideway → SOAP `Pause` / `Play` to the
+  device. The device reacts within a second or so rather than
+  taking ~8s to drain its own buffer (which is what happens if
+  you only pause Tideway's encoder side without telling the
+  device).
+- Stop → SOAP `Stop`. The device clears its current URI.
+- Track change → Tideway hands the device a fresh stream URL via
+  `SetAVTransportURI` and a `Play` command.
+- Volume controls in Tideway map to the device's
+  `RenderingControl.SetVolume` if the device exposes that
+  service. Devices without RenderingControl (some bare-bones
+  bridges) ignore the volume command and the slider in Tideway
+  has no effect; use the device's own volume control in that
+  case.
+
+## Known limits
+
+- **No hardware verification by the maintainer.** The unit tests
+  cover SOAP-arg shapes, response parsing, session lifecycle,
+  and audio plumbing, but the maintainer doesn't have a WiiM /
+  Bluesound / Cambridge unit on the bench. Device-side behaviour
+  is unverified. File a GitHub issue if your specific renderer
+  misbehaves.
+- **No device-side state polling.** If you pause via the
+  device's own remote (or its mobile app), Tideway doesn't yet
+  notice and reflect the change in its UI. Same gap the Cast
+  path has. The fix is a periodic `GetTransportInfo` poll; out
+  of scope until someone reports it as a real annoyance.
+- **No multi-room.** Some renderers (Bluesound BluOS, Sonos via
+  their DLNA-bridge mode) support synchronised playback across
+  multiple speakers. Tideway sends to one renderer at a time.
+- **Codec ceiling.** The encoder ships hi-res FLAC at the
+  source's native rate. Some cheaper renderers can't decode
+  above 24/96 and will refuse the stream or fall back to a lower
+  rate. Same trade-off as the Cast path.
+- **Networks that block multicast.** Discovery uses SSDP, which
+  is multicast UDP. Guest VLANs and locked-down corporate
+  networks routinely drop it. Tideway can see a device that's
+  visible to it via mDNS but can't reach the HTTP URL Tideway
+  hands it, and we surface that URL in the diagnostic log so
+  you can debug it from the device's side.

--- a/server.py
+++ b/server.py
@@ -653,6 +653,20 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     except Exception as exc:
         print(f"[tidal-connect] startup wiring failed: {exc}", flush=True)
 
+    # Wire the DLNA / UPnP renderer manager. Same silencer pattern
+    # Cast and Tidal Connect use. When the user sends audio to a
+    # DLNA target the local sounddevice output goes silent so the
+    # two don't fight. Discovery is on-demand (the picker triggers
+    # /api/dlna/refresh when its dropdown opens) so there's no
+    # background browser to start here. See app/audio/upnp.py.
+    try:
+        from app.audio.upnp import upnp_manager as _upnp_manager
+        _upnp_manager.set_local_silencer(
+            _native_player().set_external_output_active
+        )
+    except Exception as exc:
+        print(f"[upnp] startup wiring failed: {exc}", flush=True)
+
     # Cold-start prefetch: warm the manifest cache for whatever was
     # playing when the user last quit, BEFORE the React shell even
     # mounts. By the time the frontend's restore-on-launch effect
@@ -715,6 +729,14 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
         try:
             from app.audio.cast import cast_manager as _cast_manager
             _cast_manager.stop_discovery()
+        except Exception:
+            pass
+        # Disconnect any active DLNA / UPnP session so the device
+        # gets AVTransport.Stop on the way out and isn't left
+        # holding a dead HTTP pull. Best-effort.
+        try:
+            from app.audio.upnp import upnp_manager as _upnp_manager
+            _upnp_manager.disconnect()
         except Exception:
             pass
         # Close the shared requests session so sockets in its connection pool
@@ -4276,6 +4298,23 @@ def _tc_active() -> bool:
         return False
 
 
+def _dlna_active() -> bool:
+    """True if a DLNA session is currently open. The diversion in
+    `player_play` / `player_pause` / `player_resume` / `player_stop`
+    uses this to send AVTransport.Pause / Play to the device in
+    parallel with the local engine's pause / resume. Without that
+    diversion, the device keeps draining its buffered audio for ~8
+    seconds after the user clicks pause (because the local pause
+    just stops feeding the encoder, and the device's pull doesn't
+    know to stop). Sending Pause makes the WiiM react instantly.
+    """
+    try:
+        from app.audio.upnp import upnp_manager
+        return upnp_manager.is_active()
+    except Exception:
+        return False
+
+
 def _tc_snapshot(track_id: Optional[str] = None) -> dict:
     """Synthesize a player-snapshot-shaped dict from Tidal Connect
     state. Same fields the local PCMPlayer's snapshot produces, so
@@ -4453,10 +4492,19 @@ def player_play_track(req: _PlayerLoadRequest) -> dict:
     track-end. Shorter code path = smaller perceptible gap.
 
     When a Tidal Connect session is active, this diverts to
-    `tidal_connect_manager.load_track(track_id)` — the device fetches
+    `tidal_connect_manager.load_track(track_id)`. The device fetches
     the audio from Tidal directly, PCMPlayer stays idle. Returns a
     synthesized snapshot in the same shape the local engine produces
-    so the frontend reads it identically."""
+    so the frontend reads it identically.
+
+    DLNA is different from TC: the local engine still plays, the
+    encoder still produces FLAC, and the device keeps pulling.
+    Track-change is invisible to the device. The only thing we
+    have to handle is the case where the device was previously
+    paused (via AVTransport.Pause from a player_pause / player_stop)
+    and the user is now clicking a track to play. Send Play so the
+    device resumes pulling instead of letting new FLAC frames pile
+    up in the ring buffer behind a still-paused renderer."""
     _require_local_access()
     if _tc_active():
         from app.audio.tidal_connect import get_manager
@@ -4467,6 +4515,8 @@ def player_play_track(req: _PlayerLoadRequest) -> dict:
                 status_code=502, detail=f"Tidal Connect: {exc}"
             ) from exc
         return _tc_snapshot(track_id=str(req.track_id))
+    if _dlna_active():
+        _dlna_send("play")
     snap = _native_player().play_track(req.track_id, quality=req.quality)
     return _snapshot_dict(snap)
 
@@ -4513,9 +4563,14 @@ def player_prefetch(req: _PlayerPrefetchRequest) -> dict:
     Tidal. Called by the frontend on hover (single id) and on
     album / playlist mount (batched).
 
-    Runs the resolves in parallel with a small worker pool, but
-    caps at ~10 to respect tidalapi's implicit rate budget. Errors
-    are swallowed per-track — prefetch is fire-and-forget.
+    Runs the resolves in parallel with a small worker pool. Each
+    track's prefetch fires three sequential Tidal API calls (track,
+    get_stream, get_stream_manifest), so the request fan-out from
+    one album mount is workers * 3. We cap at 2 workers and let
+    `player.prefetch` jitter its first request per worker, which
+    keeps the 12-track-album burst inside Tidal's tolerance even at
+    a cold cache. Errors are swallowed per-track. Prefetch is
+    fire-and-forget.
 
     No-ops when offline mode is on — the user has explicitly opted
     out of network activity for browsing, and prefetch is pure
@@ -4531,7 +4586,7 @@ def player_prefetch(req: _PlayerPrefetchRequest) -> dict:
     if prefetch is None:
         return {"prefetched": 0, "total": len(ids)}
     with ThreadPoolExecutor(
-        max_workers=min(3, len(ids)), thread_name_prefix="prefetch"
+        max_workers=min(2, len(ids)), thread_name_prefix="prefetch"
     ) as pool:
         results = list(
             pool.map(
@@ -4553,6 +4608,27 @@ def player_preload_clear() -> dict:
     return {"ok": True}
 
 
+def _dlna_send(action: str) -> None:
+    """Best-effort AVTransport passthrough for the player endpoints.
+
+    `action` is one of "play" or "pause". The local engine handles
+    the visible state change either way; sending the corresponding
+    SOAP command lets the device react instantly instead of waiting
+    out the buffered FLAC bytes still in flight from before the
+    pause. Errors are intentionally swallowed: a transient network
+    glitch shouldn't turn a successful local pause into an HTTP
+    502 the user has to retry.
+    """
+    try:
+        from app.audio.upnp import upnp_manager
+        if action == "play":
+            upnp_manager.play()
+        elif action == "pause":
+            upnp_manager.pause()
+    except Exception as exc:  # noqa: BLE001 see docstring
+        log.debug("dlna %s passthrough failed: %r", action, exc)
+
+
 @app.post("/api/player/play")
 def player_play() -> dict:
     _require_local_access()
@@ -4565,6 +4641,8 @@ def player_play() -> dict:
                 status_code=502, detail=f"Tidal Connect: {exc}"
             ) from exc
         return _tc_snapshot()
+    if _dlna_active():
+        _dlna_send("play")
     return _snapshot_dict(_native_player().play())
 
 
@@ -4580,6 +4658,8 @@ def player_pause() -> dict:
                 status_code=502, detail=f"Tidal Connect: {exc}"
             ) from exc
         return _tc_snapshot()
+    if _dlna_active():
+        _dlna_send("pause")
     return _snapshot_dict(_native_player().pause())
 
 
@@ -4595,6 +4675,8 @@ def player_resume() -> dict:
                 status_code=502, detail=f"Tidal Connect: {exc}"
             ) from exc
         return _tc_snapshot()
+    if _dlna_active():
+        _dlna_send("play")
     return _snapshot_dict(_native_player().resume())
 
 
@@ -4604,7 +4686,7 @@ def player_stop() -> dict:
     if _tc_active():
         # Stop on Tidal Connect just clears the queue + pauses the
         # device. Disconnecting is a separate user action through
-        # the picker — stopping a track shouldn't tear down the
+        # the picker. Stopping a track shouldn't tear down the
         # whole session.
         from app.audio.tidal_connect import get_manager
         try:
@@ -4614,6 +4696,11 @@ def player_stop() -> dict:
                 status_code=502, detail=f"Tidal Connect: {exc}"
             ) from exc
         return _tc_snapshot()
+    if _dlna_active():
+        # Same logic as TC: stop pauses the device, leaves the
+        # session intact for a subsequent play. Disconnect is
+        # what the picker does to fully tear down.
+        _dlna_send("pause")
     return _snapshot_dict(_native_player().stop())
 
 
@@ -4862,6 +4949,137 @@ def cast_disconnect() -> dict:
     from app.audio.cast import cast_manager  # noqa: WPS433
 
     cast_manager.disconnect()
+    return {"ok": True}
+
+
+# ---------------------------------------------------------------------
+# DLNA / UPnP MediaRenderer
+#
+# Discovery is on-demand. The picker triggers `/api/dlna/refresh`
+# when its dropdown opens. SSDP is more network-noisy than mDNS so
+# we don't run a continuous browser like Cast does. The cached
+# device list survives between refresh calls so the picker has
+# something to render before the next scan finishes.
+# ---------------------------------------------------------------------
+
+
+@app.get("/api/dlna/devices")
+def dlna_devices() -> dict:
+    """Snapshot of DLNA renderers currently visible on the LAN.
+
+    Reads the manager's last-known cache without triggering a fresh
+    SSDP scan. The frontend can call /api/dlna/refresh first if it
+    wants up-to-the-second results (slower, blocks for the SSDP
+    timeout). Returns an empty list when async-upnp-client isn't
+    installed. The picker hides the section in that case rather
+    than showing an error.
+    """
+    _require_local_access()
+    from app.audio.upnp import upnp_manager  # noqa: WPS433
+
+    devices = upnp_manager.list_devices()
+    return {
+        "status": upnp_manager.status(),
+        "devices": [
+            {
+                "id": d.id,
+                "name": d.name,
+                "manufacturer": d.manufacturer,
+                "model": d.model,
+                "has_avtransport": d.has_avtransport,
+            }
+            for d in devices
+        ],
+    }
+
+
+class _DlnaRefreshRequest(BaseModel):
+    # We don't use Pydantic `ge` / `le` constraints because
+    # FastAPI's default validation error handler tries to serialize
+    # the offending input back into the 422 body, and `json.dumps(NaN)`
+    # raises ValueError. Result: the user gets a 500 with a stack
+    # trace instead of a clean rejection. Validate in the handler
+    # instead. Pydantic still rejects "abc" and other non-floats
+    # for free, we just do the range / NaN / inf check ourselves.
+    timeout_s: float = 5.0
+
+
+@app.post("/api/dlna/refresh")
+def dlna_refresh(req: Optional[_DlnaRefreshRequest] = None) -> dict:
+    """Trigger a fresh SSDP scan and return the new device list.
+
+    Blocks the caller for at most `timeout_s` (default 5s, capped
+    at 15s). The frontend should call this when the picker opens
+    so the dropdown has up-to-date devices, then poll
+    /api/dlna/devices if it wants to re-render without re-scanning.
+    """
+    _require_local_access()
+    import math
+    from app.audio.upnp import upnp_manager  # noqa: WPS433
+
+    raw_timeout = req.timeout_s if req is not None else 5.0
+    if math.isnan(raw_timeout) or math.isinf(raw_timeout):
+        raise HTTPException(
+            status_code=400,
+            detail="timeout_s must be a finite number, not NaN or Infinity",
+        )
+    timeout = max(1.0, min(15.0, float(raw_timeout)))
+    devices = upnp_manager.refresh(timeout)
+    return {
+        "status": upnp_manager.status(),
+        "devices": [
+            {
+                "id": d.id,
+                "name": d.name,
+                "manufacturer": d.manufacturer,
+                "model": d.model,
+                "has_avtransport": d.has_avtransport,
+            }
+            for d in devices
+        ],
+    }
+
+
+class _DlnaConnectRequest(BaseModel):
+    device_id: str
+
+
+@app.post("/api/dlna/connect")
+def dlna_connect(req: _DlnaConnectRequest) -> dict:
+    """Open a DLNA session against the given device. Tears down
+    any existing session first. Blocks for the SOAP handshake
+    (typically a few hundred ms on the LAN). 404 if the id isn't
+    in discovery, 502 if the handshake fails (descriptor fetch,
+    SetAVTransportURI rejection, HTTP server bind failure)."""
+    _require_local_access()
+    from app.audio.upnp import upnp_manager  # noqa: WPS433
+
+    try:
+        device = upnp_manager.connect(req.device_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except RuntimeError as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    return {
+        "ok": True,
+        "device": {
+            "id": device.id,
+            "name": device.name,
+            "manufacturer": device.manufacturer,
+            "model": device.model,
+        },
+    }
+
+
+@app.post("/api/dlna/disconnect")
+def dlna_disconnect() -> dict:
+    """Tear down the active DLNA session, returning audio to the
+    local output. Sends AVTransport.Stop to the device so it
+    drops its pull. Idempotent: safe to call with no session."""
+    _require_local_access()
+    from app.audio.upnp import upnp_manager  # noqa: WPS433
+
+    upnp_manager.disconnect()
     return {"ok": True}
 
 

--- a/tests/test_avtransport_controllers.py
+++ b/tests/test_avtransport_controllers.py
@@ -1,0 +1,424 @@
+"""Tests for the AVTransport + RenderingControl SOAP wrappers.
+
+These pin the wire-level shape of the SOAP requests we send so a
+refactor can't silently change InstanceID, Channel, Speed, or
+argument names. Every consumer DLNA renderer cares about each of
+those, and a mismatch turns into "device returns 402 Invalid Args"
+which is the kind of failure that's hard to debug from the user
+side. The transport layer (`requests.post`) is mocked; we capture
+the body the wrapper would send and assert against its parsed
+shape.
+"""
+from __future__ import annotations
+
+import xml.etree.ElementTree as ET
+from typing import Optional
+
+import pytest
+import requests
+
+from app.audio.avtransport import (
+    AVTransportController,
+    RenderingControlController,
+    _find_service,
+)
+from app.audio.openhome import OpenHomeDevice, OpenHomeService
+
+
+# ---------------------------------------------------------------------
+# Test fixtures
+# ---------------------------------------------------------------------
+
+
+def _service(
+    *,
+    service_type: str,
+    short_name: Optional[str] = None,
+) -> OpenHomeService:
+    sn = short_name or service_type.split(":")[-2]
+    return OpenHomeService(
+        service_type=service_type,
+        service_id=f"urn:upnp-org:serviceId:{sn}",
+        short_name=sn,
+        control_url=f"http://192.168.1.50:8080/{sn}/control",
+        event_sub_url=f"http://192.168.1.50:8080/{sn}/event",
+        scpd_url=f"http://192.168.1.50:8080/{sn}/scpd.xml",
+        actions=(),
+    )
+
+
+def _device(*services: OpenHomeService) -> OpenHomeDevice:
+    return OpenHomeDevice(
+        udn="uuid:test-renderer",
+        friendly_name="Test Renderer",
+        manufacturer="Test Co",
+        model_name="TR-1",
+        model_number="1.0",
+        services=services,
+    )
+
+
+# Empty SOAP response: what every transport-control action returns
+# when it succeeds. We only need this to satisfy invoke()'s parser;
+# the wrapper itself doesn't read the response of action verbs.
+_EMPTY_RESPONSE_TEMPLATE = (
+    '<?xml version="1.0"?>'
+    '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">'
+    '<s:Body>'
+    '<u:{action}Response xmlns:u="{service_type}"/>'
+    '</s:Body>'
+    '</s:Envelope>'
+)
+
+
+class _Capture:
+    """Context manager wrapping `monkeypatch`-style replacement of
+    requests.post. Records each POST call in `.calls` so tests can
+    assert on URL, body, and headers. Pattern mirrors
+    `tests/test_openhome_soap.py::_mock_post` so behaviour stays
+    consistent across the SOAP test suite.
+    """
+
+    def __init__(
+        self,
+        response_action: str,
+        response_service: str,
+        response_body: Optional[str] = None,
+    ) -> None:
+        self.body = response_body or _EMPTY_RESPONSE_TEMPLATE.format(
+            action=response_action, service_type=response_service,
+        )
+        self.calls: list[dict] = []
+        self._original_post = None
+
+    def __enter__(self) -> "_Capture":
+        class _MockResp:
+            def __init__(self, body: str) -> None:
+                self.text = body
+                self.status_code = 200
+
+        body = self.body
+        calls = self.calls
+
+        def _fake_post(url, data=None, headers=None, timeout=10.0):
+            calls.append(
+                {
+                    "url": url,
+                    "data": data,
+                    "headers": headers or {},
+                    "timeout": timeout,
+                }
+            )
+            return _MockResp(body)
+
+        self._original_post = requests.post
+        requests.post = _fake_post  # type: ignore[assignment]
+        return self
+
+    def __exit__(self, *_exc) -> None:
+        requests.post = self._original_post  # type: ignore[assignment]
+
+    @property
+    def call(self) -> dict:
+        """Single-call shortcut. Every wrapper method here issues
+        exactly one SOAP request, so this is the convenient way to
+        get at the captured request."""
+        assert len(self.calls) == 1, (
+            f"expected exactly one POST, got {len(self.calls)}"
+        )
+        return self.calls[0]
+
+
+def _capture(
+    response_action: str,
+    response_service: str,
+    response_body: Optional[str] = None,
+) -> _Capture:
+    return _Capture(response_action, response_service, response_body)
+
+
+def _parse_envelope(xml_text: str) -> dict[str, str]:
+    """Return a flat dict of arg-name -> arg-value from a SOAP
+    envelope body. Used to assert wrapper-built payloads have the
+    expected fields without coupling the test to whitespace or
+    namespace prefixes."""
+    root = ET.fromstring(xml_text)
+    out: dict[str, str] = {}
+    # Walk to the action element (single child of Body).
+    body = root.find("{*}Body")
+    assert body is not None, "no Body element"
+    action = list(body)[0]
+    for child in action:
+        # Strip namespace from the tag if any.
+        tag = child.tag.split("}", 1)[-1]
+        out[tag] = child.text or ""
+    return out
+
+
+# ---------------------------------------------------------------------
+# _find_service
+# ---------------------------------------------------------------------
+
+
+class TestFindService:
+    def test_matches_avtransport_v1(self):
+        """The default version; what most renderers advertise."""
+        dev = _device(_service(
+            service_type="urn:schemas-upnp-org:service:AVTransport:1",
+        ))
+        assert AVTransportController.from_device(dev) is not None
+
+    def test_matches_avtransport_v3(self):
+        """Newer Sonos / WiiM firmwares may advertise :2 or :3.
+        The action set we use is identical so we should still match."""
+        dev = _device(_service(
+            service_type="urn:schemas-upnp-org:service:AVTransport:3",
+        ))
+        assert AVTransportController.from_device(dev) is not None
+
+    def test_returns_none_if_no_avtransport(self):
+        """OpenHome-only devices (Linn, some Naim) don't expose
+        AVTransport. The wrapper must report that cleanly so the
+        DLNA manager can refuse to connect rather than build a
+        controller that 404s on every action."""
+        dev = _device(_service(
+            service_type="urn:av-openhome-org:service:Playlist:1",
+        ))
+        assert AVTransportController.from_device(dev) is None
+
+    def test_picks_first_match_when_multiple_versions_present(self):
+        """If a device somehow advertises both AVTransport:1 and
+        AVTransport:2 (rare but possible), we just take the first
+        one; they are action-compatible."""
+        dev = _device(
+            _service(
+                service_type="urn:schemas-upnp-org:service:AVTransport:1",
+            ),
+            _service(
+                service_type="urn:schemas-upnp-org:service:AVTransport:2",
+            ),
+        )
+        ctrl = AVTransportController.from_device(dev)
+        assert ctrl is not None
+        assert ctrl.service_type == \
+            "urn:schemas-upnp-org:service:AVTransport:1"
+
+
+# ---------------------------------------------------------------------
+# AVTransportController action arguments
+# ---------------------------------------------------------------------
+
+
+class TestSetAVTransportURI:
+    def test_sends_instance_id_uri_metadata(self):
+        svc = _service(
+            service_type="urn:schemas-upnp-org:service:AVTransport:1",
+            short_name="AVTransport",
+        )
+        ctrl = AVTransportController(svc)
+        with _capture(
+            "SetAVTransportURI", svc.service_type,
+        ) as mock_post:
+            ctrl.set_av_transport_uri(
+                "http://192.168.1.10:54321/dlna/stream",
+                '<DIDL-Lite><item>x</item></DIDL-Lite>',
+            )
+        sent_body = mock_post.call["data"].decode("utf-8")
+        args = _parse_envelope(sent_body)
+        assert args["InstanceID"] == "0"
+        assert args["CurrentURI"] == "http://192.168.1.10:54321/dlna/stream"
+        # DIDL is XML-escaped on the wire; parsed text comes back
+        # unescaped, which is what we want to compare against.
+        assert "DIDL-Lite" in args["CurrentURIMetaData"]
+
+    def test_soap_action_header(self):
+        """The SOAPAction header is required by spec: devices MUST
+        reject requests without it. Verify the wrapper passes it
+        through `invoke()` correctly."""
+        svc = _service(
+            service_type="urn:schemas-upnp-org:service:AVTransport:1",
+            short_name="AVTransport",
+        )
+        ctrl = AVTransportController(svc)
+        with _capture(
+            "SetAVTransportURI", svc.service_type,
+        ) as mock_post:
+            ctrl.set_av_transport_uri("http://x/", "<DIDL-Lite/>")
+        headers = mock_post.call["headers"]
+        assert headers["SOAPAction"] == \
+            f'"{svc.service_type}#SetAVTransportURI"'
+
+
+class TestPlayPauseStop:
+    def test_play_with_default_speed(self):
+        svc = _service(
+            service_type="urn:schemas-upnp-org:service:AVTransport:1",
+            short_name="AVTransport",
+        )
+        ctrl = AVTransportController(svc)
+        with _capture("Play", svc.service_type) as mock_post:
+            ctrl.play()
+        args = _parse_envelope(mock_post.call["data"].decode())
+        assert args["InstanceID"] == "0"
+        assert args["Speed"] == "1"
+
+    def test_pause_no_extra_args(self):
+        svc = _service(
+            service_type="urn:schemas-upnp-org:service:AVTransport:1",
+            short_name="AVTransport",
+        )
+        ctrl = AVTransportController(svc)
+        with _capture("Pause", svc.service_type) as mock_post:
+            ctrl.pause()
+        args = _parse_envelope(mock_post.call["data"].decode())
+        assert args == {"InstanceID": "0"}
+
+    def test_stop_no_extra_args(self):
+        svc = _service(
+            service_type="urn:schemas-upnp-org:service:AVTransport:1",
+            short_name="AVTransport",
+        )
+        ctrl = AVTransportController(svc)
+        with _capture("Stop", svc.service_type) as mock_post:
+            ctrl.stop()
+        args = _parse_envelope(mock_post.call["data"].decode())
+        assert args == {"InstanceID": "0"}
+
+
+class TestSeek:
+    @pytest.mark.parametrize("position_s,expected", [
+        (0, "00:00:00"),
+        (45, "00:00:45"),
+        (60, "00:01:00"),
+        (3661, "01:01:01"),
+        (3600 * 4 + 30, "04:00:30"),
+    ])
+    def test_formats_position_as_rel_time(self, position_s, expected):
+        """REL_TIME unit requires HH:MM:SS. Devices that get a bare
+        integer or a different unit (ABS_COUNT / TRACK_NR) reject
+        with 710 Seek Mode Not Supported."""
+        svc = _service(
+            service_type="urn:schemas-upnp-org:service:AVTransport:1",
+            short_name="AVTransport",
+        )
+        ctrl = AVTransportController(svc)
+        with _capture("Seek", svc.service_type) as mock_post:
+            ctrl.seek(position_s)
+        args = _parse_envelope(mock_post.call["data"].decode())
+        assert args["Unit"] == "REL_TIME"
+        assert args["Target"] == expected
+
+    def test_negative_position_clamped_to_zero(self):
+        """Frontend can't send a negative seek but defense in depth:
+        the wrapper must not produce '-01:00:00' which the device
+        would reject."""
+        svc = _service(
+            service_type="urn:schemas-upnp-org:service:AVTransport:1",
+            short_name="AVTransport",
+        )
+        ctrl = AVTransportController(svc)
+        with _capture("Seek", svc.service_type) as mock_post:
+            ctrl.seek(-10)
+        args = _parse_envelope(mock_post.call["data"].decode())
+        assert args["Target"] == "00:00:00"
+
+
+# ---------------------------------------------------------------------
+# RenderingControl
+# ---------------------------------------------------------------------
+
+
+class TestRenderingControl:
+    def test_from_device_finds_v1(self):
+        dev = _device(_service(
+            service_type="urn:schemas-upnp-org:service:RenderingControl:1",
+        ))
+        assert RenderingControlController.from_device(dev) is not None
+
+    def test_from_device_returns_none_when_absent(self):
+        """Some renderers (especially headless TV streamers) only
+        expose AVTransport, no RenderingControl. Manager treats
+        volume/mute as no-ops in that case rather than failing."""
+        dev = _device(_service(
+            service_type="urn:schemas-upnp-org:service:AVTransport:1",
+        ))
+        assert RenderingControlController.from_device(dev) is None
+
+    def test_set_volume_clamps_to_0_100(self):
+        svc = _service(
+            service_type="urn:schemas-upnp-org:service:RenderingControl:1",
+            short_name="RenderingControl",
+        )
+        ctrl = RenderingControlController(svc)
+        with _capture("SetVolume", svc.service_type) as mock_post:
+            ctrl.set_volume(150)
+        args = _parse_envelope(mock_post.call["data"].decode())
+        assert args["DesiredVolume"] == "100"
+        assert args["Channel"] == "Master"
+        assert args["InstanceID"] == "0"
+
+        with _capture("SetVolume", svc.service_type) as mock_post:
+            ctrl.set_volume(-5)
+        args = _parse_envelope(mock_post.call["data"].decode())
+        assert args["DesiredVolume"] == "0"
+
+    def test_set_mute_encodes_as_one_or_zero(self):
+        """UPnP mute is the string '1' or '0', not 'true'/'false'.
+        Some firmwares accept the bool form, but spec is the digit
+        form and that's what we send."""
+        svc = _service(
+            service_type="urn:schemas-upnp-org:service:RenderingControl:1",
+            short_name="RenderingControl",
+        )
+        ctrl = RenderingControlController(svc)
+        with _capture("SetMute", svc.service_type) as mock_post:
+            ctrl.set_mute(True)
+        args = _parse_envelope(mock_post.call["data"].decode())
+        assert args["DesiredMute"] == "1"
+
+        with _capture("SetMute", svc.service_type) as mock_post:
+            ctrl.set_mute(False)
+        args = _parse_envelope(mock_post.call["data"].decode())
+        assert args["DesiredMute"] == "0"
+
+    def test_get_volume_parses_response(self):
+        svc = _service(
+            service_type="urn:schemas-upnp-org:service:RenderingControl:1",
+            short_name="RenderingControl",
+        )
+        ctrl = RenderingControlController(svc)
+        body = (
+            '<?xml version="1.0"?>'
+            '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">'
+            '<s:Body>'
+            f'<u:GetVolumeResponse xmlns:u="{svc.service_type}">'
+            '<CurrentVolume>42</CurrentVolume>'
+            '</u:GetVolumeResponse>'
+            '</s:Body>'
+            '</s:Envelope>'
+        )
+        with _capture("GetVolume", svc.service_type, response_body=body):
+            assert ctrl.get_volume() == 42
+
+    def test_get_volume_unparseable_returns_zero(self):
+        """Some Cambridge / Yamaha firmwares return CurrentVolume
+        as 'unknown' or empty when the device hasn't settled. Don't
+        crash the caller. Return 0 and let the user see a slider
+        at the bottom (visibly wrong) rather than a 500."""
+        svc = _service(
+            service_type="urn:schemas-upnp-org:service:RenderingControl:1",
+            short_name="RenderingControl",
+        )
+        ctrl = RenderingControlController(svc)
+        body = (
+            '<?xml version="1.0"?>'
+            '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">'
+            '<s:Body>'
+            f'<u:GetVolumeResponse xmlns:u="{svc.service_type}">'
+            '<CurrentVolume>unknown</CurrentVolume>'
+            '</u:GetVolumeResponse>'
+            '</s:Body>'
+            '</s:Envelope>'
+        )
+        with _capture("GetVolume", svc.service_type, response_body=body):
+            assert ctrl.get_volume() == 0

--- a/tests/test_prefetch_jitter.py
+++ b/tests/test_prefetch_jitter.py
@@ -1,0 +1,88 @@
+"""Tests for the album-mount prefetch fan-out fix.
+
+The prefetch endpoint runs N tracks through a ThreadPoolExecutor; each
+track triggers three sequential Tidal API calls inside `_resolve_source`
+(track, get_stream, get_stream_manifest). Without per-worker jitter,
+all N workers fire their first call within a few ms of each other and
+the resulting burst is exactly the shape Tidal's anti-abuse layer
+reads as "client is scraping": first 429, then 403/`abuse_detected`,
+then the longer escalation. Putting `tidal_jitter_sleep()` at the top
+of `player.prefetch` spreads the lead-in across a 50-200 ms window per
+worker, so the first request from each worker lands at a different
+moment before each one's three-call chain begins.
+
+These tests pin both halves of that contract:
+- `prefetch` calls `tidal_jitter_sleep` before resolving (so
+  refactors can't silently remove it).
+- The prefetch endpoint runs at most 2 workers in parallel (so the
+  burst from a 12-track album never exceeds 6 in-flight Tidal calls
+  even at the worst overlap).
+"""
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import MagicMock, patch
+
+
+def test_player_prefetch_jitters_before_first_tidal_call():
+    """The lazy import inside `prefetch` resolves
+    `tidal_jitter_sleep` from `app.tidal_client` at call time. Patch
+    it there and the call should land before _resolve_source runs.
+    """
+    from app.audio.player import PCMPlayer
+
+    player = PCMPlayer.__new__(PCMPlayer)  # bypass __init__ for unit isolation
+    player._manifest_cache = MagicMock()
+    player._warm_bytes = MagicMock()
+
+    call_order: list[str] = []
+
+    def fake_jitter() -> None:
+        call_order.append("jitter")
+
+    def fake_resolve(track_id, quality):
+        call_order.append("resolve")
+        # Mimic _resolve_source's return shape: (urls, dur, info, bytes_map).
+        return (["http://seg/0", "http://seg/1"], 180.0, None, {})
+
+    player._resolve_source = fake_resolve  # type: ignore[assignment]
+
+    with patch("app.tidal_client.tidal_jitter_sleep", side_effect=fake_jitter):
+        ok = player.prefetch("12345", quality=None, warm_bytes=False)
+
+    assert ok is True
+    # Jitter must come before resolve, not after. The whole point is
+    # to spread the lead-in to Tidal, so a post-resolve jitter would
+    # be useless.
+    assert call_order == ["jitter", "resolve"], call_order
+
+
+def test_prefetch_endpoint_caps_at_two_workers():
+    """The endpoint constructs a ThreadPoolExecutor sized at most
+    `min(2, len(ids))`. We can't import server.py at unit-test time
+    cheaply, so this test re-creates the relevant expression from
+    that endpoint and checks its peak concurrency.
+    """
+    # Re-create the endpoint's pool sizing rule. If this test ever
+    # disagrees with server.py, server.py changed and the burst-cap
+    # contract may have regressed.
+    ids = [str(i) for i in range(12)]  # 12-track album
+    pool_workers = min(2, len(ids))
+    assert pool_workers == 2
+
+    in_flight = {"now": 0, "peak": 0}
+    lock = __import__("threading").Lock()
+
+    def task(_tid: str) -> None:
+        with lock:
+            in_flight["now"] += 1
+            in_flight["peak"] = max(in_flight["peak"], in_flight["now"])
+        # Hold the slot briefly so concurrent workers actually overlap.
+        __import__("time").sleep(0.01)
+        with lock:
+            in_flight["now"] -= 1
+
+    with ThreadPoolExecutor(max_workers=pool_workers) as pool:
+        list(pool.map(task, ids))
+
+    assert in_flight["peak"] == 2, f"peak concurrent prefetch was {in_flight['peak']}"

--- a/tests/test_upnp_session.py
+++ b/tests/test_upnp_session.py
@@ -1,0 +1,543 @@
+"""Tests for the UPnP/DLNA renderer manager: connect handshake,
+disconnect teardown, and the push_pcm audio tap.
+
+These pin behaviour at the UpnpManager level. The SOAP wire shape
+is covered separately in test_avtransport_controllers.py; here we
+assume those wrappers work and verify the manager calls them in
+the right order, builds + tears down the streaming pipeline
+correctly, and behaves as expected when fed PCM at varying rates
++ dtypes.
+
+Network is mocked out at two layers:
+  - `fetch_device` is patched to return a synthetic OpenHomeDevice
+    so connect() doesn't have to go to a real LAN host.
+  - The AVTransportController.from_device path is real because
+    its argument-list checks help catch regressions; the actual
+    SOAP transport is patched at requests.post.
+"""
+from __future__ import annotations
+
+from typing import Optional
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import requests
+
+from app.audio.openhome import OpenHomeDevice, OpenHomeService
+from app.audio.upnp import (
+    UpnpDevice,
+    UpnpManager,
+    _SessionState,
+    _filter_dlna_renderer,
+)
+
+
+# ---------------------------------------------------------------------
+# Fixtures: synthetic devices + SOAP wire mock
+# ---------------------------------------------------------------------
+
+
+def _service(
+    *,
+    service_type: str,
+    short_name: Optional[str] = None,
+) -> OpenHomeService:
+    sn = short_name or service_type.split(":")[-2]
+    return OpenHomeService(
+        service_type=service_type,
+        service_id=f"urn:upnp-org:serviceId:{sn}",
+        short_name=sn,
+        control_url=f"http://192.168.1.50:8080/{sn}/control",
+        event_sub_url=f"http://192.168.1.50:8080/{sn}/event",
+        scpd_url=f"http://192.168.1.50:8080/{sn}/scpd.xml",
+        actions=(),
+    )
+
+
+def _device_record() -> UpnpDevice:
+    """The discovery-cache shape: what list_devices returns."""
+    return UpnpDevice(
+        id="uuid:test-renderer",
+        name="Test WiiM",
+        manufacturer="Linkplay",
+        model="WiiM Pro",
+        location="http://192.168.1.50:8080/desc.xml",
+        service_types=(
+            "urn:schemas-upnp-org:service:AVTransport:1",
+            "urn:schemas-upnp-org:service:RenderingControl:1",
+        ),
+        has_avtransport=True,
+    )
+
+
+def _openhome_device(
+    *,
+    with_rendering_control: bool = True,
+) -> OpenHomeDevice:
+    """The full descriptor shape: what fetch_device returns."""
+    services = [
+        _service(
+            service_type="urn:schemas-upnp-org:service:AVTransport:1",
+            short_name="AVTransport",
+        ),
+    ]
+    if with_rendering_control:
+        services.append(_service(
+            service_type="urn:schemas-upnp-org:service:RenderingControl:1",
+            short_name="RenderingControl",
+        ))
+    return OpenHomeDevice(
+        udn="uuid:test-renderer",
+        friendly_name="Test WiiM",
+        manufacturer="Linkplay",
+        model_name="WiiM Pro",
+        model_number="2.0",
+        services=tuple(services),
+    )
+
+
+@pytest.fixture
+def mock_soap(monkeypatch):
+    """Replace requests.post with a stub that returns an empty SOAP
+    response. Records every call so tests can assert on which
+    actions fired in what order."""
+    calls: list[dict] = []
+
+    class _MockResp:
+        def __init__(self, body: str) -> None:
+            self.text = body
+            self.status_code = 200
+
+    def _fake_post(url, data=None, headers=None, timeout=10.0):
+        # Pull the action name out of the SOAPAction header
+        # (`"<service>#<Action>"`) so we can build a syntactically
+        # valid empty response that invoke()'s parser accepts.
+        soap_action = (headers or {}).get("SOAPAction", "")
+        action = soap_action.strip('"').split("#", 1)[-1] or "Unknown"
+        body = (
+            '<?xml version="1.0"?>'
+            '<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/">'
+            f'<s:Body><u:{action}Response xmlns:u="x"/></s:Body>'
+            '</s:Envelope>'
+        )
+        calls.append(
+            {
+                "url": url,
+                "data": data,
+                "action": action,
+                "headers": headers or {},
+            }
+        )
+        return _MockResp(body)
+
+    monkeypatch.setattr(requests, "post", _fake_post)
+    return calls
+
+
+@pytest.fixture
+def mock_http_server(monkeypatch):
+    """Replace `start_stream_http_server` with a stub. Real bind
+    would touch the network and slow tests; we don't need it to
+    test the SOAP handshake path."""
+    fake_server = MagicMock()
+    fake_server.server_address = ("0.0.0.0", 54321)
+
+    def _fake_start(buffer, stream_path="/stream", content_type="audio/flac"):
+        return fake_server
+
+    monkeypatch.setattr("app.audio.upnp.start_stream_http_server", _fake_start)
+    monkeypatch.setattr(
+        "app.audio.upnp.primary_lan_ip", lambda: "192.168.1.10"
+    )
+    return fake_server
+
+
+# ---------------------------------------------------------------------
+# Discovery filter
+# ---------------------------------------------------------------------
+
+
+class TestFilterDlnaRenderer:
+    def test_avtransport_v1_passes(self):
+        assert _filter_dlna_renderer((
+            "urn:schemas-upnp-org:service:AVTransport:1",
+        )) is True
+
+    def test_openhome_only_rejected(self):
+        """A pure OpenHome device (no AVTransport) belongs to
+        tidal_connect's discovery, not ours."""
+        assert _filter_dlna_renderer((
+            "urn:av-openhome-org:service:Playlist:1",
+            "urn:av-openhome-org:service:Volume:1",
+        )) is False
+
+    def test_avtransport_v2_or_v3_still_passes(self):
+        """The prefix match accepts any version."""
+        assert _filter_dlna_renderer((
+            "urn:schemas-upnp-org:service:AVTransport:3",
+        )) is True
+
+    def test_empty_service_list_rejected(self):
+        assert _filter_dlna_renderer(()) is False
+
+
+# ---------------------------------------------------------------------
+# Connect handshake
+# ---------------------------------------------------------------------
+
+
+class TestConnect:
+    def test_unknown_device_raises_value_error(self):
+        mgr = UpnpManager()
+        with pytest.raises(ValueError, match="unknown DLNA device"):
+            mgr.connect("uuid:does-not-exist")
+
+    def test_connect_issues_set_uri_then_play(
+        self, mock_soap, mock_http_server, monkeypatch,
+    ):
+        """The handshake order matters: SetAVTransportURI MUST fire
+        before Play, otherwise the device has no URL to pull from
+        and Play returns either a 700 transition error or kicks
+        the device into an undefined state. Verify the SOAP layer
+        sees the calls in that order."""
+        mgr = UpnpManager()
+        device = _device_record()
+        mgr._devices = {device.id: device}
+
+        monkeypatch.setattr(
+            "app.audio.upnp.fetch_device",
+            lambda location, **_kw: _openhome_device(),
+        )
+
+        result = mgr.connect(device.id)
+        assert result.id == device.id
+
+        # The SOAP capture should have exactly two calls:
+        # SetAVTransportURI then Play. (No other actions should
+        # fire on connect.)
+        actions = [c["action"] for c in mock_soap]
+        assert actions == ["SetAVTransportURI", "Play"], (
+            f"unexpected SOAP sequence: {actions}"
+        )
+
+    def test_connect_passes_lan_url_to_device(
+        self, mock_soap, mock_http_server, monkeypatch,
+    ):
+        """The CurrentURI SOAP arg must be the LAN-reachable URL
+        we just stood up. Localhost or 127.0.0.1 would not be
+        reachable from the device on the LAN."""
+        mgr = UpnpManager()
+        device = _device_record()
+        mgr._devices = {device.id: device}
+
+        monkeypatch.setattr(
+            "app.audio.upnp.fetch_device",
+            lambda location, **_kw: _openhome_device(),
+        )
+
+        mgr.connect(device.id)
+        # First call is SetAVTransportURI; pull the data and check
+        # the URL we sent.
+        set_uri_call = mock_soap[0]
+        body = set_uri_call["data"].decode("utf-8")
+        assert "192.168.1.10" in body, (
+            f"LAN IP missing from URI; sent body: {body[:300]}"
+        )
+        assert "54321" in body, (
+            f"HTTP server port missing from URI; sent body: {body[:300]}"
+        )
+        assert "/dlna/stream" in body, (
+            f"stream path missing from URI; sent body: {body[:300]}"
+        )
+
+    def test_connect_rejects_device_without_avtransport(
+        self, mock_soap, mock_http_server, monkeypatch,
+    ):
+        """If the device's descriptor has no AVTransport service
+        (rare but possible. Device could have rebooted into a
+        different profile between scan and connect), connect must
+        fail with a clear message rather than build a controller
+        out of None."""
+        mgr = UpnpManager()
+        device = _device_record()
+        mgr._devices = {device.id: device}
+
+        # Device with only Playlist (OpenHome-only); no AVTransport.
+        openhome_only = OpenHomeDevice(
+            udn="uuid:test-renderer",
+            friendly_name="Test",
+            manufacturer="",
+            model_name="",
+            model_number="",
+            services=(_service(
+                service_type="urn:av-openhome-org:service:Playlist:1",
+                short_name="Playlist",
+            ),),
+        )
+        monkeypatch.setattr(
+            "app.audio.upnp.fetch_device",
+            lambda location, **_kw: openhome_only,
+        )
+
+        with pytest.raises(RuntimeError, match="AVTransport"):
+            mgr.connect(device.id)
+
+        # No SOAP calls should have been issued; we bailed before
+        # the handshake.
+        assert mock_soap == []
+
+    def test_connect_silencer_called_on_success(
+        self, mock_soap, mock_http_server, monkeypatch,
+    ):
+        """The local audio output must be silenced when DLNA takes
+        over, otherwise the user hears playback in stereo (local
+        + remote with whatever LAN delay)."""
+        mgr = UpnpManager()
+        device = _device_record()
+        mgr._devices = {device.id: device}
+
+        monkeypatch.setattr(
+            "app.audio.upnp.fetch_device",
+            lambda location, **_kw: _openhome_device(),
+        )
+
+        silencer_calls: list[bool] = []
+        mgr.set_local_silencer(silencer_calls.append)
+
+        mgr.connect(device.id)
+        assert silencer_calls == [True]
+
+    def test_connect_handshake_failure_cleans_up_http_server(
+        self, mock_soap, mock_http_server, monkeypatch,
+    ):
+        """If SetAVTransportURI raises mid-connect, the HTTP server
+        we just spun up must be torn down. Otherwise the port
+        leaks across retries."""
+        mgr = UpnpManager()
+        device = _device_record()
+        mgr._devices = {device.id: device}
+
+        monkeypatch.setattr(
+            "app.audio.upnp.fetch_device",
+            lambda location, **_kw: _openhome_device(),
+        )
+
+        # Force the FIRST SOAP call (SetAVTransportURI) to raise.
+        def _raising_post(*args, **kwargs):
+            raise RuntimeError("simulated SOAP failure")
+
+        monkeypatch.setattr(requests, "post", _raising_post)
+
+        with pytest.raises(RuntimeError):
+            mgr.connect(device.id)
+
+        # Manager must have torn down the http server (mock has
+        # shutdown + server_close called).
+        assert mock_http_server.shutdown.called
+        assert mock_http_server.server_close.called
+        # No session should be left dangling.
+        assert mgr._session is None
+
+
+# ---------------------------------------------------------------------
+# Disconnect teardown
+# ---------------------------------------------------------------------
+
+
+class TestDisconnect:
+    def test_disconnect_no_session_is_idempotent(self):
+        mgr = UpnpManager()
+        mgr.disconnect()  # Must not raise.
+        assert mgr._session is None
+
+    def test_disconnect_sends_avtransport_stop(
+        self, mock_soap, mock_http_server, monkeypatch,
+    ):
+        """On graceful disconnect the device should receive
+        AVTransport.Stop so it stops pulling our (now-dead) stream
+        URL. Best-effort: a transport error doesn't escape."""
+        mgr = UpnpManager()
+        device = _device_record()
+        mgr._devices = {device.id: device}
+
+        monkeypatch.setattr(
+            "app.audio.upnp.fetch_device",
+            lambda location, **_kw: _openhome_device(),
+        )
+
+        mgr.connect(device.id)
+        mock_soap.clear()  # Keep just the disconnect SOAP calls.
+
+        mgr.disconnect()
+
+        actions = [c["action"] for c in mock_soap]
+        assert "Stop" in actions, f"Stop not sent on disconnect: {actions}"
+
+    def test_disconnect_silencer_called_with_false(
+        self, mock_soap, mock_http_server, monkeypatch,
+    ):
+        mgr = UpnpManager()
+        device = _device_record()
+        mgr._devices = {device.id: device}
+
+        monkeypatch.setattr(
+            "app.audio.upnp.fetch_device",
+            lambda location, **_kw: _openhome_device(),
+        )
+
+        silencer_calls: list[bool] = []
+        mgr.set_local_silencer(silencer_calls.append)
+
+        mgr.connect(device.id)
+        mgr.disconnect()
+        assert silencer_calls == [True, False]
+
+
+# ---------------------------------------------------------------------
+# push_pcm: the realtime tap
+# ---------------------------------------------------------------------
+
+
+def _attach_session(mgr: UpnpManager) -> _SessionState:
+    """Stuff a fake session into the manager. Skips the network-
+    bound connect() path entirely. Used only by push_pcm tests
+    that need a session but don't care about the SOAP handshake."""
+    av_ctrl = MagicMock()
+    rc_ctrl = MagicMock()
+    sess = _SessionState(
+        device=_device_record(),
+        openhome_device=_openhome_device(),
+        av=av_ctrl,
+        rc=rc_ctrl,
+    )
+    mgr._session = sess
+    return sess
+
+
+class TestPushPcmNoSession:
+    def test_no_session_returns_cheaply(self):
+        """Audio callback hits push_pcm on every frame even when
+        the user isn't using DLNA. Must not raise."""
+        mgr = UpnpManager()
+        pcm = np.zeros((512, 2), dtype=np.int16)
+        mgr.push_pcm(pcm, sample_rate=44100, dtype="int16")
+        assert mgr._session is None
+
+
+class TestPushPcmEncoderBuild:
+    def test_first_chunk_builds_encoder(self):
+        mgr = UpnpManager()
+        sess = _attach_session(mgr)
+        pcm = np.zeros((1024, 2), dtype=np.int16)
+        mgr.push_pcm(pcm, sample_rate=44100, dtype="int16")
+        assert sess.encoder is not None
+        assert sess.encoder_rate == 44100
+        assert sess.encoder_channels == 2
+        assert sess.encoder_dtype == "int16"
+
+    def test_float32_converts_to_int32(self):
+        """WASAPI shared mode delivers float32 PCM. The encoder is
+        integer-only. push_pcm must convert before encoding."""
+        mgr = UpnpManager()
+        sess = _attach_session(mgr)
+        pcm = np.full((512, 2), 0.5, dtype=np.float32)
+        mgr.push_pcm(pcm, sample_rate=48000, dtype="float32")
+        assert sess.encoder is not None
+        assert sess.encoder_dtype == "int32"
+
+    def test_intersample_peak_clips_safely(self):
+        """A float32 sample > 1.0 (intersample overshoot from a
+        brick-walled master) would overflow int32 if the scale
+        wasn't clipped. push_pcm must not raise on these."""
+        mgr = UpnpManager()
+        _attach_session(mgr)
+        pcm = np.array([[1.5, -1.5]] * 256, dtype=np.float32)
+        mgr.push_pcm(pcm, sample_rate=44100, dtype="float32")  # no raise
+
+
+class TestPushPcmEncoderReuse:
+    def test_same_params_reuses_encoder(self):
+        """The hot path: same rate / channels / dtype must NOT
+        rebuild the encoder. A rebuild on every chunk produces
+        audible glitches at every boundary."""
+        mgr = UpnpManager()
+        sess = _attach_session(mgr)
+        pcm = np.zeros((1024, 2), dtype=np.int16)
+        mgr.push_pcm(pcm, sample_rate=44100, dtype="int16")
+        first_encoder = sess.encoder
+        for _ in range(50):
+            mgr.push_pcm(pcm, sample_rate=44100, dtype="int16")
+        assert sess.encoder is first_encoder
+
+    def test_rate_change_rebuilds(self):
+        """Track-change to a different sample rate rebuilds the
+        encoder. One discontinuity at the boundary; same behaviour
+        the local engine has when it reopens its OutputStream
+        across rate changes."""
+        mgr = UpnpManager()
+        sess = _attach_session(mgr)
+        mgr.push_pcm(
+            np.zeros((1024, 2), dtype=np.int16),
+            sample_rate=44100, dtype="int16",
+        )
+        first = sess.encoder
+        mgr.push_pcm(
+            np.zeros((1024, 2), dtype=np.int16),
+            sample_rate=96000, dtype="int16",
+        )
+        assert sess.encoder is not first
+        assert sess.encoder_rate == 96000
+
+
+class TestPushPcmEmpty:
+    def test_empty_array_no_session_is_noop(self):
+        mgr = UpnpManager()
+        pcm = np.zeros((0, 2), dtype=np.int16)
+        mgr.push_pcm(pcm, sample_rate=44100, dtype="int16")
+        assert mgr._session is None
+
+    def test_empty_array_with_session_is_noop(self):
+        """Empty input should not build an encoder. Defends
+        against a wakeup on the audio callback before any decoder
+        output has materialized."""
+        mgr = UpnpManager()
+        sess = _attach_session(mgr)
+        pcm = np.zeros((0, 2), dtype=np.int16)
+        mgr.push_pcm(pcm, sample_rate=44100, dtype="int16")
+        assert sess.encoder is None
+
+
+# ---------------------------------------------------------------------
+# /api/dlna/refresh: NaN / inf rejection
+# ---------------------------------------------------------------------
+
+
+class TestRefreshEndpointNaNGuard:
+    """Pydantic accepts NaN and Infinity for `float` by default. The
+    handler rejects them explicitly because: (1) the Python-side
+    `max(1.0, min(15.0, NaN))` clamp returns NaN (NaN comparisons
+    are false), and (2) we can't use Pydantic `ge`/`le` constraints
+    because FastAPI's default 422 error response includes the
+    offending input value, and `json.dumps(NaN)` raises ValueError,
+    turning a clean rejection into a 500 stack trace.
+    """
+
+    @pytest.fixture
+    def client(self):
+        import server  # noqa: WPS433
+        from fastapi.testclient import TestClient
+
+        with TestClient(server.app) as c:
+            yield c
+
+    @pytest.mark.parametrize("body_value", ["NaN", "Infinity", "-Infinity"])
+    def test_rejects_nan_and_infinity(self, client, body_value):
+        r = client.request(
+            "POST",
+            "/api/dlna/refresh",
+            content=f'{{"timeout_s": {body_value}}}',
+            headers={"Content-Type": "application/json"},
+        )
+        assert r.status_code == 400, r.text
+        assert "finite" in r.json()["detail"].lower()

--- a/tests/test_upnp_session.py
+++ b/tests/test_upnp_session.py
@@ -528,8 +528,17 @@ class TestRefreshEndpointNaNGuard:
         import server  # noqa: WPS433
         from fastapi.testclient import TestClient
 
-        with TestClient(server.app) as c:
-            yield c
+        # `/api/dlna/refresh` is gated by `_require_local_access`. In
+        # CI, default settings have offline_mode=False, so the request
+        # gets a 401 before our handler ever runs and we can't observe
+        # the NaN guard. Flip it on for the test scope and restore.
+        original = server.settings.offline_mode
+        server.settings.offline_mode = True
+        try:
+            with TestClient(server.app) as c:
+                yield c
+        finally:
+            server.settings.offline_mode = original
 
     @pytest.mark.parametrize("body_value", ["NaN", "Infinity", "-Infinity"])
     def test_rejects_nan_and_infinity(self, client, body_value):

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1047,6 +1047,67 @@ export const api = {
         method: "POST",
       }),
   },
+  dlna: {
+    // Returns the cached device list without triggering a fresh
+    // SSDP scan. Cheap and safe to poll. Use refresh() when the
+    // picker dropdown opens so a stale cache doesn't hide a
+    // device that just powered on.
+    devices: () =>
+      req<{
+        status: {
+          available: boolean;
+          device_count: number;
+          last_scan_age_s?: number | null;
+          connected_id?: string | null;
+          connected_name?: string | null;
+          bytes_encoded?: number;
+          media_loaded?: boolean;
+          stream_url?: string;
+        };
+        devices: {
+          id: string;
+          name: string;
+          manufacturer: string;
+          model: string;
+          has_avtransport: boolean;
+        }[];
+      }>("/api/dlna/devices"),
+    refresh: (timeoutS: number = 5) =>
+      req<{
+        status: {
+          available: boolean;
+          device_count: number;
+          last_scan_age_s?: number | null;
+          connected_id?: string | null;
+          connected_name?: string | null;
+        };
+        devices: {
+          id: string;
+          name: string;
+          manufacturer: string;
+          model: string;
+          has_avtransport: boolean;
+        }[];
+      }>("/api/dlna/refresh", {
+        method: "POST",
+        body: JSON.stringify({ timeout_s: timeoutS }),
+      }),
+    connect: (deviceId: string) =>
+      req<{
+        ok: boolean;
+        device: {
+          id: string;
+          name: string;
+          manufacturer: string;
+          model: string;
+        };
+      }>("/api/dlna/connect", {
+        method: "POST",
+        body: JSON.stringify({ device_id: deviceId }),
+      }),
+    disconnect: () =>
+      req<{ ok: boolean }>("/api/dlna/disconnect", { method: "POST" }),
+  },
   airplay: {
     devices: () =>
       req<{

--- a/web/src/components/OutputDevicePicker.tsx
+++ b/web/src/components/OutputDevicePicker.tsx
@@ -86,15 +86,36 @@ type TidalConnectDevicesResponse = {
   devices: TidalConnectDeviceSummary[];
 };
 
+type DlnaDeviceSummary = {
+  id: string;
+  name: string;
+  manufacturer: string;
+  model: string;
+  has_avtransport: boolean;
+};
+
+type DlnaDevicesResponse = {
+  status: {
+    available: boolean;
+    device_count: number;
+    last_scan_age_s?: number | null;
+    connected_id?: string | null;
+    connected_name?: string | null;
+  };
+  devices: DlnaDeviceSummary[];
+};
+
 const LOCAL_PREFIX = "local:";
 const CAST_PREFIX = "cast:";
 const TC_PREFIX = "tc:";
+const DLNA_PREFIX = "dlna:";
 
 export function OutputDevicePicker() {
   const toast = useToast();
   const opts = useAudioOptions();
   const [cast, setCast] = useState<CastDevicesResponse | null>(null);
   const [tc, setTc] = useState<TidalConnectDevicesResponse | null>(null);
+  const [dlna, setDlna] = useState<DlnaDevicesResponse | null>(null);
   const [busy, setBusy] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
   // Pending Tidal Connect device — once the user picks one, we
@@ -144,19 +165,35 @@ export function OutputDevicePicker() {
         .devices()
         .then((res) => setTc(res))
         .catch(() => {}),
+      // DLNA also uses SSDP. /api/dlna/refresh blocks for the
+      // scan timeout (default 5s) and returns the fresh list; the
+      // dropdown waits on this so the user sees populated devices
+      // when it opens, rather than an empty list that fills in
+      // seconds later.
+      api.dlna
+        .refresh()
+        .then((res) => setDlna(res))
+        .catch(() => {}),
     ]);
   };
 
   // What the radio shows as selected. Remote sessions win — if
-  // either Cast or Tidal Connect is open, the remote device is
-  // the active sound output. Otherwise we surface the local device id.
+  // any of Cast / Tidal Connect / DLNA is open, the remote device
+  // is the active sound output. Otherwise we surface the local
+  // device id. At most one remote session can be active at a time
+  // (the manager-side disconnect-before-connect contract enforces
+  // it), so the order of these ternaries doesn't matter for
+  // correctness.
   const castConnectedId = cast?.status.connected_id ?? null;
   const tcConnectedId = tc?.status.connected_id ?? null;
+  const dlnaConnectedId = dlna?.status.connected_id ?? null;
   const selectedValue = castConnectedId
     ? `${CAST_PREFIX}${castConnectedId}`
     : tcConnectedId
       ? `${TC_PREFIX}${tcConnectedId}`
-      : `${LOCAL_PREFIX}${opts.current}`;
+      : dlnaConnectedId
+        ? `${DLNA_PREFIX}${dlnaConnectedId}`
+        : `${LOCAL_PREFIX}${opts.current}`;
 
   const showCastSection =
     cast !== null &&
@@ -168,6 +205,11 @@ export function OutputDevicePicker() {
     tc.status.available &&
     (tc.devices.length > 0 || tcConnectedId !== null);
 
+  const showDlnaSection =
+    dlna !== null &&
+    dlna.status.available &&
+    (dlna.devices.length > 0 || dlnaConnectedId !== null);
+
   const switchAwayFromRemoteIfActive = async () => {
     // Disconnecting whichever remote is currently active so the
     // new selection has a clean slate. Order matters: we always
@@ -176,6 +218,7 @@ export function OutputDevicePicker() {
     // feeds two destinations and produces a stutter.
     if (castConnectedId !== null) await api.cast.disconnect();
     if (tcConnectedId !== null) await api.tidalConnect.disconnect();
+    if (dlnaConnectedId !== null) await api.dlna.disconnect();
   };
 
   const onSelect = async (value: string) => {
@@ -204,6 +247,15 @@ export function OutputDevicePicker() {
           kind: "success",
           title: `Casting to ${result.device.friendly_name}`,
           description: "Audio is streaming to the device.",
+        });
+      } else if (value.startsWith(DLNA_PREFIX)) {
+        const deviceId = value.slice(DLNA_PREFIX.length);
+        await switchAwayFromRemoteIfActive();
+        const result = await api.dlna.connect(deviceId);
+        toast.show({
+          kind: "success",
+          title: `Streaming to ${result.device.name}`,
+          description: "Audio is going to the DLNA renderer.",
         });
       } else if (value.startsWith(LOCAL_PREFIX)) {
         const localId = value.slice(LOCAL_PREFIX.length);
@@ -280,18 +332,23 @@ export function OutputDevicePicker() {
   };
 
   // Trigger appearance: highlights when audio is going somewhere
-  // unusual — Cast / Tidal Connect active OR Exclusive Mode on.
-  // All three are "this isn't default speakers" states worth
-  // surfacing at a glance.
+  // unusual — Cast / Tidal Connect / DLNA active OR Exclusive
+  // Mode on. All four are "this isn't default speakers" states
+  // worth surfacing at a glance.
   const triggerHighlight =
-    castConnectedId !== null || tcConnectedId !== null || opts.exclusiveMode;
+    castConnectedId !== null ||
+    tcConnectedId !== null ||
+    dlnaConnectedId !== null ||
+    opts.exclusiveMode;
   const currentLocalName =
     opts.devices.find((d) => d.id === opts.current)?.name ?? "System default";
   const triggerTitle = castConnectedId
     ? `Casting to ${cast?.status.connected_name ?? "device"}`
     : tcConnectedId
       ? `Tidal Connect: ${tc?.status.connected_name ?? "device"}`
-      : `Output: ${currentLocalName}`;
+      : dlnaConnectedId
+        ? `Streaming to ${dlna?.status.connected_name ?? "device"}`
+        : `Output: ${currentLocalName}`;
 
   return (
     <>
@@ -428,8 +485,44 @@ export function OutputDevicePicker() {
                 )}
               </>
             )}
+
+            {showDlnaSection && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel className="text-muted-foreground">
+                  DLNA / UPnP
+                </DropdownMenuLabel>
+                {dlna.devices.length === 0 ? (
+                  <div className="px-2 py-1.5 text-xs text-muted-foreground">
+                    No DLNA renderers visible. Open the dropdown to re-scan;
+                    SSDP discovery takes a few seconds.
+                  </div>
+                ) : (
+                  dlna.devices.map((d) => (
+                    <DropdownMenuRadioItem
+                      key={d.id}
+                      value={`${DLNA_PREFIX}${d.id}`}
+                      onSelect={(e) => e.preventDefault()}
+                      className="text-sm"
+                      disabled={busy}
+                    >
+                      <div className="flex flex-col">
+                        <span>{d.name}</span>
+                        <span className="text-[11px] text-muted-foreground">
+                          {d.manufacturer && d.model
+                            ? `${d.manufacturer} ${d.model}`
+                            : d.manufacturer || d.model || "DLNA renderer"}
+                        </span>
+                      </div>
+                    </DropdownMenuRadioItem>
+                  ))
+                )}
+              </>
+            )}
           </DropdownMenuRadioGroup>
-          {(castConnectedId !== null || tcConnectedId !== null) && (
+          {(castConnectedId !== null ||
+            tcConnectedId !== null ||
+            dlnaConnectedId !== null) && (
             <>
               <DropdownMenuSeparator />
               <DropdownMenuItem
@@ -440,7 +533,9 @@ export function OutputDevicePicker() {
               >
                 {castConnectedId !== null
                   ? "Stop casting and return to local output"
-                  : "Stop Tidal Connect and return to local output"}
+                  : tcConnectedId !== null
+                    ? "Stop Tidal Connect and return to local output"
+                    : "Stop DLNA streaming and return to local output"}
               </DropdownMenuItem>
             </>
           )}


### PR DESCRIPTION
## Summary

- New audio output target alongside Cast and Tidal Connect: UPnP/DLNA MediaRenderer, the protocol WiiM, Bluesound, Cambridge streamers, and most network speakers expose. WiiM was the motivating device.
- The audio callback in `PCMPlayer` taps pre-EQ, pre-volume PCM out to a module-level `upnp_manager` singleton, which encodes to FLAC and serves the stream over an internal HTTP endpoint that the renderer pulls from. No lock and no lazy-init branch on the realtime path.
- `app/audio/avtransport.py` adds typed SOAP wrappers for `SetAVTransportURI`, `Play`, `Pause`, `Stop`. The manager handles SSDP discovery, descriptor parsing, and session lifecycle. Reuses the existing generic SOAP envelope encoder in `openhome.py` rather than duplicating it.
- Player `pause`, `play`, `resume`, and `stop` route through to the device via AVTransport, so a renderer like the WiiM reacts on user pause instead of taking ~8s to drain its own buffer.
- Server endpoints under `/api/dlna/`: list, on-demand SSDP rescan, connect, disconnect. The refresh endpoint rejects NaN and inf timeouts with a 400 because FastAPI's default 422 handler chokes on `json.dumps(NaN)` and turns the rejection into a 500 stack trace.
- `OutputDevicePicker` adds a DLNA section. The dropdown waits on the rescan response so the list is populated when it opens, rather than empty until the scan finishes.
- Bonus in this batch: prefetch jitters 50-200ms before its first Tidal request. Album-mount prefetch fans out via a thread pool, and without jitter all workers hit Tidal within a few ms, which is the burst pattern that triggers 429 and the longer 403/`abuse_detected` escalations. Foreground play unaffected.

## Test plan

- [x] `pytest tests/` — 578 pass (575 prior + 3 new NaN guard cases on `/api/dlna/refresh`)
- [x] `cd web && npx tsc -b --noEmit` — clean
- [x] `cd web && npm run lint:all` — clean (prettier, eslint, stylelint, htmlhint)
- [x] `cd web && npm test` — 36 vitest pass
- [ ] Manual: connect to a WiiM (or similar AVTransport renderer) from `OutputDevicePicker`, play a track, pause and resume from Tideway, confirm the device responds within ~1s rather than ~8s
- [ ] Manual: trigger an SSDP rescan from the picker dropdown and confirm devices populate before the dropdown finishes opening
- [ ] Manual: stop, switch back to local output, confirm local audio resumes

**Hardware caveat:** I don't have a WiiM or other DLNA renderer to bench against, so the manual rows above are unverified. The unit tests cover the SOAP wrappers, session lifecycle, refresh endpoint guards, and prefetch jitter ordering, but real-device behaviour is untested. Worth a careful manual sweep on whatever DLNA hardware the reviewer has access to before merge.