### PR TITLE
Open external URLs via the sanitized opener so Linux login works

### DIFF
--- a/desktop.py
+++ b/desktop.py
@@ -176,9 +176,10 @@ def _child_env() -> dict:
     return env
 
 
-def _open_in_browser(url: str) -> None:
+def _open_in_browser(url: str) -> bool:
     """Open `url` in the user's browser without leaking the bundle's
-    library path into the opener.
+    library path into the opener. Returns True if an opener was
+    launched, False if none could be (caller can then fall back).
 
     macOS (`open`) and Windows (`os.startfile`) openers don't exec a
     shell that would load our libs, so webbrowser is used directly.
@@ -187,12 +188,17 @@ def _open_in_browser(url: str) -> None:
     /bin/sh, which is exactly what crashes, so call the opener
     directly. If no opener is found we print the URL rather than
     re-trip the crash.
+
+    This is also what /api/open-external uses on a frozen Linux
+    build: plain webbrowser.open() there spawns the opener with the
+    bundle's polluted LD_LIBRARY_PATH and silently fails (or returns
+    success without opening anything), which is exactly why the
+    paste-the-Oops-URL login couldn't open the Tidal page on Linux.
     """
     if sys.platform != "linux" or not getattr(sys, "frozen", False):
         import webbrowser
 
-        webbrowser.open(url)
-        return
+        return bool(webbrowser.open(url))
     import shutil
     import subprocess
 
@@ -211,7 +217,7 @@ def _open_in_browser(url: str) -> None:
                 stderr=subprocess.DEVNULL,
                 start_new_session=True,
             )
-            return
+            return True
         except OSError:
             continue
     print(
@@ -219,6 +225,7 @@ def _open_in_browser(url: str) -> None:
         file=sys.stderr,
         flush=True,
     )
+    return False
 
 
 def _run_uvicorn_in_thread() -> "uvicorn.Server":  # type: ignore[name-defined]
@@ -1292,6 +1299,15 @@ def main(argv: Optional[list[str]] = None) -> int:
     # returns `supported: false` and the frontend falls back to the
     # paste flow, opening Safari itself via /api/open-external.
     # Windows / Linux keep the inline pywebview child window.
+    # /api/open-external (the "Open Tidal login" button in the
+    # paste-the-Oops-URL flow, plus other external links) must use
+    # this sanitized opener, not webbrowser.open(): on a frozen
+    # Linux build webbrowser spawns through the bundle's polluted
+    # LD_LIBRARY_PATH and fails, which is what broke URL login on
+    # Linux. Registered on every platform — it degrades to
+    # webbrowser.open() off Linux/non-frozen anyway.
+    _server.register_external_opener(_open_in_browser)
+
     if sys.platform != "darwin":
         _server.register_inapp_login_callback(_open_login_window)
 

--- a/server.py
+++ b/server.py
@@ -1463,6 +1463,21 @@ def register_inapp_login_callback(fn: Callable[[str], None]) -> None:
     _inapp_login_callback = fn
 
 
+# Set by the desktop launcher to its sanitized browser opener
+# (desktop._open_in_browser). /api/open-external prefers it over
+# webbrowser.open() because on a frozen Linux build webbrowser
+# spawns the opener with the bundle's polluted LD_LIBRARY_PATH and
+# fails — that's what broke the paste-the-Oops-URL login on Linux.
+# Returns True if it launched an opener. None in dev / when the
+# server runs without the desktop shell (falls back to webbrowser).
+_external_opener: Optional[Callable[[str], bool]] = None
+
+
+def register_external_opener(fn: Callable[[str], bool]) -> None:
+    global _external_opener
+    _external_opener = fn
+
+
 # ---------------------------------------------------------------------------
 # App version + update check
 # ---------------------------------------------------------------------------
@@ -2990,8 +3005,18 @@ def open_external(req: OpenExternalRequest) -> dict:
             status_code=403,
             detail=f"Host not allowed: {parsed.hostname}",
         )
+    # Prefer the desktop shell's sanitized opener when present. On a
+    # frozen Linux build webbrowser.open() spawns the opener through
+    # the bundle's polluted LD_LIBRARY_PATH and fails (or "succeeds"
+    # without opening anything), which is exactly why the
+    # paste-the-Oops-URL login couldn't open the Tidal page on
+    # Linux. The registered opener (desktop._open_in_browser) uses a
+    # sanitized child env and explicit xdg-open/gio.
     try:
-        ok = webbrowser.open(req.url, new=2)
+        if _external_opener is not None:
+            ok = _external_opener(req.url)
+        else:
+            ok = webbrowser.open(req.url, new=2)
     except Exception as exc:
         raise HTTPException(status_code=500, detail=str(exc))
     if not ok:


### PR DESCRIPTION
## Summary

Fixes the reported Linux bug: the "Oops URL" (paste-back PKCE)
login does not work on Linux while device-code login does.

- **Root cause (reproduced in a real Linux build VM):** the
  "Open Tidal login" button hits `/api/open-external`, which used
  `webbrowser.open()`. In a frozen Linux build that spawns the
  opener through the bundle's polluted `LD_LIBRARY_PATH` and fails
  — the endpoint returns HTTP 500 "No browser available", so the
  login page never opens and PKCE can't proceed. Device-code was
  unaffected because its UI just shows the URL+code as text.
- **Fix:** route `/api/open-external` through the sanitized opener
  `desktop._open_in_browser` (explicit `xdg-open`/`gio` + a
  scrubbed child env) that already exists for exactly this reason,
  via a `register_external_opener` hook mirroring the existing
  `register_inapp_login_callback`. No import cycle, no duplicated
  logic. `_open_in_browser` now returns success/failure.
- **No regression surface off Linux:** registered on all
  platforms but degrades to `webbrowser.open()` off frozen-Linux,
  and dev/`run.sh` (no desktop shell) falls back identically, so
  macOS/Windows/dev behaviour is unchanged. Host/scheme allowlists
  untouched.

`server.py` + `desktop.py` only.

## Test plan

- [x] `pytest tests/`, `tsc -b`, `lint:all`, `vitest` — all green
- [x] Reproduced in Ubuntu 22.04 multipass VM (matches CI): frozen
      app `/api/open-external` returned **HTTP 500** before
- [x] After fix in the same VM: `/api/open-external` returns
      **HTTP 200** and the sanitized opener receives the exact
      Tidal URL
- [ ] Manual on a real Linux desktop: "Open Tidal login" opens
      the Tidal page, paste the Oops URL, PKCE login completes

## Noted, out of scope (separate follow-up)

On frozen Linux there is no pywebview, yet desktop.py still
registers the in-app login callback (`sys.platform != "darwin"`).
The frontend defaults to the paste flow so this isn't in the
reported path, but the in-app option is effectively dead on Linux
and should later be gated on actual webview availability.