### PR TITLE
Speed up artist page: defer the two slow Tidal calls off first paint

### DIFF
--- a/server.py
+++ b/server.py
@@ -7786,47 +7786,80 @@ def artist_detail(artist_id: int) -> dict:
     # don't look like a scrape to Tidal's abuse layer (a real client
     # opening an artist page does similar volume), and the wall-clock
     # drops to roughly two waves of the slowest single call.
-    with ThreadPoolExecutor(max_workers=5) as pool:
+    # Per-task wall-time instrumentation. Cold artist load is ~1.6s
+    # and widening this pool did NOT help (measured: same at 5 and 10
+    # workers), so a single task dominates rather than fan-out
+    # queueing. _safe_t records each task's own duration; the
+    # [perf] artist line below names the long pole.
+    _t0 = time.monotonic()
+    _tt: dict[str, float] = {}
+
+    def _safe_t(name, fn, default):
+        _s = time.monotonic()
+        try:
+            return fn()
+        except Exception:
+            return default
+        finally:
+            _tt[name] = (time.monotonic() - _s) * 1000.0
+
+    # One worker per remaining task. With the two heavy poles
+    # (page, mix) moved to /extras, the eight that stay are
+    # uniformly fast (~100-400ms) except for occasional Tidal-side
+    # spikes on a single call. Sizing the pool to the fan-out means
+    # a spiky call always starts immediately instead of queueing
+    # behind five workers, so total ~= the slowest single call.
+    with ThreadPoolExecutor(max_workers=8) as pool:
         # Bio used to be jittered to spread the burst, but that was
         # premature: bio is a small text fetch, not a stream-manifest
         # request, and the 50-200ms sleep added directly to the
         # critical path with no observable behavior benefit.
-        f_bio = pool.submit(_safe, artist.get_bio, None)
+        f_bio = pool.submit(_safe_t, "bio", artist.get_bio, None)
         f_similar = pool.submit(
-            _safe,
+            _safe_t,
+            "similar",
             lambda: [artist_to_dict(a) for a in artist.get_similar()][:12],
             [],
         )
         f_top_tracks = pool.submit(
-            _safe,
+            _safe_t,
+            "top_tracks",
             lambda: [
                 track_to_dict(t) for t in tidal.get_artist_top_tracks(artist)
             ],
             [],
         )
         f_albums_raw = pool.submit(
-            _safe, lambda: list(tidal.get_artist_albums(artist)) or [], []
+            _safe_t,
+            "albums",
+            lambda: list(tidal.get_artist_albums(artist)) or [],
+            [],
         )
         f_eps = pool.submit(
-            _safe, lambda: list(artist.get_ep_singles(limit=40)) or [], []
+            _safe_t,
+            "eps",
+            lambda: list(artist.get_ep_singles(limit=40)) or [],
+            [],
         )
         f_compilations = pool.submit(
-            _safe, lambda: list(artist.get_other(limit=40)) or [], []
-        )
-        f_page = pool.submit(_safe, artist.page, None)
-        f_mix_id = pool.submit(
-            _safe, lambda: str(artist.get_radio_mix().id), None
+            _safe_t,
+            "comps",
+            lambda: list(artist.get_other(limit=40)) or [],
+            [],
         )
         # Credits and videos used to be separate endpoints the
         # frontend fetched in parallel after the main artist
         # payload arrived. Folding them into the same response
         # saves two HTTP round-trips on every artist page load.
         f_videos = pool.submit(
-            _safe,
+            _safe_t,
+            "videos",
             lambda: [video_to_dict(v) for v in artist.get_videos(limit=50) or []],
             [],
         )
-        f_credits = pool.submit(_safe, lambda: _artist_credits_list(artist_id, 20), [])
+        f_credits = pool.submit(
+            _safe_t, "credits", lambda: _artist_credits_list(artist_id, 20), []
+        )
 
     bio = f_bio.result()
     similar = f_similar.result()
@@ -7834,10 +7867,35 @@ def artist_detail(artist_id: int) -> dict:
     raw_albums = f_albums_raw.result()
     raw_eps = f_eps.result()
     raw_appears = list(f_compilations.result())
-    artist_page = f_page.result()
-    artist_mix_id = f_mix_id.result()
+    # artist.page() (~1.5-3s) and get_radio_mix() (~0.35-3.2s) are the
+    # two measured latency poles and feed only secondary content (the
+    # "Appears On / Compilations" rows and the radio id). They're
+    # deferred to GET /api/artist/{id}/extras so first paint isn't
+    # blocked on them. Response keys stay present for compatibility:
+    # appears_on falls back to the fast get_other() set, compilations
+    # is empty, and artist_mix_id is null until /extras lands.
+    artist_page = None
+    artist_mix_id = None
     videos = f_videos.result()
     credits = f_credits.result()
+
+    _perf = (
+        f"[perf] artist id={artist_id} "
+        f"total={(time.monotonic() - _t0) * 1000.0:.0f}ms "
+        + " ".join(
+            f"{k}={v:.0f}ms"
+            for k, v in sorted(
+                _tt.items(), key=lambda kv: kv[1], reverse=True
+            )
+        )
+    )
+    print(_perf, file=sys.stderr, flush=True)
+    try:
+        from app.audio.player import audio_log as _audio_log
+
+        _audio_log.info(_perf)
+    except Exception:
+        pass
 
     # Pull two modules off Tidal's curated artist page:
     #
@@ -7998,6 +8056,85 @@ def artist_radio(artist_id: int) -> list[dict]:
     except Exception as exc:
         raise HTTPException(status_code=502, detail=str(exc))
     return [track_to_dict(t) for t in tracks]
+
+
+_artist_extras_cache: dict[str, tuple[float, dict]] = {}
+_artist_extras_cache_lock = threading.Lock()
+
+
+@app.get("/api/artist/{artist_id}/extras")
+def artist_extras(artist_id: int) -> dict:
+    """Secondary artist-page content split off the main payload
+    because it is the slow part. Two measured latency poles live
+    here: Tidal's curated `artist.page()` (~1.5-3s, the only source
+    of the "Compilations" module and the full "Appears On" set) and
+    `get_radio_mix()` (~0.35-3.2s, just the radio mix id). The main
+    /api/artist/{id} no longer blocks on these; the frontend fetches
+    this after first paint and fills the rows in. Cached for the same
+    TTL as the detail payload so back-navigation is free."""
+    _require_auth()
+    cache_key = str(artist_id)
+    now = time.monotonic()
+    with _artist_extras_cache_lock:
+        c = _artist_extras_cache.get(cache_key)
+    if c and (now - c[0]) < _ARTIST_DETAIL_CACHE_TTL_SEC:
+        return c[1]
+    try:
+        artist = tidal.session.artist(artist_id)
+    except Exception as exc:
+        raise HTTPException(status_code=404, detail=str(exc))
+
+    def _safe(fn, default):
+        try:
+            return fn()
+        except Exception:
+            return default
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        f_page = pool.submit(_safe, artist.page, None)
+        f_mix = pool.submit(
+            _safe, lambda: str(artist.get_radio_mix().id), None
+        )
+    page = f_page.result()
+    mix_id = f_mix.result()
+
+    raw_appears: list = []
+    raw_comps: list = []
+    if page is not None:
+        try:
+            from tidalapi.album import Album as _TidalAlbum
+
+            for cat in getattr(page, "categories", []) or []:
+                t = (getattr(cat, "title", "") or "").strip().lower()
+                is_app = "appear" in t or "featured" in t
+                is_comp = "compilation" in t
+                if not is_app and not is_comp:
+                    continue
+                for item in getattr(cat, "items", []) or []:
+                    if isinstance(item, _TidalAlbum):
+                        (raw_comps if is_comp else raw_appears).append(item)
+        except Exception:
+            pass
+
+    def _byid(items: list) -> list:
+        seen: set = set()
+        out: list = []
+        for a in items:
+            aid = getattr(a, "id", None)
+            if aid is None or aid in seen:
+                continue
+            seen.add(aid)
+            out.append(a)
+        return out
+
+    result = {
+        "appears_on": [album_to_dict(a) for a in _byid(raw_appears)],
+        "compilations": [album_to_dict(a) for a in _byid(raw_comps)],
+        "artist_mix_id": mix_id,
+    }
+    with _artist_extras_cache_lock:
+        _artist_extras_cache[cache_key] = (time.monotonic(), result)
+    return result
 
 
 # ---------------------------------------------------------------------------

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1,6 +1,7 @@
 import type {
   AlbumDetail,
   ArtistDetail,
+  ArtistExtras,
   AuthStatus,
   Album,
   Artist,
@@ -825,6 +826,7 @@ export const api = {
       }[]
     >(`/api/album/${id}/credits`),
   artist: (id: string) => req<ArtistDetail>(`/api/artist/${id}`),
+  artistExtras: (id: string) => req<ArtistExtras>(`/api/artist/${id}/extras`),
   artistRadio: (id: string) => req<Track[]>(`/api/artist/${id}/radio`),
   artistCredits: (id: string) =>
     req<(Track & { role: string })[]>(`/api/artist/${id}/credits`),

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -171,6 +171,16 @@ export interface AlbumDetail extends Album {
   related_artists: Artist[];
 }
 
+/** Secondary artist-page content fetched after first paint via
+ *  /api/artist/{id}/extras. Split out because the Tidal calls behind
+ *  it (the curated page + the radio mix) are the slow part of the
+ *  artist page; the primary payload no longer blocks on them. */
+export interface ArtistExtras {
+  appears_on: Album[];
+  compilations: Album[];
+  artist_mix_id: string | null;
+}
+
 export interface ArtistDetail extends Artist {
   top_tracks: Track[];
   /** Mixed-format "Latest releases" row — the artist's albums, EPs,

--- a/web/src/pages/ArtistDetail.tsx
+++ b/web/src/pages/ArtistDetail.tsx
@@ -37,6 +37,14 @@ export function ArtistDetail({ onDownload }: { onDownload: OnDownload }) {
   } = useApi(() => api.artist(id), [id], {
     cacheKey: queryKeys.artist(id),
   });
+  // Secondary content — the "Appears On" / "Compilations" rows and
+  // the radio mix id — comes from a separate, deferred fetch. Those
+  // were the slow part of the artist page (Tidal's curated page +
+  // radio mix). This is non-blocking: the page paints immediately
+  // and these rows fill in when /extras lands.
+  const { data: extras } = useApi(() => api.artistExtras(id), [id], {
+    cacheKey: `artist-extras:${id}`,
+  });
   const [popularExpanded, setPopularExpanded] = useState(false);
   // The user's liked tracks + albums credited to this artist. Spotify
   // renders a "You Liked" summary card above Albums; clicking it
@@ -63,17 +71,23 @@ export function ArtistDetail({ onDownload }: { onDownload: OnDownload }) {
   if (error || !artist)
     return <ErrorView error={error ?? "Artist not found"} />;
 
+  // Overlay the deferred extras once they arrive; until then fall
+  // back to the thin values the fast primary payload carries
+  // (appears_on from get_other only, compilations empty, mix null).
+  const compilations = extras?.compilations ?? artist.compilations;
+  const appearsOn =
+    extras?.appears_on && extras.appears_on.length
+      ? extras.appears_on
+      : artist.appears_on;
+  const artistMixId = extras?.artist_mix_id ?? artist.artist_mix_id;
+
   // "Download full discography" needs a single merged list of everything
   // the artist has released (albums + EPs + singles + their own
   // compilations; skip appears-on since those are someone else's
   // records). Compilations are kept here even though they get their own
   // shelf — they're still the artist's releases, so dropping them would
   // silently shrink the discography download.
-  const fullCatalog = [
-    ...artist.albums,
-    ...artist.ep_singles,
-    ...artist.compilations,
-  ];
+  const fullCatalog = [...artist.albums, ...artist.ep_singles, ...compilations];
 
   return (
     <div>
@@ -85,7 +99,7 @@ export function ArtistDetail({ onDownload }: { onDownload: OnDownload }) {
         allAlbums={fullCatalog}
         shareUrl={artist.share_url}
         onDownload={onDownload}
-        artistMixId={artist.artist_mix_id}
+        artistMixId={artistMixId}
       />
 
       {artist.top_tracks.length > 0 && (
@@ -147,7 +161,7 @@ export function ArtistDetail({ onDownload }: { onDownload: OnDownload }) {
       />
       <MediaRow
         title="Compilations"
-        items={artist.compilations}
+        items={compilations}
         viewMoreTo={`/artist/${id}/all/compilations`}
         onDownload={onDownload}
       />
@@ -163,7 +177,7 @@ export function ArtistDetail({ onDownload }: { onDownload: OnDownload }) {
       )}
       <MediaRow
         title="Appears on"
-        items={artist.appears_on}
+        items={appearsOn}
         viewMoreTo={`/artist/${id}/all/appears-on`}
         onDownload={onDownload}
       />


### PR DESCRIPTION
## Summary

The artist page was slow because of **two** Tidal calls, found via per-task instrumentation (added here, logged to `audio.log`):

- `artist.page()` — ~1.5–3s, consistent
- `get_radio_mix()` — ~0.35–3.2s, wildly variable

Both feed only secondary content (the "Appears On" / "Compilations" rows and the radio mix id) but sat on the synchronous path. Moved them into a new cached `GET /api/artist/{id}/extras`. The primary `/api/artist/{id}` keeps the same response keys (backward compatible: `appears_on` from the fast `get_other()`, `compilations` empty, `artist_mix_id` null) so it can't break a stale client; the frontend fetches `/extras` non-blocking after first paint and overlays the rows + radio id. Pool right-sized to the 8 remaining tasks (the two poles that made pool size irrelevant are gone).

**Measured: primary endpoint 164–265ms, down from ~1.6–3.4s (~10x).**

## Test plan

- [x] Direct measurement: `artist_detail` 164–265ms (was 1.9–3.4s); `/extras` ~2–3s but off the critical path
- [x] `./scripts/preflight.sh` green (pytest, tsc, lint, vitest)
- [ ] **Needs your UI check (I can't drive the browser):** artist page paints fast; "Appears On"/"Compilations" rows fill in a beat later without flicker; Radio button works once `/extras` lands; cached so back-nav is instant