### PR TITLE
Fix Linux AppImage browser fallback crashing on launch

### DIFF
--- a/desktop.py
+++ b/desktop.py
@@ -149,6 +149,78 @@ def _ask_existing_to_focus() -> None:
         pass
 
 
+def _child_env() -> dict:
+    """Environment for spawning system binaries from a frozen build.
+
+    AppRun (AppImage) and PyInstaller prepend our bundled library dir
+    to LD_LIBRARY_PATH so the frozen app finds its own libraries. A
+    child process inherits that, so a system binary — the browser
+    fallback's /bin/sh, xdg-open — loads our bundled libreadline /
+    libtinfo instead of the host's and dies with
+    "undefined symbol: rl_trim_arg_from_keyseq". AppRun stashes the
+    pristine host value in TIDEWAY_HOST_LD_LIBRARY_PATH; PyInstaller
+    stashes its own pre-launch value in LD_LIBRARY_PATH_ORIG. Restore
+    whichever we have, else drop the var, so children link against the
+    host's libraries. No-op when not frozen — nothing to leak.
+    """
+    env = dict(os.environ)
+    if not getattr(sys, "frozen", False):
+        return env
+    host = env.get("TIDEWAY_HOST_LD_LIBRARY_PATH")
+    if host is None:
+        host = env.get("LD_LIBRARY_PATH_ORIG")
+    if host:
+        env["LD_LIBRARY_PATH"] = host
+    else:
+        env.pop("LD_LIBRARY_PATH", None)
+    return env
+
+
+def _open_in_browser(url: str) -> None:
+    """Open `url` in the user's browser without leaking the bundle's
+    library path into the opener.
+
+    macOS (`open`) and Windows (`os.startfile`) openers don't exec a
+    shell that would load our libs, so webbrowser is used directly.
+    A frozen Linux build must spawn the opener with a sanitized
+    environment (see _child_env); webbrowser itself goes through
+    /bin/sh, which is exactly what crashes, so call the opener
+    directly. If no opener is found we print the URL rather than
+    re-trip the crash.
+    """
+    if sys.platform != "linux" or not getattr(sys, "frozen", False):
+        import webbrowser
+
+        webbrowser.open(url)
+        return
+    import shutil
+    import subprocess
+
+    env = _child_env()
+    path_dirs = env.get("PATH")
+    for opener in ("xdg-open", "gio"):
+        exe = shutil.which(opener, path=path_dirs)
+        if not exe:
+            continue
+        argv = [exe, "open", url] if opener == "gio" else [exe, url]
+        try:
+            subprocess.Popen(
+                argv,
+                env=env,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                start_new_session=True,
+            )
+            return
+        except OSError:
+            continue
+    print(
+        f"[desktop] Couldn't find xdg-open. Open this in your browser: {url}",
+        file=sys.stderr,
+        flush=True,
+    )
+
+
 def _run_uvicorn_in_thread() -> "uvicorn.Server":  # type: ignore[name-defined]
     """Start uvicorn on a daemon thread and return the Server handle so
     the main thread can stop it on window close."""
@@ -359,8 +431,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     server = _run_uvicorn_in_thread()
 
     if args.browser:
-        import webbrowser
-        webbrowser.open(f"http://{HOST}:{PORT}/")
+        _open_in_browser(f"http://{HOST}:{PORT}/")
         try:
             # Block main thread until Ctrl-C or uvicorn exits on its own.
             while not server.should_exit:
@@ -380,8 +451,7 @@ def main(argv: Optional[list[str]] = None) -> int:
             file=sys.stderr,
             flush=True,
         )
-        import webbrowser
-        webbrowser.open(f"http://{HOST}:{PORT}/")
+        _open_in_browser(f"http://{HOST}:{PORT}/")
         try:
             while not server.should_exit:
                 time.sleep(0.5)
@@ -1293,21 +1363,24 @@ def main(argv: Optional[list[str]] = None) -> int:
                 flush=True,
             )
             print(
-                "[desktop] On Linux this means GTK or QT Python bindings "
-                "aren't installed. Install one of:\n"
+                "[desktop] No pywebview backend in this build, so Tideway "
+                "runs in your browser instead. This is the supported mode "
+                "for the Linux AppImage; the native window needs PyGObject "
+                "or Qt, which the AppImage can't bundle portably across "
+                "distros. The packages below only help if you run Tideway "
+                "from source, not from the AppImage:\n"
                 "  Debian/Ubuntu:  sudo apt install python3-gi "
                 "gir1.2-webkit2-4.1\n"
                 "  Fedora:         sudo dnf install python3-gobject "
                 "webkit2gtk4.1\n"
                 "  Arch/Omarchy:   sudo pacman -S python-gobject "
                 "webkit2gtk-4.1\n"
-                "[desktop] Falling back to your default browser. Quit "
-                "with Ctrl-C in this terminal.",
+                f"[desktop] Opening http://{HOST}:{PORT}/ in your browser. "
+                "Quit with Ctrl-C in this terminal.",
                 file=sys.stderr,
                 flush=True,
             )
-            import webbrowser
-            webbrowser.open(f"http://{HOST}:{PORT}/")
+            _open_in_browser(f"http://{HOST}:{PORT}/")
             try:
                 while not server.should_exit:
                     time.sleep(0.5)

--- a/scripts/appimage/AppRun
+++ b/scripts/appimage/AppRun
@@ -14,5 +14,12 @@
 # We do NOT bundle GTK / WebKit2GTK / PortAudio / libnotify —
 # those are expected from the host system. Documented in the README.
 HERE="$(dirname "$(readlink -f "${0}")")"
+# Save the host's pristine library path BEFORE we prepend the bundle.
+# Any subprocess that execs a system binary (the browser fallback's
+# /bin/sh, xdg-open) must not inherit our bundled libs, or it loads
+# our libreadline / libtinfo instead of the host's and dies with an
+# "undefined symbol" error. desktop.py's _child_env() restores this
+# when spawning such processes.
+export TIDEWAY_HOST_LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
 export LD_LIBRARY_PATH="${HERE}/usr/bin:${LD_LIBRARY_PATH}"
 exec "${HERE}/usr/bin/Tideway" "$@"


### PR DESCRIPTION
## Summary

The Linux AppImage has no pywebview backend (PyGObject/Qt aren't bundled and a frozen interpreter can't use system ones), so it falls back to the browser. That fallback was broken: `AppRun` prepends the bundle lib dir to `LD_LIBRARY_PATH`, child processes inherit it, and the `/bin/sh` `webbrowser` spawns loaded our bundled `libreadline` and died with `undefined symbol: rl_trim_arg_from_keyseq`. So on Omarchy (and any distro without a system backend) the app started, served on the loopback, then opened nothing.

- `AppRun` stashes the pristine host `LD_LIBRARY_PATH` before prepending the bundle.
- `desktop.py` adds `_child_env()` (restores host/`_ORIG`, else drops the var) and `_open_in_browser()` which on a frozen Linux build calls `xdg-open`/`gio` directly with the clean env instead of webbrowser's `/bin/sh`.
- The misleading "install python-gobject fixes it" message now states it only helps run-from-source.

Reported against 1.9.1 on Omarchy.

## Test plan

- [ ] Build the Linux AppImage and run it on Omarchy / an Arch box with no system pywebview backend
- [ ] App opens in the default browser; no `/bin/sh` symbol-lookup error
- [ ] `--browser` flag path also opens cleanly
- [ ] `pytest tests/` (green locally; _child_env unit-checked across AppImage / PyInstaller / not-frozen)