### PR TITLE
Wider screens get more grid columns, not bigger cards

### DIFF
--- a/web/src/components/Grid.tsx
+++ b/web/src/components/Grid.tsx
@@ -3,8 +3,15 @@ import { Link } from "react-router-dom";
 import { ChevronRight } from "lucide-react";
 
 export function Grid({ children }: PropsWithChildren) {
+  // Column count grows with viewport width so wide displays show more
+  // cards rather than fewer huge ones. The tiers above 2xl (1536px)
+  // matter for 1920p, 1440p widescreens, and 4K monitors where the
+  // default cap of 6 cols left each card around 400px wide.
+  // Keep in lockstep with `useColumnCount` — single-row sections slice
+  // their data by that hook, and the slice has to match what the CSS
+  // grid will actually render or trailing cards wrap to a phantom row.
   return (
-    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 min-[1920px]:grid-cols-7 min-[2400px]:grid-cols-8">
       {children}
     </div>
   );

--- a/web/src/components/PageView.tsx
+++ b/web/src/components/PageView.tsx
@@ -137,7 +137,7 @@ function Section({
     return (
       <div>
         {title && <SectionHeader title={title} subtitle={subtitle} />}
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6">
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 min-[1920px]:grid-cols-7 min-[2400px]:grid-cols-8">
           {links.map((l) => (
             <PageLinkTile key={l.path} link={l} />
           ))}
@@ -153,11 +153,13 @@ function Section({
   // sections is quick; the only cost is some rows lose their "view
   // more" affordance when Tidal didn't send a viewAllPath for them.
   const singleRow = forceSingleRow || Boolean(context || viewAllPath);
-  // Cap single rows at whichever is smaller: five (matches Tidal's
-  // homepage density) or the actual visible column count. Without the
-  // second cap a narrower viewport renders 4 cards then an orphaned
+  // Cap single rows at whichever is smaller: the row-cap or the actual
+  // visible column count. The cap matches the maximum useColumnCount
+  // produces (8 at 2400px+) so wide displays render a full row of
+  // cards rather than padding empty space. Without the columnCount
+  // floor a narrower viewport renders e.g. 4 cards then an orphaned
   // 5th on a partial second row.
-  const ROW_CAP = 5;
+  const ROW_CAP = 8;
   const visible = singleRow
     ? items.slice(0, Math.min(ROW_CAP, columnCount))
     : items;
@@ -178,8 +180,8 @@ function Section({
         className={cn(
           "grid gap-4",
           singleRow
-            ? "grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5"
-            : "grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6",
+            ? "grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 min-[1920px]:grid-cols-7 min-[2400px]:grid-cols-8"
+            : "grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 min-[1920px]:grid-cols-7 min-[2400px]:grid-cols-8",
         )}
       >
         {visible.map((it, idx) => (

--- a/web/src/components/Skeletons.tsx
+++ b/web/src/components/Skeletons.tsx
@@ -24,7 +24,7 @@ export function CardSkeleton() {
 
 export function GridSkeleton({ count = 12 }: { count?: number }) {
   return (
-    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 min-[1920px]:grid-cols-7 min-[2400px]:grid-cols-8">
       {Array.from({ length: count }, (_, i) => (
         <CardSkeleton key={i} />
       ))}

--- a/web/src/hooks/useColumnCount.ts
+++ b/web/src/hooks/useColumnCount.ts
@@ -10,12 +10,16 @@ import { useEffect, useState } from "react";
  * this hook exists to prevent.
  *
  * Grid's classes: `grid-cols-2 sm:grid-cols-3 lg:grid-cols-4
- *                  xl:grid-cols-5 2xl:grid-cols-6`. That means:
- *   base  < 640   → 2
- *   sm   >= 640   → 3
- *   lg   >= 1024  → 4
- *   xl   >= 1280  → 5
- *   2xl  >= 1536  → 6
+ *                  xl:grid-cols-5 2xl:grid-cols-6
+ *                  min-[1920px]:grid-cols-7 min-[2400px]:grid-cols-8`.
+ * That means:
+ *   base       < 640   → 2
+ *   sm        >= 640   → 3
+ *   lg        >= 1024  → 4
+ *   xl        >= 1280  → 5
+ *   2xl       >= 1536  → 6
+ *   ultrawide >= 1920  → 7
+ *   4k+       >= 2400  → 8
  */
 export function useColumnCount(): number {
   const [cols, setCols] = useState(() => compute(safeWindowWidth()));
@@ -36,6 +40,8 @@ function safeWindowWidth(): number {
 }
 
 function compute(width: number): number {
+  if (width >= 2400) return 8;
+  if (width >= 1920) return 7;
   if (width >= 1536) return 6;
   if (width >= 1280) return 5;
   if (width >= 1024) return 4;

--- a/web/src/pages/AlbumDetail.tsx
+++ b/web/src/pages/AlbumDetail.tsx
@@ -284,7 +284,7 @@ function SingleRowSection({
         <h2 className="text-xl font-bold tracking-tight">{title}</h2>
         {viewAllHref && <ViewMoreLink to={viewAllHref} />}
       </div>
-      <div className="grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 2xl:grid-cols-6">
+      <div className="grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 2xl:grid-cols-6 min-[1920px]:grid-cols-7 min-[2400px]:grid-cols-8">
         {items.slice(0, 6).map((it, i) => (
           // Hide items past the current breakpoint's column count so
           // the section is always exactly one row — previously the

--- a/web/src/pages/PopularPage.tsx
+++ b/web/src/pages/PopularPage.tsx
@@ -163,7 +163,7 @@ function ChartArtists() {
     );
   }
   return (
-    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 min-[1920px]:grid-cols-7 min-[2400px]:grid-cols-8">
       {data.map((a, i) => (
         <ArtistChartCard key={`${a.name}-${i}`} rank={i + 1} artist={a} />
       ))}
@@ -327,7 +327,7 @@ function formatCompact(n: number): string {
 
 function ArtistGridSkeleton() {
   return (
-    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 min-[1920px]:grid-cols-7 min-[2400px]:grid-cols-8">
       {Array.from({ length: 12 }).map((_, i) => (
         <Skeleton key={i} className="aspect-square w-full" />
       ))}

--- a/web/src/pages/StatsDetail.tsx
+++ b/web/src/pages/StatsDetail.tsx
@@ -103,7 +103,7 @@ function ArtistsList({ period }: { period: LastFmPeriod }) {
     );
   }
   return (
-    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 min-[1920px]:grid-cols-7 min-[2400px]:grid-cols-8">
       {data.map((a, i) => (
         <ArtistCard key={`${a.name}-${i}`} rank={i + 1} artist={a} />
       ))}
@@ -171,7 +171,7 @@ function AlbumsList({ period }: { period: LastFmPeriod }) {
     );
   }
   return (
-    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 min-[1920px]:grid-cols-7 min-[2400px]:grid-cols-8">
       {data.map((a, i) => (
         <AlbumCard key={`${a.name}-${a.artist}-${i}`} rank={i + 1} album={a} />
       ))}
@@ -215,7 +215,7 @@ function LovedList() {
 
 function GridSkeleton() {
   return (
-    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6">
+    <div className="grid grid-cols-2 gap-4 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 min-[1920px]:grid-cols-7 min-[2400px]:grid-cols-8">
       {Array.from({ length: 18 }).map((_, i) => (
         <Skeleton key={i} className="aspect-square w-full" />
       ))}


### PR DESCRIPTION
## Summary
- Card grids previously capped at 6 columns above 1536px viewport width. On a 1920p / 1440p widescreen / 4K display each card stretched to ~400px wide instead of another column appearing.
- Adds two breakpoints (`min-[1920px]` → 7 cols, `min-[2400px]` → 8 cols) to every multi-column card grid: `Grid.tsx`, `PageView.tsx` (single-row + multi-row), `Skeletons.tsx`, `StatsDetail.tsx`, `AlbumDetail.tsx`, `PopularPage.tsx`.
- Bumps PageView's `ROW_CAP` from 5 to 8 so single-row hero sections actually fill a wide row.
- Updates `useColumnCount` to match (it drives item slicing for single-row sections; needs to stay in lockstep with the Grid CSS or the slice trims a card the grid had room for).

## Test plan
- [x] Manual: dragged the dev window across the 1920px and 2400px thresholds, confirmed columns add rather than cards growing.
- [x] `npx tsc -b --noEmit` clean.
- [x] `npm run lint:all` clean.
- [x] `npm test` passes (36 frontend tests).
- [ ] CI pytest, tsc, lint, vitest.