### PR TITLE
README: clarify Apple Silicon requirement on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,10 @@ Grab the latest from the Releases page for whichever fork of this
 repo you are installing from.
 
 On macOS, download `Tideway-<version>.dmg`, double-click it, and
-drag the `Tideway` app into `/Applications`.
+drag the `Tideway` app into `/Applications`. Apple Silicon only:
+the binary is arm64-native and won't launch on Intel Macs. This
+has been the case since the earliest signed release; the README
+just hadn't called it out before.
 
 On Windows, download `Tideway-setup-<version>.exe` and run it. The
 installer drops the app under your user profile, registers a Start


### PR DESCRIPTION
## Summary

Documentation correction. The macOS build has always been arm64-only (the release workflow runs PyInstaller on `macos-14`, which produces a single-arch arm64 `.app`), but the README install line didn't say so. Intel Mac users downloading the DMG would get a "this app is not supported" error on launch with no warning.

This PR just tells the truth on the install line. Users on Intel Macs can now see the constraint before downloading.

## Why this is smaller than originally planned

The earlier discussion framed v1.5.0 as "drop Intel Mac" with workflow + script + README changes, on the assumption v1.4.3 had shipped a universal2 DMG. It didn't (the universal2 PR [#97](https://github.com/J-M-PUNK/tideway/pull/97) was closed without merging when GitHub's `macos-13` runner pool starved out the v1.4.3 build). The workflow on main is already a single arm64 job; there's no matrix, no `merge-macos-universal` job, and no `scripts/lipo_merge_macos.sh` to remove.

So this is a documentation-only change. The "drop" already happened, implicitly, when [#97](https://github.com/J-M-PUNK/tideway/pull/97) was abandoned.

## Test plan

- [x] `pytest tests/` — 531 pass
- [x] README diff renders as expected on GitHub preview
- [ ] Reviewer: confirm the install line wording reads well next to the Windows and Linux lines

## Follow-up worth considering (out of scope here)

If you care about Intel Mac users who somehow installed an older build and are hitting the auto-updater on it, the auto-updater could short-circuit to "no compatible update" when it sees `platform.machine() == "x86_64"` on Darwin. Without that, it'll keep trying to push them an arm64 DMG they can't run. Probably a tiny user count; skip unless someone files a bug.