### PR TITLE
Reset the scroll container to top on navigation

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -449,6 +449,20 @@ function Shell({
     el.classList.add("animate-route");
   }, [location.pathname]);
 
+  // Reset the scroll container to the top on navigation. The routed
+  // view lives inside a custom overflow-y-auto <main> (not the
+  // window), so the browser's default scroll-to-top on navigation
+  // never fires. Without this, opening a short page like an album
+  // from a long scrolled one (artist, search, library) leaves the
+  // container clamped at the previous offset, so the new page renders
+  // scrolled to its bottom. Keyed on pathname only: it sets scrollTop,
+  // it does not remount the subtree, so the param-change state the
+  // fade wrapper above preserves stays intact.
+  const scrollRef = useRef<HTMLElement | null>(null);
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: 0 });
+  }, [location.pathname]);
+
   // Esc closes any open side panel. Lyrics wins over queue so the user can
   // stack them without ambiguity.
   useEffect(() => {
@@ -501,6 +515,7 @@ function Shell({
           offline={offline}
         />
         <main
+          ref={scrollRef}
           data-scroll-container
           className="min-w-0 flex-1 overflow-y-auto rounded-lg bg-gradient-to-b from-secondary to-background scrollbar-thin"
         >


### PR DESCRIPTION
## Summary

The routed view lives inside a custom `overflow-y-auto` `<main>`, not the window, so the browser's default scroll-to-top on navigation never fired. Opening a short page like an album from a long scrolled one left the container clamped at the previous offset, rendering the album page scrolled to its bottom. Adds a ref to the scroll container and resets `scrollTop` on pathname change.

## Test plan

- [ ] Scroll deep into a long page, click an album: it opens at the top
- [ ] Album to album navigation also lands at the top
- [ ] `cd web && npx tsc -b --noEmit` and `npm run lint:all`