### PR TITLE
Recover playback from expired Tidal tokens; keep sessions durable

### DIFF
--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -207,16 +207,38 @@ class PlayerSnapshot:
     force_volume: bool = False
 
 
+def _looks_like_auth_error(exc: BaseException) -> bool:
+    """Best-effort detection of a Tidal auth (expired-token) error.
+
+    Mirrors server._looks_like_401 deliberately — duplicated rather
+    than imported because player.py must not import server (server
+    imports player). tidalapi wraps these as requests.HTTPError with
+    .response.status_code 401/403, or surfaces them as a RuntimeError
+    whose str() carries '401' / 'Unauthorized'."""
+    resp = getattr(exc, "response", None)
+    if resp is not None and getattr(resp, "status_code", None) in (401, 403):
+        return True
+    msg = str(exc)
+    return "401" in msg or "Unauthorized" in msg
+
+
 class PCMPlayer:
     def __init__(
         self,
         session_getter: Callable[[], tidalapi.Session],
         local_lookup: Optional[Callable[[str], Optional[str]]] = None,
         quality_clamp: Optional[Callable[[str], Optional[str]]] = None,
+        force_refresh: Optional[Callable[[], bool]] = None,
     ):
         self._session_getter = session_getter
         self._local_lookup = local_lookup
         self._quality_clamp = quality_clamp
+        # Called when a playback resolve hits an expired Tidal token.
+        # Returns True if the token was refreshed (caller retries
+        # once), False if the refresh token itself is dead (caller
+        # surfaces a clear "log in again"). Injected by the server
+        # the same way session_getter is; None in tests/standalone.
+        self._force_refresh = force_refresh
 
         self._lock = threading.RLock()
         # Serializes load/stop/seek/preload so concurrent HTTP calls
@@ -1864,6 +1886,54 @@ class PCMPlayer:
             )
             return (list(urls), duration, info, bytes_map)
 
+        try:
+            return self._resolve_uncached(
+                session, track_id, quality, cache_key, t0
+            )
+        except Exception as exc:
+            # The playback resolve path must recover from an expired
+            # Tidal token exactly like the download and metadata
+            # paths already do. Without this, a stale access token
+            # surfaces as a silent "press play, nothing happens":
+            # the 401 propagates, the player flips to error, and the
+            # user is neither refreshed nor bounced to Login.
+            # getattr (not self._force_refresh) because some unit
+            # tests build PCMPlayer via __new__ and never run
+            # __init__; a missing injector just means "no refresh".
+            force_refresh = getattr(self, "_force_refresh", None)
+            if force_refresh is not None and _looks_like_auth_error(exc):
+                if force_refresh():
+                    log.info(
+                        "playback resolve hit a Tidal auth error; "
+                        "token refreshed, retrying once"
+                    )
+                    return self._resolve_uncached(
+                        self._session_getter(),
+                        track_id,
+                        quality,
+                        cache_key,
+                        t0,
+                    )
+                raise RuntimeError(
+                    "Tidal session expired. Please log out and log "
+                    "back in."
+                ) from exc
+            raise
+
+    def _resolve_uncached(
+        self,
+        session: tidalapi.Session,
+        track_id: str,
+        quality: Optional[str],
+        cache_key: tuple,
+        t0: float,
+    ) -> tuple[
+        Union[str, list[str]], Optional[float], StreamInfo, dict[int, bytes]
+    ]:
+        """Cache-miss network resolution: fetch track + playback-info,
+        parse the manifest, populate the cache. Split out of
+        _resolve_source so the caller can retry it once after a
+        force-refresh when Tidal returns an expired-token 401."""
         override = None
         if quality:
             try:

--- a/app/tidal_client.py
+++ b/app/tidal_client.py
@@ -1,7 +1,9 @@
 import json
+import logging
 import os
 import re
 import stat
+import sys
 import tempfile
 import threading
 import time
@@ -9,11 +11,32 @@ import webbrowser
 from concurrent.futures import Future
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Optional, Tuple
+from typing import Callable, Optional, Tuple
 
 import tidalapi
 
 from app.paths import user_data_dir
+
+# audio.log is bound to the "tideway.audio" logger in
+# app/audio/player.py (a RotatingFileHandler, propagate=False).
+# Auth-lifecycle lines used to print only to stderr, which is
+# invisible in the packaged app — so a user "getting logged out"
+# left no diagnosable trace in production. Mirror the high-signal
+# auth lines to audio.log as well, same pattern the AirPlay
+# diagnostics use.
+_audit_log = logging.getLogger("tideway.audio")
+
+
+def _tlog(msg: str) -> None:
+    """High-signal Tidal auth line: dev console (stderr) + audio.log."""
+    line = f"[tidal] {msg}"
+    print(line, file=sys.stderr, flush=True)
+    try:
+        _audit_log.info(line)
+    except Exception:
+        # Logging to file must never break the auth path; the
+        # stderr line already carried the signal.
+        pass
 
 SESSION_FILE = user_data_dir() / "tidal_session.json"
 
@@ -399,6 +422,11 @@ class TidalClient:
         self.session = tidalapi.Session(config)
         _install_tidal_request_gate(self.session)
         _swap_to_impersonated_transport(self.session)
+        self._install_capturing_refresh()
+        # Set by the server to its auth-cache invalidator. Invoked
+        # when a hard refresh failure logs the user out, so the UI
+        # bounces to Login immediately instead of after the cache TTL.
+        self.on_auth_lost: Optional[Callable[[], None]] = None
         self._login_future: Optional[Future] = None
         # Cached subscription-tier result. Populated on first call and
         # refreshed every _SUB_TTL_SEC. Subscription almost never changes
@@ -530,6 +558,52 @@ class TidalClient:
             session.refresh_token = new_refresh
         return True
 
+    def _token_refresh_and_persist(self, refresh_token: str) -> bool:
+        """token_refresh that captures rotation AND persists.
+
+        This is what tidalapi's own request layer calls on a 401
+        (request.py: `self.session.token_refresh(refresh_token)`).
+        tidalapi's native implementation drops a rotated refresh
+        token, so a few days later the next refresh fails and the
+        user is silently logged out. Routing that internal path
+        through the capturing implementation — and saving the
+        result so a process exit right after a mid-session
+        auto-refresh doesn't lose the rotated token — is what makes
+        the session durable rather than expiring every few days.
+        """
+        ok = self._token_refresh_capturing(refresh_token)
+        if ok:
+            try:
+                self.save_session()
+            except Exception:
+                # Persisting is best-effort here; the in-memory
+                # session is already correct and the watchdog /
+                # explicit force_refresh will re-save shortly.
+                pass
+        return ok
+
+    def _install_capturing_refresh(self) -> None:
+        """Shadow tidalapi's Session.token_refresh on this session
+        with the rotation-capturing+persisting version, so EVERY
+        refresh path — explicit force_refresh, the background
+        watchdog, and tidalapi's own internal auto-refresh-on-401 —
+        keeps a rotated refresh token. Re-applied after logout()
+        because that builds a fresh Session. Same monkeypatch
+        approach already used for the request gate and impersonated
+        transport on this object."""
+        self.session.token_refresh = self._token_refresh_and_persist
+
+    def _notify_auth_lost(self) -> None:
+        """Tell the server its cached auth state is stale (refresh
+        token dead, user logged out) so the next /auth/status flips
+        to logged-out and the UI bounces to Login immediately."""
+        cb = getattr(self, "on_auth_lost", None)
+        if cb is not None:
+            try:
+                cb()
+            except Exception:
+                pass
+
     def force_refresh(self) -> bool:
         """Explicitly refresh the access token using the stored refresh
         token. Called by the download path when it hits a 401 — tidalapi's
@@ -546,43 +620,33 @@ class TidalClient:
         workers don't fire two token_refresh RPCs at once. The second
         caller will see the fresh token after the first finishes.
         """
-        import sys as _sys
-
         with self._refresh_lock:
             refresh_token = getattr(self.session, "refresh_token", None)
             if not refresh_token:
-                print(
-                    "[tidal] force_refresh: no refresh_token on session",
-                    file=_sys.stderr,
-                    flush=True,
-                )
+                _tlog("force_refresh: no refresh_token on session")
                 return False
             try:
                 ok = self._token_refresh_capturing(refresh_token)
             except Exception as exc:
-                print(
-                    f"[tidal] force_refresh: token_refresh raised: {exc!r}",
-                    file=_sys.stderr,
-                    flush=True,
-                )
-                # AuthenticationError means the refresh token itself is dead.
-                # Blow the session away so the user is prompted to log in
-                # again rather than chasing 401s forever.
+                _tlog(f"force_refresh: token_refresh raised: {exc!r}")
+                # AuthenticationError means the refresh token itself is
+                # dead. Blow the session away so the user is prompted to
+                # log in again rather than chasing 401s forever, and tell
+                # the server to drop its cached auth state so the very
+                # next /auth/status bounces the UI to Login immediately
+                # instead of waiting out the cache TTL.
                 if type(exc).__name__ == "AuthenticationError":
                     try:
                         self.logout()
                     except Exception:
                         pass
+                    self._notify_auth_lost()
                 return False
             if not ok:
-                print(
-                    "[tidal] force_refresh: token_refresh returned False",
-                    file=_sys.stderr,
-                    flush=True,
-                )
+                _tlog("force_refresh: token_refresh returned False")
                 return False
             self.save_session()
-            print("[tidal] force_refresh: success", file=_sys.stderr, flush=True)
+            _tlog("force_refresh: success")
             return True
 
     def _refresh_watchdog(self) -> None:
@@ -594,8 +658,6 @@ class TidalClient:
         logged there; the watchdog swallows its own errors so a transient
         network blip doesn't kill the thread.
         """
-        import sys as _sys
-
         while not self._refresh_stop.is_set():
             # Wake up early if someone signals stop (e.g. tests).
             if self._refresh_stop.wait(self._REFRESH_CHECK_INTERVAL_SEC):
@@ -613,19 +675,13 @@ class TidalClient:
                 seconds_left = (expiry - now).total_seconds()
                 if seconds_left > self._REFRESH_WINDOW_SEC:
                     continue
-                print(
-                    f"[tidal] refresh watchdog: token expires in "
-                    f"{seconds_left:.0f}s — refreshing",
-                    file=_sys.stderr,
-                    flush=True,
+                _tlog(
+                    f"refresh watchdog: token expires in "
+                    f"{seconds_left:.0f}s — refreshing"
                 )
                 self.force_refresh()
             except Exception as exc:
-                print(
-                    f"[tidal] refresh watchdog: ignoring error: {exc!r}",
-                    file=_sys.stderr,
-                    flush=True,
-                )
+                _tlog(f"refresh watchdog: ignoring error: {exc!r}")
 
     def get_max_quality(self) -> Optional[str]:
         """Return the highest audio quality the logged-in account is
@@ -793,6 +849,10 @@ class TidalClient:
         self.session = tidalapi.Session(config)
         _install_tidal_request_gate(self.session)
         _swap_to_impersonated_transport(self.session)
+        # logout() builds a fresh Session, so re-shadow token_refresh
+        # or the next login's session would fall back to tidalapi's
+        # rotation-dropping native implementation.
+        self._install_capturing_refresh()
         # The subscription-tier cache belongs to the previous session.
         # Bust it so the next login re-detects under the new client_id.
         with self._sub_lock:

--- a/server.py
+++ b/server.py
@@ -334,6 +334,14 @@ def _invalidate_auth_cache() -> None:
         _auth_cache["ok"] = False
 
 
+# When a hard refresh failure logs the user out (dead refresh
+# token), drop the cached auth state immediately so the very next
+# /auth/status returns logged_in=false and the frontend bounces to
+# Login, instead of waiting out the cache TTL while play silently
+# fails.
+tidal.on_auth_lost = _invalidate_auth_cache
+
+
 def _invalidate_preview_cache() -> None:
     with _preview_cache_lock:
         _preview_cache.clear()
@@ -4717,6 +4725,10 @@ def _native_player() -> PCMPlayer:
             if local_index.get(str(tid))
             else None,
             quality_clamp=tidal.clamp_quality_to_subscription,
+            # Lets the playback resolve path recover from an expired
+            # token (refresh + retry once) the same way the download
+            # path does, instead of failing silently on "press play".
+            force_refresh=tidal.force_refresh,
         )
         # Mirror state changes into macOS Now Playing so media keys
         # can find us. update_state() no-ops on non-macOS / when the


### PR DESCRIPTION
## Summary

Fixes the recurring "press play and nothing happens" plus the
"logged out every few days" behavior, both rooted in Tidal token
handling.

- **Playback path now recovers from an expired token.** The
  download and metadata paths already force-refresh and retry on a
  401; the playback resolve path in `player.py` did not, so an
  expired access token surfaced as a silent error (player flips to
  error, no refresh, no retry, no clean logout). `_resolve_source`
  is split into `_resolve_uncached`; on an auth error it
  force-refreshes and retries once, then raises a clear
  "session expired, log in again" instead of failing silently.
  `force_refresh` is injected into the player like `session_getter`.
- **Sessions are now durable across Tidal's refresh-token
  rotation.** tidalapi's internal auto-refresh calls
  `Session.token_refresh`, whose native impl drops a rotated
  refresh token; once Tidal invalidates the old one the next
  refresh fails and the user is logged out. We shadow
  `session.token_refresh` with the rotation-capturing-and-persisting
  variant (re-applied after `logout()` since it builds a fresh
  Session) so every refresh path keeps and saves the rotated token.
- **Production diagnosability + clean bounce.** Auth-lifecycle
  lines also go to `audio.log` (were stderr-only, invisible in the
  packaged app). A hard refresh failure notifies the server to drop
  cached auth state so the next `/auth/status` bounces to Login
  immediately.

Scope: `app/audio/player.py`, `app/tidal_client.py`, `server.py`.
No frontend changes.

## Test plan

- [x] `pytest tests/` green (783 passed)
- [x] `cd web && npx tsc -b --noEmit` clean
- [x] `cd web && npm run lint:all` clean
- [x] `cd web && npm test` green (47 passed)
- [x] Smoke: `token_refresh` shadowed on init and re-shadowed after
      `logout()`; `on_auth_lost` fires; `_looks_like_auth_error`
      detects 401/403/Unauthorized and ignores benign errors
- [ ] Manual: with a stale/expired token, press play → audio
      starts after a transparent refresh (no silent failure)
- [ ] Manual: leave the app days across token rotation → still
      logged in; a genuinely dead refresh token bounces cleanly to
      Login and the reason is visible in `audio.log`