### PR TITLE
macOS: X button hides, dock reopens, fix double-click zoom

### DIFF
--- a/app/window_chrome.py
+++ b/app/window_chrome.py
@@ -728,10 +728,36 @@ def _install_drag_monitor(nswindow) -> None:
                 return event
             if location.x > (window_width - float(_CORNER_RESIZE_ZONE_PT)):
                 return event
-            # In the titlebar zone — start a native window drag.
-            # The OS's drag loop tracks mouseUp on its own and
-            # decides drag vs double-click-zoom based on movement
-            # within its threshold.
+            # In the titlebar zone. Two paths from here:
+            #
+            #   1. Double-click. The standard macOS title-bar action
+            #      depending on System Settings > Desktop & Dock >
+            #      "Double-click a window's title bar to" (Maximize,
+            #      Minimize, or do nothing). performWindowDragWithEvent_
+            #      doesn't handle this on its own despite what its docs
+            #      imply, so detect it explicitly via clickCount and
+            #      call the matching NSWindow action.
+            #
+            #   2. Single click. Start a native window drag. The OS's
+            #      drag loop tracks mouseUp on its own.
+            if event.clickCount() >= 2:
+                pref = "Maximize"
+                try:
+                    defaults = AppKit.NSUserDefaults.standardUserDefaults()
+                    user_pref = defaults.stringForKey_("AppleActionOnDoubleClick")
+                    if isinstance(user_pref, str) and user_pref:
+                        pref = user_pref
+                except Exception:
+                    pass
+                try:
+                    if pref == "Minimize":
+                        nswindow.performMiniaturize_(None)
+                    elif pref == "Maximize":
+                        nswindow.zoom_(None)
+                    # "None" pref: deliberately do nothing.
+                except Exception:
+                    return event
+                return None
             try:
                 nswindow.performWindowDragWithEvent_(event)
             except Exception:
@@ -742,8 +768,6 @@ def _install_drag_monitor(nswindow) -> None:
                 # crash.
                 return event
             # Consume the event so WKWebView doesn't ALSO see it.
-            # NSWindow.performWindowDragWithEvent_ handles the
-            # entire interaction internally.
             return None
         except Exception:
             log.exception(
@@ -757,6 +781,65 @@ def _install_drag_monitor(nswindow) -> None:
     )
     if monitor is not None:
         _drag_monitors[window_id] = monitor
+
+
+# Observer kept alive for the lifetime of the process. NSNotificationCenter
+# holds a weak reference to the observer, so a local that goes out of scope
+# stops receiving notifications.
+_dock_reopen_observer = None
+
+
+def install_macos_dock_reopen(show_callback) -> None:
+    """Re-show the hidden main window when the user clicks the dock icon.
+
+    On macOS the X button hides the window (see the closing handler in
+    desktop.py); the dock icon brings it back. NSApplication's default
+    behaviour reopens the main window only when applicationShouldHandleReopen
+    returns YES, but pywebview's app delegate doesn't implement that
+    method. Rather than swizzle pywebview's delegate (fragile across
+    pywebview versions), observe NSApplicationDidBecomeActiveNotification
+    and call the show callback. The callback is idempotent: showing an
+    already-visible window is a no-op orderFront, and showing a hidden
+    one brings it back, which is what we want in both cases.
+
+    Idempotent. Re-calling replaces the existing observer."""
+    global _dock_reopen_observer
+    if sys.platform != "darwin":
+        return
+
+    try:
+        import AppKit  # type: ignore
+        from Foundation import NSObject, NSNotificationCenter  # type: ignore
+    except Exception as exc:
+        log.warning("window_chrome: dock-reopen observer requires PyObjC: %s", exc)
+        return
+
+    if _dock_reopen_observer is not None:
+        try:
+            NSNotificationCenter.defaultCenter().removeObserver_(
+                _dock_reopen_observer
+            )
+        except Exception:
+            pass
+        _dock_reopen_observer = None
+
+    class _DockReopenObserver(NSObject):  # type: ignore[misc]
+        def applicationDidBecomeActive_(self, _notification):  # noqa: N802
+            try:
+                show_callback()
+            except Exception:
+                log.exception(
+                    "window_chrome: dock-reopen show callback raised"
+                )
+
+    observer = _DockReopenObserver.alloc().init()
+    NSNotificationCenter.defaultCenter().addObserver_selector_name_object_(
+        observer,
+        b"applicationDidBecomeActive:",
+        AppKit.NSApplicationDidBecomeActiveNotification,
+        None,
+    )
+    _dock_reopen_observer = observer
 
 
 # ---------------------------------------------------------------------------

--- a/desktop.py
+++ b/desktop.py
@@ -382,17 +382,22 @@ def main(argv: Optional[list[str]] = None) -> int:
         easy_drag=False,
     )
 
-    # Close behavior: clicking the X (or Cmd+Q on macOS, or any
-    # other native close path) destroys the window and exits the
-    # process. There is no hide-to-tray; the tray icon was removed
-    # in v1.5.2 because the hide-on-close behavior was unexpected
-    # and the tray's only documented purpose was to give the user
-    # a way back from the hidden state.
+    # Close behavior. On Windows / Linux the X destroys the window and
+    # the process exits. On macOS we follow the platform convention:
+    # the X hides the window without quitting, and the dock icon
+    # brings it back. Cmd+Q still quits because that goes through
+    # NSApplication.terminate, a separate code path that doesn't
+    # fire pywebview's `closing` event. Same for the in-app Quit
+    # menu's `_quit_app` below, which calls window.destroy() directly.
+    #
+    # We removed the Windows tray icon in v1.5.2 because hide-to-tray
+    # was unexpected and the tray's only purpose was to bring the
+    # window back. macOS has the dock for that, so it's not unexpected.
 
     def _show_window() -> None:
-        # Used by the focus callback for second-instance launches:
-        # bring the existing window to front instead of spawning a
-        # second one.
+        # Used by the focus callback for second-instance launches and
+        # by the dock-icon reopen handler on macOS: bring the existing
+        # window to front instead of spawning a second one.
         try:
             window.show()
         except Exception:
@@ -404,10 +409,45 @@ def main(argv: Optional[list[str]] = None) -> int:
 
     def _quit_app() -> None:
         # Used by the in-app Quit menu's /api/_internal/quit
-        # endpoint. Equivalent to clicking the OS close button
-        # now that there's no hide-to-tray interception.
+        # endpoint. Bypasses the closing-to-hide path on macOS by
+        # calling destroy directly.
         try:
             window.destroy()
+        except Exception:
+            pass
+
+    if sys.platform == "darwin":
+        def _on_closing_macos() -> bool:
+            """Cancel the X-button close path and hide instead.
+
+            Returning False from `closing` tells pywebview to keep the
+            window alive. Cmd+Q and the in-app Quit menu both bypass
+            this handler (they go through NSApp.terminate / window
+            .destroy respectively), so the user can still quit; only
+            the X click is intercepted."""
+            try:
+                window.hide()
+            except Exception:
+                pass
+            return False
+
+        try:
+            window.events.closing += _on_closing_macos
+        except Exception:
+            pass
+
+        # Re-show the hidden window when the user clicks the dock icon.
+        # Wired AFTER webview.start() so NSApp is up; we hook this from
+        # the `shown` event below rather than registering at create time.
+        def _install_dock_reopen() -> None:
+            try:
+                from app import window_chrome as _window_chrome
+                _window_chrome.install_macos_dock_reopen(_show_window)
+            except Exception:
+                pass
+
+        try:
+            window.events.shown += _install_dock_reopen
         except Exception:
             pass
 


### PR DESCRIPTION
## Summary
- On macOS, clicking the X now hides the window instead of quitting the app, matching macOS HIG. Cmd+Q and the in-app Quit menu still quit (they bypass the closing handler via NSApp.terminate / window.destroy on different code paths). The dock icon brings the hidden window back via an NSApplicationDidBecomeActiveNotification observer.
- Double-click on the title bar now zooms or minimizes per the user's System Settings → Desktop & Dock → "Double-click a window's title bar to" preference. Was broken because the drag monitor relied on performWindowDragWithEvent_ to handle the double-click case, which it doesn't actually do; added explicit clickCount detection.
- Windows / Linux behavior unchanged.

## Test plan
- [x] Manual: launched dev `desktop.py` on macOS, verified all four behaviors (X hides, dock reopens, Cmd+Q quits, double-click zooms).
- [ ] CI: pytest, tsc, lint, vitest.
- [ ] Smoke test on Windows / Linux to confirm no regression in close behavior (dev branches don't gate on these manually but the CI build will produce installers).