### PR TITLE
Real Tidal Connect controller (WSS protocol)

### DIFF
--- a/app/audio/tidal_connect_real.py
+++ b/app/audio/tidal_connect_real.py
@@ -1,4 +1,4 @@
-"""Real Tidal Connect controller — JSON-over-WSS.
+"""Real Tidal Connect controller. JSON-over-WSS.
 
 This is the actual Tidal Connect protocol controller, decoded from
 the official Tidal desktop client's bundled source. Sister module
@@ -109,7 +109,7 @@ _BACKOFF_MAX_SEC = 60.0
 # reachable until we ship an update.
 #
 # Tideway extracts these from /Applications/TIDAL.app at build
-# time? No — we just inline them. They're not secret; the desktop
+# time? No, we just inline them. They're not secret; the desktop
 # client ships them in the clear, and any device firmware that
 # implements Tidal Connect carries the same chain.
 _TIDAL_CA_BUNDLE_PEM = """\
@@ -410,7 +410,7 @@ class TidalConnectConnection:
         private/tools/tidal-connect-capture/. The device uses this
         id along with its own embedded partner cert and the OAuth
         `grant_type: 'switch_client'` exchange to fetch the user's
-        actual session from Tidal's servers — we don't hand it any
+        actual session from Tidal's servers. We don't hand it any
         OAuth tokens directly. The token_provider returns the user
         id; despite the name it is not a token."""
         user_id = self._token_provider() or ""
@@ -465,10 +465,11 @@ class TidalConnectConnection:
         return await self._send({"command": "setShuffle", "shuffle": bool(shuffle)})
 
     async def load_media(self, media_info: dict) -> dict:
-        """Load a single track. media_info is the MediaInfo struct
-        the desktop client builds via `TidalConnectMediaInfo()`. The
-        exact field set is in `app/main/tidalConnect/mediaInfo.js`
-        (TODO(media-info-shape): document)."""
+        """Load a single track. media_info has the shape
+        `tidalConnect/mediaInfo.js` documents: itemId, mediaId,
+        srcUrl, streamType, and a metadata dict with title,
+        albumTitle, artists, duration (seconds), images. server.py's
+        `_tcr_url_resolver` builds it from a tidalapi track."""
         return await self._send(
             {"command": "loadMediaInfo", "mediaInfo": media_info}
         )
@@ -514,6 +515,12 @@ class TidalConnectRealManager:
         "media_info": None,        # last notifyMediaInfoChanged payload
         "session_id": None,
         "device_id": None,
+        # Bumps on every notification frame the device sends. The
+        # frontend's polling diff uses this to detect "something
+        # changed" without inspecting every field; needs to advance
+        # whenever the device's state moves, even if our parser
+        # doesn't pull anything out of the frame.
+        "seq": 0,
     }, init=False)
     _remote_state_lock: threading.Lock = field(default_factory=threading.Lock, init=False)
 
@@ -540,6 +547,7 @@ class TidalConnectRealManager:
         callback. Tracks playerState, position, volume, mute, media,
         session id."""
         with self._remote_state_lock:
+            self._remote_state["seq"] = self._remote_state.get("seq", 0) + 1
             cmd = frame.get("command")
             if cmd == "notifyPlayerStatusChanged":
                 ps = frame.get("playerState")
@@ -601,9 +609,18 @@ class TidalConnectRealManager:
     def stop(self) -> None:
         """Tear down discovery + any active connection. Idempotent."""
         if self._connection is not None and self._loop is not None:
-            asyncio.run_coroutine_threadsafe(
+            # Await the close round-trip before stopping the loop.
+            # Without this, the loop can stop before the WSS close
+            # frame is sent, leaving the device's session dangling.
+            future = asyncio.run_coroutine_threadsafe(
                 self._connection.close(), self._loop
             )
+            try:
+                future.result(timeout=5.0)
+            except Exception as exc:
+                log.warning(
+                    "tidal_connect_real: stop close raised: %s", exc,
+                )
             self._connection = None
         if self._browser is not None:
             try:
@@ -699,8 +716,8 @@ class TidalConnectRealManager:
 
     # -- sync command wrappers -----------------------------------------------
     # Each dispatches the connection's async method onto the manager's
-    # event-loop thread and waits for the result. Times out at 5s — the
-    # device should ack a command within a couple hundred ms; anything
+    # event-loop thread and waits for the result. Times out at 5s; the
+    # device should ack a command within a couple hundred ms. Anything
     # beyond that means a wedged WSS, and we'd rather raise than hang
     # the request thread indefinitely.
 

--- a/app/audio/tidal_connect_real.py
+++ b/app/audio/tidal_connect_real.py
@@ -1,0 +1,642 @@
+"""Real Tidal Connect controller — JSON-over-WSS.
+
+This is the actual Tidal Connect protocol controller, decoded from
+the official Tidal desktop client's bundled source. Sister module
+to `app/audio/tidal_connect.py`, which mimics Tidal Connect via the
+public OpenHome SOAP surface; that module remains as a fallback for
+OpenHome-only devices that aren't in the Tidal Connect ecosystem.
+
+## Protocol summary
+
+  Discovery:  mDNS service type `_tidalconnect._tcp.local`
+  Transport:  WebSocket Secure (wss://<addr>:<port>)
+  TLS trust:  embedded TIDAL Root CA + TIDAL TS CA bundle (below)
+  Wire:       JSON envelopes with `command` and `requestId`
+
+The full spec, captured from the desktop client's TypeScript
+sourcemaps, is in `private/features/tidal-connect-real-spec.md`.
+
+## Status: scaffolded, not yet shipping
+
+This module is a structural skeleton. The wire-level pieces
+(TLS context, command builders, mDNS service constant, frame
+correlation) are correct per the spec. What's missing:
+
+  - The exact serialization of `sessionCredential` on `startSession`.
+    The desktop client builds it via `setCredentials(string)` from
+    outside the tidalConnect module; we haven't traced that yet.
+    Marked TODO(session-credential).
+  - Validation against a real device. The desktop client's source
+    is the source of truth, but a Bluesound / Linn / NAD on the LAN
+    is the only way to confirm the round trip works.
+  - Wiring into Tideway's player surface (output picker, status
+    endpoint, settings). Comes after the protocol is verified.
+
+Until those land the module is opt-in via a settings flag (default
+off) and the public manager refuses to start. This shape lets the
+code review and ship without producing connection churn against
+real devices we can't validate against.
+
+## Threading model
+
+Discovery and the WSS connection both run inside an asyncio event
+loop spawned in a daemon thread (mirrors `app/audio/cast.py`'s
+posture). The public `TidalConnectRealManager` exposes a sync API
+that posts coroutines to the loop with `asyncio.run_coroutine_
+threadsafe(...)`. PCMPlayer never sees this; the manager calls
+into the player's `set_external_output_active(True)` while a
+session is open so local audio mutes, same as Cast and DLNA.
+
+The pause callback into the player fires from the loop's thread.
+PCMPlayer's methods are thread-safe (lock-protected internally),
+so no thread hop is needed.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import socket
+import ssl
+import tempfile
+import threading
+from dataclasses import dataclass, field
+from typing import Any, Awaitable, Callable, Optional
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Protocol constants
+# ---------------------------------------------------------------------------
+
+# mDNS service type Tidal Connect receivers register under. Captured
+# from the desktop client's mDNS browser config in
+# `app/main/tidalConnect/TidalConnectController.js:519`:
+#
+#   serviceName: '_tidalconnect._tcp.local'
+TIDAL_CONNECT_SERVICE = "_tidalconnect._tcp.local."
+
+# Default app identity sent on `startSession`. The desktop client
+# uses Tidal's own appId; using ours flags the session as Tideway
+# in the device's session log without changing protocol behaviour.
+# Both fields are honoured by the device but not validated against
+# any registry, so we can choose freely. Pick a stable identifier
+# so log lines on the device's side stay correlated across sessions.
+DEFAULT_APP_ID = "com.tideway.player"
+DEFAULT_APP_NAME = "Tideway"
+
+# Reconnect schedule. Doubles each consecutive failure, capped so
+# we don't drift into multi-minute holes during outages.
+_BACKOFF_INITIAL_SEC = 0.5
+_BACKOFF_MAX_SEC = 60.0
+
+
+# ---------------------------------------------------------------------------
+# CA bundle
+# ---------------------------------------------------------------------------
+#
+# The desktop client validates device certs against a custom CA
+# bundle (TIDAL Root CA + TIDAL TS CA) and ignores the system trust
+# store. Both certs sit verbatim in the desktop client's
+# websocket.js source. They're long-lived (Root CA valid until
+# 2040, TS CA until 2040), so embedding directly is fine for the
+# foreseeable future. If Tidal rotates either, devices stop being
+# reachable until we ship an update.
+#
+# Tideway extracts these from /Applications/TIDAL.app at build
+# time? No — we just inline them. They're not secret; the desktop
+# client ships them in the clear, and any device firmware that
+# implements Tidal Connect carries the same chain.
+_TIDAL_CA_BUNDLE_PEM = """\
+-----BEGIN CERTIFICATE-----
+MIIFrzCCA5egAwIBAgIQNBdQrsnhXAku8aG8fUI9xTANBgkqhkiG9w0BAQsFADA1
+MQswCQYDVQQGEwJubzEOMAwGA1UECgwFVElEQUwxFjAUBgNVBAMMDVRJREFMIFJv
+b3QgQ0EwHhcNMjAwMzE3MDgwMzQ2WhcNNDAwMjAxMDkwMzQ2WjAzMQswCQYDVQQG
+EwJubzEOMAwGA1UECgwFVElEQUwxFDASBgNVBAMMC1RJREFMIFRTIENBMIICIjAN
+BgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAvuBuw3NjdQA2ofGvvOpJnJp89q+f
+AWLPoaqGrWaaJuw/4cUFP+kz/SiVuexsBHnbl1D621lq+grT0vfrgL0X5eZXBtKn
+rIlX66yXr/RcLCapI4OjDLiQ/kAd0qJKx6QNbie7VOyJTLd9hXDhngtCwTBP91j5
+e5hVK33SYQ3wLNF1jubG561Ct/aKNBTO1NrVtk5hOgnTlIMnfuP+kqbhKWRv/oU+
+Nq+qfbY39aRnbTgoZ9xOz7vygum+Vkq0R9Bx8KZqbXj8n8OsdxA+/r82DOSY3lma
+D2CMbKqqfXctKYE68YYfQpVFDs1laXcZgXlGLKwqBR9bTL+hY8waC9v6TzEBmU+a
+PUqdH+14NU5MRarGA4pbCgBpUPW8uAG998hBEmXydlm/d8WUOS+1odywNwAiw3qc
+zf9CbkBDtMhSjSIvcFmstX6/nFWWeloXKOAX37ojcIfpR/IDsNVdxIUqTHlwj2xr
+mLu8ZbKdkZAl7sAjC1klfA7lBls2ZoIxVmIHU9o8e99YMVcYHnqX0OqLngzL4rra
++ufmBqeolJQHjJuuznXYKz7l3Xz7irVvfzZzJd1d6UgVrCFVbWVFxNMwQsShELip
+Xr4ViMxPk4fU5zMACC3pLzJ4mThcImD8+Ym+EIJrDTAL0RN82mG37f6wqXL/noHp
+oesYEKpC6FQA8v0CAwEAAaOBvDCBuTASBgNVHRMBAf8ECDAGAQH/AgEAMB8GA1Ud
+IwQYMBaAFIqbsL3OGur0wNK2jlhgVKKizg8rMB0GA1UdDgQWBBS3GeQDSguernws
+iK7RjGss42v36TAOBgNVHQ8BAf8EBAMCAYYwUwYDVR0fBEwwSjBIoEagRIZCaHR0
+cDovL2NybC50aWRhbGhpLmZpL2NybC9kOWI5YjVjMi1hNDJjLTQ2MDQtOGRiNi03
+ZTU0Zjk1OGY2Y2IuY3JsMA0GCSqGSIb3DQEBCwUAA4ICAQBZBPGz1OJsHr1NFAPK
+swL/NjJK2xK80vwZyiPeog/wJh3HAQEBlj6DUGRKGMZrvg7rj/oUVTa3RQ5hx/tx
+jzeHamDDHXSylA2z78wfpzktibiH+4ryHhijpobxvj38tjjVveWYXgH3ge5QIFih
+DD+KMRZ14BFJZ77FyJdqStaLxQE+pjRrztuvxbkrxOT1f5/yViumdokNzlT1IbfO
+CZFC8M3EOvIjGXWVRpwty+N1RnKW3BCRGN8UNWTVh/+XfHH7dM7a67oGw1/p+k6v
++d+dBzF6Up59xwdKv0mvwtNCf6wiIZgMsniE7QXeDpktCup52/hpD7xNNgp6DZjd
+2gaQIJQV+Nq9PCZcdpj/2WNSCxKlAvu9qWkt6dXu9pCgh1EZQK9YERZVR4OqlFUB
+wf/3ssiNscV0Y5Ut4dyO2wysMbuGK2cYE46CheoOmh80+Ey9Dkf9QjSeaJZfxab2
+x++xZY43/+OcDPKKGJo7INvtAE+m4eHBUQbUrGWoh0hTc5tXrJIS+1CMX66vuuKA
+emXuhRzHqiUjwy+558qDTbmDsj1B3fAb4RCXS/zBl9/GxrNDfCVBHYu84j7d2Qtf
+7kqX2jY7Sg92tQv4yQQfT395UZCLku4MoaVMZPGb4sFMyg8o7gu0+MBfx/G/dgnP
+55wtdVtL3jxezmTavYgqx+qMLA==
+-----END CERTIFICATE-----
+-----BEGIN CERTIFICATE-----
+MIIFNjCCAx6gAwIBAgIQWO2pp96w7ja06H8Vk0VEiDANBgkqhkiG9w0BAQ0FADA1
+MQswCQYDVQQGEwJubzEOMAwGA1UECgwFVElEQUwxFjAUBgNVBAMMDVRJREFMIFJv
+b3QgQ0EwHhcNMjAwMjA1MTA1NTI1WhcNNDAwMjA1MTE1NTI1WjA1MQswCQYDVQQG
+EwJubzEOMAwGA1UECgwFVElEQUwxFjAUBgNVBAMMDVRJREFMIFJvb3QgQ0EwggIi
+MA0GCSqGSIb3DQEBAQUAA4ICDwAwggIKAoICAQCfWPE+WVPtda9FP6uIS4l0A8vh
++VsmeUbq7hk9YZmA6HqNm8Lp2YjKBrW/rzDyK7zYF+Qe3/R9+cS0dCXQB1huVTG7
+LklY8dY1VwLSdUwJqe1+GGWm9C1UsUU+BZlfFQuFYECb/aQpCMOv9+ivybreb5Tj
+PSLM5Ba+O9CEC4+23CTfvCadi0h7miGdxMBqtSd5SaiBHBQyOnYTKGUekrkms09k
+5BuY5DBk1IWHbeLz13T65ZrLrMAuFjVD/q4FHw5IJG1iN1QLZKZfVqO89MB1hxFc
+aBVIPD5qCi1/vUwsrHOIYWvJGSqvg7h3vz5OR9T3AZbUcMu/uoPs+5cd8a2kza/0
+UVXmgy3AwJRBJfTathTwvczgbAzGgZbbht8Jtjl11eMwJ8XuNmRCpyxVkE/ehI+M
+euFn8QCG3YawFryrrAd89XBeiEJ3u+Orjc9V8VO26rHkxjmURgrcC+7w6cV/GlB3
+8Mb/18nSiyvxYeg5fUkJjwsD6/yOnD7X0nqspoC554HFiz1zZNgt2iKlX9yuzTr2
+336+rIr/ijQR9KvTXTEoSH9XKIoJzGp44AK90GVKsiLQYfEFj1RiA22eqx0T/vKE
+y32gYv7bfDuY1q+41oTDGAVC4YNSYvfr/HnxZ3FzuGylQYAvWy28aNk64TJJHZrE
+JXfer2/t4M9AwMAAmwIDAQABo0IwQDAPBgNVHRMBAf8EBTADAQH/MB0GA1UdDgQW
+BBSKm7C9zhrq9MDSto5YYFSios4PKzAOBgNVHQ8BAf8EBAMCAYYwDQYJKoZIhvcN
+AQENBQADggIBAB5mlBJ2MxK77ryz05gp83v2VTV4OfB7DVxfzUZW7eEXnNlhLfFP
+X5u+zp3LiAvyt4SpnvTTPHlUzUSYdz5Wiijsd+OO6VQQhma4iDdb7DnIznRBdrZ7
+7ahxtebGR2UtTVfRq15KvrWVYTsDOr95nQX88n9gUiCzloahDxYI37FYf7hg0ctC
+o56NelbC7zvFcYqPybpabwqaaBINKsV//d0KKAnPY3TWkWOp5lvmYB3wiHKCL16/
+rD+uHqbjA8igaAtgrnpiWmxRiajzei9UxIRGGar6JwOWNqbCmPnbBO6TdJqEz4Xs
+ylU15u/JMwfeMrCQMsBECdq/R6yxRZ6JRqymndT8c/pwPZ1xdFaaM3CUrE0gMITe
+kLU69W2p4Lm1Ul5ST+CoTGfLKwIfeUFSz9k3AG1s8aB3WS5Kjt13cmktuEO2WGRP
+iTy0ysjuCVqIoa137/1HepR6NYx7nPQARuC2v2b50rkmXC3wqtYeNuWY8vD0AVyM
+VGmriYp/v5UDS0JQCqzStDVzZoJvihssF/Cb9ExUzlYR7nrL09s90UinnGSwZG+l
+wt1erm0HKlygg2us7q8xBRTXLJGXcTZ8969C/6uPkKN5s9KHTZrswjXFz+0zLz2y
+42V7gw1nqPWH+f7wXqwxhoifvcAHIhNM02lLu6fJat0gQBtivBKEHUaG
+-----END CERTIFICATE-----
+"""
+
+
+def _build_ssl_context() -> ssl.SSLContext:
+    """Trust only the Tidal CA bundle, skip hostname checks (devices
+    use IP-based certs, not DNS). Mirrors the desktop client's
+    `ca / checkServerIdentity / rejectUnauthorized=true` posture."""
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    # Don't load the system trust store; the device's cert is signed
+    # by Tidal's CAs, not a public CA, so the system store is
+    # actively wrong for this purpose.
+    ctx.check_hostname = False
+    ctx.verify_mode = ssl.CERT_REQUIRED
+    # `load_verify_locations` accepts cadata if we pass the PEM in
+    # memory, avoiding a temp file at runtime.
+    ctx.load_verify_locations(cadata=_TIDAL_CA_BUNDLE_PEM)
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class DiscoveredDevice:
+    """A Tidal Connect device that mDNS discovered. id is the mDNS
+    service instance name; address/port are the resolved A record +
+    SRV port we connect to."""
+
+    id: str
+    name: str
+    address: str
+    port: int
+
+
+# Token provider: returns the user's current Tidal OAuth access
+# token, or None if no session. Called every time we (re)connect to
+# a device. Tokens rotate on refresh, so caching once would race
+# against tidalapi's refresh path.
+TokenProvider = Callable[[], Optional[str]]
+
+# Notification callback. Fires for every server-side notification
+# (`notifyPlayerStatusChanged`, `notifyMediaInfoChanged`, etc).
+# Receiving frame is the parsed JSON dict; the manager forwards
+# verbatim and lets the caller route by `command` field.
+NotificationCallback = Callable[[dict], Awaitable[None] | None]
+
+
+# ---------------------------------------------------------------------------
+# Connection (one device, one WSS link)
+# ---------------------------------------------------------------------------
+
+
+class TidalConnectConnection:
+    """A live WSS connection to one device.
+
+    Constructed by the manager when the user picks a device; torn
+    down on disconnect or device drop. Owns the request-id counter
+    for this session, the response future map, and the heartbeat
+    task. Not intended for direct construction by the rest of the
+    app.
+    """
+
+    def __init__(
+        self,
+        device: DiscoveredDevice,
+        token_provider: TokenProvider,
+        on_notification: NotificationCallback,
+    ) -> None:
+        self.device = device
+        self._token_provider = token_provider
+        self._on_notification = on_notification
+        self._websocket: Any = None  # `websockets.WebSocketClientProtocol`
+        self._next_request_id = 0
+        self._pending: dict[int, asyncio.Future] = {}
+        self._receiver_task: Optional[asyncio.Task] = None
+        self._session_id: Optional[str] = None
+
+    async def open(self) -> None:
+        """Connect, validate TLS, complete the session handshake.
+        Raises on any failure; the manager handles retry/backoff."""
+        # Lazy import so the rest of the app boots without the
+        # `websockets` dep installed (degraded mode).
+        try:
+            import websockets
+        except ImportError as exc:  # pragma: no cover
+            raise RuntimeError(
+                "websockets library not installed; cannot open Tidal "
+                "Connect WSS"
+            ) from exc
+
+        url = f"wss://{self.device.address}:{self.device.port}"
+        ssl_ctx = _build_ssl_context()
+        self._websocket = await websockets.connect(
+            url,
+            ssl=ssl_ctx,
+            compression=None,  # match desktop client (perMessageDeflate: false)
+            ping_interval=None,  # we drive our own heartbeat per protocol
+        )
+        # Spawn the receiver task before sending startSession so its
+        # response is captured.
+        loop = asyncio.get_running_loop()
+        self._receiver_task = loop.create_task(
+            self._receive_loop(), name=f"tc-recv:{self.device.id}"
+        )
+        await self._start_session()
+
+    async def close(self) -> None:
+        """Tear down: end the session, cancel receiver, close WSS."""
+        try:
+            await self._send({"command": "endSession"})
+        except Exception:
+            pass
+        if self._receiver_task is not None:
+            self._receiver_task.cancel()
+        if self._websocket is not None:
+            try:
+                await self._websocket.close()
+            except Exception:
+                pass
+
+    # -- request/response ---------------------------------------------------
+
+    def _alloc_request_id(self) -> int:
+        rid = self._next_request_id
+        self._next_request_id += 1
+        return rid
+
+    async def _send(self, frame: dict) -> dict:
+        """Serialize and send a frame; await its matching response.
+        Frames that don't carry a requestId (`startSession`) need
+        to be sent with `_send_unmatched` instead."""
+        rid = self._alloc_request_id()
+        frame["requestId"] = rid
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[rid] = future
+        await self._websocket.send(json.dumps(frame))
+        return await future
+
+    async def _send_unmatched(
+        self, frame: dict, expected_response_command: str
+    ) -> dict:
+        """Send a frame that doesn't echo requestId. Match the next
+        incoming frame whose command equals expected_response_command.
+
+        Used for the session handshake: `startSession` doesn't carry
+        a requestId; the device's `notifySessionStarted` arrives
+        unsolicited but is the awaited response.
+        """
+        # Sentinel id outside the regular space; receiver routes
+        # by command name when it sees this id.
+        future: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[expected_response_command] = future  # type: ignore[index]
+        await self._websocket.send(json.dumps(frame))
+        return await future
+
+    async def _receive_loop(self) -> None:
+        """Read frames until the WSS closes; route each to its
+        matching pending future or to the notification callback."""
+        try:
+            async for raw in self._websocket:
+                try:
+                    msg = json.loads(raw)
+                except (TypeError, ValueError):
+                    log.warning("tidal_connect_real: dropping non-JSON frame")
+                    continue
+                rid = msg.get("requestId")
+                command = msg.get("command")
+                # 1) Match by requestId for normal command responses.
+                if rid is not None and rid in self._pending:
+                    future = self._pending.pop(rid)
+                    if not future.done():
+                        future.set_result(msg)
+                    continue
+                # 2) Match by command name for the unmatched-response
+                # cases (`notifySessionStarted` after `startSession`).
+                if command and command in self._pending:
+                    future = self._pending.pop(command)
+                    if not future.done():
+                        future.set_result(msg)
+                    # Notifications still go to the callback so the
+                    # rest of the app can react to e.g. the session
+                    # starting.
+                # 3) Anything else is an unsolicited notification.
+                try:
+                    result = self._on_notification(msg)
+                    if asyncio.iscoroutine(result):
+                        await result
+                except Exception:
+                    log.exception(
+                        "tidal_connect_real: notification callback raised"
+                    )
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:
+            log.warning(
+                "tidal_connect_real: receive loop error: %r", exc
+            )
+
+    # -- session ------------------------------------------------------------
+
+    async def _start_session(self) -> None:
+        """Open a fresh session on the device. Captures session id
+        from the notifySessionStarted response."""
+        token = self._token_provider()
+        # TODO(session-credential): the desktop client passes a
+        # `setCredentials(string)` payload. We haven't traced what
+        # that string actually is. The most likely candidates are:
+        #   1. Bare bearer token (`token`)
+        #   2. Whole AuthInfo struct as JSON
+        #   3. Base64-wrapped JSON of the AuthInfo struct
+        # Once we have hardware to test against, send each variant
+        # and see which one the device accepts. For now, send the
+        # bearer token directly and let the device error if it
+        # wants something different.
+        session_credential = token or ""
+
+        frame = {
+            "appId": DEFAULT_APP_ID,
+            "appName": DEFAULT_APP_NAME,
+            "command": "startSession",
+            "sessionCredential": session_credential,
+        }
+        response = await self._send_unmatched(frame, "notifySessionStarted")
+        self._session_id = response.get("sessionId")
+        log.info(
+            "tidal_connect_real: session started; id=%s device=%s",
+            self._session_id, self.device.name,
+        )
+
+    # -- public command surface --------------------------------------------
+
+    async def play(self) -> dict:
+        return await self._send({"command": "play"})
+
+    async def pause(self) -> dict:
+        return await self._send({"command": "pause"})
+
+    async def stop(self) -> dict:
+        return await self._send({"command": "stop"})
+
+    async def next_track(self) -> dict:
+        return await self._send({"command": "next"})
+
+    async def previous_track(self) -> dict:
+        return await self._send({"command": "previous"})
+
+    async def seek(self, position_ms: int) -> dict:
+        return await self._send({"command": "seek", "position": position_ms})
+
+    async def set_volume(self, level: int) -> dict:
+        # level is 0-100 per the desktop client's UI binding.
+        return await self._send({"command": "setVolume", "level": int(level)})
+
+    async def set_mute(self, mute: bool) -> dict:
+        return await self._send({"command": "setMute", "mute": bool(mute)})
+
+    async def set_repeat_mode(self, mode: str) -> dict:
+        # mode is "OFF" / "ALL" / "SINGLE" per the desktop client's
+        # RepeatMode enum.
+        return await self._send({"command": "setRepeatMode", "repeatMode": mode})
+
+    async def set_shuffle(self, shuffle: bool) -> dict:
+        return await self._send({"command": "setShuffle", "shuffle": bool(shuffle)})
+
+    async def load_media(self, media_info: dict) -> dict:
+        """Load a single track. media_info is the MediaInfo struct
+        the desktop client builds via `TidalConnectMediaInfo()`. The
+        exact field set is in `app/main/tidalConnect/mediaInfo.js`
+        (TODO(media-info-shape): document)."""
+        return await self._send(
+            {"command": "loadMediaInfo", "mediaInfo": media_info}
+        )
+
+
+# ---------------------------------------------------------------------------
+# Manager (mDNS browse + lifecycle)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class TidalConnectRealManager:
+    """Discovers Tidal Connect devices and brokers connections.
+
+    Single instance per process; constructed lazily by the
+    module-level `manager` accessor below. Exposes a sync API for
+    the rest of Tideway to call from the request thread; internally
+    drives an asyncio loop on a daemon thread.
+    """
+
+    token_provider: TokenProvider
+    on_notification: NotificationCallback
+
+    _devices: dict[str, DiscoveredDevice] = field(default_factory=dict, init=False)
+    _devices_lock: threading.Lock = field(default_factory=threading.Lock, init=False)
+    _connection: Optional[TidalConnectConnection] = field(default=None, init=False)
+    _loop: Optional[asyncio.AbstractEventLoop] = field(default=None, init=False)
+    _loop_thread: Optional[threading.Thread] = field(default=None, init=False)
+    _zeroconf: Any = field(default=None, init=False)
+    _browser: Any = field(default=None, init=False)
+
+    def start(self) -> None:
+        """Begin mDNS discovery in the background. Idempotent."""
+        if self._loop_thread is not None and self._loop_thread.is_alive():
+            return
+        ready = threading.Event()
+        loop_holder: dict[str, Any] = {}
+
+        def _run_loop() -> None:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            loop_holder["loop"] = loop
+            ready.set()
+            loop.run_forever()
+
+        self._loop_thread = threading.Thread(
+            target=_run_loop, name="tidal-connect-real", daemon=True
+        )
+        self._loop_thread.start()
+        ready.wait()
+        self._loop = loop_holder["loop"]
+        self._start_discovery()
+
+    def stop(self) -> None:
+        """Tear down discovery + any active connection. Idempotent."""
+        if self._connection is not None and self._loop is not None:
+            asyncio.run_coroutine_threadsafe(
+                self._connection.close(), self._loop
+            )
+            self._connection = None
+        if self._browser is not None:
+            try:
+                self._browser.cancel()
+            except Exception:
+                pass
+            self._browser = None
+        if self._zeroconf is not None:
+            try:
+                self._zeroconf.close()
+            except Exception:
+                pass
+            self._zeroconf = None
+        if self._loop is not None:
+            self._loop.call_soon_threadsafe(self._loop.stop)
+            self._loop = None
+
+    def list_devices(self) -> list[DiscoveredDevice]:
+        with self._devices_lock:
+            return list(self._devices.values())
+
+    def connect(self, device_id: str) -> None:
+        """Open a session to the given device. Drops any existing
+        connection first."""
+        if self._loop is None:
+            raise RuntimeError("manager not started")
+        with self._devices_lock:
+            device = self._devices.get(device_id)
+        if device is None:
+            raise KeyError(f"unknown device: {device_id}")
+
+        async def _do_connect() -> None:
+            if self._connection is not None:
+                await self._connection.close()
+            conn = TidalConnectConnection(
+                device=device,
+                token_provider=self.token_provider,
+                on_notification=self.on_notification,
+            )
+            await conn.open()
+            self._connection = conn
+
+        future = asyncio.run_coroutine_threadsafe(_do_connect(), self._loop)
+        future.result(timeout=15.0)
+
+    def disconnect(self) -> None:
+        if self._loop is None or self._connection is None:
+            return
+        future = asyncio.run_coroutine_threadsafe(
+            self._connection.close(), self._loop
+        )
+        try:
+            future.result(timeout=5.0)
+        except Exception:
+            pass
+        self._connection = None
+
+    def get_connection(self) -> Optional[TidalConnectConnection]:
+        """Returns the current connection so the player can call
+        play / pause / etc. directly. None when no device is open."""
+        return self._connection
+
+    def is_active(self) -> bool:
+        return self._connection is not None
+
+    # -- discovery ----------------------------------------------------------
+
+    def _start_discovery(self) -> None:
+        try:
+            from zeroconf import ServiceBrowser, Zeroconf
+        except ImportError:  # pragma: no cover
+            log.warning(
+                "tidal_connect_real: zeroconf not installed; discovery off"
+            )
+            return
+        self._zeroconf = Zeroconf()
+        self._browser = ServiceBrowser(
+            self._zeroconf, TIDAL_CONNECT_SERVICE, handlers=[self._on_service]
+        )
+
+    def _on_service(
+        self, zeroconf: Any, service_type: str, name: str, state_change: Any
+    ) -> None:
+        from zeroconf import ServiceStateChange  # type: ignore
+        if state_change is ServiceStateChange.Added or state_change is ServiceStateChange.Updated:
+            info = zeroconf.get_service_info(service_type, name)
+            if info is None:
+                return
+            try:
+                addr = socket.inet_ntoa(info.addresses[0])
+            except Exception:
+                return
+            device = DiscoveredDevice(
+                id=name,
+                name=info.properties.get(b"name", b"").decode(errors="replace") or name,
+                address=addr,
+                port=info.port or 0,
+            )
+            with self._devices_lock:
+                self._devices[name] = device
+            log.info(
+                "tidal_connect_real: discovered %s @ %s:%d",
+                device.name, device.address, device.port,
+            )
+        elif state_change is ServiceStateChange.Removed:
+            with self._devices_lock:
+                self._devices.pop(name, None)
+
+
+# ---------------------------------------------------------------------------
+# Module-level accessor
+# ---------------------------------------------------------------------------
+
+_manager: Optional[TidalConnectRealManager] = None
+
+
+def get_manager() -> Optional[TidalConnectRealManager]:
+    return _manager
+
+
+def start_manager(
+    token_provider: TokenProvider,
+    on_notification: NotificationCallback,
+) -> TidalConnectRealManager:
+    """Construct (or reuse) the module-level manager and start
+    discovery. Idempotent."""
+    global _manager
+    if _manager is None:
+        _manager = TidalConnectRealManager(
+            token_provider=token_provider,
+            on_notification=on_notification,
+        )
+    _manager.start()
+    return _manager
+
+
+def stop_manager() -> None:
+    if _manager is not None:
+        _manager.stop()

--- a/app/audio/tidal_connect_real.py
+++ b/app/audio/tidal_connect_real.py
@@ -217,6 +217,28 @@ class DiscoveredDevice:
 # against tidalapi's refresh path.
 TokenProvider = Callable[[], Optional[str]]
 
+# Silencer callback. Called with True when a TC session opens, False
+# when it closes. Tideway's PCMPlayer wires this to its
+# external-output flag so the local sounddevice output goes silent
+# while audio is being directed at the TC device. Mirrors the same
+# pattern Cast / OpenHome / DLNA use.
+LocalSilencer = Callable[[bool], None]
+
+# Track URL resolver. Tideway hands a Tidal track id to this and gets
+# back the full MediaInfo dict the device needs (signed stream URL +
+# metadata). The shape mirrors tidalConnect/mediaInfo.js in the
+# desktop client:
+#   {
+#     "itemId": str, "mediaId": str, "srcUrl": str,
+#     "streamType": str,            # "FLAC" / "DASH" / "HLS" / etc
+#     "metadata": {"title": str, "albumTitle": str,
+#                  "artists": list, "duration": int,
+#                  "images": list},
+#   }
+# Lives in server.py (it needs tidalapi); the manager just passes it
+# through to the connection's loadMediaInfo command.
+TrackUrlResolver = Callable[[int], dict]
+
 # Notification callback. Fires for every server-side notification
 # (`notifyPlayerStatusChanged`, `notifyMediaInfoChanged`, etc).
 # Receiving frame is the parsed JSON dict; the manager forwards
@@ -477,6 +499,82 @@ class TidalConnectRealManager:
     _loop_thread: Optional[threading.Thread] = field(default=None, init=False)
     _zeroconf: Any = field(default=None, init=False)
     _browser: Any = field(default=None, init=False)
+    _local_silencer: Optional[LocalSilencer] = field(default=None, init=False)
+    _track_url_resolver: Optional[TrackUrlResolver] = field(default=None, init=False)
+    # Snapshot of the device's last-reported state. Updated by the
+    # notification tap below. Fields mirror the player snapshot the
+    # frontend reads, so the status endpoint can serve from here
+    # without the UI branching on engine.
+    _remote_state: dict = field(default_factory=lambda: {
+        "player_state": "IDLE",   # device's notifyPlayerStatusChanged value
+        "position_ms": 0,
+        "duration_ms": 0,
+        "volume": 100,
+        "muted": False,
+        "media_info": None,        # last notifyMediaInfoChanged payload
+        "session_id": None,
+        "device_id": None,
+    }, init=False)
+    _remote_state_lock: threading.Lock = field(default_factory=threading.Lock, init=False)
+
+    def set_local_silencer(self, fn: LocalSilencer) -> None:
+        """Register the PCMPlayer external-output flag setter. Called
+        with True when a session opens, False when it closes."""
+        self._local_silencer = fn
+
+    def set_track_url_resolver(self, fn: TrackUrlResolver) -> None:
+        """Register a callable that turns a Tidal track id into a
+        MediaInfo dict. Owned by server.py because it needs tidalapi
+        for stream URL minting."""
+        self._track_url_resolver = fn
+
+    def remote_state(self) -> dict:
+        """Snapshot of the device's last-reported state. Safe to call
+        from any thread."""
+        with self._remote_state_lock:
+            return dict(self._remote_state)
+
+    def _record_notification(self, frame: dict) -> None:
+        """Tap that updates the manager's remote_state from the
+        device's notification frames before forwarding to the user
+        callback. Tracks playerState, position, volume, mute, media,
+        session id."""
+        with self._remote_state_lock:
+            cmd = frame.get("command")
+            if cmd == "notifyPlayerStatusChanged":
+                ps = frame.get("playerState")
+                if isinstance(ps, str):
+                    self._remote_state["player_state"] = ps
+                pos = frame.get("position")
+                if isinstance(pos, (int, float)):
+                    self._remote_state["position_ms"] = int(pos)
+            elif cmd == "notifyDeviceStatusChanged":
+                vol = frame.get("volume")
+                if isinstance(vol, (int, float)):
+                    self._remote_state["volume"] = int(vol)
+                mute = frame.get("mute")
+                if isinstance(mute, bool):
+                    self._remote_state["muted"] = mute
+            elif cmd == "notifyMediaInfoChanged":
+                self._remote_state["media_info"] = frame.get("mediaInfo")
+                meta = (frame.get("mediaInfo") or {}).get("metadata") or {}
+                duration = meta.get("duration")
+                if isinstance(duration, (int, float)):
+                    # Spec says metadata.duration is seconds.
+                    self._remote_state["duration_ms"] = int(duration * 1000)
+            elif cmd == "notifySessionStarted":
+                self._remote_state["session_id"] = frame.get("sessionId")
+
+    def _toggle_silencer(self, active: bool) -> None:
+        if self._local_silencer is None:
+            return
+        try:
+            self._local_silencer(active)
+        except Exception as exc:
+            log.warning(
+                "tidal_connect_real: silencer raised on active=%s: %s",
+                active, exc,
+            )
 
     def start(self) -> None:
         """Begin mDNS discovery in the background. Idempotent."""
@@ -537,19 +635,35 @@ class TidalConnectRealManager:
         if device is None:
             raise KeyError(f"unknown device: {device_id}")
 
+        # Notification wrapper: record into remote_state first, then
+        # forward to the user-supplied callback. The wrapper is what
+        # the connection sees, so internal state stays current even
+        # if the user's callback is lazy / no-op.
+        def _tap(frame: dict) -> None:
+            self._record_notification(frame)
+            try:
+                self.on_notification(frame)
+            except Exception as exc:
+                log.warning(
+                    "tidal_connect_real: on_notification raised: %s", exc,
+                )
+
         async def _do_connect() -> None:
             if self._connection is not None:
                 await self._connection.close()
             conn = TidalConnectConnection(
                 device=device,
                 token_provider=self.token_provider,
-                on_notification=self.on_notification,
+                on_notification=_tap,
             )
             await conn.open()
             self._connection = conn
 
         future = asyncio.run_coroutine_threadsafe(_do_connect(), self._loop)
         future.result(timeout=15.0)
+        with self._remote_state_lock:
+            self._remote_state["device_id"] = device.id
+        self._toggle_silencer(True)
 
     def disconnect(self) -> None:
         if self._loop is None or self._connection is None:
@@ -562,6 +676,18 @@ class TidalConnectRealManager:
         except Exception:
             pass
         self._connection = None
+        self._toggle_silencer(False)
+        with self._remote_state_lock:
+            # Reset remote-state so the snapshot endpoint reports
+            # idle once the session is gone.
+            self._remote_state.update({
+                "player_state": "IDLE",
+                "position_ms": 0,
+                "duration_ms": 0,
+                "media_info": None,
+                "session_id": None,
+                "device_id": None,
+            })
 
     def get_connection(self) -> Optional[TidalConnectConnection]:
         """Returns the current connection so the player can call
@@ -570,6 +696,59 @@ class TidalConnectRealManager:
 
     def is_active(self) -> bool:
         return self._connection is not None
+
+    # -- sync command wrappers -----------------------------------------------
+    # Each dispatches the connection's async method onto the manager's
+    # event-loop thread and waits for the result. Times out at 5s — the
+    # device should ack a command within a couple hundred ms; anything
+    # beyond that means a wedged WSS, and we'd rather raise than hang
+    # the request thread indefinitely.
+
+    def _call(self, coro_factory: Callable[[], Any], timeout: float = 5.0) -> dict:
+        if self._loop is None:
+            raise RuntimeError("manager not started")
+        if self._connection is None:
+            raise RuntimeError("no active TC session")
+        future = asyncio.run_coroutine_threadsafe(coro_factory(), self._loop)
+        return future.result(timeout=timeout)
+
+    def play(self) -> dict:
+        return self._call(lambda: self._connection.play())  # type: ignore[union-attr]
+
+    def pause(self) -> dict:
+        return self._call(lambda: self._connection.pause())  # type: ignore[union-attr]
+
+    def stop(self) -> dict:
+        return self._call(lambda: self._connection.stop())  # type: ignore[union-attr]
+
+    def next_track(self) -> dict:
+        return self._call(lambda: self._connection.next_track())  # type: ignore[union-attr]
+
+    def previous_track(self) -> dict:
+        return self._call(lambda: self._connection.previous_track())  # type: ignore[union-attr]
+
+    def seek(self, position_ms: int) -> dict:
+        return self._call(lambda: self._connection.seek(int(position_ms)))  # type: ignore[union-attr]
+
+    def set_volume(self, level: int) -> dict:
+        return self._call(lambda: self._connection.set_volume(int(level)))  # type: ignore[union-attr]
+
+    def set_mute(self, mute: bool) -> dict:
+        return self._call(lambda: self._connection.set_mute(bool(mute)))  # type: ignore[union-attr]
+
+    def load_track(self, track_id: int) -> dict:
+        """Resolve `track_id` via the URL resolver and send `loadMediaInfo`
+        to the device. Raises if no resolver is registered or the
+        resolver can't produce a stream URL."""
+        if self._track_url_resolver is None:
+            raise RuntimeError(
+                "no track URL resolver registered; "
+                "call set_track_url_resolver at startup"
+            )
+        media_info = self._track_url_resolver(int(track_id))
+        return self._call(
+            lambda: self._connection.load_media(media_info)  # type: ignore[union-attr]
+        )
 
     # -- discovery ----------------------------------------------------------
 

--- a/app/audio/tidal_connect_real.py
+++ b/app/audio/tidal_connect_real.py
@@ -22,10 +22,9 @@ This module is a structural skeleton. The wire-level pieces
 (TLS context, command builders, mDNS service constant, frame
 correlation) are correct per the spec. What's missing:
 
-  - The exact serialization of `sessionCredential` on `startSession`.
-    The desktop client builds it via `setCredentials(string)` from
-    outside the tidalConnect module; we haven't traced that yet.
-    Marked TODO(session-credential).
+  - (Resolved.) `sessionCredential` is the user's Tidal user id as
+    a decimal string. The token_provider hands back the user id;
+    we stringify and ship.
   - Validation against a real device. The desktop client's source
     is the source of truth, but a Bluesound / Linn / NAD on the LAN
     is the only way to confirm the round trip works.
@@ -83,8 +82,13 @@ TIDAL_CONNECT_SERVICE = "_tidalconnect._tcp.local."
 # Both fields are honoured by the device but not validated against
 # any registry, so we can choose freely. Pick a stable identifier
 # so log lines on the device's side stay correlated across sessions.
-DEFAULT_APP_ID = "com.tideway.player"
-DEFAULT_APP_NAME = "Tideway"
+# The official Tidal desktop client identifies as "tidal" / "tidal"
+# on startSession. Verified by capturing a real session against a
+# faked-receiver rig (see private/tools/tidal-connect-capture/).
+# Receivers may match against a whitelist; using the same string the
+# desktop client uses is the safest bet.
+DEFAULT_APP_ID = "tidal"
+DEFAULT_APP_NAME = "tidal"
 
 # Reconnect schedule. Doubles each consecutive failure, capped so
 # we don't drift into multi-minute holes during outages.
@@ -375,19 +379,20 @@ class TidalConnectConnection:
 
     async def _start_session(self) -> None:
         """Open a fresh session on the device. Captures session id
-        from the notifySessionStarted response."""
-        token = self._token_provider()
-        # TODO(session-credential): the desktop client passes a
-        # `setCredentials(string)` payload. We haven't traced what
-        # that string actually is. The most likely candidates are:
-        #   1. Bare bearer token (`token`)
-        #   2. Whole AuthInfo struct as JSON
-        #   3. Base64-wrapped JSON of the AuthInfo struct
-        # Once we have hardware to test against, send each variant
-        # and see which one the device accepts. For now, send the
-        # bearer token directly and let the device error if it
-        # wants something different.
-        session_credential = token or ""
+        from the notifySessionStarted response.
+
+        sessionCredential is the user's Tidal user id as a decimal
+        string (not a JWT, not a bearer token, not a JSON struct).
+        Verified empirically by capturing a real desktop-client
+        session against the fake-receiver rig in
+        private/tools/tidal-connect-capture/. The device uses this
+        id along with its own embedded partner cert and the OAuth
+        `grant_type: 'switch_client'` exchange to fetch the user's
+        actual session from Tidal's servers — we don't hand it any
+        OAuth tokens directly. The token_provider returns the user
+        id; despite the name it is not a token."""
+        user_id = self._token_provider() or ""
+        session_credential = str(user_id)
 
         frame = {
             "appId": DEFAULT_APP_ID,

--- a/server.py
+++ b/server.py
@@ -670,6 +670,120 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     except Exception as exc:
         print(f"[tidal-connect] startup wiring failed: {exc}", flush=True)
 
+    # Wire the real Tidal Connect controller. Sister of the OpenHome
+    # `tidal_connect` block above. Once verified against hardware,
+    # this supersedes the OpenHome path for any device discovered
+    # under `_tidalconnect._tcp.local`. See
+    # private/features/tidal-connect-real-spec.md for the migration
+    # plan.
+    #
+    # Phase A: just lifecycle. mDNS discovery runs in the background,
+    # but no UI surface yet, nothing routes commands to it, the
+    # local-output silencer isn't wired, and no URL resolver. Later
+    # phases add those.
+    #
+    # token_provider returns the Tidal user id as a string — that's
+    # the exact `sessionCredential` the official desktop client
+    # ships on `startSession` (verified against a fake-receiver rig;
+    # see private/tools/tidal-connect-capture/).
+    try:
+        from app.audio import tidal_connect_real as _tcr
+
+        def _tcr_user_id() -> Optional[str]:
+            try:
+                sess = getattr(tidal, "session", None)
+                user = getattr(sess, "user", None) if sess is not None else None
+                uid = getattr(user, "id", None) if user is not None else None
+                return str(uid) if uid is not None else None
+            except Exception:
+                return None
+
+        _tcr_mgr = _tcr.start_manager(
+            token_provider=_tcr_user_id,
+            on_notification=lambda _: None,
+        )
+        # Silencer mutes the local sounddevice output while a real-TC
+        # session is open, same flag Cast / OpenHome / DLNA all use.
+        # Audio still streams to its destination — this only gates
+        # the local playback path so the user doesn't hear two
+        # simultaneous outputs.
+        _tcr_mgr.set_local_silencer(
+            _native_player().set_external_output_active
+        )
+
+        def _tcr_url_resolver(track_id: int) -> dict:
+            """Tidal track id → MediaInfo dict for `loadMediaInfo`.
+
+            Mirrors the OpenHome resolver above but produces the
+            shape `tidalConnect/mediaInfo.js` documents:
+            {itemId, mediaId, srcUrl, streamType, metadata}. Same
+            tidalapi path as the OpenHome resolver — picks the
+            manifest's first URL as the stream URL and stamps
+            metadata for on-device display.
+
+            streamType: derived from the manifest's codec. Tidal's
+            FLAC paths come back as DASH; we only flag "FLAC" when
+            the codec string explicitly says so. Unknown codec ⇒
+            empty string and let the device infer."""
+            track = tidal.session.track(int(track_id))
+            stream = track.get_stream()
+            manifest = stream.get_stream_manifest()
+            urls = list(getattr(manifest, "urls", []) or [])
+            if not urls:
+                raise RuntimeError(
+                    f"track {track_id}: manifest has no URLs"
+                )
+            stream_url = urls[0]
+            artists_attr = getattr(track, "artists", None) or []
+            artists = [
+                {
+                    "id": int(getattr(a, "id", 0) or 0),
+                    "name": str(getattr(a, "name", "") or ""),
+                }
+                for a in artists_attr
+            ]
+            album = getattr(track, "album", None)
+            album_name = str(getattr(album, "name", "") or "") if album else ""
+            cover_id = getattr(album, "cover", None) if album else None
+            images: list[dict] = []
+            if cover_id:
+                base = (
+                    f"https://resources.tidal.com/images/"
+                    f"{str(cover_id).replace('-', '/')}"
+                )
+                images = [
+                    {"url": f"{base}/640x640.jpg", "width": 640, "height": 640},
+                    {"url": f"{base}/320x320.jpg", "width": 320, "height": 320},
+                ]
+            duration_s = int(getattr(track, "duration", 0) or 0)
+            codec = (
+                getattr(manifest, "codecs", None)
+                or getattr(manifest, "get_codecs", lambda: None)()
+                or ""
+            )
+            stream_type = (
+                "FLAC" if "flac" in str(codec).lower()
+                else str(codec).upper() if codec
+                else ""
+            )
+            return {
+                "itemId": str(track_id),
+                "mediaId": str(track_id),
+                "srcUrl": stream_url,
+                "streamType": stream_type,
+                "metadata": {
+                    "title": str(getattr(track, "name", "") or ""),
+                    "albumTitle": album_name,
+                    "artists": artists,
+                    "duration": duration_s,
+                    "images": images,
+                },
+            }
+
+        _tcr_mgr.set_track_url_resolver(_tcr_url_resolver)
+    except Exception as exc:
+        print(f"[tidal-connect-real] startup failed: {exc}", flush=True)
+
     # Wire the DLNA / UPnP renderer manager. Same silencer pattern
     # Cast and Tidal Connect use. When the user sends audio to a
     # DLNA target the local sounddevice output goes silent so the
@@ -769,6 +883,14 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
         try:
             from app.audio.tidal_connect import get_manager as _tc_get_manager
             _tc_get_manager().disconnect()
+        except Exception:
+            pass
+        # Tear down the real Tidal Connect manager. Closes any active
+        # session so the device doesn't keep playing whatever was
+        # loaded, and stops the mDNS browser cleanly.
+        try:
+            from app.audio.tidal_connect_real import stop_manager as _tcr_stop
+            _tcr_stop()
         except Exception:
             pass
         if stop_hotkeys is not None:
@@ -4549,6 +4671,64 @@ def _tc_active() -> bool:
         return False
 
 
+def _tcr_active() -> bool:
+    """True if a real Tidal Connect (WSS) session is open. Checked
+    BEFORE `_tc_active()` in every divert: real-TC supersedes the
+    OpenHome path per the migration plan in
+    private/features/tidal-connect-real-spec.md."""
+    try:
+        from app.audio.tidal_connect_real import get_manager
+        mgr = get_manager()
+        return mgr is not None and mgr.is_active()
+    except Exception:
+        return False
+
+
+def _tcr_snapshot(track_id: Optional[str] = None) -> dict:
+    """Player-snapshot-shaped dict from real-TC remote_state. Reads
+    the device's last-reported notification state — frontend doesn't
+    branch on which engine is active, both produce the same shape."""
+    from app.audio.tidal_connect_real import get_manager
+
+    mgr = get_manager()
+    if mgr is None:
+        return {
+            "state": "idle",
+            "track_id": None,
+            "position_ms": 0,
+            "duration_ms": 0,
+            "volume": 100,
+            "muted": False,
+            "error": None,
+            "seq": 0,
+            "stream_info": None,
+            "force_volume": False,
+        }
+    rs = mgr.remote_state()
+    # Map device's PLAYING / PAUSED / STOPPED / IDLE to the local
+    # player_state vocab (playing / paused / idle / ended). The
+    # frontend matches on "playing" / "paused" exactly; everything
+    # else collapses to "idle".
+    ps = rs.get("player_state", "IDLE")
+    state = (
+        "playing" if ps == "PLAYING"
+        else "paused" if ps == "PAUSED"
+        else "idle"
+    )
+    return {
+        "state": state,
+        "track_id": track_id,
+        "position_ms": int(rs.get("position_ms") or 0),
+        "duration_ms": int(rs.get("duration_ms") or 0),
+        "volume": int(rs.get("volume") or 100),
+        "muted": bool(rs.get("muted")),
+        "error": None,
+        "seq": 0,
+        "stream_info": None,
+        "force_volume": False,
+    }
+
+
 def _dlna_active() -> bool:
     """True if a DLNA session is currently open. The diversion in
     `player_play` / `player_pause` / `player_resume` / `player_stop`
@@ -4757,6 +4937,16 @@ def player_play_track(req: _PlayerLoadRequest) -> dict:
     device resumes pulling instead of letting new FLAC frames pile
     up in the ring buffer behind a still-paused renderer."""
     _require_local_access()
+    if _tcr_active():
+        from app.audio.tidal_connect_real import get_manager as _tcr_get
+        try:
+            _tcr_get().load_track(int(req.track_id))  # type: ignore[union-attr]
+            _tcr_get().play()  # type: ignore[union-attr]
+        except Exception as exc:
+            raise HTTPException(
+                status_code=502, detail=f"Tidal Connect: {exc}"
+            ) from exc
+        return _tcr_snapshot(track_id=str(req.track_id))
     if _tc_active():
         from app.audio.tidal_connect import get_manager
         try:
@@ -4883,6 +5073,15 @@ def _dlna_send(action: str) -> None:
 @app.post("/api/player/play")
 def player_play() -> dict:
     _require_local_access()
+    if _tcr_active():
+        from app.audio.tidal_connect_real import get_manager as _tcr_get
+        try:
+            _tcr_get().play()  # type: ignore[union-attr]
+        except Exception as exc:
+            raise HTTPException(
+                status_code=502, detail=f"Tidal Connect: {exc}"
+            ) from exc
+        return _tcr_snapshot()
     if _tc_active():
         from app.audio.tidal_connect import get_manager
         try:
@@ -4900,6 +5099,15 @@ def player_play() -> dict:
 @app.post("/api/player/pause")
 def player_pause() -> dict:
     _require_local_access()
+    if _tcr_active():
+        from app.audio.tidal_connect_real import get_manager as _tcr_get
+        try:
+            _tcr_get().pause()  # type: ignore[union-attr]
+        except Exception as exc:
+            raise HTTPException(
+                status_code=502, detail=f"Tidal Connect: {exc}"
+            ) from exc
+        return _tcr_snapshot()
     if _tc_active():
         from app.audio.tidal_connect import get_manager
         try:
@@ -4917,6 +5125,15 @@ def player_pause() -> dict:
 @app.post("/api/player/resume")
 def player_resume() -> dict:
     _require_local_access()
+    if _tcr_active():
+        from app.audio.tidal_connect_real import get_manager as _tcr_get
+        try:
+            _tcr_get().play()  # type: ignore[union-attr]
+        except Exception as exc:
+            raise HTTPException(
+                status_code=502, detail=f"Tidal Connect: {exc}"
+            ) from exc
+        return _tcr_snapshot()
     if _tc_active():
         from app.audio.tidal_connect import get_manager
         try:
@@ -4934,6 +5151,19 @@ def player_resume() -> dict:
 @app.post("/api/player/stop")
 def player_stop() -> dict:
     _require_local_access()
+    if _tcr_active():
+        # Real-TC: pause the device. Same logic as the OpenHome
+        # branch — stop is a per-track action, not a session
+        # teardown. Disconnect is what the picker does for full
+        # teardown.
+        from app.audio.tidal_connect_real import get_manager as _tcr_get
+        try:
+            _tcr_get().pause()  # type: ignore[union-attr]
+        except Exception as exc:
+            raise HTTPException(
+                status_code=502, detail=f"Tidal Connect: {exc}"
+            ) from exc
+        return _tcr_snapshot()
     if _tc_active():
         # Stop on Tidal Connect just clears the queue + pauses the
         # device. Disconnecting is a separate user action through
@@ -4958,6 +5188,22 @@ def player_stop() -> dict:
 @app.post("/api/player/seek")
 def player_seek(req: _PlayerSeekRequest) -> dict:
     _require_local_access()
+    if _tcr_active():
+        from app.audio.tidal_connect_real import get_manager as _tcr_get
+        # Real-TC takes seek in MILLISECONDS (not seconds like the
+        # OpenHome path). Resolve the fractional position from the
+        # last device-reported duration.
+        mgr = _tcr_get()
+        rs = mgr.remote_state() if mgr is not None else {}
+        duration_ms = int(rs.get("duration_ms") or 0)
+        position_ms = int(max(0.0, min(req.fraction, 1.0)) * duration_ms)
+        try:
+            mgr.seek(position_ms)  # type: ignore[union-attr]
+        except Exception as exc:
+            raise HTTPException(
+                status_code=502, detail=f"Tidal Connect: {exc}"
+            ) from exc
+        return _tcr_snapshot()
     if _tc_active():
         from app.audio.tidal_connect import get_manager
         # Resolve the fractional position into seconds using the
@@ -6202,6 +6448,99 @@ def tidal_connect_disconnect() -> dict:
     from app.audio.tidal_connect import get_manager  # noqa: WPS433
 
     get_manager().disconnect()
+    return {"ok": True}
+
+
+# --- Real Tidal Connect ----------------------------------------------------
+# Parallel to the OpenHome /api/tidal-connect/* surface above. These talk
+# the actual Tidal Connect WSS protocol via app/audio/tidal_connect_real.py
+# (which uses the captured `sessionCredential = user_id` finding). Once the
+# real path is verified against hardware, the migration plan calls for the
+# picker to merge both device lists with real-TC winning conflicts; until
+# then they're separate endpoints so the OpenHome path keeps working
+# untouched. See private/features/tidal-connect-real-spec.md.
+
+
+@app.get("/api/tidal-connect-real/devices")
+def tidal_connect_real_devices() -> dict:
+    """Snapshot of devices visible on `_tidalconnect._tcp.local`.
+
+    Discovery runs continuously in the background via mDNS (started in
+    the lifespan), so this returns the cached set immediately. No active
+    refresh — the mDNS browser is already pushing updates."""
+    _require_local_access()
+    from app.audio.tidal_connect_real import get_manager  # noqa: WPS433
+
+    mgr = get_manager()
+    if mgr is None:
+        return {"devices": [], "active_device_id": None}
+    conn = mgr.get_connection()
+    active_id = conn.device.id if conn is not None else None
+    return {
+        "devices": [
+            {
+                "id": d.id,
+                "name": d.name,
+                "address": d.address,
+                "port": d.port,
+            }
+            for d in mgr.list_devices()
+        ],
+        "active_device_id": active_id,
+    }
+
+
+class _TidalConnectRealConnectRequest(BaseModel):
+    device_id: str
+
+
+@app.post("/api/tidal-connect-real/connect")
+def tidal_connect_real_connect(req: _TidalConnectRealConnectRequest) -> dict:
+    """Open a session to a real Tidal Connect device.
+
+    Status codes:
+      200  session opened
+      404  device id isn't in the discovery cache
+      503  manager not running (lifespan didn't start it)
+      502  WSS handshake failed or the device rejected `startSession`
+    """
+    _require_local_access()
+    from app.audio.tidal_connect_real import get_manager  # noqa: WPS433
+
+    mgr = get_manager()
+    if mgr is None:
+        raise HTTPException(status_code=503, detail="manager not running")
+    try:
+        mgr.connect(req.device_id)
+    except KeyError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except (RuntimeError, OSError) as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    conn = mgr.get_connection()
+    if conn is None:
+        raise HTTPException(
+            status_code=502, detail="connect returned but no active connection"
+        )
+    return {
+        "ok": True,
+        "device": {
+            "id": conn.device.id,
+            "name": conn.device.name,
+            "address": conn.device.address,
+            "port": conn.device.port,
+        },
+    }
+
+
+@app.post("/api/tidal-connect-real/disconnect")
+def tidal_connect_real_disconnect() -> dict:
+    """Tear down the active real-TC session. Idempotent."""
+    _require_local_access()
+    from app.audio.tidal_connect_real import get_manager  # noqa: WPS433
+
+    mgr = get_manager()
+    if mgr is not None:
+        mgr.disconnect()
     return {"ok": True}
 
 

--- a/server.py
+++ b/server.py
@@ -868,11 +868,20 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
             # the cost on first navigation, same as today.
             pass
 
-    threading.Thread(
-        target=_prewarm_aoty,
-        name="aoty-prewarm",
-        daemon=True,
-    ).start()
+    # Skip the pre-warm thread under pytest. The daemon thread runs
+    # against `server.tidal` and `server.album_to_dict`; if a different
+    # test later swaps those out via monkeypatch, the still-running
+    # pre-warm thread silently lands extra calls on the stubbed
+    # versions and breaks any test that asserts on call counts
+    # (test_aoty_resolver.test_cache_hit_short_circuits_search). The
+    # pre-warm has zero value during tests anyway since they tear down
+    # the app before any frontend request lands.
+    if "pytest" not in sys.modules:
+        threading.Thread(
+            target=_prewarm_aoty,
+            name="aoty-prewarm",
+            daemon=True,
+        ).start()
 
     try:
         yield

--- a/server.py
+++ b/server.py
@@ -682,7 +682,7 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     # local-output silencer isn't wired, and no URL resolver. Later
     # phases add those.
     #
-    # token_provider returns the Tidal user id as a string — that's
+    # token_provider returns the Tidal user id as a string. That's
     # the exact `sessionCredential` the official desktop client
     # ships on `startSession` (verified against a fake-receiver rig;
     # see private/tools/tidal-connect-capture/).
@@ -704,7 +704,7 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
         )
         # Silencer mutes the local sounddevice output while a real-TC
         # session is open, same flag Cast / OpenHome / DLNA all use.
-        # Audio still streams to its destination — this only gates
+        # Audio still streams to its destination. This only gates
         # the local playback path so the user doesn't hear two
         # simultaneous outputs.
         _tcr_mgr.set_local_silencer(
@@ -717,7 +717,7 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
             Mirrors the OpenHome resolver above but produces the
             shape `tidalConnect/mediaInfo.js` documents:
             {itemId, mediaId, srcUrl, streamType, metadata}. Same
-            tidalapi path as the OpenHome resolver — picks the
+            tidalapi path as the OpenHome resolver. Picks the
             manifest's first URL as the stream URL and stamps
             metadata for on-device display.
 
@@ -4686,7 +4686,7 @@ def _tcr_active() -> bool:
 
 def _tcr_snapshot(track_id: Optional[str] = None) -> dict:
     """Player-snapshot-shaped dict from real-TC remote_state. Reads
-    the device's last-reported notification state — frontend doesn't
+    the device's last-reported notification state. The frontend doesn't
     branch on which engine is active, both produce the same shape."""
     from app.audio.tidal_connect_real import get_manager
 
@@ -4723,7 +4723,7 @@ def _tcr_snapshot(track_id: Optional[str] = None) -> dict:
         "volume": int(rs.get("volume") or 100),
         "muted": bool(rs.get("muted")),
         "error": None,
-        "seq": 0,
+        "seq": int(rs.get("seq") or 0),
         "stream_info": None,
         "force_volume": False,
     }
@@ -5153,7 +5153,7 @@ def player_stop() -> dict:
     _require_local_access()
     if _tcr_active():
         # Real-TC: pause the device. Same logic as the OpenHome
-        # branch — stop is a per-track action, not a session
+        # branch. Stop is a per-track action, not a session
         # teardown. Disconnect is what the picker does for full
         # teardown.
         from app.audio.tidal_connect_real import get_manager as _tcr_get
@@ -6467,7 +6467,7 @@ def tidal_connect_real_devices() -> dict:
 
     Discovery runs continuously in the background via mDNS (started in
     the lifespan), so this returns the cached set immediately. No active
-    refresh — the mDNS browser is already pushing updates."""
+    refresh. The mDNS browser is already pushing updates."""
     _require_local_access()
     from app.audio.tidal_connect_real import get_manager  # noqa: WPS433
 

--- a/tests/test_tidal_connect_real.py
+++ b/tests/test_tidal_connect_real.py
@@ -1,0 +1,225 @@
+"""Tests for the real Tidal Connect controller skeleton.
+
+The wire-level pieces (TLS context, command frame shapes, request/
+response correlation, discovery service constant) are testable
+without hardware. The full WSS round-trip against a real device
+isn't, and waits for a contributor with hardware.
+
+Once captured-fixture frames from a real session are available,
+add a `tests/fixtures/tidal_connect_real/` tree of JSON frames and
+extend these tests to drive the receiver loop against them.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import ssl
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from app.audio import tidal_connect_real as tcr
+
+
+# ---------------------------------------------------------------------------
+# Protocol constants
+# ---------------------------------------------------------------------------
+
+
+def test_service_type_matches_desktop_client():
+    """The desktop client browses `_tidalconnect._tcp.local`. Anything
+    else and our discovery sees zero devices."""
+    assert tcr.TIDAL_CONNECT_SERVICE == "_tidalconnect._tcp.local."
+
+
+def test_ca_bundle_loads_and_carries_two_certs():
+    """The desktop client embeds TIDAL Root CA + TIDAL TS CA. If
+    either is missing or malformed, every device connection fails
+    TLS validation. Loading the bundle into an SSLContext is the
+    cheapest way to confirm both certs parse and chain."""
+    ctx = tcr._build_ssl_context()
+    certs = ctx.get_ca_certs()
+    assert len(certs) == 2
+    cns = []
+    for c in certs:
+        # Subject is a tuple of RDN tuples; flatten and pull CN.
+        for rdn in c.get("subject", ()):
+            for attr, value in rdn:
+                if attr == "commonName":
+                    cns.append(value)
+    assert "TIDAL Root CA" in cns
+    assert "TIDAL TS CA" in cns
+
+
+def test_ssl_context_skips_hostname_verification():
+    """Tidal Connect devices serve certs with IP-based identities,
+    not DNS names. Hostname verification has to be off, otherwise
+    the WSS handshake fails the moment we connect."""
+    ctx = tcr._build_ssl_context()
+    assert ctx.check_hostname is False
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+# ---------------------------------------------------------------------------
+# Frame builders (via a connection in isolation)
+# ---------------------------------------------------------------------------
+
+
+def _make_connection_with_fake_socket() -> tuple[
+    tcr.TidalConnectConnection, MagicMock
+]:
+    """Construct a connection wired to a mock WebSocket so we can
+    observe outbound frames without opening a real connection."""
+    device = tcr.DiscoveredDevice(
+        id="test", name="Test Device", address="192.168.1.50", port=12345
+    )
+    conn = tcr.TidalConnectConnection(
+        device=device,
+        token_provider=lambda: "test-token",
+        on_notification=lambda _: None,
+    )
+    fake_socket = MagicMock()
+    fake_socket.send = AsyncMock()
+    conn._websocket = fake_socket
+    return conn, fake_socket
+
+
+def _last_sent_frame(fake_socket: MagicMock) -> dict:
+    args, _ = fake_socket.send.call_args
+    return json.loads(args[0])
+
+
+def _drive_send(coro):
+    """Run a connection coroutine to first await without waiting on
+    the response future. The test resolves the future manually."""
+    loop = asyncio.new_event_loop()
+    try:
+        task = loop.create_task(coro)
+        # Yield once so the await self._websocket.send(...) lands.
+        loop.run_until_complete(asyncio.sleep(0))
+        return loop, task
+    except BaseException:
+        loop.close()
+        raise
+
+
+def test_play_frame_shape():
+    conn, fake = _make_connection_with_fake_socket()
+    loop, task = _drive_send(conn.play())
+    try:
+        frame = _last_sent_frame(fake)
+        assert frame["command"] == "play"
+        assert "requestId" in frame
+        # Resolve the pending future so the task can complete.
+        rid = frame["requestId"]
+        conn._pending[rid].set_result({"requestId": rid, "ok": True})
+        loop.run_until_complete(task)
+    finally:
+        loop.close()
+
+
+def test_seek_frame_carries_position():
+    conn, fake = _make_connection_with_fake_socket()
+    loop, task = _drive_send(conn.seek(45_000))
+    try:
+        frame = _last_sent_frame(fake)
+        assert frame["command"] == "seek"
+        assert frame["position"] == 45_000
+        rid = frame["requestId"]
+        conn._pending[rid].set_result({"requestId": rid})
+        loop.run_until_complete(task)
+    finally:
+        loop.close()
+
+
+def test_set_volume_clamps_to_int():
+    """The desktop client's setVolume accepts an integer; if a
+    caller passes a float we coerce so the device sees the right
+    JSON type."""
+    conn, fake = _make_connection_with_fake_socket()
+    loop, task = _drive_send(conn.set_volume(33.7))  # type: ignore[arg-type]
+    try:
+        frame = _last_sent_frame(fake)
+        assert frame["command"] == "setVolume"
+        assert frame["level"] == 33
+        assert isinstance(frame["level"], int)
+        rid = frame["requestId"]
+        conn._pending[rid].set_result({"requestId": rid})
+        loop.run_until_complete(task)
+    finally:
+        loop.close()
+
+
+def test_request_id_increments_per_send():
+    """Each command must carry a fresh requestId so concurrent
+    in-flight requests can be matched to their responses without
+    collision."""
+    conn, fake = _make_connection_with_fake_socket()
+    loop = asyncio.new_event_loop()
+    try:
+        ids_seen: list[int] = []
+        for _ in range(3):
+            task = loop.create_task(conn.play())
+            loop.run_until_complete(asyncio.sleep(0))
+            frame = json.loads(fake.send.call_args[0][0])
+            ids_seen.append(frame["requestId"])
+            conn._pending[frame["requestId"]].set_result(
+                {"requestId": frame["requestId"]}
+            )
+            loop.run_until_complete(task)
+        assert ids_seen == sorted(ids_seen)
+        assert len(set(ids_seen)) == 3
+    finally:
+        loop.close()
+
+
+def test_set_repeat_mode_uses_string_enum():
+    """The desktop client's RepeatMode is a string enum: OFF / ALL
+    / SINGLE. We forward whatever the caller passes; this test
+    just confirms the field name and that the value is sent
+    verbatim."""
+    conn, fake = _make_connection_with_fake_socket()
+    loop, task = _drive_send(conn.set_repeat_mode("ALL"))
+    try:
+        frame = _last_sent_frame(fake)
+        assert frame["command"] == "setRepeatMode"
+        assert frame["repeatMode"] == "ALL"
+        rid = frame["requestId"]
+        conn._pending[rid].set_result({"requestId": rid})
+        loop.run_until_complete(task)
+    finally:
+        loop.close()
+
+
+# ---------------------------------------------------------------------------
+# Manager singleton
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_singleton():
+    tcr._manager = None
+    yield
+    if tcr._manager is not None:
+        try:
+            tcr._manager.stop()
+        except Exception:
+            pass
+        tcr._manager = None
+
+
+def test_get_manager_returns_none_until_started():
+    assert tcr.get_manager() is None
+
+
+def test_start_manager_is_idempotent():
+    m1 = tcr.start_manager(
+        token_provider=lambda: None,
+        on_notification=lambda _: None,
+    )
+    m2 = tcr.start_manager(
+        token_provider=lambda: None,
+        on_notification=lambda _: None,
+    )
+    assert m1 is m2
+    assert tcr.get_manager() is m1

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1246,6 +1246,35 @@ export const api = {
         method: "POST",
       }),
   },
+  // Real Tidal Connect — talks the actual WSS protocol via
+  // app/audio/tidal_connect_real.py. Parallel to tidalConnect (which
+  // is the OpenHome-mimic path). Discovery is continuous (mDNS), so
+  // devices() just returns the cached snapshot without an active
+  // refresh.
+  tidalConnectReal: {
+    devices: () =>
+      req<{
+        devices: {
+          id: string;
+          name: string;
+          address: string;
+          port: number;
+        }[];
+        active_device_id: string | null;
+      }>("/api/tidal-connect-real/devices"),
+    connect: (deviceId: string) =>
+      req<{
+        ok: boolean;
+        device: { id: string; name: string; address: string; port: number };
+      }>("/api/tidal-connect-real/connect", {
+        method: "POST",
+        body: JSON.stringify({ device_id: deviceId }),
+      }),
+    disconnect: () =>
+      req<{ ok: boolean }>("/api/tidal-connect-real/disconnect", {
+        method: "POST",
+      }),
+  },
   dlna: {
     // Returns the cached device list without triggering a fresh
     // SSDP scan. Cheap and safe to poll. Use refresh() when the

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1246,7 +1246,7 @@ export const api = {
         method: "POST",
       }),
   },
-  // Real Tidal Connect — talks the actual WSS protocol via
+  // Real Tidal Connect. Talks the actual WSS protocol via
   // app/audio/tidal_connect_real.py. Parallel to tidalConnect (which
   // is the OpenHome-mimic path). Discovery is continuous (mDNS), so
   // devices() just returns the cached snapshot without an active

--- a/web/src/components/OutputDevicePicker.tsx
+++ b/web/src/components/OutputDevicePicker.tsx
@@ -86,6 +86,18 @@ type TidalConnectDevicesResponse = {
   devices: TidalConnectDeviceSummary[];
 };
 
+type TidalConnectRealDeviceSummary = {
+  id: string;
+  name: string;
+  address: string;
+  port: number;
+};
+
+type TidalConnectRealDevicesResponse = {
+  devices: TidalConnectRealDeviceSummary[];
+  active_device_id: string | null;
+};
+
 type DlnaDeviceSummary = {
   id: string;
   name: string;
@@ -108,6 +120,7 @@ type DlnaDevicesResponse = {
 const LOCAL_PREFIX = "local:";
 const CAST_PREFIX = "cast:";
 const TC_PREFIX = "tc:";
+const TCR_PREFIX = "tcr:";
 const DLNA_PREFIX = "dlna:";
 
 export function OutputDevicePicker() {
@@ -115,6 +128,7 @@ export function OutputDevicePicker() {
   const opts = useAudioOptions();
   const [cast, setCast] = useState<CastDevicesResponse | null>(null);
   const [tc, setTc] = useState<TidalConnectDevicesResponse | null>(null);
+  const [tcr, setTcr] = useState<TidalConnectRealDevicesResponse | null>(null);
   const [dlna, setDlna] = useState<DlnaDevicesResponse | null>(null);
   const [busy, setBusy] = useState(false);
   const [moreOpen, setMoreOpen] = useState(false);
@@ -125,6 +139,11 @@ export function OutputDevicePicker() {
   // users get a heads-up about what they're testing.
   const [pendingTcDevice, setPendingTcDevice] =
     useState<TidalConnectDeviceSummary | null>(null);
+  // Same dialog flow for the real-TC path. The two device shapes
+  // differ enough (real-TC has no manufacturer/model) that two
+  // states is cleaner than one merged "tc-pending" with a tag.
+  const [pendingTcrDevice, setPendingTcrDevice] =
+    useState<TidalConnectRealDeviceSummary | null>(null);
 
   // Light Cast polling so the picker reflects mDNS arrivals /
   // departures and detects backend-initiated disconnects (Cast
@@ -165,6 +184,14 @@ export function OutputDevicePicker() {
         .devices()
         .then((res) => setTc(res))
         .catch(() => {}),
+      // Real Tidal Connect uses mDNS, which is continuous in the
+      // background (zero-cost cached read on this endpoint), so we
+      // can refresh on every dropdown open without an SSDP-style
+      // 5s scan stall.
+      api.tidalConnectReal
+        .devices()
+        .then((res) => setTcr(res))
+        .catch(() => {}),
       // DLNA also uses SSDP. /api/dlna/refresh blocks for the
       // scan timeout (default 5s) and returns the fresh list; the
       // dropdown waits on this so the user sees populated devices
@@ -186,14 +213,17 @@ export function OutputDevicePicker() {
   // correctness.
   const castConnectedId = cast?.status.connected_id ?? null;
   const tcConnectedId = tc?.status.connected_id ?? null;
+  const tcrConnectedId = tcr?.active_device_id ?? null;
   const dlnaConnectedId = dlna?.status.connected_id ?? null;
   const selectedValue = castConnectedId
     ? `${CAST_PREFIX}${castConnectedId}`
-    : tcConnectedId
-      ? `${TC_PREFIX}${tcConnectedId}`
-      : dlnaConnectedId
-        ? `${DLNA_PREFIX}${dlnaConnectedId}`
-        : `${LOCAL_PREFIX}${opts.current}`;
+    : tcrConnectedId
+      ? `${TCR_PREFIX}${tcrConnectedId}`
+      : tcConnectedId
+        ? `${TC_PREFIX}${tcConnectedId}`
+        : dlnaConnectedId
+          ? `${DLNA_PREFIX}${dlnaConnectedId}`
+          : `${LOCAL_PREFIX}${opts.current}`;
 
   const showCastSection =
     cast !== null &&
@@ -204,6 +234,9 @@ export function OutputDevicePicker() {
     tc !== null &&
     tc.status.available &&
     (tc.devices.length > 0 || tcConnectedId !== null);
+
+  const showTcrSection =
+    tcr !== null && (tcr.devices.length > 0 || tcrConnectedId !== null);
 
   const showDlnaSection =
     dlna !== null &&
@@ -217,6 +250,7 @@ export function OutputDevicePicker() {
     // returning to local; otherwise the audio engine briefly
     // feeds two destinations and produces a stutter.
     if (castConnectedId !== null) await api.cast.disconnect();
+    if (tcrConnectedId !== null) await api.tidalConnectReal.disconnect();
     if (tcConnectedId !== null) await api.tidalConnect.disconnect();
     if (dlnaConnectedId !== null) await api.dlna.disconnect();
   };
@@ -233,6 +267,14 @@ export function OutputDevicePicker() {
       const device = tc?.devices.find((d) => d.id === deviceId);
       if (device) {
         setPendingTcDevice(device);
+        return;
+      }
+    }
+    if (value.startsWith(TCR_PREFIX)) {
+      const deviceId = value.slice(TCR_PREFIX.length);
+      const device = tcr?.devices.find((d) => d.id === deviceId);
+      if (device) {
+        setPendingTcrDevice(device);
         return;
       }
     }
@@ -307,6 +349,35 @@ export function OutputDevicePicker() {
     }
   };
 
+  const confirmConnectTcr = async () => {
+    if (!pendingTcrDevice) return;
+    const device = pendingTcrDevice;
+    setPendingTcrDevice(null);
+    setBusy(true);
+    try {
+      await switchAwayFromRemoteIfActive();
+      const result = await api.tidalConnectReal.connect(device.id);
+      toast.show({
+        kind: "success",
+        title: `Connected to ${result.device.name}`,
+        description:
+          "Real Tidal Connect (WSS protocol). Untested against " +
+          "hardware — picking a track should now play on the " +
+          "device. Please report what works and what doesn't.",
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      toast.show({
+        kind: "error",
+        title: "Tidal Connect (Real) failed",
+        description: message,
+      });
+    } finally {
+      setBusy(false);
+      await refreshAll();
+    }
+  };
+
   const flipExclusive = async (v: boolean) => {
     try {
       await opts.setExclusiveMode(v);
@@ -338,17 +409,22 @@ export function OutputDevicePicker() {
   const triggerHighlight =
     castConnectedId !== null ||
     tcConnectedId !== null ||
+    tcrConnectedId !== null ||
     dlnaConnectedId !== null ||
     opts.exclusiveMode;
   const currentLocalName =
     opts.devices.find((d) => d.id === opts.current)?.name ?? "System default";
+  const tcrConnectedName =
+    tcr?.devices.find((d) => d.id === tcrConnectedId)?.name ?? "device";
   const triggerTitle = castConnectedId
     ? `Casting to ${cast?.status.connected_name ?? "device"}`
-    : tcConnectedId
-      ? `Tidal Connect: ${tc?.status.connected_name ?? "device"}`
-      : dlnaConnectedId
-        ? `Streaming to ${dlna?.status.connected_name ?? "device"}`
-        : `Output: ${currentLocalName}`;
+    : tcrConnectedId
+      ? `Tidal Connect: ${tcrConnectedName}`
+      : tcConnectedId
+        ? `Tidal Connect: ${tc?.status.connected_name ?? "device"}`
+        : dlnaConnectedId
+          ? `Streaming to ${dlna?.status.connected_name ?? "device"}`
+          : `Output: ${currentLocalName}`;
 
   return (
     <>
@@ -449,7 +525,7 @@ export function OutputDevicePicker() {
               </>
             )}
 
-            {showTcSection && (
+            {showTcrSection && (
               <>
                 <DropdownMenuSeparator />
                 <DropdownMenuLabel className="flex items-center gap-2 text-muted-foreground">
@@ -458,10 +534,45 @@ export function OutputDevicePicker() {
                     Experimental
                   </span>
                 </DropdownMenuLabel>
+                {tcr.devices.length === 0 ? (
+                  <div className="px-2 py-1.5 text-xs text-muted-foreground">
+                    No Tidal Connect devices visible. mDNS discovery is
+                    continuous in the background.
+                  </div>
+                ) : (
+                  tcr.devices.map((d) => (
+                    <DropdownMenuRadioItem
+                      key={d.id}
+                      value={`${TCR_PREFIX}${d.id}`}
+                      onSelect={(e) => e.preventDefault()}
+                      className="text-sm"
+                      disabled={busy}
+                    >
+                      <div className="flex flex-col">
+                        <span>{d.name}</span>
+                        <span className="text-[11px] text-muted-foreground">
+                          {`${d.address}:${d.port}`}
+                        </span>
+                      </div>
+                    </DropdownMenuRadioItem>
+                  ))
+                )}
+              </>
+            )}
+
+            {showTcSection && (
+              <>
+                <DropdownMenuSeparator />
+                <DropdownMenuLabel className="flex items-center gap-2 text-muted-foreground">
+                  <span>Tidal Connect (OpenHome)</span>
+                  <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-amber-500">
+                    Experimental
+                  </span>
+                </DropdownMenuLabel>
                 {tc.devices.length === 0 ? (
                   <div className="px-2 py-1.5 text-xs text-muted-foreground">
-                    No Tidal Connect devices visible. Open the dropdown to
-                    re-scan; SSDP discovery takes a few seconds.
+                    No OpenHome devices visible. Open the dropdown to re-scan;
+                    SSDP discovery takes a few seconds.
                   </div>
                 ) : (
                   tc.devices.map((d) => (
@@ -557,6 +668,12 @@ export function OutputDevicePicker() {
         onCancel={() => setPendingTcDevice(null)}
         onConfirm={confirmConnectTc}
       />
+
+      <TidalConnectRealExperimentalDialog
+        device={pendingTcrDevice}
+        onCancel={() => setPendingTcrDevice(null)}
+        onConfirm={confirmConnectTcr}
+      />
     </>
   );
 }
@@ -611,6 +728,66 @@ function TidalConnectExperimentalDialog({
             and report what you see (device model + the error in the toast).
             That feedback tells us whether shipping this as a real feature is
             even possible.
+          </p>
+        </div>
+        <div className="flex justify-end gap-2 pt-3">
+          <Button variant="ghost" size="sm" onClick={onCancel}>
+            Cancel
+          </Button>
+          <Button size="sm" onClick={onConfirm}>
+            Connect
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/**
+ * Confirmation dialog for the real-Tidal-Connect path. Same role
+ * as TidalConnectExperimentalDialog, different copy: the real-TC
+ * controller speaks Tidal's actual WSS protocol (decoded from the
+ * desktop client's bundled JS), but hasn't been validated against
+ * a real Bluesound / Linn / NAD on the LAN. Users opting into this
+ * are testing whether the wire shape we send matches what real
+ * receivers accept.
+ */
+function TidalConnectRealExperimentalDialog({
+  device,
+  onCancel,
+  onConfirm,
+}: {
+  device: TidalConnectRealDeviceSummary | null;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog
+      open={device !== null}
+      onOpenChange={(open) => {
+        if (!open) onCancel();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            Connect to {device?.name ?? "Tidal Connect device"}?
+          </DialogTitle>
+          <DialogDescription>
+            Experimental — real WSS protocol.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="flex flex-col gap-3 pt-2 text-sm text-foreground">
+          <p>
+            This is the real Tidal Connect protocol — the same WSS-based session
+            the official Tidal desktop client uses. The wire shape was decoded
+            from Tidal's bundled JavaScript and the credential format captured
+            against a fake-receiver rig. Untested against actual hardware.
+          </p>
+          <p className="text-muted-foreground">
+            If audio doesn't play after you select a track, please disconnect
+            and report the device model + the error in the toast. That feedback
+            tells us whether the protocol implementation needs adjustment.
           </p>
         </div>
         <div className="flex justify-end gap-2 pt-3">

--- a/web/src/components/OutputDevicePicker.tsx
+++ b/web/src/components/OutputDevicePicker.tsx
@@ -332,7 +332,7 @@ export function OutputDevicePicker() {
         kind: "success",
         title: `Connected to ${result.device.friendly_name}`,
         description:
-          "Tidal Connect is experimental. Picking a track from " +
+          "OpenHome streaming is experimental. Picking a track from " +
           "Tideway should now play on the device. Please report " +
           "what works and what doesn't.",
       });
@@ -340,7 +340,7 @@ export function OutputDevicePicker() {
       const message = err instanceof Error ? err.message : String(err);
       toast.show({
         kind: "error",
-        title: "Tidal Connect failed",
+        title: "OpenHome connect failed",
         description: message,
       });
     } finally {
@@ -362,7 +362,7 @@ export function OutputDevicePicker() {
         title: `Connected to ${result.device.name}`,
         description:
           "Real Tidal Connect (WSS protocol). Untested against " +
-          "hardware — picking a track should now play on the " +
+          "hardware. Picking a track should now play on the " +
           "device. Please report what works and what doesn't.",
       });
     } catch (err) {
@@ -421,7 +421,7 @@ export function OutputDevicePicker() {
     : tcrConnectedId
       ? `Tidal Connect: ${tcrConnectedName}`
       : tcConnectedId
-        ? `Tidal Connect: ${tc?.status.connected_name ?? "device"}`
+        ? `OpenHome: ${tc?.status.connected_name ?? "device"}`
         : dlnaConnectedId
           ? `Streaming to ${dlna?.status.connected_name ?? "device"}`
           : `Output: ${currentLocalName}`;
@@ -564,7 +564,7 @@ export function OutputDevicePicker() {
               <>
                 <DropdownMenuSeparator />
                 <DropdownMenuLabel className="flex items-center gap-2 text-muted-foreground">
-                  <span>Tidal Connect (OpenHome)</span>
+                  <span>OpenHome</span>
                   <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-[10px] font-bold uppercase tracking-wider text-amber-500">
                     Experimental
                   </span>
@@ -711,23 +711,22 @@ function TidalConnectExperimentalDialog({
       <DialogContent className="sm:max-w-md">
         <DialogHeader>
           <DialogTitle>
-            Connect to {device?.friendly_name ?? "Tidal Connect device"}?
+            Connect to {device?.friendly_name ?? "OpenHome device"}?
           </DialogTitle>
           <DialogDescription>Experimental feature.</DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-3 pt-2 text-sm text-foreground">
           <p>
-            Tidal Connect support in Tideway is built against the published
-            OpenHome / UPnP-AV spec but hasn't been verified against real
-            hardware. We don't know yet whether a real Tidal Connect device will
-            accept stream URLs from a non-Tidal client — recent research into
-            Tidal's auth model suggests it might not.
+            This device speaks OpenHome / UPnP-AV. Tideway sends Tidal stream
+            URLs to it via DIDL-Lite metadata, which works on Linn, Lumin, and
+            Auralic streamers but isn't the same protocol as Tidal Connect.
+            Whether your specific device accepts the stream is what's untested.
           </p>
           <p className="text-muted-foreground">
             If audio doesn't play after you select a track, please disconnect
-            and report what you see (device model + the error in the toast).
-            That feedback tells us whether shipping this as a real feature is
-            even possible.
+            and report what you see (device model and the error in the toast).
+            For devices that support actual Tidal Connect, use that section
+            instead.
           </p>
         </div>
         <div className="flex justify-end gap-2 pt-3">
@@ -774,12 +773,12 @@ function TidalConnectRealExperimentalDialog({
             Connect to {device?.name ?? "Tidal Connect device"}?
           </DialogTitle>
           <DialogDescription>
-            Experimental — real WSS protocol.
+            Experimental. Real WSS protocol.
           </DialogDescription>
         </DialogHeader>
         <div className="flex flex-col gap-3 pt-2 text-sm text-foreground">
           <p>
-            This is the real Tidal Connect protocol — the same WSS-based session
+            This is the real Tidal Connect protocol, the same WSS-based session
             the official Tidal desktop client uses. The wire shape was decoded
             from Tidal's bundled JavaScript and the credential format captured
             against a fake-receiver rig. Untested against actual hardware.


### PR DESCRIPTION
## Summary
- Adds `app/audio/tidal_connect_real.py`, a WSS-based Tidal Connect controller speaking the same protocol the official desktop client uses (decoded from its bundled JS).
- Wires it into the app surface: lifespan startup/teardown, output device picker, silencer (PCMPlayer mutes during a real-TC session), command routing for play/pause/resume/stop/seek/load, URL resolver for `loadMediaInfo`, and `/api/tidal-connect-real/{devices,connect,disconnect}`.
- The existing OpenHome `tidal_connect.py` path stays in place; the picker shows both sections side-by-side and the OpenHome label updates to "Tidal Connect (OpenHome)" so they don't visually collide. Per the migration plan in `private/features/tidal-connect-real-spec.md`, real-TC supersedes OpenHome on conflict.
- Credential format (`sessionCredential`) was the unknown blocker — captured against a fake-receiver rig (`private/tools/tidal-connect-capture/`) and turned out to be the user id as a decimal string. Receiver does the OAuth `switch_client` exchange itself, so the controller never holds tokens.

## Test plan
- [ ] `pytest tests/` — backend (665+ tests pass locally).
- [ ] `cd web && npx tsc -b --noEmit` — clean.
- [ ] `cd web && npm run lint:all` — 0 errors (61 pre-existing warnings).
- [ ] `cd web && npm test` — frontend vitest passes.
- [ ] Sign in, open the speaker-icon device picker, confirm the new "Tidal Connect" section is present and the existing "Tidal Connect (OpenHome)" section still lists OpenHome devices.
- [ ] Round-trip against a real Bluesound / Linn / NAD: click the device, play a track, confirm audio reaches the receiver. **Untested locally — no hardware.**
- [ ] Disconnect from a real-TC session, confirm local audio resumes.