### PR TITLE
Close dead OutputStream after natural EOF

### DIFF
--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -3089,8 +3089,28 @@ class PCMPlayer:
             ).start()
             return
 
+        # Natural EOF. PortAudio's `paComplete` puts the stream
+        # into a terminal "stopped" state that `Pa_StartStream`
+        # cannot revive — the docs say it has to be reopened. If
+        # we leave `self._stream` pointing at this corpse, the
+        # next `load()` snapshots it as `active_stream`, takes
+        # path (A) ("kept stream open"), and rebinds the new
+        # pipeline against a dead OutputStream. `play()` calls
+        # `stream.start()` on macOS, which returns without error
+        # but never re-wakes the CoreAudio callback thread. The
+        # decoder fills the queue, blocks on `put`, and the
+        # stall watchdog reports `state=playing, silent`. Close
+        # and drop the ref here so the next load takes the full
+        # reopen path (B) — that path already works correctly.
+        old_stream = self._stream
         with self._lock:
+            self._stream = None
             self._transition("ended")
+        if old_stream is not None:
+            try:
+                old_stream.close()
+            except Exception:
+                pass
         self._emit()
 
     def _recover_from_device_loss(self) -> None:

--- a/tests/test_pcm_stream_eof.py
+++ b/tests/test_pcm_stream_eof.py
@@ -1,0 +1,106 @@
+"""Regression guard for the dead-stream-after-EOF freeze.
+
+When a track plays to natural end-of-file, the audio callback raises
+`sd.CallbackStop`. PortAudio's docs say the stream is now in a
+"stopped" terminal state and `Pa_StartStream` cannot revive it — the
+stream must be reopened. Before this fix, `_on_stream_finished`
+transitioned state to "ended" but left `self._stream` pointing at the
+corpse. The next `load()` then snapshotted that ref as `active_stream`,
+took path (A) ("kept stream open"), and rebound the new pipeline
+against a dead OutputStream. `play()` called `stream.start()`, which
+on macOS returns without error but never re-wakes the CoreAudio
+callback thread. State said "playing", no callback fired, the
+decoder filled the queue and blocked.
+
+This test pins the contract: on natural EOF, the stream ref is
+cleared AND the underlying OutputStream is closed.
+"""
+from __future__ import annotations
+
+import queue
+import threading
+
+from app.audio.player import PCMPlayer
+
+
+def _player() -> PCMPlayer:
+    return PCMPlayer(lambda: None)
+
+
+class _FakeStream:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_natural_eof_closes_and_nulls_stream():
+    p = _player()
+    fake = _FakeStream()
+    p._stream = fake
+    p._state = "playing"
+    p._replacing_stream = False
+    p._preload = None
+    p._pcm_queue = queue.Queue()
+    p._decoder_done = threading.Event()
+    p._decoder_done.set()
+
+    p._on_stream_finished()
+
+    assert p._stream is None, (
+        "natural EOF must clear self._stream so next load() takes "
+        "the full-reopen path, not the kept-stream-open path"
+    )
+    assert fake.closed, "the dead OutputStream must be closed"
+    assert p._state == "ended"
+
+
+def test_eof_close_swallows_close_errors():
+    """A close() that raises must not propagate — finished_callback
+    runs on sounddevice's own thread and a bare exception there
+    would crash the audio path entirely. The state transition still
+    has to happen."""
+    p = _player()
+
+    class _RaisingStream:
+        def close(self) -> None:
+            raise RuntimeError("boom")
+
+    p._stream = _RaisingStream()
+    p._state = "playing"
+    p._replacing_stream = False
+    p._preload = None
+    p._pcm_queue = queue.Queue()
+    p._decoder_done = threading.Event()
+    p._decoder_done.set()
+
+    p._on_stream_finished()
+
+    assert p._stream is None
+    assert p._state == "ended"
+
+
+def test_device_loss_path_does_not_null_stream():
+    """The device-loss recovery path needs `self._stream` to still
+    point at the (just-aborted) OutputStream so it can be replaced.
+    The EOF close-and-null behavior must only fire on natural EOF,
+    not when the decoder still has work pending."""
+    p = _player()
+    fake = _FakeStream()
+    p._stream = fake
+    p._state = "playing"
+    p._replacing_stream = False
+    p._preload = None
+    p._pcm_queue = queue.Queue()
+    p._decoder_done = threading.Event()
+    # decoder NOT done -> device-loss heuristic should fire and
+    # spawn the recovery thread, leaving self._stream alone.
+
+    p._on_stream_finished()
+
+    assert p._stream is fake, (
+        "device-loss path must not null self._stream — recovery "
+        "needs to reopen on a fresh device"
+    )
+    assert not fake.closed


### PR DESCRIPTION
## Summary

- Chronic freeze where the stall watchdog reports `state=playing, callback silent for ~12s` had a root cause distinct from the gapless-swap deadlock fixed in v1.9.4.
- After a track plays to natural EOF, the audio callback raises `sd.CallbackStop`. PortAudio puts the stream in a terminal "stopped" state — its docs say it cannot be revived by `Pa_StartStream` and must be reopened. `_on_stream_finished` was transitioning state to `"ended"` but leaving `self._stream` pointing at that dead OutputStream.
- The next `load()` then snapshotted `self._stream` as `active_stream`, took path (A) "kept stream open", and bound the new pipeline against the corpse. `play()` called `stream.start()` — on macOS that returns without error but never re-wakes the CoreAudio callback thread. State went to `"playing"`, no callback fired, the decoder filled the queue and blocked.
- Reproduction is timing-sensitive: it happens when `load()`'s build phase runs long enough that the previous track ends naturally before path (A) does its ref swap. The failed swap in the user's most recent stall took `build=978ms`, plenty of room for the previous track to EOF mid-build. Faster builds (~250ms) usually beat the EOF and path (A) works fine.
- Fix: in the natural-EOF tail of `_on_stream_finished`, close and null `self._stream`. The next `load()` then takes path (B), full teardown plus fresh open, which already works correctly.

## Test plan

- [x] `pytest tests/test_pcm_stream_eof.py` — three new regression tests cover EOF clears and closes the stream, a raising `close()` is swallowed (this runs on sounddevice's own thread; an uncaught exception there is catastrophic), and the device-loss path is left intact.
- [x] `pytest tests/` — 786 passed.
- [x] `cd web && npx tsc -b --noEmit` — clean.
- [x] `cd web && npm run lint:all` — clean.
- [x] `cd web && npm test` — 47 passed.
- [ ] Manual: leave a track playing to natural end, then click a different track; verify it starts within a second and the watchdog stays quiet for the next several minutes of normal playback.