### PR TITLE
Show the playing track on Chromecast and cut the cast delay

### DIFF
--- a/app/audio/cast.py
+++ b/app/audio/cast.py
@@ -114,6 +114,27 @@ def is_audio_only(device: CastDevice) -> bool:
     return device.cast_type in _AUDIO_CAST_TYPES
 
 
+def _music_metadata(
+    title: str, artist: str, album: str, art_url: str
+) -> dict:
+    """Build the Cast Default Media Receiver now-playing card.
+
+    metadataType 3 is MusicTrackMediaMetadata — the shape the DMR
+    renders as a music card (title, artist, album, cover) on TVs and
+    hub displays. Empty fields are omitted so the receiver falls back
+    to its own layout instead of showing blank rows. Title always
+    falls back to "Tideway" so the card is never nameless.
+    """
+    meta: dict = {"metadataType": 3, "title": title or "Tideway"}
+    if artist:
+        meta["artist"] = artist
+    if album:
+        meta["albumName"] = album
+    if art_url:
+        meta["images"] = [{"url": art_url}]
+    return meta
+
+
 # ---------------------------------------------------------------------
 # CastSession — the live connection to one device
 # ---------------------------------------------------------------------
@@ -161,6 +182,11 @@ class _SessionState:
     receiver_state: Optional[str] = None
     receiver_idle_reason: Optional[str] = None
     receiver_status_at: float = 0.0
+    # Last now-playing metadata dict pushed to the receiver. Used to
+    # skip a redundant reload (position ticks fire often; only a real
+    # title/artist/album change should reload) and to re-send the
+    # card if the receiver reconnects.
+    now_playing: Optional[dict] = None
 
 
 # ---------------------------------------------------------------------
@@ -198,6 +224,12 @@ class CastManager:
         # so the frontend's NowPlaying can show "casting to X" /
         # "stopped casting" without polling.
         self._listeners: list[Callable[[Optional[CastDevice]], None]] = []
+
+        # Last now-playing metadata seen (set by set_now_playing even
+        # when no session is active), so a connect() that happens
+        # mid-playback can seed the receiver's card with the current
+        # track instead of a bare "Tideway".
+        self._last_np: Optional[dict] = None
 
         # Local-output silencer hook. Called with True when a
         # session opens, False when it closes. server.py wires this
@@ -451,11 +483,17 @@ class CastManager:
         # speakers).
         try:
             mc = cast_obj.media_controller
+            # Seed the card with the track that's already playing (if
+            # we've seen a now-playing update this session) instead of
+            # a bare "Tideway". set_now_playing keeps it current after
+            # this on every track change.
+            init_meta = self._last_np or _music_metadata("", "", "", "")
+            session.now_playing = init_meta
             mc.play_media(
                 session.stream_url,
                 "audio/flac",
-                title="Tideway",
                 stream_type="LIVE",
+                metadata=init_meta,
             )
             mc.block_until_active(timeout=10.0)
             session.media_loaded = True
@@ -562,6 +600,91 @@ class CastManager:
         print(f"[cast] disconnected: {session.device.friendly_name}",
               flush=True)
         self._notify_listeners(None)
+
+    def set_now_playing(
+        self,
+        title: str = "",
+        artist: str = "",
+        album: str = "",
+        art_url: str = "",
+    ) -> None:
+        """Update the receiver's now-playing card for the current
+        track. Called off the realtime path (the /api/now-playing
+        endpoint the frontend hits on every track change).
+
+        Tideway casts one continuous live FLAC, so the receiver keeps
+        the single session it was handed at connect — its card never
+        changed and showed "Tideway" forever. The Default Media
+        Receiver only takes metadata from a LOAD, and a mid-stream
+        re-LOAD of the same URL would hand the receiver headerless
+        FLAC (the STREAMINFO went by long ago). So a real track change
+        does three things together, under the encoder lock so the
+        realtime push can't interleave:
+
+          1. drop the encoder so the next push rebuilds it and a
+             fresh FLAC header leads the stream again,
+          2. flush the ring to the live edge so the receiver's new
+             connection doesn't replay the backlog (this is also the
+             latency fix — that backlog was the permanent delay
+             floor),
+          3. re-issue play_media with the new card.
+
+        The cost is a brief re-buffer at each track boundary; that is
+        the deliberate tradeoff for the card actually being correct,
+        and it starts at the live edge so it is far better than the
+        old wrong-card-plus-huge-delay behaviour. Dedup'd so position
+        ticks (same title/artist/album) don't trigger a reload.
+        """
+        meta = _music_metadata(title, artist, album, art_url)
+        self._last_np = meta
+        with self._session_lock:
+            session = self._session
+        if session is None:
+            return
+        if session.now_playing == meta:
+            return  # same track — nothing visible would change
+
+        # Steps 1 + 2 under the encoder lock so a concurrent
+        # push_pcm() can't encode into the buffer between the flush
+        # and the rebuild. push_pcm rebuilds the encoder whenever
+        # session.encoder is None, writing a fresh header first.
+        with session.encoder_lock:
+            old_encoder = session.encoder
+            session.encoder = None
+            session.encoder_rate = 0
+            session.encoder_channels = 0
+            session.encoder_dtype = ""
+            session.buffer.flush()
+            session.now_playing = meta
+        if old_encoder is not None:
+            # Discard the old encoder's tail on purpose — we want the
+            # stream to restart, not to splice the previous track's
+            # final frames in ahead of the new header.
+            try:
+                old_encoder.close()
+            except Exception as exc:
+                log.debug("cast: old encoder close on reload: %r", exc)
+
+        # Network call OUTSIDE the encoder lock so it never stalls the
+        # realtime audio callback. Best-effort: a receiver that
+        # rejects the reload is logged, not raised, so a track change
+        # can't take down playback.
+        try:
+            mc = session.cast.media_controller  # type: ignore[attr-defined]
+            mc.play_media(
+                session.stream_url,
+                "audio/flac",
+                stream_type="LIVE",
+                metadata=meta,
+            )
+            mc.block_until_active(timeout=5.0)
+            print(
+                f"[cast] now playing: {meta.get('title')} — "
+                f"{meta.get('artist', '')}".rstrip(" —"),
+                flush=True,
+            )
+        except Exception as exc:
+            log.debug("cast: now-playing reload failed: %r", exc)
 
     # ---- PCM tap (called from PCMPlayer's audio callback) -----------
 

--- a/app/audio/http_stream.py
+++ b/app/audio/http_stream.py
@@ -69,6 +69,32 @@ class RingBuffer:
         self._buf = bytearray()
         self._cv = threading.Condition()
         self._closed = False
+        # Single-active-consumer guard. read() is destructive (it
+        # deletes the bytes it returns), so two HTTP serve threads on
+        # the same buffer would split the FLAC stream and corrupt
+        # both. The Cast track-change reload issues a fresh play_media
+        # per track, and the receiver's new GET can briefly overlap
+        # the old connection. attach() bumps this generation; an
+        # older serve loop sees it move and exits, leaving exactly
+        # one consumer.
+        self._gen = 0
+
+    def attach(self) -> int:
+        """Register as the current consumer and supersede any prior
+        one. Returns this consumer's generation token; pass it to
+        read()/is_superseded(). Wakes a blocked older reader so it
+        notices it's been superseded promptly instead of after its
+        next idle timeout."""
+        with self._cv:
+            self._gen += 1
+            self._cv.notify_all()
+            return self._gen
+
+    def is_superseded(self, gen: int) -> bool:
+        """True once a newer consumer has attach()ed. The serve loop
+        checks this each iteration and returns, so a stale connection
+        stops draining the shared buffer."""
+        return gen != self._gen
 
     def write(self, data: bytes) -> None:
         with self._cv:
@@ -86,14 +112,24 @@ class RingBuffer:
             self._buf.extend(data)
             self._cv.notify_all()
 
-    def read(self, n: int, timeout: float = 1.0) -> bytes:
+    def read(
+        self, n: int, timeout: float = 1.0, gen: Optional[int] = None
+    ) -> bytes:
         deadline = time.monotonic() + timeout
         with self._cv:
             while not self._buf and not self._closed:
+                if gen is not None and gen != self._gen:
+                    # Superseded by a newer consumer while we were
+                    # blocked here — return empty so the stale serve
+                    # loop exits instead of consuming the new
+                    # consumer's bytes.
+                    return b""
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     return b""
                 self._cv.wait(timeout=remaining)
+            if gen is not None and gen != self._gen:
+                return b""
             chunk = bytes(self._buf[:n])
             del self._buf[: len(chunk)]
             return chunk
@@ -348,12 +384,21 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         self.send_header("Connection", "close")
         self.end_headers()
         buf = server.buffer
+        # Become the sole consumer. A later GET (the Cast per-track
+        # reload's new connection) supersedes this one so two threads
+        # never drain the destructive buffer at once.
+        my_gen = buf.attach()
         try:
             while True:
-                chunk = buf.read(16384, timeout=2.0)
+                if buf.is_superseded(my_gen):
+                    # A newer connection took over. End this stream
+                    # cleanly and stop reading the shared buffer.
+                    self._write_chunk(b"")
+                    return
+                chunk = buf.read(16384, timeout=2.0, gen=my_gen)
                 if not chunk:
                     # Idle read with a closed buffer ends the stream.
-                    if buf.is_closed:
+                    if buf.is_closed or buf.is_superseded(my_gen):
                         self._write_chunk(b"")
                         return
                     continue

--- a/app/audio/http_stream.py
+++ b/app/audio/http_stream.py
@@ -98,6 +98,18 @@ class RingBuffer:
             del self._buf[: len(chunk)]
             return chunk
 
+    def flush(self) -> None:
+        """Drop all buffered bytes, keep the stream open.
+
+        Used on a Cast track-change reset: the encoder is rebuilt so
+        a fresh FLAC header leads the stream, and the receiver's new
+        connection then starts at the live edge instead of replaying
+        the seconds of backlog that pile up FIFO. That backlog is the
+        permanent latency floor today.
+        """
+        with self._cv:
+            self._buf.clear()
+
     def close(self) -> None:
         with self._cv:
             self._closed = True

--- a/server.py
+++ b/server.py
@@ -5086,6 +5086,20 @@ def now_playing_update(payload: _NowPlayingMetadata) -> dict:
         duration_ms=payload.duration_ms,
         artwork_url=payload.artwork_url,
     )
+    # Keep a Chromecast session's now-playing card in sync with the
+    # track. No-op when nothing is casting; dedup'd internally so the
+    # frequent same-track calls don't trigger a receiver reload.
+    try:
+        from app.audio.cast import cast_manager as _cast_manager
+
+        _cast_manager.set_now_playing(
+            title=payload.title,
+            artist=payload.artist,
+            album=payload.album,
+            art_url=payload.artwork_url,
+        )
+    except Exception:
+        pass
     return {"ok": True}
 
 

--- a/tests/test_cast_now_playing.py
+++ b/tests/test_cast_now_playing.py
@@ -1,0 +1,99 @@
+"""Unit coverage for the Chromecast now-playing + latency fix.
+
+The end-to-end behaviour (card on the TV, A/V latency) can only be
+confirmed on a real Chromecast. What is verifiable here is the logic
+that drives it: the metadata card shape, the live-edge buffer flush,
+and that a track change resets the encoder + flushes the buffer +
+re-issues play_media exactly once per real change (not per position
+tick).
+"""
+from __future__ import annotations
+
+import threading
+from types import SimpleNamespace
+
+from app.audio.cast import CastManager, _music_metadata
+from app.audio.http_stream import RingBuffer
+
+
+def test_ring_buffer_flush_drops_backlog_keeps_open():
+    rb = RingBuffer(max_bytes=1024)
+    rb.write(b"old-backlog-bytes")
+    rb.flush()
+    assert not rb.is_closed
+    rb.write(b"live")
+    assert rb.read(64, timeout=0.1) == b"live"
+
+
+def test_music_metadata_shape_and_fallbacks():
+    full = _music_metadata("Song", "Artist", "Album", "http://art/x.jpg")
+    assert full == {
+        "metadataType": 3,
+        "title": "Song",
+        "artist": "Artist",
+        "albumName": "Album",
+        "images": [{"url": "http://art/x.jpg"}],
+    }
+    # Empty fields are omitted; title never blank.
+    assert _music_metadata("", "", "", "") == {
+        "metadataType": 3,
+        "title": "Tideway",
+    }
+
+
+def _fake_session():
+    calls = []
+    mc = SimpleNamespace(
+        play_media=lambda *a, **k: calls.append(("play_media", a, k)),
+        block_until_active=lambda timeout=0: calls.append(("wait", timeout)),
+    )
+    buf = SimpleNamespace(
+        flushed=0,
+    )
+    buf.flush = lambda: setattr(buf, "flushed", buf.flushed + 1)
+    sess = SimpleNamespace(
+        encoder=object(),
+        encoder_lock=threading.Lock(),
+        encoder_rate=44100,
+        encoder_channels=2,
+        encoder_dtype="int16",
+        buffer=buf,
+        now_playing=None,
+        stream_url="http://lan:9/cast/stream",
+        cast=SimpleNamespace(media_controller=mc),
+    )
+    return sess, calls, buf
+
+
+def test_set_now_playing_no_session_is_noop_but_caches():
+    m = CastManager()
+    m.set_now_playing("T", "A", "Al", "art")
+    assert m._last_np == _music_metadata("T", "A", "Al", "art")  # seeded
+
+
+def test_track_change_resets_encoder_flushes_and_reloads_once():
+    m = CastManager()
+    sess, calls, buf = _fake_session()
+    m._session = sess
+
+    m.set_now_playing("Song 1", "Artist", "Album", "art1")
+    assert sess.encoder is None, "encoder dropped so a fresh header leads"
+    assert sess.encoder_rate == 0
+    assert buf.flushed == 1, "buffer flushed to the live edge"
+    assert sess.now_playing == _music_metadata(
+        "Song 1", "Artist", "Album", "art1"
+    )
+    play_calls = [c for c in calls if c[0] == "play_media"]
+    assert len(play_calls) == 1
+    assert play_calls[0][2]["metadata"]["title"] == "Song 1"
+    assert play_calls[0][2]["stream_type"] == "LIVE"
+
+    # Same track again (position ticks) -> no second reload/flush.
+    m.set_now_playing("Song 1", "Artist", "Album", "art1")
+    assert buf.flushed == 1
+    assert len([c for c in calls if c[0] == "play_media"]) == 1
+
+    # Real change -> exactly one more reset + reload.
+    m.set_now_playing("Song 2", "Artist", "Album", "art2")
+    assert buf.flushed == 2
+    assert len([c for c in calls if c[0] == "play_media"]) == 2

--- a/tests/test_cast_now_playing.py
+++ b/tests/test_cast_now_playing.py
@@ -25,6 +25,26 @@ def test_ring_buffer_flush_drops_backlog_keeps_open():
     assert rb.read(64, timeout=0.1) == b"live"
 
 
+def test_ring_buffer_single_consumer_supersede():
+    # read() is destructive; two overlapping serve threads (the
+    # Cast per-track reload's new GET racing the old one) must not
+    # both drain the buffer. A newer attach() supersedes the old.
+    rb = RingBuffer(max_bytes=1024)
+    g1 = rb.attach()
+    rb.write(b"AAAA")
+    assert rb.read(64, timeout=0.1, gen=g1) == b"AAAA"
+
+    g2 = rb.attach()  # new connection takes over
+    assert rb.is_superseded(g1)
+    assert not rb.is_superseded(g2)
+
+    rb.write(b"BBBB")
+    # The stale consumer gets nothing and is told to stop...
+    assert rb.read(64, timeout=0.1, gen=g1) == b""
+    # ...the live one gets the bytes.
+    assert rb.read(64, timeout=0.1, gen=g2) == b"BBBB"
+
+
 def test_music_metadata_shape_and_fallbacks():
     full = _music_metadata("Song", "Artist", "Album", "http://art/x.jpg")
     assert full == {


### PR DESCRIPTION
## Summary

Two long-standing Cast problems, same root cause (one continuous live FLAC the receiver attaches to once):

- **Card never updates.** Only one `play_media(title="Tideway")` at connect, never refreshed on track change. Now sends full `MusicTrackMediaMetadata` and updates per track.
- **Huge delay.** The ring buffer is served oldest-first with an 8 MB cap; backlog between encoder start and receiver pull becomes a permanent latency floor. Now flushed to the live edge.

A mid-stream re-LOAD would serve headerless FLAC, so `set_now_playing()` treats a real track change as a stream restart: drop the encoder (fresh FLAC header on next push), flush the ring to live, re-issue `play_media` with the new card. Wired off the realtime path via the existing `/api/now-playing` endpoint, dedup'd against position ticks. Cost: a brief re-buffer per track — the deliberate tradeoff for a correct card, and it resyncs to now so it's far better than today.

## Test plan

- [ ] `pytest tests/test_cast_now_playing.py` (added; green in preflight)
- [ ] **On a real Chromecast** (cannot be verified without one): the TV card shows the actual song/artist/album/art and updates each track; audio latency is small, not the old multi-second lag; a track change re-buffers briefly then resyncs to live
- [ ] Confirm casting still works at all (audio plays, no headerless-FLAC silence)