### PR TITLE
Correct README: lossy tiers download as .m4a, not FLAC

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,9 +141,13 @@ in the global popularity signal.
 
 ![Stats page](assets/screenshots/stats.png)
 
-**Downloads.** Hi-res stereo FLAC and music video downloads all
-run through a concurrent queue that you can tune. Metadata and
-artwork are embedded with mutagen. Any track you have downloaded
+**Downloads.** The file format follows the quality tier. High and
+Max are lossless and download as FLAC. Tidal delivers that FLAC
+inside an MP4, so Tideway remuxes it into a native `.flac` file.
+Low and Medium are lossy AAC and download as `.m4a`, which is the
+standard AAC container, not a deprecated format. Music videos
+download as well. Everything runs through a concurrent queue that
+you can tune. Metadata and artwork are embedded with mutagen. Any track you have downloaded
 plays straight from disk without touching the Tidal streaming
 path. A filename template, toggles for per-album and per-playlist
 folders, and a skip-existing option cover the common download


### PR DESCRIPTION
## Summary

The Downloads section implied FLAC-only ("Hi-res stereo FLAC and music video downloads"). The format actually follows the quality tier: High/Max are lossless FLAC (Tidal serves FLAC-in-MP4, remuxed to native `.flac`), Low/Medium are lossy AAC delivered as `.m4a`. `.m4a` is the standard AAC container and is correct for the lossy tiers — this is a documentation accuracy fix, not a behaviour change. Prompted by a user noticing the discrepancy.

## Test plan

- [ ] README Downloads paragraph reads accurately; no code touched