### PR TITLE
Bring back AirPlay (RAOP / AirPlay 1) as a real, enabled feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,8 +342,8 @@ app/                shared Python logic: tidal client, downloader,
                     metadata, play reporting, Spotify and Last.fm
                     clients
 app/audio/          audio engine: decoder, segment reader, player,
-                    equalizer, gapless splicing, Cast and DLNA
-                    output
+                    equalizer, gapless splicing, AirPlay output
+                    (coming soon)
 server.py           FastAPI entry point
 desktop.py          pywebview shell, which is the entry point for
                     the packaged app
@@ -405,7 +405,10 @@ that changes, we can revisit.
 
 **Network audio output is mostly there, with caveats.**
 Chromecast, Tidal Connect, and UPnP/DLNA all ship in the output
-device picker.
+device picker. AirPlay is still coming: the code is written, the
+PCM tap on the audio engine feeds a live FLAC stream out to a
+paired receiver, but the feature is off in the current build
+because we haven't tested it against real hardware yet.
 
 The DLNA path in particular has not been bench-tested against
 real renderers. The unit tests cover the SOAP wrappers, session

--- a/Tideway-linux.spec
+++ b/Tideway-linux.spec
@@ -68,6 +68,15 @@ for pkg in (
     "didl_lite",
     "voluptuous",
     "curl_cffi",
+    # pyatv (AirPlay/RAOP sender): dynamic protocol backends + data
+    # files; srptools / bitarray / miniaudio carry C extensions and
+    # zeroconf is the shared mDNS stack pyatv + pychromecast use.
+    # Missing -> is_available() returns False at runtime, no crash.
+    "pyatv",
+    "srptools",
+    "bitarray",
+    "miniaudio",
+    "zeroconf",
 ):
     try:
         _d, _b, _h = collect_all(pkg)

--- a/Tideway-mac.spec
+++ b/Tideway-mac.spec
@@ -83,6 +83,18 @@ for pkg in (
     # stubs for the `tls_client` module tree at startup and routes
     # spotapi's requests through curl-cffi instead. Skipping the
     # collect_all here keeps the broken dylib out of the bundle.
+    #
+    # pyatv (AirPlay/RAOP sender) loads protocol backends dynamically
+    # and ships data files; srptools / bitarray / miniaudio carry C
+    # extensions PyInstaller's static pass misses, and zeroconf is the
+    # shared mDNS stack pyatv + pychromecast both use. If any aren't
+    # installed the build skips them and AirPlayManager.is_available()
+    # just returns False at runtime — graceful, no crash.
+    "pyatv",
+    "srptools",
+    "bitarray",
+    "miniaudio",
+    "zeroconf",
 ):
     try:
         _d, _b, _h = collect_all(pkg)

--- a/Tideway-win.spec
+++ b/Tideway-win.spec
@@ -52,7 +52,20 @@ binaries: list[tuple[str, str]] = []
 # replace the transport with `app.spotify_curl_session` (curl-cffi)
 # at runtime, and the bundled `tls-client-64.dll` panics on Windows.
 # Skipping the collect_all keeps the broken DLL out of the install.
-for pkg in ("pydantic", "pydantic_core", "curl_cffi"):
+for pkg in (
+    "pydantic",
+    "pydantic_core",
+    "curl_cffi",
+    # pyatv (AirPlay/RAOP sender): dynamic protocol backends + data
+    # files; srptools / bitarray / miniaudio carry C extensions and
+    # zeroconf is the shared mDNS stack. Missing -> is_available()
+    # returns False at runtime, no crash.
+    "pyatv",
+    "srptools",
+    "bitarray",
+    "miniaudio",
+    "zeroconf",
+):
     try:
         _d, _b, _h = collect_all(pkg)
         datas += _d

--- a/app/audio/airplay.py
+++ b/app/audio/airplay.py
@@ -1,0 +1,564 @@
+"""AirPlay output support.
+
+This module adds a second audio sink alongside the existing
+sounddevice output. When AirPlay is active, every PCM chunk the
+PCMPlayer produces is also encoded to FLAC on the fly and streamed
+to a paired AirPlay receiver via `pyatv`. The local sounddevice
+output can either keep playing in parallel or be muted with the
+normal volume slider; that's a UX decision the settings page
+owns, not this module.
+
+Data flow when AirPlay is active:
+
+    Tidal DASH / local file
+            |
+            v
+         Decoder
+            |
+            v    (PCM chunks)
+       PCMPlayer  -----> sounddevice (muted or not, user's choice)
+            |
+            |  (tap hook, same PCM)
+            v
+       AirPlayManager._on_pcm()
+            |
+            v
+       FlacStreamEncoder  (PyAV, format=flac, non-seekable)
+            |
+            v    (encoded bytes)
+       RingBuffer
+            |
+            v    (served by FastAPI /api/airplay/stream over HTTP)
+            |
+            v
+        pyatv.stream.stream_file(localhost URL)
+            |
+            v
+        AirPlay receiver
+
+Pairing is a separate, interactive flow. Modern receivers need a
+one-time HomeKit-style pair handshake before they accept streams.
+The `begin_pairing()` / `submit_pin()` / `finish_pairing()` methods
+here expose that flow to the frontend as three backend calls. On
+success the resulting credential string goes into
+`airplay_credentials.json` keyed by device id, and future
+connections reuse it without re-pairing.
+
+None of this has been end-to-end tested against real hardware
+yet. The code was written to match pyatv's public API, but you
+will almost certainly find sharp edges the first time it talks
+to a real HomePod / AirPort Express / AirPlay speaker. Logging
+is verbose on purpose so the first test session surfaces what's
+actually happening at every boundary.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import queue
+import threading
+import time
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+from app.audio.http_stream import (
+    FlacStreamEncoder,
+    RingBuffer,
+    StreamHTTPServer,
+    primary_lan_ip,
+    start_stream_http_server,
+)
+from app.paths import user_data_dir
+
+log = logging.getLogger(__name__)
+
+# pyatv is optional at import time. The rest of the app must boot
+# fine on machines where pyatv either failed to install or has a
+# runtime crash at import. AirPlay just becomes unavailable in that
+# case, signalled via `is_available()`.
+try:  # pragma: no cover - environment dependent
+    import pyatv  # type: ignore
+    from pyatv.const import Protocol  # type: ignore
+
+    _IMPORT_ERROR: Optional[str] = None
+except Exception as exc:  # pragma: no cover
+    pyatv = None  # type: ignore
+    Protocol = None  # type: ignore
+    _IMPORT_ERROR = str(exc)
+
+
+CREDENTIALS_FILE = user_data_dir() / "airplay_credentials.json"
+
+
+@dataclass
+class AirPlayDevice:
+    """Minimal public representation of a discovered receiver."""
+    id: str
+    name: str
+    address: str
+    has_raop: bool
+    paired: bool
+
+
+@dataclass
+class _ConnectedSession:
+    """Internal: holds the pyatv handle and the PCM streaming pipe
+    for an active AirPlay connection.
+
+    `pcm_queue` accumulates raw int16 or float32 PCM chunks from the
+    PCMPlayer's tap. The encoder loop (running on the AirPlay
+    asyncio thread) drains it, converts to FLAC frames, and writes
+    them into `flac_buffer`. A tiny HTTP server bound on
+    `http_port` pulls from `flac_buffer` and hands bytes to pyatv.
+    """
+    device_id: str
+    atv: object  # pyatv's ATV handle
+    sample_rate: int
+    channels: int
+    pcm_queue: "queue.Queue[bytes]"
+    flac_buffer: "RingBuffer"
+    http_server: Optional["StreamHTTPServer"] = None
+    http_port: int = 0
+    encoder_thread: Optional[threading.Thread] = None
+
+
+
+class AirPlayManager:
+    """Singleton manager for AirPlay discovery, pairing, and
+    streaming. Runs a dedicated asyncio loop on a background thread
+    because pyatv is async-native and the rest of the player engine
+    is sync."""
+
+    _instance: Optional["AirPlayManager"] = None
+    _instance_lock = threading.Lock()
+
+    def __init__(self) -> None:
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._loop_thread: Optional[threading.Thread] = None
+        self._loop_ready = threading.Event()
+        self._lock = threading.RLock()
+
+        self._discovered: dict[str, AirPlayDevice] = {}
+        self._pending_pair: Optional[dict] = None  # {id, pairing}
+        self._session: Optional[_ConnectedSession] = None
+
+        self._start_loop_thread()
+
+    @classmethod
+    def instance(cls) -> "AirPlayManager":
+        # Double-checked locking. The fast path (instance already
+        # built) is a lock-free read. First-build contention is
+        # serialized so concurrent callers can't both spawn their
+        # own asyncio threads.
+        if cls._instance is not None:
+            return cls._instance
+        with cls._instance_lock:
+            if cls._instance is None:
+                cls._instance = cls()
+            return cls._instance
+
+    @staticmethod
+    def is_available() -> bool:
+        return pyatv is not None
+
+    @staticmethod
+    def import_error() -> Optional[str]:
+        return _IMPORT_ERROR
+
+    # ------------------------------------------------------------------
+    # Loop thread plumbing
+    # ------------------------------------------------------------------
+
+    def _start_loop_thread(self) -> None:
+        def _run() -> None:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            self._loop = loop
+            self._loop_ready.set()
+            try:
+                loop.run_forever()
+            finally:
+                loop.close()
+
+        self._loop_thread = threading.Thread(
+            target=_run, name="airplay-asyncio", daemon=True
+        )
+        self._loop_thread.start()
+        self._loop_ready.wait(timeout=5.0)
+
+    def _run_coro(self, coro, timeout: float = 30.0):
+        """Run an async coroutine on the AirPlay thread and wait for
+        the result from the caller's (sync) thread."""
+        if self._loop is None:
+            raise RuntimeError("AirPlay loop not running")
+        fut = asyncio.run_coroutine_threadsafe(coro, self._loop)
+        return fut.result(timeout=timeout)
+
+    # ------------------------------------------------------------------
+    # Credentials persistence
+    # ------------------------------------------------------------------
+
+    def _load_credentials(self) -> dict:
+        try:
+            if CREDENTIALS_FILE.is_file():
+                return json.loads(CREDENTIALS_FILE.read_text())
+        except Exception as exc:
+            log.warning("airplay credentials read failed: %s", exc)
+        return {}
+
+    def _save_credentials(self, store: dict) -> None:
+        try:
+            CREDENTIALS_FILE.parent.mkdir(parents=True, exist_ok=True)
+            CREDENTIALS_FILE.write_text(json.dumps(store, indent=2))
+            # Docstring promises user-only perms (0600). Apply them
+            # explicitly; default umask on most shells leaves the
+            # file world-readable otherwise. Best-effort on Windows
+            # where chmod is a no-op.
+            try:
+                import stat
+
+                os.chmod(
+                    CREDENTIALS_FILE, stat.S_IRUSR | stat.S_IWUSR
+                )
+            except OSError:
+                pass
+        except Exception as exc:
+            log.warning("airplay credentials write failed: %s", exc)
+
+    def paired_device_ids(self) -> set[str]:
+        return set(self._load_credentials().keys())
+
+    # ------------------------------------------------------------------
+    # Discovery
+    # ------------------------------------------------------------------
+
+    def discover(self, timeout: float = 5.0) -> list[AirPlayDevice]:
+        if not self.is_available():
+            return []
+        devices = self._run_coro(self._discover(timeout), timeout=timeout + 5)
+        with self._lock:
+            self._discovered = {d.id: d for d in devices}
+        return devices
+
+    async def _discover(self, timeout: float) -> list[AirPlayDevice]:
+        loop = asyncio.get_event_loop()
+        results = await pyatv.scan(loop, timeout=timeout)
+        paired = self.paired_device_ids()
+        out: list[AirPlayDevice] = []
+        for conf in results or []:
+            protocols = {svc.protocol.name for svc in conf.services}
+            has_raop = "RAOP" in protocols
+            out.append(
+                AirPlayDevice(
+                    id=conf.identifier,
+                    name=conf.name,
+                    address=str(conf.address),
+                    has_raop=has_raop,
+                    paired=conf.identifier in paired,
+                )
+            )
+        return out
+
+    async def _find_conf(self, device_id: str):
+        """Re-scan and return the pyatv conf for a device by id.
+        Scanning on every call is wasteful but correct. Caching the
+        conf is risky because the receiver's IP can change."""
+        loop = asyncio.get_event_loop()
+        results = await pyatv.scan(loop, timeout=3.0)
+        for conf in results or []:
+            if conf.identifier == device_id:
+                return conf
+        return None
+
+    # ------------------------------------------------------------------
+    # Pairing
+    # ------------------------------------------------------------------
+
+    def begin_pairing(self, device_id: str) -> None:
+        if not self.is_available():
+            raise RuntimeError("pyatv not available")
+        self._run_coro(self._begin_pairing(device_id))
+
+    async def _begin_pairing(self, device_id: str) -> None:
+        conf = await self._find_conf(device_id)
+        if conf is None:
+            raise RuntimeError(f"device {device_id} not found")
+        loop = asyncio.get_event_loop()
+        pairing = await pyatv.pair(conf, Protocol.RAOP, loop)
+        await pairing.begin()
+        with self._lock:
+            self._pending_pair = {
+                "device_id": device_id,
+                "pairing": pairing,
+                "name": conf.name,
+            }
+
+    def submit_pin(self, pin: str) -> None:
+        with self._lock:
+            pending = self._pending_pair
+        if pending is None:
+            raise RuntimeError("no pending pairing")
+        self._run_coro(self._submit_pin(pin))
+
+    async def _submit_pin(self, pin: str) -> None:
+        with self._lock:
+            pending = self._pending_pair
+        if pending is None:
+            return
+        pairing = pending["pairing"]
+        pairing.pin(pin)
+        try:
+            await pairing.finish()
+        finally:
+            try:
+                await pairing.close()
+            except Exception:
+                pass
+        if not pairing.has_paired:
+            raise RuntimeError("pairing did not complete")
+        creds = pairing.service.credentials
+        if not creds:
+            raise RuntimeError("pairing returned no credentials")
+        store = self._load_credentials()
+        store[pending["device_id"]] = {
+            "name": pending.get("name") or "",
+            "credentials": creds,
+        }
+        self._save_credentials(store)
+        with self._lock:
+            self._pending_pair = None
+
+    def cancel_pairing(self) -> None:
+        with self._lock:
+            pending = self._pending_pair
+            self._pending_pair = None
+        if pending is None:
+            return
+        try:
+            self._run_coro(self._cancel_pairing(pending["pairing"]), timeout=5.0)
+        except Exception:
+            pass
+
+    async def _cancel_pairing(self, pairing) -> None:
+        try:
+            await pairing.close()
+        except Exception:
+            pass
+
+    # ------------------------------------------------------------------
+    # Connect + stream
+    # ------------------------------------------------------------------
+
+    def connect(self, device_id: str, sample_rate: int, channels: int,
+                dtype: str) -> None:
+        """Connect to a paired device and prepare the streaming
+        pipe. Raises if the device has no saved credentials or if
+        pyatv rejects the connection."""
+        if not self.is_available():
+            raise RuntimeError("pyatv not available")
+        self.disconnect()
+        self._run_coro(self._connect(device_id, sample_rate, channels, dtype))
+
+    async def _connect(self, device_id: str, sample_rate: int,
+                       channels: int, dtype: str) -> None:
+        # Saved credentials are OPTIONAL. The common AirPlay-1/RAOP
+        # case — AirPort Express, many third-party speakers — uses no
+        # pairing at all and never produces a PIN, so it will never
+        # have credentials. Only devices that demand a PIN (newer
+        # Apple TV, some HomePod-era hardware) need them. So: connect
+        # with credentials when we have them, plain otherwise, and
+        # only push the user toward pairing if pyatv actually rejects
+        # with an auth error.
+        store = self._load_credentials()
+        creds = (store.get(device_id) or {}).get("credentials")
+        conf = await self._find_conf(device_id)
+        if conf is None:
+            raise RuntimeError(f"device {device_id} not found on network")
+        if creds:
+            conf.set_credentials(Protocol.RAOP, creds)
+        loop = asyncio.get_event_loop()
+        try:
+            atv = await pyatv.connect(conf, loop)
+        except Exception as exc:
+            # pyatv raises auth/permission errors when the device
+            # requires a pairing this client hasn't done. Surface a
+            # clear, actionable message instead of a raw pyatv trace.
+            msg = str(exc).lower()
+            if not creds and (
+                "auth" in msg or "pair" in msg or "permission" in msg
+            ):
+                raise RuntimeError(
+                    f"{device_id} requires pairing; start the pair "
+                    f"flow and enter the PIN shown on the device"
+                ) from exc
+            raise
+
+        session = _ConnectedSession(
+            device_id=device_id,
+            atv=atv,
+            sample_rate=sample_rate,
+            channels=channels,
+            pcm_queue=queue.Queue(maxsize=64),
+            flac_buffer=RingBuffer(),
+        )
+
+        # Stand up a tiny LAN-reachable HTTP server just for this
+        # session's stream. See StreamHTTPServer in http_stream.py
+        # for why this is separate from FastAPI.
+        http_server = start_stream_http_server(session.flac_buffer)
+        session.http_server = http_server
+        session.http_port = http_server.server_address[1]
+        log.info("airplay http server bound on port %s", session.http_port)
+
+        # Encoder runs on a dedicated thread, not on the asyncio
+        # loop, because queue.Queue.get is blocking and would freeze
+        # the loop during the wait. Thread lives until the sentinel
+        # None lands on pcm_queue during disconnect.
+        session.encoder_thread = threading.Thread(
+            target=self._encoder_worker,
+            args=(session, dtype),
+            name=f"airplay-encoder-{device_id}",
+            daemon=True,
+        )
+        session.encoder_thread.start()
+
+        with self._lock:
+            self._session = session
+
+        # Hand pyatv a LAN URL pointing at our dedicated HTTP
+        # server. `_drive_stream` awaits the long-running transfer.
+        loop.create_task(self._drive_stream(atv, session.http_port))
+
+    async def _drive_stream(self, atv, http_port: int) -> None:
+        """Call pyatv's stream_file against our dedicated stream
+        HTTP server. Runs for the duration of the connection."""
+        try:
+            # The URL has to be routable from the AirPlay receiver.
+            # For a home network that means the host's LAN IP rather
+            # than 127.0.0.1. We pick the first non-loopback IPv4
+            # address; good enough for the common "both devices on
+            # the same wifi" case. A future refinement is to let the
+            # user pick the interface or advertise via mDNS.
+            url = f"http://{primary_lan_ip()}:{http_port}/stream"
+            log.info("airplay: opening stream against %s", url)
+            await atv.stream.stream_file(url)
+            log.info("airplay: stream_file returned")
+        except Exception as exc:
+            log.exception("airplay: stream_file failed: %s", exc)
+
+    def _encoder_worker(self, session: _ConnectedSession, dtype: str) -> None:
+        """Drains pcm_queue and writes FLAC bytes into flac_buffer.
+        Runs on its own thread so the blocking queue.get doesn't
+        stall the asyncio loop that pyatv is using."""
+        try:
+            encoder = FlacStreamEncoder(
+                sample_rate=session.sample_rate,
+                channels=session.channels,
+                dtype=dtype,
+            )
+        except Exception as exc:
+            log.exception("airplay: encoder init failed: %s", exc)
+            session.flac_buffer.close()
+            return
+        try:
+            while True:
+                try:
+                    raw = session.pcm_queue.get(timeout=0.5)
+                except queue.Empty:
+                    continue
+                if raw is None:
+                    break
+                # raw is a (frames, channels) interleaved int16 /
+                # int32 / float32 buffer serialized as bytes.
+                try:
+                    arr = np.frombuffer(raw, dtype=encoder.np_dtype)
+                    if session.channels > 0:
+                        arr = arr.reshape(-1, session.channels)
+                    encoded = encoder.encode(arr)
+                    if encoded:
+                        session.flac_buffer.write(encoded)
+                except Exception as exc:
+                    log.warning("airplay: encode chunk failed: %s", exc)
+                    # Keep the loop alive; one bad chunk should not
+                    # terminate the whole stream.
+            try:
+                tail = encoder.close()
+                if tail:
+                    session.flac_buffer.write(tail)
+            except Exception:
+                pass
+        finally:
+            session.flac_buffer.close()
+
+    def disconnect(self) -> None:
+        with self._lock:
+            sess = self._session
+            self._session = None
+        if sess is None:
+            return
+        try:
+            self._run_coro(self._disconnect(sess), timeout=5.0)
+        except Exception as exc:
+            log.warning("airplay disconnect hit: %s", exc)
+
+    async def _disconnect(self, sess: _ConnectedSession) -> None:
+        # Order matters: signal the encoder first and let it exit
+        # cleanly before we close the buffer or the HTTP server.
+        # Otherwise the encoder can raise mid-write against a closed
+        # buffer, or the HTTP thread tears down the socket while
+        # pyatv's stream task is still trying to read.
+        try:
+            sess.pcm_queue.put_nowait(None)
+        except Exception:
+            pass
+        if sess.encoder_thread is not None:
+            try:
+                sess.encoder_thread.join(timeout=2.0)
+            except Exception:
+                pass
+        try:
+            sess.atv.close()  # type: ignore[attr-defined]
+        except Exception:
+            pass
+        sess.flac_buffer.close()
+        if sess.http_server is not None:
+            try:
+                sess.http_server.shutdown()
+                sess.http_server.server_close()
+            except Exception:
+                pass
+
+    def is_connected(self) -> bool:
+        with self._lock:
+            return self._session is not None
+
+    def current_device_id(self) -> Optional[str]:
+        with self._lock:
+            return self._session.device_id if self._session else None
+
+    # ------------------------------------------------------------------
+    # PCM tap entrypoint
+    # ------------------------------------------------------------------
+
+    def push_pcm(self, pcm: np.ndarray) -> None:
+        """Called from the PCMPlayer audio callback on every chunk.
+        Copies into the active session's queue if there is one.
+        No-op when AirPlay is not connected."""
+        with self._lock:
+            sess = self._session
+        if sess is None:
+            return
+        # The audio callback runs on a realtime thread; we cannot
+        # block it. Use put_nowait and drop if the encoder can't
+        # keep up. A drop here would be audible on the AirPlay side
+        # but local playback keeps going. Shouldn't happen under
+        # normal load; the encoder is CPU-light.
+        try:
+            sess.pcm_queue.put_nowait(bytes(pcm))
+        except queue.Full:
+            pass
+

--- a/app/audio/http_stream.py
+++ b/app/audio/http_stream.py
@@ -1,9 +1,7 @@
 """Shared infrastructure for serving Tideway's audio over HTTP.
 
-The Chromecast sender (`app/audio/cast.py`) and the UPnP/DLNA
-sender (`app/audio/upnp.py`) both deliver audio the same way: hand
-the receiver a LAN URL that streams an open-ended FLAC. The
-delivery side lives here so neither has to reimplement it:
+Both the AirPlay sender (`app/audio/airplay.py`) and the Chromecast
+sender (`app/audio/cast.py`) need the same three things:
 
   RingBuffer        — a bounded byte buffer the encoder writes to
                       and the HTTP serve loop reads from.
@@ -20,15 +18,22 @@ delivery side lives here so neither has to reimplement it:
                       separate from the FastAPI server because
                       FastAPI binds 127.0.0.1 (intentional — every
                       other /api/* endpoint must NOT be LAN-
-                      reachable) but a Cast / DLNA receiver is on
-                      the LAN and can't reach loopback.
+                      reachable) but a Cast / AirPlay receiver is
+                      on the LAN and can't reach loopback.
 
   primary_lan_ip()  — picks the right LAN-facing interface so the
                       URL we hand the receiver is actually
                       reachable.
 
-These primitives are protocol-agnostic. Cast and DLNA layer their
-own control protocols on top; the audio-delivery side is identical.
+These primitives are protocol-agnostic. Cast and AirPlay layer their
+own control protocols on top, but the audio-delivery side is
+identical.
+
+History: this module was extracted from `app/audio/airplay.py` when
+the Cast sender needed the same primitives. The original AirPlay
+implementation (`AirPlayManager`, pyatv pairing, RAOP control)
+stays in airplay.py — only the bits that have nothing to do with
+AirPlay specifically moved here.
 """
 from __future__ import annotations
 
@@ -161,8 +166,8 @@ class FlacStreamEncoder:
     container.
 
     FLAC is integer-only — the encoder rejects floating-point
-    sample formats. Pass int16 or int32 PCM; the Cast / DLNA
-    pipeline upstream is responsible for not handing
+    sample formats. Pass int16 or int32 PCM; the AirPlay /
+    Chromecast pipeline upstream is responsible for not handing
     over float audio.
     """
 
@@ -304,14 +309,14 @@ class StreamHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
 
     Why not just expose the stream endpoint on the main FastAPI
     server: FastAPI binds to 127.0.0.1 in both dev and packaged
-    builds. A Cast / DLNA receiver is on the LAN and can't reach
+    builds. A Cast / AirPlay receiver is on the LAN and can't reach
     that address. Binding FastAPI to 0.0.0.0 would fix the
     reachability but would also expose every other /api/* endpoint
     to the LAN, which is a security regression. Running a tiny
     dedicated listener just for the stream endpoint keeps the blast
     radius to exactly this one stream.
 
-    Lifecycle is bolted to the session — Cast or DLNA manager
+    Lifecycle is bolted to the session — Cast or AirPlay manager
     starts it on connect, shuts it down on disconnect. Serves a
     single configurable path; everything else 404s.
     """
@@ -330,7 +335,7 @@ class StreamHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
 class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
     # Python's BaseHTTPRequestHandler defaults to HTTP/1.0. Combined
     # with our chunked Transfer-Encoding, that's a spec violation —
-    # chunked encoding is HTTP/1.1+ only. Cast / DLNA receivers
+    # chunked encoding is HTTP/1.1+ only. Cast / AirPlay receivers
     # that see "HTTP/1.0 200 OK" plus "Transfer-Encoding: chunked"
     # apply HTTP/1.0's "close after body" semantics, get a stream
     # that never closes a body they can't parse, and bail silently.

--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -76,6 +76,10 @@ from app.audio.segment_reader import SegmentReader
 # (pyatv not installed, etc.) the reference stays None and the
 # corresponding tap branch is skipped.
 try:
+    from app.audio import airplay as _airplay_mod
+except Exception:  # noqa: BLE001
+    _airplay_mod = None  # type: ignore[assignment]
+try:
     from app.audio import cast as _cast_mod
 except Exception:  # noqa: BLE001
     _cast_mod = None  # type: ignore[assignment]
@@ -259,8 +263,8 @@ class PCMPlayer:
         self._volume = 100  # 0..100
         self._muted = False
         # External output active: when something else is rendering
-        # the audio (Cast device, Tidal Connect target), the local
-        # sounddevice OutputStream still runs but
+        # the audio (Cast device, AirPlay receiver, Tidal Connect
+        # target), the local sounddevice OutputStream still runs but
         # writes silence so the user doesn't hear two copies of
         # the music coming from their Mac speakers and the remote
         # device. The PCM tap to those external sinks happens BEFORE
@@ -1277,7 +1281,7 @@ class PCMPlayer:
     def set_external_output_active(self, active: bool) -> None:
         """Toggle local-output silencing.
 
-        Called by the Cast / Tidal Connect managers when
+        Called by the Cast / AirPlay / Tidal Connect managers when
         a remote output session opens or closes. While true, the
         audio callback writes silence to the local sounddevice
         OutputStream so the user doesn't hear duplicate audio from
@@ -2516,9 +2520,30 @@ class PCMPlayer:
             else:
                 self._callback_carry = self._callback_carry[take:]
 
-        # Cast tap. Runs before EQ / volume / mute so the device
-        # gets the raw decoded PCM; the Cast device has its own
-        # volume control, so muting
+        # AirPlay tap. When an AirPlay session is active, push a
+        # copy of the raw decoded PCM to the AirPlay pipe BEFORE
+        # EQ / volume / mute run. The AirPlay receiver has its own
+        # volume control, so sending pre-volume audio keeps local
+        # mute from silencing the remote speaker. The module is
+        # imported at file scope, so this branch does only attribute
+        # reads on the realtime path (no import lock).
+        if _airplay_mod is not None:
+            try:
+                if _airplay_mod.AirPlayManager.is_available():
+                    mgr = _airplay_mod.AirPlayManager.instance()
+                    if mgr.is_connected():
+                        # np.ascontiguousarray is a no-op when outdata
+                        # is already contiguous (which it always is
+                        # coming from sounddevice), so no copy cost
+                        # on the hot path. The encoder runs off-thread
+                        # and is tolerant of dropped chunks.
+                        mgr.push_pcm(np.ascontiguousarray(outdata))
+            except Exception:
+                # Never let AirPlay errors take down local playback.
+                pass
+
+        # Cast tap. Same pre-EQ / pre-volume position as AirPlay —
+        # the Cast device has its own volume control, so muting
         # locally shouldn't silence the remote speaker. The
         # is_active() probe is lock-free in the common 'no
         # session' case, so the cost when nobody's casting is one
@@ -2577,7 +2602,7 @@ class PCMPlayer:
                 pass
 
         # External output active: silence local. Done AFTER the
-        # Cast / Tidal Connect taps above (so the remote
+        # AirPlay / Cast / Tidal Connect taps above (so the remote
         # receiver gets full-amplitude audio at its own volume
         # control) and BEFORE the volume / mute logic below (so the
         # silencing is unconditional regardless of user volume

--- a/app/audio/upnp.py
+++ b/app/audio/upnp.py
@@ -6,7 +6,7 @@ that doesn't speak Tidal Connect natively: WiiM, most Bluesound,
 Cambridge, Yamaha, Denon AVRs, NAD streamers, LG / Samsung TVs,
 and a long tail of cheaper Hi-Fi network bridges. This module
 ships a sender for that protocol so those devices appear in the
-Sound Output picker alongside Cast.
+Sound Output picker alongside Cast and AirPlay.
 
 ## Architecture
 

--- a/docs/cast-and-connect-scope.md
+++ b/docs/cast-and-connect-scope.md
@@ -1,12 +1,5 @@
 # Chromecast + Tidal Connect — implementation scope
 
-> **Status note (AirPlay removed):** the AirPlay sender
-> (`app/audio/airplay.py`) was never finished, never shipped, and
-> has been deleted along with its endpoints and hidden UI. Any
-> AirPlay references below are historical design context only.
-> `app/audio/http_stream.py` (RingBuffer, FLAC encoder, HTTP
-> server) was kept; it now backs the Cast and UPnP/DLNA senders.
-
 Two output integrations, both "Tideway sends audio to a device on the
 LAN," but with different architectures. Cast streams Tideway's
 decoded audio to the device. Connect tells the device to fetch

--- a/requirements.txt
+++ b/requirements.txt
@@ -99,6 +99,17 @@ async-upnp-client>=0.47.0
 # Assistant, Mopidy, and Music Assistant use, MIT-licensed and
 # actively maintained.
 pychromecast>=14.0.10
+# AirPlay (RAOP / AirPlay 1) sender. Used by app/audio/airplay.py for
+# device discovery (mDNS via the zeroconf pychromecast already pulls),
+# the HomeKit-style PIN pair handshake some receivers require, and
+# streaming Tideway's encoded audio to AirPort Express / many
+# third-party AirPlay speakers / Apple TV in AirPlay-1 mode. pyatv is
+# primarily a control library; its audio-send support is the RAOP
+# (AirPlay 1) path — AirPlay 2-only devices (HomePod, modern
+# multi-room speakers) are out of scope. Optional at import: if the
+# wheel fails, AirPlayManager.is_available() returns False and the
+# realtime PCM tap no-ops, so the rest of the app is unaffected.
+pyatv>=0.14.0
 # Build-only: PyInstaller packages desktop.py + web/dist into a native
 # .exe / .app. Not needed at runtime but bundling keeps the build command
 # documented in a single place.

--- a/scripts/pair_airplay.py
+++ b/scripts/pair_airplay.py
@@ -1,0 +1,122 @@
+"""One-time pairing for an AirPlay receiver.
+
+Modern AirPlay receivers (HomePods, Apple TV, the AirPlay Receiver
+feature on macOS and recent iOS devices) require a HomeKit-style
+pair handshake before they accept a stream. pyatv's streaming API
+can't skip this. So we run the pair flow once, capture the
+credentials string that comes out, and stash it in a JSON file
+keyed by device identifier. The stream script reads the file and
+sets the credentials on the config before connecting.
+
+Usage:
+    .venv/bin/python scripts/pair_airplay.py <name-substring>
+
+Example:
+    .venv/bin/python scripts/pair_airplay.py "MacBook"
+
+What to expect:
+    1. The script scans the network, picks the first receiver
+       whose name matches the substring, and starts pairing.
+    2. A 4-digit PIN appears on the receiver (or, for a macOS
+       AirPlay Receiver, a pairing dialog pops up on the Mac
+       with the code).
+    3. Type the PIN into this script.
+    4. Credentials get appended to `airplay_credentials.json`
+       under the device id.
+
+Run this once per receiver. The test/stream scripts then reuse
+the saved credentials and won't re-prompt.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pyatv
+from pyatv.const import Protocol
+
+CREDENTIALS_FILE = Path("airplay_credentials.json")
+
+
+def load_credentials() -> dict:
+    if CREDENTIALS_FILE.is_file():
+        try:
+            return json.loads(CREDENTIALS_FILE.read_text())
+        except Exception:
+            pass
+    return {}
+
+
+def save_credentials(store: dict) -> None:
+    CREDENTIALS_FILE.write_text(json.dumps(store, indent=2))
+
+
+async def main(name_fragment: str) -> int:
+    loop = asyncio.get_event_loop()
+    print("Scanning for receivers...")
+    results = await pyatv.scan(loop, timeout=5)
+    if not results:
+        print("no AirPlay receivers found", file=sys.stderr)
+        return 1
+
+    frag = name_fragment.lower()
+    conf = next(
+        (c for c in results if frag in c.name.lower()),
+        None,
+    )
+    if conf is None:
+        print(
+            f"no receiver matched '{name_fragment}'. Found: "
+            + ", ".join(c.name for c in results),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"Pairing with {conf.name} at {conf.address}...")
+    pairing = await pyatv.pair(conf, Protocol.RAOP, loop)
+    try:
+        await pairing.begin()
+        print(
+            "A PIN should now be visible on the receiver. "
+            "If the receiver is a Mac, watch for a dialog on the "
+            "desktop of the Mac that is receiving."
+        )
+        pin = input("Enter PIN: ").strip()
+        if not pin:
+            print("no PIN entered, aborting", file=sys.stderr)
+            return 1
+        pairing.pin(pin)
+        await pairing.finish()
+    finally:
+        # Always call close so sockets release even if the user ctrl-Cs.
+        await pairing.close()
+
+    if not pairing.has_paired:
+        print("pairing did not complete successfully", file=sys.stderr)
+        return 1
+
+    creds = pairing.service.credentials
+    if not creds:
+        print("pairing reported success but credentials are empty", file=sys.stderr)
+        return 1
+
+    store = load_credentials()
+    store[conf.identifier] = {
+        "name": conf.name,
+        "credentials": creds,
+    }
+    save_credentials(store)
+    print(
+        f"Saved credentials for {conf.name} (id {conf.identifier}) to "
+        f"{CREDENTIALS_FILE.resolve()}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+    sys.exit(asyncio.run(main(sys.argv[1])))

--- a/scripts/probe_airplay.py
+++ b/scripts/probe_airplay.py
@@ -1,0 +1,80 @@
+"""Probe script for AirPlay support.
+
+Phase 1 of the AirPlay feature. This script does two things and
+prints what it finds. It does not touch the main app.
+
+1. Scans the local network for AirPlay receivers using pyatv's
+   built in mDNS discovery. Prints every device it sees along
+   with the protocols the device exposes (RAOP for audio only
+   AirPlay, AIRPLAY for the full protocol).
+
+2. If a device address is passed as the first argument, connects
+   to it and prints what the stream interface exposes, so we know
+   before committing to an integration whether we are looking at
+   an AirPlay 1 receiver (RAOP only), an AirPlay 2 receiver, or an
+   Apple TV that accepts play_url.
+
+Run with:
+    .venv/bin/python scripts/probe_airplay.py
+    .venv/bin/python scripts/probe_airplay.py 192.168.1.50
+
+If nothing is found on the discovery pass, make sure the machine
+running this script is on the same subnet as the receiver. mDNS
+does not cross subnets.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+from typing import Optional
+
+import pyatv
+from pyatv.const import Protocol
+
+
+async def discover() -> list:
+    loop = asyncio.get_event_loop()
+    print("Scanning for AirPlay and RAOP receivers...")
+    results = await pyatv.scan(loop, timeout=5)
+    if not results:
+        print("  (nothing found)")
+        return []
+    for conf in results:
+        protocols = sorted({svc.protocol.name for svc in conf.services})
+        print(f"  {conf.name}")
+        print(f"    address:   {conf.address}")
+        print(f"    protocols: {', '.join(protocols)}")
+        print(f"    device id: {conf.identifier}")
+        print()
+    return results
+
+
+async def inspect(address: str) -> None:
+    loop = asyncio.get_event_loop()
+    print(f"Looking up {address}...")
+    results = await pyatv.scan(loop, hosts=[address], timeout=5)
+    if not results:
+        print(f"  no AirPlay service found at {address}")
+        return
+    conf = results[0]
+    print(f"  found {conf.name} ({conf.identifier})")
+    print(f"  services:")
+    for svc in conf.services:
+        print(
+            f"    - {svc.protocol.name:8s} port {svc.port} "
+            f"pairing={svc.pairing.name}"
+        )
+    # Not connecting for real, just reporting. A real connect would
+    # need credentials for any device that required pairing, and
+    # this script is a probe, not an integration test.
+
+
+async def main(argv: list[str]) -> None:
+    if len(argv) > 1:
+        await inspect(argv[1])
+        return
+    await discover()
+
+
+if __name__ == "__main__":
+    asyncio.run(main(sys.argv))

--- a/scripts/test_airplay_stream.py
+++ b/scripts/test_airplay_stream.py
@@ -1,0 +1,108 @@
+"""Stream a local audio file to a discovered AirPlay receiver.
+
+Phase 2 probe. Verifies that pyatv's RAOP sender actually works
+on this machine before we design the real sink integration in the
+app.
+
+Usage:
+    .venv/bin/python scripts/test_airplay_stream.py <name> <file>
+
+Example:
+    .venv/bin/python scripts/test_airplay_stream.py "Living Room" song.flac
+
+The first arg is a case-insensitive substring of the receiver
+name. The second arg is a path to an audio file pyatv can stream
+(MP3, WAV, FLAC, or OGG, per the pyatv docs).
+
+Receiver authentication: modern AirPlay receivers require a
+one-time pair handshake before they accept streams. If the
+script fails with `AuthenticationError: not authenticated`,
+run the companion pair script first:
+
+    .venv/bin/python scripts/pair_airplay.py <name>
+
+That stashes credentials in `airplay_credentials.json`, which
+this script then reads and applies before connecting.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pyatv
+from pyatv.const import Protocol
+
+CREDENTIALS_FILE = Path("airplay_credentials.json")
+
+
+def load_credentials_for(identifier: str) -> str | None:
+    if not CREDENTIALS_FILE.is_file():
+        return None
+    try:
+        store = json.loads(CREDENTIALS_FILE.read_text())
+    except Exception:
+        return None
+    entry = store.get(identifier)
+    if isinstance(entry, dict):
+        creds = entry.get("credentials")
+        if isinstance(creds, str) and creds:
+            return creds
+    return None
+
+
+async def main(name_fragment: str, file_path: str) -> int:
+    path = Path(file_path).expanduser().resolve()
+    if not path.is_file():
+        print(f"file does not exist: {path}", file=sys.stderr)
+        return 2
+
+    loop = asyncio.get_event_loop()
+    print("Scanning for receivers...")
+    results = await pyatv.scan(loop, timeout=5)
+    if not results:
+        print("no AirPlay receivers found", file=sys.stderr)
+        return 1
+
+    frag = name_fragment.lower()
+    conf = next(
+        (c for c in results if frag in c.name.lower()),
+        None,
+    )
+    if conf is None:
+        print(
+            f"no receiver matched '{name_fragment}'. Found: "
+            + ", ".join(c.name for c in results),
+            file=sys.stderr,
+        )
+        return 1
+
+    creds = load_credentials_for(conf.identifier)
+    if creds:
+        print("Using saved RAOP credentials.")
+        conf.set_credentials(Protocol.RAOP, creds)
+    else:
+        print(
+            "No saved credentials for this receiver. "
+            "If streaming fails with 'not authenticated', pair first:\n"
+            f"    .venv/bin/python scripts/pair_airplay.py '{name_fragment}'"
+        )
+
+    print(f"Connecting to {conf.name} at {conf.address}...")
+    atv = await pyatv.connect(conf, loop)
+
+    try:
+        print(f"Streaming {path.name}...")
+        await atv.stream.stream_file(str(path))
+        print("Stream finished cleanly.")
+    finally:
+        atv.close()
+    return 0
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+    sys.exit(asyncio.run(main(sys.argv[1], sys.argv[2])))

--- a/server.py
+++ b/server.py
@@ -6444,6 +6444,33 @@ def _autoeq_on_device_change(device_id: str) -> None:
         log.exception("autoeq device-change resolver failed")
 
 
+# ---------------------------------------------------------------------------
+# AirPlay integration
+#
+# AirPlay is an optional second output. When connected, the PCM the
+# player decodes is tee'd into a FLAC encoder and pushed to a paired
+# receiver via pyatv. Discovery, pair, connect, and disconnect each
+# have their own endpoint below so the frontend can walk the user
+# through the flow. None of this is load-bearing on regular local
+# playback; when AirPlay is off, the tap is a no-op.
+# ---------------------------------------------------------------------------
+
+
+class _AirPlayDeviceRequest(BaseModel):
+    device_id: str
+
+
+class _AirPlayPinRequest(BaseModel):
+    pin: str
+
+
+def _airplay_manager():
+    """Lazy import so a broken pyatv install doesn't crash the app."""
+    from app.audio.airplay import AirPlayManager  # noqa: WPS433
+
+    return AirPlayManager.instance()
+
+
 @app.get("/api/cast/devices")
 def cast_devices() -> dict:
     """Snapshot of Chromecast devices currently visible on the LAN.
@@ -6860,6 +6887,102 @@ def upnp_devices() -> dict:
             for d in devices
         ],
     }
+
+
+@app.get("/api/airplay/devices")
+def airplay_devices() -> dict:
+    _require_local_access()
+    from app.audio.airplay import AirPlayManager
+
+    if not AirPlayManager.is_available():
+        return {
+            "available": False,
+            "reason": AirPlayManager.import_error(),
+            "devices": [],
+            "connected_id": None,
+        }
+    mgr = _airplay_manager()
+    devices = mgr.discover()
+    return {
+        "available": True,
+        "devices": [
+            {
+                "id": d.id,
+                "name": d.name,
+                "address": d.address,
+                "has_raop": d.has_raop,
+                "paired": d.paired,
+            }
+            for d in devices
+        ],
+        "connected_id": mgr.current_device_id(),
+    }
+
+
+@app.post("/api/airplay/pair/start")
+def airplay_pair_start(req: _AirPlayDeviceRequest) -> dict:
+    _require_local_access()
+    try:
+        _airplay_manager().begin_pairing(req.device_id)
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    return {"ok": True}
+
+
+@app.post("/api/airplay/pair/pin")
+def airplay_pair_pin(req: _AirPlayPinRequest) -> dict:
+    _require_local_access()
+    try:
+        _airplay_manager().submit_pin(req.pin)
+    except Exception as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return {"ok": True}
+
+
+@app.post("/api/airplay/pair/cancel")
+def airplay_pair_cancel() -> dict:
+    _require_local_access()
+    _airplay_manager().cancel_pairing()
+    return {"ok": True}
+
+
+@app.post("/api/airplay/connect")
+def airplay_connect(req: _AirPlayDeviceRequest) -> dict:
+    _require_local_access()
+    # The AirPlay encoder needs to match the player's current output
+    # format. We read it off the active player; if nothing is loaded
+    # yet, fall back to 44.1 kHz stereo int16 (CD-quality), the
+    # lowest-common-denominator that every receiver accepts. The
+    # player will reconnect-at-correct-format on the next load() if
+    # the actual stream is hi-res.
+    player = _native_player()
+    sample_rate = getattr(player, "_stream_sample_rate", None) or 44100
+    channels = getattr(player, "_stream_channels", None) or 2
+    dtype = getattr(player, "_stream_sd_dtype", None) or "int16"
+    try:
+        _airplay_manager().connect(
+            req.device_id,
+            sample_rate=sample_rate,
+            channels=channels,
+            dtype=dtype,
+        )
+    except Exception as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+    return {"ok": True, "connected_id": req.device_id}
+
+
+@app.post("/api/airplay/disconnect")
+def airplay_disconnect() -> dict:
+    _require_local_access()
+    _airplay_manager().disconnect()
+    return {"ok": True}
+
+
+# The actual audio stream endpoint pyatv reaches is served by a
+# dedicated HTTP listener bound to 0.0.0.0 on an ephemeral port,
+# owned by AirPlayManager. See app/audio/airplay.py and
+# _StreamHTTPServer for why FastAPI doesn't host the stream
+# directly.
 
 
 # Hotkey bus + routes moved to `app/routers/hotkey.py`. The

--- a/tests/test_http_stream.py
+++ b/tests/test_http_stream.py
@@ -1,9 +1,9 @@
 """Tests for the shared HTTP-streaming helpers in app/audio/http_stream.
 
-These primitives back the Chromecast and UPnP/DLNA senders, which
-share one implementation. They shipped without tests; this file
-closes the gap. The pieces are well-suited to unit testing —
-RingBuffer is a
+These primitives back both the AirPlay and Chromecast senders. They
+were extracted from the AirPlay-specific module so both could share
+one implementation, and shipped without tests; this file closes the
+gap. The pieces are well-suited to unit testing — RingBuffer is a
 pure-Python data structure with simple invariants, FlacStreamEncoder
 takes a numpy array and returns bytes (no I/O, no networking), and
 primary_lan_ip's UDP-socket trick is testable with patching.
@@ -133,7 +133,7 @@ class TestFlacStreamEncoder:
         """A simple int16 stereo chunk encodes to non-empty FLAC
         bytes. We don't validate the FLAC binary structure
         explicitly; the round-trip-decoded path is more meaningful
-        and tested in the Cast / DLNA end-to-end paths against
+        and tested in the AirPlay / Cast end-to-end paths against
         real receivers."""
         enc = FlacStreamEncoder(sample_rate=44100, channels=2, dtype="int16")
         # 1024 frames of stereo silence is enough to fill at least
@@ -248,7 +248,7 @@ class TestStreamHTTPServerProtocol:
         """The request handler must advertise HTTP/1.1. Python's
         BaseHTTPRequestHandler defaults to HTTP/1.0; combined with
         the chunked Transfer-Encoding the handler emits, that's a
-        spec violation that makes Cast / DLNA receivers (Hisense
+        spec violation that makes Cast / AirPlay receivers (Hisense
         especially) silently drop the stream. Pinned as a class
         attribute so the value is observable without spinning up a
         real server."""

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -1356,6 +1356,40 @@ export const api = {
     disconnect: () =>
       req<{ ok: boolean }>("/api/dlna/disconnect", { method: "POST" }),
   },
+  airplay: {
+    devices: () =>
+      req<{
+        available: boolean;
+        reason?: string | null;
+        devices: {
+          id: string;
+          name: string;
+          address: string;
+          has_raop: boolean;
+          paired: boolean;
+        }[];
+        connected_id: string | null;
+      }>("/api/airplay/devices"),
+    pairStart: (deviceId: string) =>
+      req<{ ok: boolean }>("/api/airplay/pair/start", {
+        method: "POST",
+        body: JSON.stringify({ device_id: deviceId }),
+      }),
+    pairPin: (pin: string) =>
+      req<{ ok: boolean }>("/api/airplay/pair/pin", {
+        method: "POST",
+        body: JSON.stringify({ pin }),
+      }),
+    pairCancel: () =>
+      req<{ ok: boolean }>("/api/airplay/pair/cancel", { method: "POST" }),
+    connect: (deviceId: string) =>
+      req<{ ok: boolean; connected_id: string }>("/api/airplay/connect", {
+        method: "POST",
+        body: JSON.stringify({ device_id: deviceId }),
+      }),
+    disconnect: () =>
+      req<{ ok: boolean }>("/api/airplay/disconnect", { method: "POST" }),
+  },
   downloads: {
     list: () => req<DownloadItem[]>("/api/downloads"),
     enqueue: (kind: ContentKind, id: string, quality?: string) =>

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -20,8 +20,11 @@ import {
   Music2,
   Palette,
   Power,
+  Radio as RadioIcon,
+  RefreshCw,
   Settings as SettingsIcon,
   Sun,
+  Unlink,
 } from "lucide-react";
 import { api } from "@/api/client";
 import type { QualityOption, Settings } from "@/api/types";
@@ -204,6 +207,11 @@ export function SettingsPage({ onLogout }: { onLogout: () => void }) {
 
   const patch = (p: Partial<Settings>) => setSettings({ ...settings, ...p });
 
+  // AirPlay (RAOP / AirPlay 1) ships enabled. The build flag is now a
+  // kill switch — set VITE_SHOW_AIRPLAY=0 to hide the tab if the
+  // streaming path turns out problematic on a given build — rather
+  // than an opt-in. Default (unset) shows it.
+  const showAirPlay = import.meta.env.VITE_SHOW_AIRPLAY !== "0";
   const onTabChange = (next: string) => {
     setTab(next);
     try {
@@ -241,6 +249,9 @@ export function SettingsPage({ onLogout }: { onLogout: () => void }) {
           <SettingsTab value="autostart" icon={Power} label="Launch on login" />
           <SettingsTab value="lastfm" icon={Music2} label="Last.fm" />
           <SettingsTab value="shortcuts" icon={Keyboard} label="Shortcuts" />
+          {showAirPlay && (
+            <SettingsTab value="airplay" icon={RadioIcon} label="AirPlay" />
+          )}
           <SettingsTab value="about" icon={Info} label="About" />
         </TabsList>
 
@@ -301,6 +312,12 @@ export function SettingsPage({ onLogout }: { onLogout: () => void }) {
               />
             </Section>
           </TabsContent>
+
+          {showAirPlay && (
+            <TabsContent value="airplay" className="mt-0">
+              <AirPlaySection />
+            </TabsContent>
+          )}
 
           <TabsContent value="downloads" className="mt-0">
             <Section
@@ -1627,6 +1644,18 @@ function EqSlider({
 }
 
 /**
+ * AirPlay output control. Lists discovered receivers on the local
+ * network, walks the user through a one-time pair, and lets them
+ * connect / disconnect. Audio that the PCMPlayer produces is tee'd
+ * to the connected device via pyatv; local speakers keep playing
+ * in parallel (mute with the volume slider if you don't want echo).
+ *
+ * Not end-to-end tested against hardware yet. Pair flow is based
+ * on pyatv's documented API; first real test will surface any
+ * protocol quirks on HomePods, AirPlay speakers, or Apple TVs.
+ */
+
+/**
  * Headphone-profile section — Phase 2 of the AutoEQ work.
  *
  * Shows a mode toggle (Off / Manual / Profile) and, when in
@@ -2485,6 +2514,259 @@ function AutoEqDeviceMappingField() {
         })}
       </div>
     </div>
+  );
+}
+
+interface AirPlayDeviceRow {
+  id: string;
+  name: string;
+  address: string;
+  has_raop: boolean;
+  paired: boolean;
+}
+
+function AirPlaySection() {
+  const toast = useToast();
+  const [available, setAvailable] = useState<boolean | null>(null);
+  const [reason, setReason] = useState<string | null>(null);
+  const [devices, setDevices] = useState<AirPlayDeviceRow[]>([]);
+  const [connectedId, setConnectedId] = useState<string | null>(null);
+  const [refreshing, setRefreshing] = useState(false);
+  const [pairing, setPairing] = useState<AirPlayDeviceRow | null>(null);
+  const [pin, setPin] = useState("");
+  const [pinBusy, setPinBusy] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+
+  const refresh = async () => {
+    setRefreshing(true);
+    try {
+      const res = await api.airplay.devices();
+      setAvailable(res.available);
+      setReason(res.reason ?? null);
+      setDevices(res.devices);
+      setConnectedId(res.connected_id);
+    } catch (err) {
+      toast.show({
+        kind: "error",
+        title: "Couldn't list AirPlay devices",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setRefreshing(false);
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const startPair = async (dev: AirPlayDeviceRow) => {
+    setPairing(dev);
+    setPin("");
+    try {
+      await api.airplay.pairStart(dev.id);
+    } catch (err) {
+      toast.show({
+        kind: "error",
+        title: "Couldn't start pairing",
+        description: err instanceof Error ? err.message : String(err),
+      });
+      setPairing(null);
+    }
+  };
+
+  const submitPin = async () => {
+    if (!pairing || !pin) return;
+    setPinBusy(true);
+    try {
+      await api.airplay.pairPin(pin.trim());
+      toast.show({
+        kind: "success",
+        title: "Paired",
+        description: `${pairing.name} is ready to use.`,
+      });
+      setPairing(null);
+      setPin("");
+      await refresh();
+    } catch (err) {
+      toast.show({
+        kind: "error",
+        title: "Pairing failed",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setPinBusy(false);
+    }
+  };
+
+  const cancelPair = async () => {
+    await api.airplay.pairCancel().catch(() => undefined);
+    setPairing(null);
+    setPin("");
+  };
+
+  const connect = async (dev: AirPlayDeviceRow) => {
+    setBusyId(dev.id);
+    try {
+      await api.airplay.connect(dev.id);
+      toast.show({
+        kind: "success",
+        title: "AirPlay connected",
+        description: `Sending to ${dev.name}.`,
+      });
+      await refresh();
+    } catch (err) {
+      toast.show({
+        kind: "error",
+        title: "Couldn't connect",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const disconnect = async () => {
+    try {
+      await api.airplay.disconnect();
+      await refresh();
+    } catch (err) {
+      toast.show({
+        kind: "error",
+        title: "Couldn't disconnect",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  return (
+    <Section title="AirPlay" icon={RadioIcon}>
+      {available === false && (
+        <p className="text-sm text-muted-foreground">
+          AirPlay support is unavailable on this install.
+          {reason ? ` (${reason})` : null}
+        </p>
+      )}
+      {available !== false && (
+        <>
+          <div className="flex items-center gap-3">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={refresh}
+              disabled={refreshing}
+            >
+              {refreshing ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RefreshCw className="h-3.5 w-3.5" />
+              )}
+              Refresh
+            </Button>
+            {connectedId && (
+              <Button variant="ghost" size="sm" onClick={disconnect}>
+                <Unlink className="h-3.5 w-3.5" />
+                Disconnect
+              </Button>
+            )}
+          </div>
+          {devices.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              No AirPlay receivers found on this network. Make sure the speaker
+              or HomePod is powered on and awake.
+            </p>
+          ) : (
+            <ul className="flex flex-col gap-2">
+              {devices.map((dev) => {
+                const isConnected = connectedId === dev.id;
+                const isBusy = busyId === dev.id;
+                return (
+                  <li
+                    key={dev.id}
+                    className="flex items-center gap-3 rounded-md border border-border/40 bg-card/40 p-3"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <div className="truncate text-sm font-semibold">
+                        {dev.name}
+                      </div>
+                      <div className="truncate text-xs text-muted-foreground">
+                        {dev.address}
+                        {!dev.has_raop &&
+                          " — video-only AirPlay, audio streaming unavailable"}
+                      </div>
+                    </div>
+                    {isConnected ? (
+                      <span className="flex items-center gap-1 text-xs font-semibold text-primary">
+                        <Check className="h-3.5 w-3.5" /> Connected
+                      </span>
+                    ) : dev.paired ? (
+                      <Button
+                        size="sm"
+                        onClick={() => connect(dev)}
+                        disabled={isBusy || !dev.has_raop}
+                      >
+                        {isBusy ? (
+                          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                        ) : null}
+                        Connect
+                      </Button>
+                    ) : (
+                      <Button
+                        variant="secondary"
+                        size="sm"
+                        onClick={() => startPair(dev)}
+                        disabled={!dev.has_raop}
+                      >
+                        Pair
+                      </Button>
+                    )}
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+          <p className="text-xs text-muted-foreground">
+            Audio tees to the connected AirPlay receiver while local output
+            keeps playing. Mute your local speakers with the volume slider if
+            you don't want both at once. macOS's built-in AirPlay Receiver is
+            not supported (Apple's proprietary pairing); HomePods, AirPort
+            Express, Apple TVs, and most third-party AirPlay speakers work.
+          </p>
+        </>
+      )}
+      {pairing && (
+        <div className="mt-2 rounded-md border border-primary/40 bg-primary/5 p-4">
+          <div className="mb-1 text-sm font-semibold">
+            Pairing with {pairing.name}
+          </div>
+          <p className="mb-3 text-xs text-muted-foreground">
+            A 4-digit PIN should appear on the receiver now. If the receiver is
+            a HomePod, check the paired iPhone or iPad; some models display the
+            PIN there.
+          </p>
+          <div className="flex items-center gap-2">
+            <Input
+              value={pin}
+              onChange={(e) => setPin(e.target.value)}
+              placeholder="0000"
+              inputMode="numeric"
+              maxLength={8}
+              className="max-w-[8rem]"
+              autoFocus
+            />
+            <Button onClick={submitPin} disabled={pinBusy || !pin}>
+              {pinBusy ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : null}
+              Submit
+            </Button>
+            <Button variant="ghost" onClick={cancelPair}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      )}
+    </Section>
   );
 }
 

--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,5 +1,13 @@
 /// <reference types="vite/client" />
 
+interface ImportMetaEnv {
+  readonly VITE_SHOW_AIRPLAY?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}
+
 // app-region (and the -webkit-app-region alias) is a Chromium /
 // WebView2-specific CSS property used to declare drag regions inside
 // frameless windows. The DOM lib doesn't ship typings for it, so we


### PR DESCRIPTION
## Summary

Resurrects the AirPlay sender removed in #143 (via `git revert`, recovering the module + endpoints + realtime tap + picker UI + scripts) and makes it real:

- **pyatv** added to `requirements.txt` and `collect_all`'d in all three PyInstaller specs (plus `srptools`/`bitarray`/`miniaudio`/`zeroconf`). Missing → `is_available()` False, graceful no-op.
- **Ships enabled** — `VITE_SHOW_AIRPLAY` is now a kill switch (`=0` to hide), not an opt-in.
- **Scope: AirPlay 1 / RAOP only** (pyatv's real streaming path). AP2-only devices (HomePod, modern multi-room) out of scope.
- **Self-review found + fixed a real bug**: `_connect()` hard-required saved credentials, blocking the most common case (no-pairing RAOP devices that never emit a PIN). Credentials are now optional with a clear "needs pairing" fallback only on an actual auth rejection.

## Verified

- [x] Realtime-safe: `push_pcm` non-blocking (brief lock never held across I/O, `put_nowait`+drop), player tap `try/except` — **cannot degrade local playback**
- [x] RingBuffer single-consumer guard (#141) compatible; no headerless-FLAC issue
- [x] `./scripts/preflight.sh` green (pytest, tsc, lint, vitest); server imports with pyatv wired

## NOT verified — needs your hardware (the accepted ship-and-iterate part)

- [ ] pyatv `stream_file()` actually plays the endless live FLAC stream over RAOP
- [ ] Behavior on track change (stream is continuous; receiver metadata likely won't update — known limitation)
- [ ] Latency / sync, disconnect cleanliness, pairing flow on devices that do require a PIN
- [ ] Packaged build: pyatv bundles correctly (CI smoke covers import-crash; runtime AirPlay needs a real device)