### PR TITLE
Linux native via Flatpak (Stage 0-3)

### DIFF
--- a/.github/workflows/flatpak-build-check.yml
+++ b/.github/workflows/flatpak-build-check.yml
@@ -35,13 +35,18 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install flatpak + flatpak-builder
+      - name: Install flatpak + flatpak-builder + elfutils
+        # elfutils provides eu-strip, which flatpak-builder shells
+        # out to for debuginfo extraction. Mirror this in
+        # release.yml — same apt line in both keeps the two build
+        # paths from drifting.
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            flatpak flatpak-builder ostree
+            flatpak flatpak-builder ostree elfutils
           flatpak --version
           flatpak-builder --version
+          eu-strip --version | head -1
 
       - name: Add Flathub remote
         run: |

--- a/.github/workflows/flatpak-build-check.yml
+++ b/.github/workflows/flatpak-build-check.yml
@@ -1,0 +1,88 @@
+name: Flatpak build check
+
+# PRs that touch the Flatpak manifest, the generated module files,
+# or the release pipeline's Flatpak jobs build the manifest end-to-
+# end so the build failure surface is the PR, not the next user-
+# triggered release tag. The release.yml build-linux-flatpak job
+# does the real per-tag work (artifact upload, repo export); this
+# job only proves the manifest still builds. They share the same
+# install + build steps so a fix here is mirrored to release.yml.
+#
+# Runs on push to main with the same path filter so a direct commit
+# also gets verified — without that, a hotfix that lands on main
+# without a PR could regress the build silently.
+on:
+  pull_request:
+    paths:
+      - "flatpak/**"
+      - ".github/workflows/flatpak-build-check.yml"
+      - ".github/workflows/release.yml"
+      - "requirements.txt"
+      - "web/package-lock.json"
+  push:
+    branches:
+      - main
+    paths:
+      - "flatpak/**"
+      - ".github/workflows/flatpak-build-check.yml"
+      - ".github/workflows/release.yml"
+      - "requirements.txt"
+      - "web/package-lock.json"
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install flatpak + flatpak-builder
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            flatpak flatpak-builder ostree
+          flatpak --version
+          flatpak-builder --version
+
+      - name: Add Flathub remote
+        run: |
+          flatpak remote-add --user --if-not-exists \
+            flathub https://flathub.org/repo/flathub.flatpakrepo
+
+      - name: Install GNOME 49 runtime + Node20 SDK extension
+        run: |
+          flatpak install --user -y --no-deps flathub \
+            org.gnome.Platform//49 \
+            org.gnome.Sdk//49 \
+            org.freedesktop.Sdk.Extension.node20//25.08
+
+      - name: Restore flatpak-builder cache
+        # Same key as release.yml so a release rebuild after this
+        # check can reuse the cached state.
+        uses: actions/cache@v4
+        with:
+          path: |
+            .flatpak-builder
+            .build-flatpak
+          key: flatpak-builder-${{ hashFiles('flatpak/com.tidaldownloader.Tideway.yaml', 'flatpak/python3-requirements.json', 'flatpak/node-sources.json') }}
+
+      - name: Build manifest (no artifact upload)
+        # `--repo` isn't needed here — we just want to verify the
+        # build succeeds. Skipping bundle export keeps this job a
+        # few minutes shorter.
+        run: |
+          flatpak-builder --user --ccache --force-clean \
+            .build-flatpak \
+            flatpak/com.tidaldownloader.Tideway.yaml
+
+      - name: Verify payload structure
+        # Quick sanity check that the build actually produced what
+        # we expect — catches manifest typos that build "cleanly"
+        # into nothing useful.
+        run: |
+          test -f .build-flatpak/files/bin/tideway || { echo "FAIL: launcher missing"; exit 1; }
+          test -f .build-flatpak/files/share/tideway/desktop.py || { echo "FAIL: desktop.py missing"; exit 1; }
+          test -f .build-flatpak/files/share/tideway/server.py || { echo "FAIL: server.py missing"; exit 1; }
+          test -d .build-flatpak/files/share/tideway/dist || { echo "FAIL: web/dist missing"; exit 1; }
+          test -f .build-flatpak/files/lib/libportaudio.so.2 || { echo "FAIL: PortAudio missing"; exit 1; }
+          echo "OK: build payload looks correct"
+          du -sh .build-flatpak/files

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -437,13 +437,20 @@ jobs:
         with:
           ref: ${{ github.event.inputs.tag || github.ref }}
 
-      - name: Install flatpak + flatpak-builder
+      - name: Install flatpak + flatpak-builder + elfutils
+        # elfutils provides eu-strip, which flatpak-builder shells
+        # out to for debuginfo extraction. It isn't pulled in as a
+        # hard dep of flatpak-builder on Ubuntu 22.04, so a stock
+        # runner fails with "Failed to execute child process
+        # eu-strip" the first time a module produces an ELF
+        # binary.
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            flatpak flatpak-builder ostree
+            flatpak flatpak-builder ostree elfutils
           flatpak --version
           flatpak-builder --version
+          eu-strip --version | head -1
 
       - name: Add Flathub remote
         # User-scoped to match how end users add it; CI doesn't need

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -464,29 +464,124 @@ jobs:
             org.gnome.Sdk//49 \
             org.freedesktop.Sdk.Extension.node20//25.08
 
+      - name: Check whether GPG signing is configured
+        id: gpg_check
+        # GPG signing of OSTree commits is opt-in. When the secrets
+        # are set, OSTree clients verify the signature on every
+        # `flatpak install` / `flatpak update`, so a compromised
+        # gh-pages host can't push malicious bits. When unset, the
+        # repo serves over HTTPS only — still authenticated by
+        # GitHub's TLS chain but with no signed-content guarantee.
+        # See docs/flatpak-gpg-signing.md for the one-time setup.
+        env:
+          OSTREE_GPG_KEY_ID: ${{ secrets.OSTREE_GPG_KEY_ID }}
+        run: |
+          if [ -n "$OSTREE_GPG_KEY_ID" ]; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+            echo "GPG signing: enabled (key $OSTREE_GPG_KEY_ID)"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+            echo "GPG signing: disabled (OSTREE_GPG_KEY_ID secret unset)"
+          fi
+
+      - name: Import OSTree signing key
+        if: steps.gpg_check.outputs.enabled == 'true'
+        env:
+          OSTREE_GPG_PRIVATE_KEY: ${{ secrets.OSTREE_GPG_PRIVATE_KEY }}
+          OSTREE_GPG_PASSPHRASE: ${{ secrets.OSTREE_GPG_PASSPHRASE }}
+        run: |
+          # Use a dedicated gpg homedir under the workspace so it
+          # gets cleaned up with the runner and doesn't bleed into
+          # GitHub's default gpg state.
+          mkdir -p "$GITHUB_WORKSPACE/.gnupg"
+          chmod 700 "$GITHUB_WORKSPACE/.gnupg"
+          echo "GNUPGHOME=$GITHUB_WORKSPACE/.gnupg" >> "$GITHUB_ENV"
+          export GNUPGHOME="$GITHUB_WORKSPACE/.gnupg"
+          # --pinentry-mode loopback lets gpg take the passphrase
+          # over stdin/env. Without it gpg tries to prompt and
+          # fails on a headless runner.
+          echo "allow-loopback-pinentry" > "$GNUPGHOME/gpg-agent.conf"
+          echo "pinentry-mode loopback" > "$GNUPGHOME/gpg.conf"
+          echo "$OSTREE_GPG_PRIVATE_KEY" \
+            | gpg --batch --import \
+              --passphrase "${OSTREE_GPG_PASSPHRASE:-}"
+          # Preset the passphrase so subsequent --gpg-sign calls
+          # don't prompt during the long flatpak-builder run.
+          if [ -n "${OSTREE_GPG_PASSPHRASE:-}" ]; then
+            KEYGRIP=$(gpg --batch --with-keygrip --list-secret-keys \
+              | awk '/Keygrip/ {print $3; exit}')
+            /usr/lib/gnupg/gpg-preset-passphrase --preset \
+              --passphrase "$OSTREE_GPG_PASSPHRASE" "$KEYGRIP" \
+              || echo "gpg-preset-passphrase failed; signing may prompt"
+          fi
+
       - name: Restore flatpak-builder cache
         # 526 MB native-dep build is slow; cache the build state
         # between runs. Keyed on the manifest + generated module
-        # files so a dep bump invalidates.
+        # files so a dep bump invalidates. NO restore-keys fallback
+        # — a near-miss on the key could restore build state for the
+        # wrong set of module hashes; flatpak-builder usually
+        # detects this and rebuilds the affected module, but only
+        # *usually*. Exact match or cold build.
         uses: actions/cache@v4
         with:
           path: |
             .flatpak-builder
             .build-flatpak
           key: flatpak-builder-${{ hashFiles('flatpak/com.tidaldownloader.Tideway.yaml', 'flatpak/python3-requirements.json', 'flatpak/node-sources.json') }}
-          restore-keys: |
-            flatpak-builder-
+
+      - name: Seed local repo with previous gh-pages OSTree state
+        # Delta updates only work when the new commit references
+        # the previous commit as its parent. Without this seeding
+        # step every `flatpak update` re-downloads the full 100 MB+
+        # bundle instead of the few MB of code that actually
+        # changed. Pull whatever OSTree state is currently published
+        # to gh-pages into ./repo so flatpak-builder appends to it
+        # below. First release (no prior OSTree state): nothing is
+        # copied and the new commit is the root commit, same as
+        # before this step existed.
+        run: |
+          mkdir -p repo
+          if git ls-remote --exit-code --heads origin gh-pages >/dev/null 2>&1; then
+            git clone --branch gh-pages --depth 1 \
+              "https://github.com/${{ github.repository }}.git" gh-pages-prev
+            # OSTree's on-disk layout. Other gh-pages files
+            # (index.html, tideway.flatpakrepo) are not OSTree state
+            # and don't need copying — publish-flatpak-repo writes
+            # them fresh each run.
+            for d in objects refs deltas state summary summary.sig config; do
+              if [ -e "gh-pages-prev/$d" ]; then
+                cp -r "gh-pages-prev/$d" "repo/$d"
+              fi
+            done
+            rm -rf gh-pages-prev
+            echo "Seeded ./repo from gh-pages:"
+            ls -la repo/ | head
+          else
+            echo "No gh-pages branch yet; building first OSTree commit"
+          fi
 
       - name: Build Flatpak (export to local OSTree repo)
-        # `--repo` puts the build into a flat OSTree repo at
-        # ./repo, which is what Stage 3c serves from GitHub Pages.
-        # `--force-clean` keeps re-runs deterministic; ccache below
-        # keeps the C builds fast across runs.
+        # `--repo` appends the new commit to ./repo. If the seed
+        # step above populated it from gh-pages, the new commit
+        # gets the previous one as parent and clients pull a small
+        # delta. `--force-clean` keeps the BUILD dir deterministic
+        # but does NOT clear --repo; ccache below keeps the C
+        # builds fast across runs.
+        env:
+          GPG_ENABLED: ${{ steps.gpg_check.outputs.enabled }}
+          OSTREE_GPG_KEY_ID: ${{ secrets.OSTREE_GPG_KEY_ID }}
         run: |
-          flatpak-builder --user --ccache --force-clean \
-            --repo=repo \
+          BUILDER_ARGS=(--user --ccache --force-clean --repo=repo)
+          UPDATE_ARGS=()
+          if [ "$GPG_ENABLED" = "true" ]; then
+            BUILDER_ARGS+=(--gpg-sign="$OSTREE_GPG_KEY_ID" --gpg-homedir="$GNUPGHOME")
+            UPDATE_ARGS+=(--gpg-sign="$OSTREE_GPG_KEY_ID" --gpg-homedir="$GNUPGHOME")
+          fi
+          flatpak-builder "${BUILDER_ARGS[@]}" \
             .build-flatpak \
             flatpak/com.tidaldownloader.Tideway.yaml
+          flatpak build-update-repo "${UPDATE_ARGS[@]}" repo
 
       - name: Build single-file .flatpak bundle from repo
         # `flatpak build-bundle` extracts a single .flatpak file
@@ -668,10 +763,25 @@ jobs:
 
       - name: Drop the .flatpakrepo subscribe file next to the OSTree repo
         # Users add the remote with `flatpak remote-add ... tideway.flatpakrepo`.
-        # The file lives in the repo at flatpak/tideway.flatpakrepo and
-        # gets served at https://j-m-punk.github.io/tideway/tideway.flatpakrepo.
+        # The file lives at flatpak/tideway.flatpakrepo and gets served
+        # at https://j-m-punk.github.io/tideway/tideway.flatpakrepo.
+        #
+        # When the project's GPG public key is committed at
+        # flatpak/tideway-release.pub.gpg (part of the opt-in OSTree
+        # signing setup in docs/flatpak-gpg-signing.md), we append a
+        # `GpgKey=` line containing its base64 so newly-added remotes
+        # turn on signature verification automatically. Without it,
+        # Flatpak adds the remote in no-gpg-verify mode, which still
+        # works but trusts only HTTPS for content authenticity.
         run: |
           cp flatpak/tideway.flatpakrepo ostree-repo/tideway.flatpakrepo
+          if [ -f flatpak/tideway-release.pub.gpg ]; then
+            GPGKEY_B64=$(base64 -w 0 flatpak/tideway-release.pub.gpg)
+            printf 'GpgKey=%s\n' "$GPGKEY_B64" >> ostree-repo/tideway.flatpakrepo
+            echo "Embedded GPG public key in tideway.flatpakrepo"
+          else
+            echo "No flatpak/tideway-release.pub.gpg checked in — remote will install in no-gpg-verify mode"
+          fi
 
       - name: Drop an index.html that links the subscribe file + bundle
         # GitHub Pages serves whatever you point it at; without an

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -638,3 +638,92 @@ jobs:
           # Mark tags containing a hyphen (v0.2.0-rc1 etc.) as
           # prereleases automatically.
           prerelease: ${{ contains(github.ref_name, '-') }}
+
+  # -------------------------------------------------------------------
+  # Publish the OSTree repo from build-linux-flatpak to GitHub Pages
+  # so users can `flatpak remote-add` and get `flatpak update`
+  # support. The bundle on the release page covers the one-shot
+  # install case; this covers the subscribe-and-auto-update case.
+  #
+  # Runs after `publish` because the GitHub Release draft is what
+  # signals a real shipping tag — pre-release builds via
+  # workflow_dispatch don't publish to Pages.
+  # -------------------------------------------------------------------
+  publish-flatpak-repo:
+    needs: [publish]
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 1
+
+      - uses: actions/download-artifact@v8
+        with:
+          name: Tideway-Linux-Flatpak-Repo
+          path: ostree-repo
+
+      - name: Drop the .flatpakrepo subscribe file next to the OSTree repo
+        # Users add the remote with `flatpak remote-add ... tideway.flatpakrepo`.
+        # The file lives in the repo at flatpak/tideway.flatpakrepo and
+        # gets served at https://j-m-punk.github.io/tideway/tideway.flatpakrepo.
+        run: |
+          cp flatpak/tideway.flatpakrepo ostree-repo/tideway.flatpakrepo
+
+      - name: Drop an index.html that links the subscribe file + bundle
+        # GitHub Pages serves whatever you point it at; without an
+        # index page, the bare root URL renders an empty directory
+        # listing. A minimal page that explains the install paths
+        # makes the URL discoverable for anyone landing on it.
+        run: |
+          VERSION=$(cat VERSION)
+          cat > ostree-repo/index.html <<HTML
+          <!doctype html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <title>Tideway — Linux install</title>
+            <style>
+              body { font-family: system-ui, sans-serif; max-width: 720px; margin: 3rem auto; padding: 0 1rem; line-height: 1.5; }
+              h1 { margin-top: 0; }
+              code, pre { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+              pre { background: #f5f5f5; padding: 0.75rem 1rem; border-radius: 6px; overflow-x: auto; }
+              a { color: #2563eb; }
+            </style>
+          </head>
+          <body>
+            <h1>Tideway — Linux install</h1>
+            <p>Tideway ships as a Flatpak for Linux. Two ways to install.</p>
+
+            <h2>Auto-updating (recommended)</h2>
+            <p>Subscribe to this Flatpak repo once; <code>flatpak update</code> pulls new releases.</p>
+            <pre>flatpak remote-add --user --if-not-exists tideway \\
+              https://j-m-punk.github.io/tideway/tideway.flatpakrepo
+            flatpak install --user tideway com.tidaldownloader.Tideway</pre>
+
+            <h2>One-shot bundle</h2>
+            <p>Download <code>Tideway-${VERSION}.flatpak</code> from the <a href="https://github.com/J-M-PUNK/tideway/releases/latest">latest release</a>, then:</p>
+            <pre>flatpak install --user --bundle Tideway-${VERSION}.flatpak</pre>
+            <p>Won't auto-update; grab a newer bundle when you want to upgrade.</p>
+
+            <p style="margin-top:3rem; color:#666;">
+              <a href="https://github.com/J-M-PUNK/tideway">Project on GitHub</a>
+            </p>
+          </body>
+          </html>
+          HTML
+
+      - name: Deploy to gh-pages branch
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ostree-repo
+          # Each release replaces the previous OSTree repo content;
+          # users `flatpak update` against the new commit. `keep_files:
+          # false` cleans out stale objects from old releases so the
+          # branch doesn't grow unboundedly.
+          keep_files: false
+          commit_message: "Publish Flatpak repo for ${{ github.ref_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -416,12 +416,113 @@ jobs:
           if-no-files-found: error
 
   # -------------------------------------------------------------------
+  # Linux Flatpak — the native-window path. The AppImage above falls
+  # back to opening the app in the system browser because a frozen
+  # PyInstaller build can't import the host's PyGObject/WebKit2GTK.
+  # The Flatpak builds under the GNOME 49 runtime (Python 3.13, GTK 3,
+  # WebKit2 4.1), so pywebview picks the GTK backend and the user
+  # gets a real native window. See docs/linux-flatpak.md.
+  #
+  # We install flatpak-builder + the GNOME 49 runtime on a stock
+  # ubuntu-22.04 runner rather than running inside a
+  # bilelmoussaoui/flatpak-github-actions container. That image lags
+  # GNOME releases by a few months; doing the install ourselves means
+  # the build mirrors what was verified manually in the dev VM and we
+  # control which runtime version ships.
+  # -------------------------------------------------------------------
+  build-linux-flatpak:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref }}
+
+      - name: Install flatpak + flatpak-builder
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            flatpak flatpak-builder ostree
+          flatpak --version
+          flatpak-builder --version
+
+      - name: Add Flathub remote
+        # User-scoped to match how end users add it; CI doesn't need
+        # the system-wide install, and user-scope avoids needing sudo
+        # on every flatpak invocation.
+        run: |
+          flatpak remote-add --user --if-not-exists \
+            flathub https://flathub.org/repo/flathub.flatpakrepo
+
+      - name: Install GNOME 49 runtime + Node20 SDK extension
+        # The manifest pins GNOME 49 (freedesktop 25.08 base, Python
+        # 3.13). Node20 SDK extension is needed in the build sandbox
+        # for the web bundle (manifest points npm at an offline cache
+        # vendored by flatpak-node-generator).
+        run: |
+          flatpak install --user -y --no-deps flathub \
+            org.gnome.Platform//49 \
+            org.gnome.Sdk//49 \
+            org.freedesktop.Sdk.Extension.node20//25.08
+
+      - name: Restore flatpak-builder cache
+        # 526 MB native-dep build is slow; cache the build state
+        # between runs. Keyed on the manifest + generated module
+        # files so a dep bump invalidates.
+        uses: actions/cache@v4
+        with:
+          path: |
+            .flatpak-builder
+            .build-flatpak
+          key: flatpak-builder-${{ hashFiles('flatpak/com.tidaldownloader.Tideway.yaml', 'flatpak/python3-requirements.json', 'flatpak/node-sources.json') }}
+          restore-keys: |
+            flatpak-builder-
+
+      - name: Build Flatpak (export to local OSTree repo)
+        # `--repo` puts the build into a flat OSTree repo at
+        # ./repo, which is what Stage 3c serves from GitHub Pages.
+        # `--force-clean` keeps re-runs deterministic; ccache below
+        # keeps the C builds fast across runs.
+        run: |
+          flatpak-builder --user --ccache --force-clean \
+            --repo=repo \
+            .build-flatpak \
+            flatpak/com.tidaldownloader.Tideway.yaml
+
+      - name: Build single-file .flatpak bundle from repo
+        # `flatpak build-bundle` extracts a single .flatpak file
+        # from the OSTree repo for users who want to install
+        # directly without adding a remote. Tag-versioned to match
+        # the DMG / .exe naming pattern.
+        run: |
+          VERSION=$(cat VERSION)
+          flatpak build-bundle repo "Tideway-${VERSION}.flatpak" \
+            com.tidaldownloader.Tideway master
+          ls -la "Tideway-${VERSION}.flatpak"
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: Tideway-Linux-Flatpak
+          path: Tideway-*.flatpak
+          if-no-files-found: error
+
+      - name: Upload OSTree repo for Stage 3c (GitHub Pages publish)
+        # Separate artifact so the publish job can pull just the
+        # bundle, and a future Pages-publish job can pull just the
+        # repo. Keeping them as siblings means we don't bake the
+        # distribution mechanism into the build step.
+        uses: actions/upload-artifact@v7
+        with:
+          name: Tideway-Linux-Flatpak-Repo
+          path: repo
+          if-no-files-found: error
+
+  # -------------------------------------------------------------------
   # Attach the artifacts to the GitHub Release. Only runs on a real
   # tag push — manual dispatch still produces the zips as workflow
   # artifacts but doesn't create a release.
   # -------------------------------------------------------------------
   publish:
-    needs: [build-macos, build-windows, build-windows-arm64, build-linux]
+    needs: [build-macos, build-windows, build-windows-arm64, build-linux, build-linux-flatpak]
     runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/tags/v')
     permissions:
@@ -456,6 +557,10 @@ jobs:
       - uses: actions/download-artifact@v8
         with:
           name: Tideway-Linux
+          path: artifacts
+      - uses: actions/download-artifact@v8
+        with:
+          name: Tideway-Linux-Flatpak
           path: artifacts
 
       # Diagnostic — show exactly what landed in artifacts/ so a
@@ -519,6 +624,7 @@ jobs:
             artifacts/Tideway-*.dmg
             artifacts/Tideway-setup-*.exe
             artifacts/Tideway-*-x86_64.AppImage
+            artifacts/Tideway-*.flatpak
           # draft: true so the maintainer can review the auto-populated
           # notes (and edit / restructure if needed) before publishing.
           # Publishing a draft is what actually triggers the auto-update

--- a/.gitignore
+++ b/.gitignore
@@ -244,3 +244,8 @@ watchlist.json
 
 # macOS
 .DS_Store
+
+# Flatpak build state (created next to the manifest when
+# flatpak-builder runs locally; never check in either)
+.flatpak-builder/
+.build-flatpak/

--- a/README.md
+++ b/README.md
@@ -220,29 +220,44 @@ On Windows, download `Tideway-setup-<version>.exe` and run it. The
 installer drops the app under your user profile, registers a Start
 Menu entry, and offers an optional desktop shortcut.
 
-On Linux, download `Tideway-<version>-x86_64.AppImage`, mark it
-executable (`chmod +x Tideway-*-x86_64.AppImage`), and run it. The
-AppImage is portable — no install step, no root needed, runs on any
-glibc-based distro.
+On Linux, the recommended install is the Flatpak. It bundles GTK
+and WebKit2GTK from the GNOME 49 runtime so the app gets a real
+native window without any host-package fiddling, and `flatpak
+update` keeps it current.
 
-> **Linux support is experimental.** There is no maintainer Linux
-> test environment, so cold-launch issues on real distros only
-> surface through user reports. The AppImage relies on these
-> packages being installed on your host (most desktop distros have
-> them by default; minimal installs like Arch / Omarchy do not):
->
-> - **GTK 3** + **WebKit2GTK 4.1** + **Python GObject bindings** —
->   pywebview imports `gi.repository.WebKit2` at startup; without
->   the bindings it falls back to the system browser with an
->   actionable error. Debian/Ubuntu:
->   `libgtk-3-0 libwebkit2gtk-4.1-0 python3-gi gir1.2-webkit2-4.1`.
->   Fedora: `gtk3 webkit2gtk4.1 python3-gobject`.
->   Arch/Omarchy: `gtk3 webkit2gtk-4.1 python-gobject`.
-> - **PortAudio** — Debian/Ubuntu: `libportaudio2`.
->   Fedora: `portaudio`. Arch: `portaudio`.
-> - **libnotify** — Debian/Ubuntu: `libnotify4`.
->   Fedora: `libnotify`. Arch: `libnotify`.
->
+```sh
+# Subscribe to the auto-updating repo (one-time)
+flatpak remote-add --user --if-not-exists tideway \
+  https://j-m-punk.github.io/tideway/tideway.flatpakrepo
+
+# Install
+flatpak install --user tideway com.tidaldownloader.Tideway
+
+# Run
+flatpak run com.tidaldownloader.Tideway
+
+# Update later
+flatpak update --user com.tidaldownloader.Tideway
+```
+
+If you'd rather not subscribe to a remote, download
+`Tideway-<version>.flatpak` from the latest release and install the
+single-file bundle:
+
+```sh
+flatpak install --user --bundle Tideway-<version>.flatpak
+```
+
+The bundle won't auto-update — grab a newer one from the release
+page when you want to upgrade.
+
+The legacy AppImage (`Tideway-<version>-x86_64.AppImage`) is still
+attached to every release as a fallback. It runs on glibc-based
+distros without any install step (`chmod +x` then double-click),
+but it opens the app in the system browser instead of a native
+window because a frozen PyInstaller build can't import the host's
+PyGObject. Prefer the Flatpak.
+
 > Global media keys require an X11 session (Wayland will degrade —
 > the player still works, the global hotkeys do not). ARM Linux
 > (Raspberry Pi etc.) is not built today.

--- a/docs/flatpak-gpg-signing.md
+++ b/docs/flatpak-gpg-signing.md
@@ -1,0 +1,139 @@
+# Flatpak GPG signing — one-time setup
+
+The Linux Flatpak ships through a self-hosted OSTree repo at
+`https://j-m-punk.github.io/tideway/`. By default the repo is
+served over HTTPS and clients verify the GitHub Pages TLS chain
+when they pull, but the OSTree commits themselves are unsigned. A
+compromise of the GitHub Pages infrastructure could substitute
+malicious bits and clients would have no way to detect it.
+
+Enabling GPG signing closes that gap. Each OSTree commit gets a
+detached GPG signature; clients verify it against the embedded
+public key before installing. The `.flatpak` bundle attached to the
+GitHub Release is independently minisign-signed by the
+`scripts/sign-release.sh` step, so direct-bundle installs are
+already protected — this doc covers the remote / `flatpak update`
+path.
+
+Setup is one-time. After it's done, every tagged release signs its
+commit automatically through GitHub Actions.
+
+## Generate the signing key
+
+The signing key is intentionally separate from the minisign
+release-signing key (different threat model, different agent on the
+client side, different rotation cadence). 5-year expiry matches
+typical Flathub guidance.
+
+```sh
+gpg --quick-gen-key 'Tideway OSTree Signing <release@tideway>' rsa3072 sign 5y
+```
+
+`gpg` will prompt for a passphrase. Choose a strong one and save it
+to a password manager — you'll need it in step 3.
+
+Find the fingerprint of the key you just generated:
+
+```sh
+gpg --list-keys --fingerprint
+```
+
+The long uppercase hex string (no spaces; copy the one printed
+below the user ID) is the `key id` for the remaining steps.
+
+## Commit the public half
+
+The public key is what clients use to verify signatures. Export it
+in binary form (Flatpak's `GpgKey=` field expects the raw key, not
+ASCII-armored) and commit it to the repo:
+
+```sh
+gpg --export <fingerprint> > flatpak/tideway-release.pub.gpg
+git add flatpak/tideway-release.pub.gpg
+git commit -m "Add OSTree signing public key"
+git push
+```
+
+`.github/workflows/release.yml`'s `publish-flatpak-repo` job
+detects this file and embeds it (base64-encoded) into the
+`tideway.flatpakrepo` served from GitHub Pages. New users who
+`flatpak remote-add` after this lands will have signature
+verification turned on automatically; existing users have to
+re-add the remote (or pass `--gpg-verify` to `flatpak
+remote-modify`) to opt in.
+
+## Stash the private half in GitHub Secrets
+
+Three secrets, all on the repo's Settings → Secrets and variables →
+Actions page:
+
+1. **`OSTREE_GPG_PRIVATE_KEY`** — armored private key:
+   ```sh
+   gpg --export-secret-keys --armor <fingerprint>
+   ```
+   Paste the entire output (`-----BEGIN PGP PRIVATE KEY BLOCK-----`
+   to `-----END PGP PRIVATE KEY BLOCK-----`).
+
+2. **`OSTREE_GPG_KEY_ID`** — the fingerprint, no spaces. CI uses
+   the presence of this secret as the on/off switch for signing.
+
+3. **`OSTREE_GPG_PASSPHRASE`** — the passphrase you set in step 1.
+   Optional if you skipped the passphrase, but you really shouldn't
+   skip it.
+
+## Test it
+
+Push a new tag (a point-release works). Watch the
+`build-linux-flatpak` job log for `GPG signing: enabled (key
+...)`. The OSTree commit it produces will carry a `.commitmeta`
+file with the signature.
+
+On a Linux machine, add the remote freshly (the existing one was
+added pre-signing and is sticky to no-gpg-verify mode):
+
+```sh
+flatpak remote-delete --user tideway
+flatpak remote-add --user tideway \
+  https://j-m-punk.github.io/tideway/tideway.flatpakrepo
+flatpak install --user tideway com.tidaldownloader.Tideway
+```
+
+`flatpak remote-list --user` should show the remote without the
+`no-gpg-verify` annotation that the unsigned remote carried before.
+
+## Rotation
+
+When the key gets close to expiry (every 5 years or sooner if
+something gets compromised):
+
+1. Generate a new key (same `gpg --quick-gen-key` command).
+2. Sign the old key's revocation (`gpg --gen-revoke <old-fingerprint>`)
+   and keep the revocation certificate offline in case you need to
+   tell users the old key shouldn't be trusted anymore.
+3. Replace `flatpak/tideway-release.pub.gpg` with the new public
+   key. Commit and push.
+4. Update the three `OSTREE_GPG_*` secrets in GitHub Settings.
+5. Tag a release. New users get the new key automatically through
+   `tideway.flatpakrepo`. Existing users have to re-add the remote
+   the same way they would after first enabling signing — the
+   `GpgKey=` field is read once at `remote-add` time, not on every
+   update.
+
+## If something breaks
+
+Build job logs `GPG signing: disabled (OSTREE_GPG_KEY_ID secret
+unset)` means the secret either isn't set or isn't visible to the
+running ref (forks don't see secrets from the upstream repo). Check
+the Actions secrets page; nothing in the manifest needs to change.
+
+Build job logs `gpg-preset-passphrase failed; signing may prompt`
+means the loopback agent couldn't cache the passphrase. The build
+might still succeed if your key has no passphrase, but a passphrase
+key plus an absent agent will hang the build. The usual cause is a
+mistyped `OSTREE_GPG_PASSPHRASE` secret.
+
+Client install logs `GPG signatures found, but none are in
+trusted keyring` means the user's local copy of the public key in
+`~/.local/share/flatpak/repo/refs/...` is out of date — usually
+because the remote was added before signing was enabled. Delete and
+re-add the remote per "Test it" above.

--- a/docs/linux-flatpak.md
+++ b/docs/linux-flatpak.md
@@ -57,15 +57,43 @@ it.
 
 ## Staged plan
 
-0. Branch, this doc, manifest scaffold. (current)
-1. `flatpak-builder` builds in the VM. Highest technical risk:
-   PyAV/libav, curl_cffi (native), numpy, sounddevice all building
-   and importing under the GNOME runtime sandbox + PortAudio.
-2. Headless VM run: prove pywebview selects the GTK/WebKit backend
-   (native, not browser-fallback) and the server comes up with no
-   crash. Visual confirmation of an actual window needs a display
-   (a GUI VM or a real Linux desktop) — explicitly out of scope of
-   the headless harness and noted as a manual check.
+0. Branch, this doc, manifest scaffold. **Done.**
+1. `flatpak-builder` builds in the VM. **Done.** All 20 Python
+   modules + PortAudio + the web bundle build clean under the
+   GNOME runtime sandbox; payload comes out around 526 MB. Two
+   lessons baked into the manifest:
+   - **Rust and Cython transitives need prebuilt wheels.**
+     Offline-hashed sdists fail in the sandbox because their
+     PEP-517 build backends (`maturin`, `setuptools-rust`,
+     `Cython`) aren't available. We pass an explicit
+     `--prefer-wheels` list to `flatpak-pip-generator` covering
+     orjson, curl-cffi, pillow, av, numpy, scipy, rapidfuzz,
+     pydantic-core, watchfiles, httptools, pyyaml, uvloop,
+     aiohttp, zeroconf, cffi. Wheels are arch-conditional
+     (`only-arches: x86_64 / aarch64`) so the same module file
+     works on either build host.
+   - **The npm install needs offline sources too.** `npm ci`
+     against the live registry fails with the sandbox's
+     network-disabled state. `flatpak-node-generator` produces
+     `node-sources.json` from `package-lock.json`, the manifest
+     points `npm_config_cache` and `XDG_CACHE_HOME` at the
+     generated `flatpak-node/` tree, and `npm ci --offline`
+     succeeds.
+2. Headless VM run. **Done.** Inside the GNOME 49 sandbox
+   (Python 3.13.13, PyGObject 3.50.1, GTK 3.0, WebKit2 4.1) the
+   FastAPI server boots, `Uvicorn running on http://127.0.0.1:
+   47823` lands, and pywebview reaches into the GTK backend
+   trying to create a window. Under `xvfb-run` the window
+   creation fails with `Gtk-WARNING: cannot open display` and
+   `Invalid MIT-MAGIC-COOKIE-1 key` — the X11 cookie can't be
+   shared into the Flatpak sandbox by xvfb, but the failure mode
+   itself is the proof: pywebview only emits Gtk-WARNINGs
+   because GTK is the backend it selected. No
+   `webbrowser`-fallback log, no missing-`gi` import, no
+   "GTK cannot be loaded". The native dependency stack (PyAV,
+   numpy, scipy, sounddevice, curl_cffi, etc.) loads at runtime,
+   not just at import. Visual confirmation of an actual window
+   needs a real display and stays out of scope here.
 3. Distribution + auto-updater + CI:
    - **Open decision:** self-hosted Flatpak repo (keeps release
      control + the existing GitHub-Actions cadence; lean) vs
@@ -81,6 +109,15 @@ it.
      `flatpak/flatpak-github-actions` actions) producing a bundle
      and/or pushing the repo; the AppImage job's fate (drop vs
      keep as a fallback artifact) is part of the Stage 3 decision.
+
+## Runtime version
+
+The manifest pins `org.gnome.Platform//49` (freedesktop 25.08 base,
+Python 3.13). The original scaffold used 47, which went EOL on
+2025-10-15. The bump is mechanical: change the runtime-version,
+re-pull `org.freedesktop.Sdk.Extension.node20//25.08`, regenerate
+`python3-requirements.json` with `--runtime org.gnome.Sdk//49` so
+wheel selection matches the new runtime's Python ABI, rebuild.
 
 ## Note
 

--- a/docs/linux-flatpak.md
+++ b/docs/linux-flatpak.md
@@ -3,8 +3,9 @@
 The Linux AppImage has no bundled webview, so pywebview falls back
 to opening the app in the system browser. That was deemed not
 acceptable. This doc covers the Flatpak that replaces it with a
-real native window, the scope, the staged plan, and the open
-decisions.
+real native window — the scope, the architecture, and the staged
+build that got it from manifest scaffold to a GitHub-Pages-hosted
+auto-updating remote.
 
 ## Why Flatpak
 
@@ -94,21 +95,37 @@ it.
    numpy, scipy, sounddevice, curl_cffi, etc.) loads at runtime,
    not just at import. Visual confirmation of an actual window
    needs a real display and stays out of scope here.
-3. Distribution + auto-updater + CI:
-   - **Open decision:** self-hosted Flatpak repo (keeps release
-     control + the existing GitHub-Actions cadence; lean) vs
-     Flathub (slower external review, but discoverability and
-     automatic user updates). Decided with a working build in
-     hand.
-   - The in-app self-updater currently downloads + minisign-
-     verifies the AppImage and execs it. On Flatpak that's wrong:
-     updates come from the Flatpak remote. The Linux updater must
-     detect Flatpak (`/.flatpak-info` / `$FLATPAK_ID`) and either
-     defer to `flatpak update` or hide the in-app install action.
-   - `release.yml` gains a `flatpak-builder` job (the
-     `flatpak/flatpak-github-actions` actions) producing a bundle
-     and/or pushing the repo; the AppImage job's fate (drop vs
-     keep as a fallback artifact) is part of the Stage 3 decision.
+3. Distribution + auto-updater + CI. **Done.** Self-hosted over
+   Flathub: keeps release control on the existing tag-driven
+   GitHub Actions cadence; no external review treadmill. AppImage
+   stays attached as a fallback artifact — same release page, same
+   pipeline — but the Flatpak is what the README recommends.
+   - **3a — In-app updater.** `_running_in_flatpak()` (server.py)
+     checks `/.flatpak-info` and `$FLATPAK_ID`. The
+     `/api/update-check` response carries `kind` (`"flatpak"` or
+     `"installer"`), and `/api/update/install` returns HTTP 409
+     with the exact `flatpak update --user
+     com.tidaldownloader.Tideway` command inside the sandbox. The
+     `UpdateBanner` reads `kind` and replaces the in-app "Install
+     now" button with that command rendered inline. Pinned by
+     `tests/test_update_flatpak.py` and
+     `web/src/components/UpdateBanner.test.tsx`.
+   - **3b — CI.** `build-linux-flatpak` in `.github/workflows/
+     release.yml` installs flatpak-builder on a stock ubuntu-22.04
+     runner, pulls the GNOME 49 runtime + Sdk + Node20 SDK
+     extension from Flathub, runs the manifest with `--repo=repo`,
+     and produces two artifacts: a `.flatpak` bundle (attached to
+     the GitHub Release, signed by `sign-release.sh` alongside the
+     DMG / .exe / AppImage) and the OSTree repo directory.
+   - **3c — Distribution.** `publish-flatpak-repo` deploys the
+     OSTree repo to the `gh-pages` branch on every tag via
+     `peaceiris/actions-gh-pages`. GitHub Pages serves it at
+     `https://j-m-punk.github.io/tideway/`, with a
+     `tideway.flatpakrepo` subscribe file and an `index.html`
+     landing page next to the repo. Users run `flatpak remote-add
+     --user tideway https://j-m-punk.github.io/tideway/
+     tideway.flatpakrepo` and `flatpak install tideway
+     com.tidaldownloader.Tideway`; `flatpak update` thereafter.
 
 ## Runtime version
 

--- a/docs/linux-flatpak.md
+++ b/docs/linux-flatpak.md
@@ -136,9 +136,27 @@ re-pull `org.freedesktop.Sdk.Extension.node20//25.08`, regenerate
 `python3-requirements.json` with `--runtime org.gnome.Sdk//49` so
 wheel selection matches the new runtime's Python ABI, rebuild.
 
+## Trust model
+
+The published repo is served over HTTPS from GitHub Pages, so
+content authenticity rides on GitHub's TLS chain. The `.flatpak`
+bundle attached to each release is also minisign-signed by the
+same `scripts/sign-release.sh` step that signs the DMG / .exe /
+AppImage, so direct-bundle installs from the release page are
+end-to-end verifiable.
+
+Signing OSTree commits with a project GPG key closes the remaining
+gap (a compromised gh-pages host could otherwise substitute
+malicious commits for users on the auto-updating remote). The CI
+side is already wired through `release.yml`'s `build-linux-flatpak`
+job — it's gated on the `OSTREE_GPG_KEY_ID` secret being present
+and is a no-op until you do the one-time setup. See
+[docs/flatpak-gpg-signing.md](flatpak-gpg-signing.md) for the
+key-generation, secret-stashing, and validation steps.
+
 ## Note
 
 The AppImage `/api/open-external` fix (PR #163) is irrelevant to
 the Flatpak path — with a native window the browser-fallback /
 external-open seam isn't taken. It still matters for the AppImage
-until/unless the AppImage is retired in Stage 3.
+until/unless the AppImage is retired in a future release.

--- a/docs/linux-flatpak.md
+++ b/docs/linux-flatpak.md
@@ -1,0 +1,90 @@
+# Linux: native Flatpak
+
+The Linux AppImage has no bundled webview, so pywebview falls back
+to opening the app in the system browser. That was deemed not
+acceptable. This doc covers the Flatpak that replaces it with a
+real native window, the scope, the staged plan, and the open
+decisions.
+
+## Why Flatpak
+
+A frozen (PyInstaller) Linux build can't reuse the host's
+PyGObject/WebKit2GTK (they're bound to the system Python), and
+bundling that stack into the AppImage is the fragile,
+high-maintenance path that pushed the build to browser-fallback in
+the first place. The GNOME Flatpak runtime supplies GTK,
+WebKit2GTK and PyGObject already, so the app runs under the
+runtime's Python with `import gi` working and pywebview's GTK
+backend giving a real native window. Flatpak therefore *replaces
+PyInstaller for Linux* — there is no freeze step in this path.
+
+macOS and Windows are unaffected: they keep their PyInstaller
+specs and the existing signed-AppImage-free pipeline.
+
+## Architecture
+
+- Runtime: `org.gnome.Platform` // SDK `org.gnome.Sdk` (version
+  pinned in the manifest). Brings Python 3, GTK3, WebKit2GTK,
+  PyGObject.
+- App id: `com.tidaldownloader.Tideway` (matches the existing
+  `com.tidaldownloader.app` macOS bundle namespace; Flatpak
+  convention capitalises the final component).
+- Python deps: generated offline+hashed from `requirements.txt`
+  via `flatpak-pip-generator` into a `python3-requirements.json`
+  module (Stage 1). No network during the build sandbox.
+- PortAudio: the GNOME runtime does not ship libportaudio, and
+  `sounddevice` needs it. Built as an autotools module in the
+  manifest.
+- Web bundle: built with the freedesktop Node SDK extension inside
+  the build sandbox (`npm ci && npm run build`), then `web/dist`
+  is installed alongside the Python source.
+- Entry point: `desktop.py` under the runtime Python. pywebview
+  selects the GTK/WebKit backend (no browser fallback).
+
+## finish-args (sandbox permissions)
+
+- `--share=network` — Tidal / Spotify / Last.fm APIs.
+- `--socket=pulseaudio` — audio out (PortAudio; PipeWire's pulse
+  shim covers it).
+- `--socket=wayland` + `--socket=fallback-x11` + `--device=dri` —
+  the WebKitGTK window + GPU compositing.
+- `--filesystem=xdg-download` — downloads land in ~/Downloads.
+- `--talk-name=org.freedesktop.Notifications` — libnotify desktop
+  notifications.
+
+Kept deliberately narrow; widen only when a feature provably needs
+it.
+
+## Staged plan
+
+0. Branch, this doc, manifest scaffold. (current)
+1. `flatpak-builder` builds in the VM. Highest technical risk:
+   PyAV/libav, curl_cffi (native), numpy, sounddevice all building
+   and importing under the GNOME runtime sandbox + PortAudio.
+2. Headless VM run: prove pywebview selects the GTK/WebKit backend
+   (native, not browser-fallback) and the server comes up with no
+   crash. Visual confirmation of an actual window needs a display
+   (a GUI VM or a real Linux desktop) — explicitly out of scope of
+   the headless harness and noted as a manual check.
+3. Distribution + auto-updater + CI:
+   - **Open decision:** self-hosted Flatpak repo (keeps release
+     control + the existing GitHub-Actions cadence; lean) vs
+     Flathub (slower external review, but discoverability and
+     automatic user updates). Decided with a working build in
+     hand.
+   - The in-app self-updater currently downloads + minisign-
+     verifies the AppImage and execs it. On Flatpak that's wrong:
+     updates come from the Flatpak remote. The Linux updater must
+     detect Flatpak (`/.flatpak-info` / `$FLATPAK_ID`) and either
+     defer to `flatpak update` or hide the in-app install action.
+   - `release.yml` gains a `flatpak-builder` job (the
+     `flatpak/flatpak-github-actions` actions) producing a bundle
+     and/or pushing the repo; the AppImage job's fate (drop vs
+     keep as a fallback artifact) is part of the Stage 3 decision.
+
+## Note
+
+The AppImage `/api/open-external` fix (PR #163) is irrelevant to
+the Flatpak path — with a native window the browser-fallback /
+external-open seam isn't taken. It still matters for the AppImage
+until/unless the AppImage is retired in Stage 3.

--- a/flatpak/com.tidaldownloader.Tideway.desktop
+++ b/flatpak/com.tidaldownloader.Tideway.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Type=Application
+Name=Tideway
+Comment=Tidal music player and downloader
+Exec=tideway
+Icon=com.tidaldownloader.Tideway
+Categories=AudioVideo;Audio;Player;
+Terminal=false
+StartupNotify=true

--- a/flatpak/com.tidaldownloader.Tideway.metainfo.xml
+++ b/flatpak/com.tidaldownloader.Tideway.metainfo.xml
@@ -42,11 +42,13 @@
 
   <url type="homepage">https://github.com/J-M-PUNK/tideway</url>
   <url type="bugtracker">https://github.com/J-M-PUNK/tideway/issues</url>
-  <url type="vcs-browser">https://github.com/J-M-PUNK/tideway</url>
 
-  <developer id="com.tidaldownloader">
-    <name>Will Pratt</name>
-  </developer>
+  <!-- The legacy developer_name tag is used here instead of the
+       newer <developer id><name>...</name></developer> because
+       AppStream 0.15 (the version shipping in Ubuntu 22.04 and
+       similar) rejects the newer form as an unknown tag. Both 0.15
+       and 1.0 accept developer_name. -->
+  <developer_name>Will Pratt</developer_name>
 
   <categories>
     <category>AudioVideo</category>

--- a/flatpak/com.tidaldownloader.Tideway.metainfo.xml
+++ b/flatpak/com.tidaldownloader.Tideway.metainfo.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  AppStream metadata for the Tideway Flatpak. GNOME Software /
+  KDE Discover read this to render the app's card (icon, name,
+  description, screenshots) and to surface "Updates available"
+  notifications keyed to the release history below. Optional for
+  self-hosted but required if we ever submit to Flathub, so doing
+  it now avoids a future migration.
+-->
+<component type="desktop-application">
+  <id>com.tidaldownloader.Tideway</id>
+  <metadata_license>MIT</metadata_license>
+  <project_license>MIT</project_license>
+
+  <name>Tideway</name>
+  <summary>Native Tidal client with hi-res playback and downloads</summary>
+
+  <description>
+    <p>
+      Tideway is a native desktop client for Tidal. It plays your
+      library bit-perfect, gaplessly, at the highest quality Tidal
+      offers, and lets you download tracks and albums for offline
+      listening. It also pulls scrobbling history from Last.fm and
+      Spotify into a unified listening view.
+    </p>
+    <p>Features:</p>
+    <ul>
+      <li>Bit-perfect, gapless audio across formats and sample rates</li>
+      <li>FLAC, MQA, Dolby Atmos, and hi-res downloads</li>
+      <li>Parametric EQ, crossfeed, ReplayGain, and a Signal Path readout</li>
+      <li>Cast to Chromecast, DLNA, AirPlay, and Tidal Connect targets</li>
+      <li>Last.fm scrobbling and Spotify listening-history import</li>
+    </ul>
+    <p>
+      This app is not made by Tidal. It talks to the same private
+      endpoints the official Tidal apps use; use your own account
+      at your own risk.
+    </p>
+  </description>
+
+  <launchable type="desktop-id">com.tidaldownloader.Tideway.desktop</launchable>
+
+  <url type="homepage">https://github.com/J-M-PUNK/tideway</url>
+  <url type="bugtracker">https://github.com/J-M-PUNK/tideway/issues</url>
+  <url type="vcs-browser">https://github.com/J-M-PUNK/tideway</url>
+
+  <developer id="com.tidaldownloader">
+    <name>Will Pratt</name>
+  </developer>
+
+  <categories>
+    <category>AudioVideo</category>
+    <category>Audio</category>
+    <category>Player</category>
+  </categories>
+
+  <content_rating type="oars-1.1">
+    <content_attribute id="social-info">mild</content_attribute>
+  </content_rating>
+
+  <!--
+    Releases are appended to over time. flatpak-builder reads
+    <release version> to label the Flatpak commit; GNOME Software
+    shows the most-recent release's <description> as the "What's new"
+    section on the app card.
+  -->
+  <releases>
+    <release version="1.9.5" date="2026-05-19">
+      <description>
+        <p>
+          Fixed a freeze on track change where the previous track's
+          audio stream wasn't reopened, leaving the new track in
+          state=playing with no sound.
+        </p>
+      </description>
+    </release>
+  </releases>
+</component>

--- a/flatpak/com.tidaldownloader.Tideway.yaml
+++ b/flatpak/com.tidaldownloader.Tideway.yaml
@@ -2,9 +2,9 @@
 # browser fallback with a real WebKitGTK window). See
 # docs/linux-flatpak.md for scope and the staged plan.
 #
-# STATUS: Stage 1. PortAudio source hash and the pip-generated
-# python3-requirements.json module are filled in. First buildable
-# revision; first real flatpak-builder run lives in the VM.
+# Builds against the GNOME 49 runtime (Python 3.13, GTK 3, WebKit2
+# 4.1). Verified end-to-end in CI on every tag — and on PRs that
+# touch this file or release.yml.
 
 app-id: com.tidaldownloader.Tideway
 runtime: org.gnome.Platform
@@ -18,6 +18,14 @@ sdk-extensions:
   # is not part of the runtime the app ships against.
   - org.freedesktop.Sdk.Extension.node20
 command: tideway
+
+# flatpak-builder auto-runs `appstream-compose` against our metainfo
+# file for the legacy share/appdata/<id>.appdata.xml output. GNOME
+# 49's Sdk doesn't ship that binary (it was deprecated in favour of
+# `appstreamcli compose` years ago) and modern AppStream readers
+# index share/metainfo/<id>.metainfo.xml directly. Disable the
+# auto-step at the manifest level so the build doesn't fail here.
+appstream-compose: false
 
 finish-args:
   - --share=network                       # Tidal / Spotify / Last.fm
@@ -75,8 +83,12 @@ modules:
         /app/share/applications/com.tidaldownloader.Tideway.desktop
       - install -Dm644 assets/icon.png
         /app/share/icons/hicolor/512x512/apps/com.tidaldownloader.Tideway.png
-      # TODO(stage1): AppStream metainfo (required by Flathub; good
-      # practice for a self-hosted repo too).
+      # AppStream metainfo. GNOME Software and KDE Discover read
+      # this to render the app card and surface "Updates available"
+      # notifications. Required for Flathub; useful for self-hosted
+      # because software centres pick the file up automatically.
+      - install -Dm644 flatpak/com.tidaldownloader.Tideway.metainfo.xml
+        /app/share/metainfo/com.tidaldownloader.Tideway.metainfo.xml
     sources:
       - type: dir
         path: ..

--- a/flatpak/com.tidaldownloader.Tideway.yaml
+++ b/flatpak/com.tidaldownloader.Tideway.yaml
@@ -2,15 +2,16 @@
 # browser fallback with a real WebKitGTK window). See
 # docs/linux-flatpak.md for scope and the staged plan.
 #
-# STATUS: Stage 0 scaffold. Items marked TODO(stage1) are filled in
-# from the VM in Stage 1 (real source hashes, the pip-generated
-# python deps module). It is intentionally not buildable yet.
+# STATUS: Stage 1. PortAudio source hash and the pip-generated
+# python3-requirements.json module are filled in. First buildable
+# revision; first real flatpak-builder run lives in the VM.
 
 app-id: com.tidaldownloader.Tideway
 runtime: org.gnome.Platform
-# GNOME 47 maps to the freedesktop 24.08 base (drives the Node
-# SDK-extension version below). Pinned; bump deliberately.
-runtime-version: "47"
+# GNOME 49 maps to the freedesktop 25.08 base (drives the Node
+# SDK-extension version below). Pinned; bump deliberately. GNOME
+# 47 (the original scaffold) went EOL 2025-10-15.
+runtime-version: "49"
 sdk: org.gnome.Sdk
 sdk-extensions:
   # Node only exists in the build sandbox to produce web/dist; it
@@ -36,29 +37,34 @@ cleanup:
 
 modules:
   # sounddevice needs libportaudio; the GNOME runtime does not ship
-  # it, so build it. TODO(stage1): pin a real release tarball + its
-  # sha256 (computed in the VM).
+  # it. Built here; sha256 computed off the upstream tarball.
   - name: portaudio
     buildsystem: autotools
     sources:
       - type: archive
         url: https://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz
-        sha256: TODO_STAGE1_PORTAUDIO_SHA256
+        sha256: 47efbf42c77c19a05d22e627d42873e991ec0c1357219c0d74ce6a2948cb2def
 
   # Offline, hashed PyPI deps generated from requirements.txt with
-  # flatpak-pip-generator. TODO(stage1): generate
-  # python3-requirements.json in the VM and include it here:
-  #   - python3-requirements.json
+  # flatpak-pip-generator. Regenerate by running the script in the
+  # VM against the project's requirements.txt and copying the
+  # resulting JSON over this file.
+  - python3-requirements.json
 
   - name: tideway
     buildsystem: simple
-    # Node extension is mounted under /usr/lib/sdk/node20; put it on
-    # PATH only for the web build.
+    # Node extension is mounted under /usr/lib/sdk/node20/bin. The
+    # build sandbox has no network; npm reads from the offline cache
+    # laid down by flatpak-node-generator under flatpak-node/.
     build-options:
       append-path: /usr/lib/sdk/node20/bin
+      env:
+        XDG_CACHE_HOME: /run/build/tideway/flatpak-node/cache
+        npm_config_cache: /run/build/tideway/flatpak-node/npm-cache
+        npm_config_offline: "true"
     build-commands:
-      # Web bundle.
-      - npm --prefix web ci --no-audit --no-fund
+      # Web bundle (offline; tarballs come from node-sources.json).
+      - npm --prefix web ci --offline --no-audit --no-fund
       - npm --prefix web run build
       # App payload. The runtime Python imports `gi`, so pywebview
       # uses the GTK/WebKit backend — no browser fallback.
@@ -74,3 +80,4 @@ modules:
     sources:
       - type: dir
         path: ..
+      - node-sources.json

--- a/flatpak/com.tidaldownloader.Tideway.yaml
+++ b/flatpak/com.tidaldownloader.Tideway.yaml
@@ -1,0 +1,76 @@
+# Flatpak manifest — native Linux build (replaces the AppImage's
+# browser fallback with a real WebKitGTK window). See
+# docs/linux-flatpak.md for scope and the staged plan.
+#
+# STATUS: Stage 0 scaffold. Items marked TODO(stage1) are filled in
+# from the VM in Stage 1 (real source hashes, the pip-generated
+# python deps module). It is intentionally not buildable yet.
+
+app-id: com.tidaldownloader.Tideway
+runtime: org.gnome.Platform
+# GNOME 47 maps to the freedesktop 24.08 base (drives the Node
+# SDK-extension version below). Pinned; bump deliberately.
+runtime-version: "47"
+sdk: org.gnome.Sdk
+sdk-extensions:
+  # Node only exists in the build sandbox to produce web/dist; it
+  # is not part of the runtime the app ships against.
+  - org.freedesktop.Sdk.Extension.node20
+command: tideway
+
+finish-args:
+  - --share=network                       # Tidal / Spotify / Last.fm
+  - --socket=pulseaudio                   # PortAudio/sounddevice out
+  - --socket=wayland                      # native window
+  - --socket=fallback-x11                 # X11 fallback
+  - --device=dri                          # WebKitGTK GPU compositing
+  - --filesystem=xdg-download             # downloads -> ~/Downloads
+  - --talk-name=org.freedesktop.Notifications  # libnotify
+
+cleanup:
+  - /include
+  - /lib/pkgconfig
+  - /share/man
+  - "*.a"
+  - "*.la"
+
+modules:
+  # sounddevice needs libportaudio; the GNOME runtime does not ship
+  # it, so build it. TODO(stage1): pin a real release tarball + its
+  # sha256 (computed in the VM).
+  - name: portaudio
+    buildsystem: autotools
+    sources:
+      - type: archive
+        url: https://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz
+        sha256: TODO_STAGE1_PORTAUDIO_SHA256
+
+  # Offline, hashed PyPI deps generated from requirements.txt with
+  # flatpak-pip-generator. TODO(stage1): generate
+  # python3-requirements.json in the VM and include it here:
+  #   - python3-requirements.json
+
+  - name: tideway
+    buildsystem: simple
+    # Node extension is mounted under /usr/lib/sdk/node20; put it on
+    # PATH only for the web build.
+    build-options:
+      append-path: /usr/lib/sdk/node20/bin
+    build-commands:
+      # Web bundle.
+      - npm --prefix web ci --no-audit --no-fund
+      - npm --prefix web run build
+      # App payload. The runtime Python imports `gi`, so pywebview
+      # uses the GTK/WebKit backend — no browser fallback.
+      - install -d /app/share/tideway
+      - cp -r app server.py desktop.py VERSION web/dist /app/share/tideway/
+      - install -Dm755 flatpak/tideway-launcher.sh /app/bin/tideway
+      - install -Dm644 flatpak/com.tidaldownloader.Tideway.desktop
+        /app/share/applications/com.tidaldownloader.Tideway.desktop
+      - install -Dm644 assets/icon.png
+        /app/share/icons/hicolor/512x512/apps/com.tidaldownloader.Tideway.png
+      # TODO(stage1): AppStream metainfo (required by Flathub; good
+      # practice for a self-hosted repo too).
+    sources:
+      - type: dir
+        path: ..

--- a/flatpak/node-sources.json
+++ b/flatpak/node-sources.json
@@ -1,0 +1,6634 @@
+[
+    {
+        "type": "archive",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+        "strip-components": 1,
+        "sha512": "6cf6f900766d6de3468c229567d506a86c28f0452ee1c2eaebc13de40e772a5c403d1994c98bf60fa174b9423ae578ac18e2f58413f9993ae89db828fb46c570",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm@0.21.5",
+        "only-arches": [
+            "arm"
+        ]
+    },
+    {
+        "type": "archive",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+        "strip-components": 1,
+        "sha512": "89b2af9b26332ac05e5fc77c23b307fd331f5835c117775be2a33ab32fbbaded185f26be2b571e9b7a27f5781d4f611018cbb8850c9985a9fb4de43c5e41a9e1",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-arm64@0.21.5",
+        "only-arches": [
+            "aarch64"
+        ]
+    },
+    {
+        "type": "archive",
+        "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+        "strip-components": 1,
+        "sha512": "62f8d70ea2d1a8f0e5d9dbd13836269a1cf8acf795298be9a5f198292346772664034d74e3aa4b5b244a288ddac7c7db2682b941bc5b954464c0afcc598d7c4e",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-ia32@0.21.5",
+        "only-arches": [
+            "i386"
+        ]
+    },
+    {
+        "type": "archive",
+        "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+        "strip-components": 1,
+        "sha512": "d6b61d4e9cafd378b2705d7e061cebcd024274eb803ad6aa1d35896425af8a3283d8de57bb44ed542f3ffb57da5aa70ff6204258e9a39a1a07f78747f360713d",
+        "dest": "flatpak-node/cache/esbuild/.package/@esbuild/linux-x64@0.21.5",
+        "only-arches": [
+            "x86_64"
+        ]
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+        "sha512": "52b700041fb86d4ac5001c1b96e4c8044ad7c2f6ec53f57b4d959f99b8097db930881bb3892f60c5d383532ba279c7dd190f398e094c5ba8ee4b7fb3e53b0a2f",
+        "dest-filename": "00041fb86d4ac5001c1b96e4c8044ad7c2f6ec53f57b4d959f99b8097db930881bb3892f60c5d383532ba279c7dd190f398e094c5ba8ee4b7fb3e53b0a2f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/52/b7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+        "sha512": "f4d8427988eaf7edeec6076da76d0b4a225726f37415e0ad346a49c6e3056752afddc59435be833a127052f7150b328647ae9cc389e3c0cea1ac92ea80ec1b73",
+        "dest-filename": "427988eaf7edeec6076da76d0b4a225726f37415e0ad346a49c6e3056752afddc59435be833a127052f7150b328647ae9cc389e3c0cea1ac92ea80ec1b73",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f4/d8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
+        "sha512": "4f534226a4ff8fdf9c9fc7ef92dee3b706cb05f2c2ff5cb573b36d09e5c5460cc64ec69f8baf0c46ff32ce46126a9067140e8bdd4d9549cd367220f3a0026126",
+        "dest-filename": "4226a4ff8fdf9c9fc7ef92dee3b706cb05f2c2ff5cb573b36d09e5c5460cc64ec69f8baf0c46ff32ce46126a9067140e8bdd4d9549cd367220f3a0026126",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4f/53"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
+        "sha512": "08639f389a968e0daa5bf31beb336c0e6faee6f150f03c577db334f73ebda7967afa61358a43f68d45f0fa3e363dfd574d8103d919e2e5ff799e961ebb030340",
+        "dest-filename": "9f389a968e0daa5bf31beb336c0e6faee6f150f03c577db334f73ebda7967afa61358a43f68d45f0fa3e363dfd574d8103d919e2e5ff799e961ebb030340",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/08/63"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+        "sha512": "aac685fbd41c9b642ff1244830cb1c02f1b83b7949d05d46b8ca391d1fc1a74d8ba293609d9042fc491b7af1c5786b3896cfe83f3f6ff81b26cdb91b7bed1d53",
+        "dest-filename": "85fbd41c9b642ff1244830cb1c02f1b83b7949d05d46b8ca391d1fc1a74d8ba293609d9042fc491b7af1c5786b3896cfe83f3f6ff81b26cdb91b7bed1d53",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/c6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+        "sha512": "258b65b3786a8b5e5f731e4669234bed209327630d9a3ae41d7838152a4e03f82bc4af0ac326796ee6c7b02abc1570a4b9aeb186e69a062b7eddbefe55945f70",
+        "dest-filename": "65b3786a8b5e5f731e4669234bed209327630d9a3ae41d7838152a4e03f82bc4af0ac326796ee6c7b02abc1570a4b9aeb186e69a062b7eddbefe55945f70",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/25/8b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+        "sha512": "f96e9c21291715ad635ec0c475803c1de7af413fc550b871cd1f7da71a6196d65c55aba0a6ce774c709e89603c4a0bb1c694a9de028f8ae61f496a2990b43887",
+        "dest-filename": "9c21291715ad635ec0c475803c1de7af413fc550b871cd1f7da71a6196d65c55aba0a6ce774c709e89603c4a0bb1c694a9de028f8ae61f496a2990b43887",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f9/6e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+        "sha512": "9795e464aeebef06bd2ee706c3d2f0672c8252c71be31dfb2564cfcfbb30c0513fd05310006a62594667f2ef43ce448158470adb98e6bee6dfa70d9d9c031d6f",
+        "dest-filename": "e464aeebef06bd2ee706c3d2f0672c8252c71be31dfb2564cfcfbb30c0513fd05310006a62594667f2ef43ce448158470adb98e6bee6dfa70d9d9c031d6f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/97/95"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+        "sha512": "ebba1714062bd9c0cb0d518b5d3100063741259e9dac4954488ed62a9ef436ba72212b28de9946f52006105eb2ef36e16bfc0ecd40725964c9bc40d534850670",
+        "dest-filename": "1714062bd9c0cb0d518b5d3100063741259e9dac4954488ed62a9ef436ba72212b28de9946f52006105eb2ef36e16bfc0ecd40725964c9bc40d534850670",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/eb/ba"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+        "sha512": "4bd83367f6f3f37191cac23b8000f8c0f4ff008dee0a763ef719fe331fca3ecd89c07248cf55bc3d9920d9cab2b7744d38133c7a3717855eb2f0e83b972fc3ba",
+        "dest-filename": "3367f6f3f37191cac23b8000f8c0f4ff008dee0a763ef719fe331fca3ecd89c07248cf55bc3d9920d9cab2b7744d38133c7a3717855eb2f0e83b972fc3ba",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4b/d8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+        "sha512": "a8c952c4a6e946502b89d0c4c64f769d2a1bc837693e28d4ab60d6ea80e752a77488e1b19908f2aa13088a123dfb3bf82cfc997518ded9c6af58f6c26d69b778",
+        "dest-filename": "52c4a6e946502b89d0c4c64f769d2a1bc837693e28d4ab60d6ea80e752a77488e1b19908f2aa13088a123dfb3bf82cfc997518ded9c6af58f6c26d69b778",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a8/c9"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+        "sha512": "a92b3889fc33289495dfdb9c363b2f73a5951ece9bed2d37b0e87639c1c5f541df54fa965802d4b0d515ce1481888b63459a0b1f1ee721aad58ea295bac519d5",
+        "dest-filename": "3889fc33289495dfdb9c363b2f73a5951ece9bed2d37b0e87639c1c5f541df54fa965802d4b0d515ce1481888b63459a0b1f1ee721aad58ea295bac519d5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a9/2b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+        "sha512": "62f8c9a30f45c5b84514a0d2b859d509ed96c57935cd6736d9f15e3d5344696244bbc22b65595d6ba374b87c3366b50cd6297b342f4c969e0c68961b61df494a",
+        "dest-filename": "c9a30f45c5b84514a0d2b859d509ed96c57935cd6736d9f15e3d5344696244bbc22b65595d6ba374b87c3366b50cd6297b342f4c969e0c68961b61df494a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/62/f8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
+        "sha512": "1e81ae52ce2c09935ecd510a755730aa664df06a078ab2d470b69854d04ad89d0369d1ad75caa0af70426ef1fcf97528e0d1a3365dd53ad4a310a373a9f1602b",
+        "dest-filename": "ae52ce2c09935ecd510a755730aa664df06a078ab2d470b69854d04ad89d0369d1ad75caa0af70426ef1fcf97528e0d1a3365dd53ad4a310a373a9f1602b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1e/81"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+        "sha512": "e06811cf2ffe7ec05aef6fd165526618a3e666ef41ca7f28e0ca0ba6635ed66f197d89f3e5e9872d0cf753880bb9de99c25d1164872088b0fb52aef2485b832c",
+        "dest-filename": "11cf2ffe7ec05aef6fd165526618a3e666ef41ca7f28e0ca0ba6635ed66f197d89f3e5e9872d0cf753880bb9de99c25d1164872088b0fb52aef2485b832c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e0/68"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+        "sha512": "e94ce40acf9e8c6759e661450bf38252bbf4dbc69bd9fa75ce76660998c03812a204ada35c3d4ef813d27d7f17daa8c9ef97d904c4a7427dd1ab69ab0492b69b",
+        "dest-filename": "e40acf9e8c6759e661450bf38252bbf4dbc69bd9fa75ce76660998c03812a204ada35c3d4ef813d27d7f17daa8c9ef97d904c4a7427dd1ab69ab0492b69b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e9/4c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+        "sha512": "cdbc284ec06bb9378a07d852abbde16baea215e247b9a16451bc2fa84967ca0a0d6e3fe31d1b127a8928c1914ddc267ae08bc4a9c9a69157bcf4e3d773b95d03",
+        "dest-filename": "284ec06bb9378a07d852abbde16baea215e247b9a16451bc2fa84967ca0a0d6e3fe31d1b127a8928c1914ddc267ae08bc4a9c9a69157bcf4e3d773b95d03",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cd/bc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+        "sha512": "600e8c6b62ac09d19bf960ba5290551491972f9f0c0c0ea8c8e35b8f217ffb9b0183163f7709212e881b313d865d7c94f38fc8851c3fd83d4eb3507f822cfe05",
+        "dest-filename": "8c6b62ac09d19bf960ba5290551491972f9f0c0c0ea8c8e35b8f217ffb9b0183163f7709212e881b313d865d7c94f38fc8851c3fd83d4eb3507f822cfe05",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/60/0e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+        "sha512": "e073e242bd17efec1a1dfc973d9a563df58bfc9edd70dd66c7d80be9675054c6cf9c5dfe66148cb3cb42c4dee81dd74913d7e1344efe9717679727a629f251b8",
+        "dest-filename": "e242bd17efec1a1dfc973d9a563df58bfc9edd70dd66c7d80be9675054c6cf9c5dfe66148cb3cb42c4dee81dd74913d7e1344efe9717679727a629f251b8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e0/73"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+        "sha512": "2f07591e949c338433f17c3688a4b34be71f825673246be87d0202cbb5bbbf871aaeee046809b252e3ba046adbc90da6615d755b453c8f998185dd7875ddc1d0",
+        "dest-filename": "591e949c338433f17c3688a4b34be71f825673246be87d0202cbb5bbbf871aaeee046809b252e3ba046adbc90da6615d755b453c8f998185dd7875ddc1d0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2f/07"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz",
+        "sha512": "16f11bdbdc79c15c2efca7fddc85b0b0e384ba11e1e9d602245def70a2f35dcd0a5c85b5f3500ecefe9c793e19a411c3bc07c6eb47aa6fe7a49ab9cb1c8cbe8f",
+        "dest-filename": "1bdbdc79c15c2efca7fddc85b0b0e384ba11e1e9d602245def70a2f35dcd0a5c85b5f3500ecefe9c793e19a411c3bc07c6eb47aa6fe7a49ab9cb1c8cbe8f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/16/f1"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz",
+        "sha512": "7a2160cc26c89dec8c94b3a6346e20f71cc5ec7bf73206b82e3c637120bfb9eb3a558ab6fa051b408f09a8dbb0fd933cb4921e21a046a6cc00b2a57657b02980",
+        "dest-filename": "60cc26c89dec8c94b3a6346e20f71cc5ec7bf73206b82e3c637120bfb9eb3a558ab6fa051b408f09a8dbb0fd933cb4921e21a046a6cc00b2a57657b02980",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7a/21"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+        "sha512": "0da0de5245d92a374686061a1cd25357da55ed8f41ddbeb8e2308bb3d52973755e34683a2d6011013e8ef90fbf08ea3eda083f6cce6b869300b5fef45aa7c175",
+        "dest-filename": "de5245d92a374686061a1cd25357da55ed8f41ddbeb8e2308bb3d52973755e34683a2d6011013e8ef90fbf08ea3eda083f6cce6b869300b5fef45aa7c175",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0d/a0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+        "sha512": "487eb46cc7eb442245de6a2b71d939ed6925ba317826bfc4b10533aa46ab7c75c415c011d6083b7d2fdc84013ddb649e860cdcd7ff93cf91f76296b51e210aae",
+        "dest-filename": "b46cc7eb442245de6a2b71d939ed6925ba317826bfc4b10533aa46ab7c75c415c011d6083b7d2fdc84013ddb649e860cdcd7ff93cf91f76296b51e210aae",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/48/7e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+        "sha512": "55dffd1150e2bba3cf26df72021eaba193fa125d711eb76f2151a3c81b07474458c0d1e02fb1493f22085b87c0349346e85b7265fbe544fa4523864cfe5b9bbf",
+        "dest-filename": "fd1150e2bba3cf26df72021eaba193fa125d711eb76f2151a3c81b07474458c0d1e02fb1493f22085b87c0349346e85b7265fbe544fa4523864cfe5b9bbf",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/55/df"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz",
+        "sha512": "1c0607edddd32d11c339440ae2664a7fd93d3e1fe6f0092cb60ebacb0291e121408a08ecdf206251e66d171cb08939b99a864c029ff95bf66e1673575d82eeb9",
+        "dest-filename": "07edddd32d11c339440ae2664a7fd93d3e1fe6f0092cb60ebacb0291e121408a08ecdf206251e66d171cb08939b99a864c029ff95bf66e1673575d82eeb9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1c/06"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
+        "sha512": "3c2a905777380a8566de474f872799d3b566051747d84a4c140fe977d3804a93840b7697346a2a3c3019f340f470ba4c0719e6934fb23611ac131df586aec6b7",
+        "dest-filename": "905777380a8566de474f872799d3b566051747d84a4c140fe977d3804a93840b7697346a2a3c3019f340f470ba4c0719e6934fb23611ac131df586aec6b7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3c/2a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
+        "sha512": "d8ff9881a5c5fa046c222870c18d600ac412627bbd6728f6a72f246397c5bd4335aa6d96036bbadfd47a60d55f538196afe64ce66a84b1f1d964ba1138d6de9b",
+        "dest-filename": "9881a5c5fa046c222870c18d600ac412627bbd6728f6a72f246397c5bd4335aa6d96036bbadfd47a60d55f538196afe64ce66a84b1f1d964ba1138d6de9b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d8/ff"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
+        "sha512": "c6418145041a6f844bc205f1a2a113202afa4b9265a2069f6e136c89d9ab915bf6611b3930bc298e8176aa98868d0b7c4bd028c6d215eb4decd06214a58e5e61",
+        "dest-filename": "8145041a6f844bc205f1a2a113202afa4b9265a2069f6e136c89d9ab915bf6611b3930bc298e8176aa98868d0b7c4bd028c6d215eb4decd06214a58e5e61",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c6/41"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
+        "sha512": "fb1aa1988233bc060c19f0586276cab8d89c7d2b24e1192c6365dd989853f87002d359e2c7a7c70b3b54ebc8e8a0588c501d352b2dc5d05c8ebe11bf059ad692",
+        "dest-filename": "a1988233bc060c19f0586276cab8d89c7d2b24e1192c6365dd989853f87002d359e2c7a7c70b3b54ebc8e8a0588c501d352b2dc5d05c8ebe11bf059ad692",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/1a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
+        "sha512": "f8c28024439f6817b94a657ab77e29f3430c2a18ef533d2f46bbd525b3d3d16125cda389ff5c6cf83f8a0effad0ff344e6e8dfac284472c85de1f2e7d30a62aa",
+        "dest-filename": "8024439f6817b94a657ab77e29f3430c2a18ef533d2f46bbd525b3d3d16125cda389ff5c6cf83f8a0effad0ff344e6e8dfac284472c85de1f2e7d30a62aa",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f8/c2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz",
+        "sha512": "89dfbb611520a145fa0a05740edba18ab416a1d79e03b2dfe22db1ef5252fefb40e6945bfe12065a5c3e1ba31e5efb0cf8c5ebcf4540c9d4c61255f5ac07e03e",
+        "dest-filename": "bb611520a145fa0a05740edba18ab416a1d79e03b2dfe22db1ef5252fefb40e6945bfe12065a5c3e1ba31e5efb0cf8c5ebcf4540c9d4c61255f5ac07e03e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/89/df"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+        "sha512": "d520e01fa6523d3960832d7223af836e48b3f31ce91c911502517f00cd6d1cf2ec7f9493a26f6bc2d8c4e21280176d057d75cd4c5a84617c893568751a265e75",
+        "dest-filename": "e01fa6523d3960832d7223af836e48b3f31ce91c911502517f00cd6d1cf2ec7f9493a26f6bc2d8c4e21280176d057d75cd4c5a84617c893568751a265e75",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/20"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+        "sha512": "bc23efcd28e93c7122d6c899765bc096c3f15e5ed66ce554041028c16ba0e2b2476faf0ec7c2ae6a507ed6870dbd3e5f8efeb0a645faa3f884a5b0eb7faf3372",
+        "dest-filename": "efcd28e93c7122d6c899765bc096c3f15e5ed66ce554041028c16ba0e2b2476faf0ec7c2ae6a507ed6870dbd3e5f8efeb0a645faa3f884a5b0eb7faf3372",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/23"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+        "sha512": "734b97f55014050edd4c30a3abec1dc862e8c0c76d47f1a80b653921893fec3d47d49602d2ab1e0fbfb5d6230fda644b37d45c08c45c8c2e1831c942cc6c12fc",
+        "dest-filename": "97f55014050edd4c30a3abec1dc862e8c0c76d47f1a80b653921893fec3d47d49602d2ab1e0fbfb5d6230fda644b37d45c08c45c8c2e1831c942cc6c12fc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/73/4b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+        "sha512": "0fb68f45450d1d10701f1cf146fa7ce7aae35074455b549d4004ca5c7da1a80d240196f584a9a2d363a961169c9744f1206cff6665d695b6608f05986826a44c",
+        "dest-filename": "8f45450d1d10701f1cf146fa7ce7aae35074455b549d4004ca5c7da1a80d240196f584a9a2d363a961169c9744f1206cff6665d695b6608f05986826a44c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/b6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+        "sha512": "0f0a97a99cae9390225967f751f2e2443279103778f7383a3bdc1c959ee450cbf659116be072a35e9ff9b7c259d7541b41f512ebf71108a1b0621b4d018f3c91",
+        "dest-filename": "97a99cae9390225967f751f2e2443279103778f7383a3bdc1c959ee450cbf659116be072a35e9ff9b7c259d7541b41f512ebf71108a1b0621b4d018f3c91",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0f/0a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+        "sha512": "b1efc98c5f0d9662951b890d22ec96315ff6d9969eac1faa6928b931dad7b5de91d3c92fb36a823780b4f668aea64b438adbe1f234457e5c0614141cc594636f",
+        "dest-filename": "c98c5f0d9662951b890d22ec96315ff6d9969eac1faa6928b931dad7b5de91d3c92fb36a823780b4f668aea64b438adbe1f234457e5c0614141cc594636f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b1/ef"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+        "sha512": "e49711c714435092d7f095e9ff07010b2de910d9c280147d6cde89b18e0e9a17d4b481dedd95b499ac00efe44301c30bacc21969fd373654225fd0c6c81f21e2",
+        "dest-filename": "11c714435092d7f095e9ff07010b2de910d9c280147d6cde89b18e0e9a17d4b481dedd95b499ac00efe44301c30bacc21969fd373654225fd0c6c81f21e2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e4/97"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+        "sha512": "27de643418f5ce46cc5ed1d51f6f5b06b890ca0317aa8550390600f884acd3fda5dd3f7f923e36a30da6a6a7ab441c432679a450309a413fdd7cd5d65ff65909",
+        "dest-filename": "643418f5ce46cc5ed1d51f6f5b06b890ca0317aa8550390600f884acd3fda5dd3f7f923e36a30da6a6a7ab441c432679a450309a413fdd7cd5d65ff65909",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/27/de"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+        "sha512": "6cf6f900766d6de3468c229567d506a86c28f0452ee1c2eaebc13de40e772a5c403d1994c98bf60fa174b9423ae578ac18e2f58413f9993ae89db828fb46c570",
+        "dest-filename": "f900766d6de3468c229567d506a86c28f0452ee1c2eaebc13de40e772a5c403d1994c98bf60fa174b9423ae578ac18e2f58413f9993ae89db828fb46c570",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6c/f6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+        "sha512": "89b2af9b26332ac05e5fc77c23b307fd331f5835c117775be2a33ab32fbbaded185f26be2b571e9b7a27f5781d4f611018cbb8850c9985a9fb4de43c5e41a9e1",
+        "dest-filename": "af9b26332ac05e5fc77c23b307fd331f5835c117775be2a33ab32fbbaded185f26be2b571e9b7a27f5781d4f611018cbb8850c9985a9fb4de43c5e41a9e1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/89/b2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+        "sha512": "62f8d70ea2d1a8f0e5d9dbd13836269a1cf8acf795298be9a5f198292346772664034d74e3aa4b5b244a288ddac7c7db2682b941bc5b954464c0afcc598d7c4e",
+        "dest-filename": "d70ea2d1a8f0e5d9dbd13836269a1cf8acf795298be9a5f198292346772664034d74e3aa4b5b244a288ddac7c7db2682b941bc5b954464c0afcc598d7c4e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/62/f8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+        "sha512": "b877f5066306f2a12fcddaf302a8364881bfd36fb8fc31c1e9af4a6f26b45c3bf00c4282a02f19456239249bcd7548ed722046150e4fb8196910e5d08fe2504a",
+        "dest-filename": "f5066306f2a12fcddaf302a8364881bfd36fb8fc31c1e9af4a6f26b45c3bf00c4282a02f19456239249bcd7548ed722046150e4fb8196910e5d08fe2504a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b8/77"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+        "sha512": "21a8ce98ef8a24adb76e3e7674548d08cb33d503f50ea33a7302d4bf75b5430cb193221679c7da7e7239e797ef486a842b08cc5d52e891c579ca01d6e5bdc96e",
+        "dest-filename": "ce98ef8a24adb76e3e7674548d08cb33d503f50ea33a7302d4bf75b5430cb193221679c7da7e7239e797ef486a842b08cc5d52e891c579ca01d6e5bdc96e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/a8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+        "sha512": "d611d5fd9e0e11f330a4b3bcae9ec2be58410e78ec0b70adb495c88418bee408f9afe301bf2e1e820ef009b7bffe14ac4fe46f0c01bbb3cd6d02fa4bd97004e3",
+        "dest-filename": "d5fd9e0e11f330a4b3bcae9ec2be58410e78ec0b70adb495c88418bee408f9afe301bf2e1e820ef009b7bffe14ac4fe46f0c01bbb3cd6d02fa4bd97004e3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d6/11"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+        "sha512": "d877570cc77d18c8131ab3d69c9ccfd802d2a2413fd0ee4785352f5886c3dd8763304f09c2f4829cd1819d34e1286101f75399873ac9e2a208c64fd2066c830c",
+        "dest-filename": "570cc77d18c8131ab3d69c9ccfd802d2a2413fd0ee4785352f5886c3dd8763304f09c2f4829cd1819d34e1286101f75399873ac9e2a208c64fd2066c830c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d8/77"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+        "sha512": "ceeb39b31cea0490f7797c70be3375c909117a900d83113d960396daa2e79abf2290c4e98648e05eed47474d4ae05260f21d641040c0a8371942d6eb467078d4",
+        "dest-filename": "39b31cea0490f7797c70be3375c909117a900d83113d960396daa2e79abf2290c4e98648e05eed47474d4ae05260f21d641040c0a8371942d6eb467078d4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ce/eb"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+        "sha512": "d6b61d4e9cafd378b2705d7e061cebcd024274eb803ad6aa1d35896425af8a3283d8de57bb44ed542f3ffb57da5aa70ff6204258e9a39a1a07f78747f360713d",
+        "dest-filename": "1d4e9cafd378b2705d7e061cebcd024274eb803ad6aa1d35896425af8a3283d8de57bb44ed542f3ffb57da5aa70ff6204258e9a39a1a07f78747f360713d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d6/b6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+        "sha512": "5a88b6317cd78cc50b71c2303272dc8b2647e2708832959002cd38f4a11e32f39c3400d5c68d1404840f7d29b107709629e767820eec59974bbcb733a5ed2d2e",
+        "dest-filename": "b6317cd78cc50b71c2303272dc8b2647e2708832959002cd38f4a11e32f39c3400d5c68d1404840f7d29b107709629e767820eec59974bbcb733a5ed2d2e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5a/88"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+        "sha512": "1cb34dc3df71b2fc75da5141530a13f04542b12bd13435713698d9edb3e7f78edbf2024fcde1d6c8d56116c69eadcd27dd3b1b38836f44fd9bc936792ca7b3a3",
+        "dest-filename": "4dc3df71b2fc75da5141530a13f04542b12bd13435713698d9edb3e7f78edbf2024fcde1d6c8d56116c69eadcd27dd3b1b38836f44fd9bc936792ca7b3a3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1c/b3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+        "sha512": "ebe823985a5fcb40475394e9a6d92e87cfaec379a7aef82cf9d48f41740ebf77a46e8addc27cd35446f8aa722f41c617aba8339324e7a19f5d646f83e206ab2a",
+        "dest-filename": "23985a5fcb40475394e9a6d92e87cfaec379a7aef82cf9d48f41740ebf77a46e8addc27cd35446f8aa722f41c617aba8339324e7a19f5d646f83e206ab2a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/eb/e8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+        "sha512": "67480e4ddef956f5eacaaee7b25f77cf06a171344e82abee01c60352bfaf3aff2e1e13522913b253deb5920b420f57bde48a8f29240a1fbb414ec9674b7b40f0",
+        "dest-filename": "0e4ddef956f5eacaaee7b25f77cf06a171344e82abee01c60352bfaf3aff2e1e13522913b253deb5920b420f57bde48a8f29240a1fbb414ec9674b7b40f0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/67/48"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+        "sha512": "4965c517508bd9154d31a56cf81042970b5f652bc382d2fffc6fec9b001ce6854afd43eed86bbdb486918059981452ab9a0dd2c808d2ac495fd13889d6ff1f60",
+        "dest-filename": "c517508bd9154d31a56cf81042970b5f652bc382d2fffc6fec9b001ce6854afd43eed86bbdb486918059981452ab9a0dd2c808d2ac495fd13889d6ff1f60",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/49/65"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+        "sha512": "b5077fd5e7c9bb33c2eab085c04bcbb5c8bfc4d15c4d9927997b3df056037c6138c0ff4294557df27c8aaf324a54f3217439e3ccb85d532317e0fb1000f8f023",
+        "dest-filename": "7fd5e7c9bb33c2eab085c04bcbb5c8bfc4d15c4d9927997b3df056037c6138c0ff4294557df27c8aaf324a54f3217439e3ccb85d532317e0fb1000f8f023",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b5/07"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+        "sha512": "a61ad898d898a6947bce714476a81f5875d1e8d0a46442bb8705831d95238adff6fd4d2be97be40e5d12627a0ce751eaec584219d2c34facf1082398d617b1b1",
+        "dest-filename": "d898d898a6947bce714476a81f5875d1e8d0a46442bb8705831d95238adff6fd4d2be97be40e5d12627a0ce751eaec584219d2c34facf1082398d617b1b1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a6/1a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+        "sha512": "12b8924e5b79382f7fed25e445208085f4b1c684948019b7dce1fe224c1b769828aac4ac520ef2dee87e208088fd08380415abdd4da2dfd4699b271bc4cab87b",
+        "dest-filename": "924e5b79382f7fed25e445208085f4b1c684948019b7dce1fe224c1b769828aac4ac520ef2dee87e208088fd08380415abdd4da2dfd4699b271bc4cab87b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/12/b8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+        "sha512": "9c99762864e5adff468cb8a6808aeef95fe6ce048ad000420d046fc70e418d444bed67c7e6ea169a2cdb1fb401e8c9a730177c7080bdb9c7969deccbd556565b",
+        "dest-filename": "762864e5adff468cb8a6808aeef95fe6ce048ad000420d046fc70e418d444bed67c7e6ea169a2cdb1fb401e8c9a730177c7080bdb9c7969deccbd556565b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/99"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+        "sha512": "801af137cf203887f747b8dae4af6c97035ac9571980ae923943919b6b81cd378811f79568884ea42b53a31dcfe91ee8da32c5c0b1532e70bb914fd119c60483",
+        "dest-filename": "f137cf203887f747b8dae4af6c97035ac9571980ae923943919b6b81cd378811f79568884ea42b53a31dcfe91ee8da32c5c0b1532e70bb914fd119c60483",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/80/1a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+        "sha512": "c8bfec2eba66b43685122523d68b113f84c8d8c0f3d4075d24bfa367b292aaf06e962378c6a618e7821f74df2a0fc4e86ba8358a5a298757f140d9233b1aeba5",
+        "dest-filename": "ec2eba66b43685122523d68b113f84c8d8c0f3d4075d24bfa367b292aaf06e962378c6a618e7821f74df2a0fc4e86ba8358a5a298757f140d9233b1aeba5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/bf"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+        "sha512": "e08949c745f4a9fb55b0de44fbfbc6ba34d1205b70b8b6cdb1551eed33bacd83c34753ba9c5c2fc2120a10a4ab97a7597219980484dacf12a85183a376d8e546",
+        "dest-filename": "49c745f4a9fb55b0de44fbfbc6ba34d1205b70b8b6cdb1551eed33bacd83c34753ba9c5c2fc2120a10a4ab97a7597219980484dacf12a85183a376d8e546",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e0/89"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+        "sha512": "9c4ec3108721bed8854f0070e0b7dbbb9f4f1be902a1f863b0a6825b3c53a6de257d18d132a1bab8c073297b847325e1387a14a7dae2026eff69660685767d73",
+        "dest-filename": "c3108721bed8854f0070e0b7dbbb9f4f1be902a1f863b0a6825b3c53a6de257d18d132a1bab8c073297b847325e1387a14a7dae2026eff69660685767d73",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9c/4e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
+        "sha512": "56d00e6b299655f65c9996e9e84da6ca6a43207bf28d7b3fd762ea5988d5c3aaa3adf17e54af9fc86df7902873de79caf92539fcd7873aaad31074bcb173b738",
+        "dest-filename": "0e6b299655f65c9996e9e84da6ca6a43207bf28d7b3fd762ea5988d5c3aaa3adf17e54af9fc86df7902873de79caf92539fcd7873aaad31074bcb173b738",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/56/d0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+        "sha512": "e37feab6b0d4a24afb2c9aa8176737f91227bbfb78cdfae961da120df632860e76af02d5e939cebdd1b87d79bb224481df012b91c9894bd88486356d3921238c",
+        "dest-filename": "eab6b0d4a24afb2c9aa8176737f91227bbfb78cdfae961da120df632860e76af02d5e939cebdd1b87d79bb224481df012b91c9894bd88486356d3921238c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e3/7f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+        "sha512": "d488785935b2c34fa52b214c7011c66dbe54e45b6e1c9bae8e8cb2af9cd36964b911831e4fa25bd80b8379fb6c0ac12e7213be98cda28f9faaf5cae1c9dccb85",
+        "dest-filename": "785935b2c34fa52b214c7011c66dbe54e45b6e1c9bae8e8cb2af9cd36964b911831e4fa25bd80b8379fb6c0ac12e7213be98cda28f9faaf5cae1c9dccb85",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d4/88"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+        "sha512": "f60652008e57337ebcf343cf326ffff5d7e2127818a02e809b68b3112d45178d3a605b23bf204c99e2768384808eedf15b0b6eca735114bdacf61831a4b23949",
+        "dest-filename": "52008e57337ebcf343cf326ffff5d7e2127818a02e809b68b3112d45178d3a605b23bf204c99e2768384808eedf15b0b6eca735114bdacf61831a4b23949",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f6/06"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+        "sha512": "702e766c7c0cfe7fc2c52f3b147d3259d9e0119ae376d2d6fea56bba8ebcaa0fa9acaed943860676eb761b20d5a6819e0187bf87cf7dad578e566e8e8b8d24d8",
+        "dest-filename": "766c7c0cfe7fc2c52f3b147d3259d9e0119ae376d2d6fea56bba8ebcaa0fa9acaed943860676eb761b20d5a6819e0187bf87cf7dad578e566e8e8b8d24d8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/70/2e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+        "sha512": "46207fc8887bf29708c65ea52cc1b40a0057019d98d1e547a8c3d8ba0bbef54d00793e9805e889a5fee56dd24d22e8053f94888f0351828e03851d50c62dba1a",
+        "dest-filename": "7fc8887bf29708c65ea52cc1b40a0057019d98d1e547a8c3d8ba0bbef54d00793e9805e889a5fee56dd24d22e8053f94888f0351828e03851d50c62dba1a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/46/20"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+        "sha512": "5215cd9be08531671b0a15f2c05c249a1aa3b373d10a67126bf85f0602c86fba10e4735bd704b489c5ac1ad48050d81e7c7788f9e06b03c2357f199b1ec19dbc",
+        "dest-filename": "cd9be08531671b0a15f2c05c249a1aa3b373d10a67126bf85f0602c86fba10e4735bd704b489c5ac1ad48050d81e7c7788f9e06b03c2357f199b1ec19dbc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/52/15"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+        "sha512": "804d5e40d67747efa44f3154a5d1a5a66cbc903643fcc2f21ea0f0aa3915408d0931d2350f9d6ccb51fde7c3cd5d890cdab01a73b7b9fc29c8299ac7b4f87705",
+        "dest-filename": "5e40d67747efa44f3154a5d1a5a66cbc903643fcc2f21ea0f0aa3915408d0931d2350f9d6ccb51fde7c3cd5d890cdab01a73b7b9fc29c8299ac7b4f87705",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/80/4d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+        "sha512": "659d70d1aa10930b94b82ed87feeec75e68d7ea42288b71245b7c8d3ca00c6a2eda5742bf402155fb032ec72c3ba22d801a14fbbca0160dabf4088bd5111c9dd",
+        "dest-filename": "70d1aa10930b94b82ed87feeec75e68d7ea42288b71245b7c8d3ca00c6a2eda5742bf402155fb032ec72c3ba22d801a14fbbca0160dabf4088bd5111c9dd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/65/9d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+        "sha512": "6f1bde57857cbf961be277054d3deb3d281904ea429237cad32e28555549c08b8354144c0d7acfc9744bf7cf22e5aa7d9bd6e7c8412359f9b95a4066b5f7cb7c",
+        "dest-filename": "de57857cbf961be277054d3deb3d281904ea429237cad32e28555549c08b8354144c0d7acfc9744bf7cf22e5aa7d9bd6e7c8412359f9b95a4066b5f7cb7c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/1b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+        "sha512": "6d5d13828f4ae217cf09e93e68c027f35469a452afdb248341e328499baf4c04b2c0d4e7549080ac2644d855aaa6f21ab4abbb54c44b5a547511acef5610f285",
+        "dest-filename": "13828f4ae217cf09e93e68c027f35469a452afdb248341e328499baf4c04b2c0d4e7549080ac2644d855aaa6f21ab4abbb54c44b5a547511acef5610f285",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6d/5d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+        "sha512": "da492dffb9e227a32010fc45d1b61d43a7ad65a03e7d0bc370b29c921cb5c8840ecdaa0a8c10634a3eb7fda2d58d8137aa146de5dbccfae5327c283a50a0816c",
+        "dest-filename": "2dffb9e227a32010fc45d1b61d43a7ad65a03e7d0bc370b29c921cb5c8840ecdaa0a8c10634a3eb7fda2d58d8137aa146de5dbccfae5327c283a50a0816c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/da/49"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+        "sha512": "2c8f6effe95a606e03b354c3292256d983eb22571560ec22d9f502eb1078de5b9e0a383157895f7ce0990ad605887e9334e5feb50297c7ded3e082876e1c8711",
+        "dest-filename": "6effe95a606e03b354c3292256d983eb22571560ec22d9f502eb1078de5b9e0a383157895f7ce0990ad605887e9334e5feb50297c7ded3e082876e1c8711",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2c/8f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+        "sha512": "6d12128022233f6d3fb5b5923d63048b9e1054f45913192e0fd9492fe508c542adc15240f305b54eb6f58ccb354455e8d42053359ff98690bd42f98a59da292b",
+        "dest-filename": "128022233f6d3fb5b5923d63048b9e1054f45913192e0fd9492fe508c542adc15240f305b54eb6f58ccb354455e8d42053359ff98690bd42f98a59da292b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6d/12"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+        "sha512": "71843ddf5d20aeac6e7966e5f96b885086a251a0dc8fb58eab97d58449633558117ce52163d7f2db34ef7e8a96b2779b87c4a5ef45527056c80af2672ca0743a",
+        "dest-filename": "3ddf5d20aeac6e7966e5f96b885086a251a0dc8fb58eab97d58449633558117ce52163d7f2db34ef7e8a96b2779b87c4a5ef45527056c80af2672ca0743a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/71/84"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+        "sha512": "cf3351f9275048327373c8e869e3fc410a0242bf0db98c76748232b65d507811191c9f6e5ba85e6ecad881bcfc849c1441aa374d608cb667d5f0dbb5b7038b03",
+        "dest-filename": "51f9275048327373c8e869e3fc410a0242bf0db98c76748232b65d507811191c9f6e5ba85e6ecad881bcfc849c1441aa374d608cb667d5f0dbb5b7038b03",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/33"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz",
+        "sha512": "59bcc4f6c76642d2b2f2facd3daf41467c19879505e2cd4a4e648ad0a5152e8dde7dfe4195034d5839c53a8b8da4a7cf2839e6b3dc729c98ec3188cc693fda15",
+        "dest-filename": "c4f6c76642d2b2f2facd3daf41467c19879505e2cd4a4e648ad0a5152e8dde7dfe4195034d5839c53a8b8da4a7cf2839e6b3dc729c98ec3188cc693fda15",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/59/bc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz",
+        "sha512": "7579f715984fbf4512fbb76d26c222d91f9ceea5988917a8121e73527b5609fe284a930d89bf050e14a879dea6dd0c99771e612bb88b164624deb371c2df2f4c",
+        "dest-filename": "f715984fbf4512fbb76d26c222d91f9ceea5988917a8121e73527b5609fe284a930d89bf050e14a879dea6dd0c99771e612bb88b164624deb371c2df2f4c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/79"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+        "sha512": "beadb806adf29b91c4426d8d282af7c970f08dceef4ec1138510e7929d832bda75baa2d1f831eeae6fcd393a34286ec760753b7a9a4a663dcccaa62e3017fada",
+        "dest-filename": "b806adf29b91c4426d8d282af7c970f08dceef4ec1138510e7929d832bda75baa2d1f831eeae6fcd393a34286ec760753b7a9a4a663dcccaa62e3017fada",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/be/ad"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+        "sha512": "46484f3e9db3aea0c0400ff68cd867ced70f025bfae17761229edaef8e78039a2f23b06e93182decc5fbb9dc00bb7ce0d437293d4d2bcf7555d5279aaaf638f8",
+        "dest-filename": "4f3e9db3aea0c0400ff68cd867ced70f025bfae17761229edaef8e78039a2f23b06e93182decc5fbb9dc00bb7ce0d437293d4d2bcf7555d5279aaaf638f8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/46/48"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+        "sha512": "a0607e53196059c810920c28f067041b07a6a1316ddc520ef5a6da6c199a1b05c8a01299f864f2d293f5f396de1a0ecb96287f3521d25765c0b35967ce7a1c4a",
+        "dest-filename": "7e53196059c810920c28f067041b07a6a1316ddc520ef5a6da6c199a1b05c8a01299f864f2d293f5f396de1a0ecb96287f3521d25765c0b35967ce7a1c4a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/60"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
+        "sha512": "324282c319574e0cfa085a09c77a42c27d3b18aa77ebe699caefeed8b9f656b0390dc7720999004840c14ddf31e708534102f90a261fe29ad728b72041dbf6f6",
+        "dest-filename": "82c319574e0cfa085a09c77a42c27d3b18aa77ebe699caefeed8b9f656b0390dc7720999004840c14ddf31e708534102f90a261fe29ad728b72041dbf6f6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/32/42"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz",
+        "sha512": "25317df54ffa5c88c2068d30aa4539b0ad7482561edbb31146c7f0a22ab9cf338464b1d4dc0dca08c6b95ff6b37a4611089d0797023472b0174bfe5d1074f30e",
+        "dest-filename": "7df54ffa5c88c2068d30aa4539b0ad7482561edbb31146c7f0a22ab9cf338464b1d4dc0dca08c6b95ff6b37a4611089d0797023472b0174bfe5d1074f30e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/25/31"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz",
+        "sha512": "17e335b4b84efa695068e5aca44f16b2d83ecfa3f0c7045df2843c21771e5b3f7691f0266a54d17f4123ae8b907a8ed0b2c10f7c29f4e41e0886cd4af5643fef",
+        "dest-filename": "35b4b84efa695068e5aca44f16b2d83ecfa3f0c7045df2843c21771e5b3f7691f0266a54d17f4123ae8b907a8ed0b2c10f7c29f4e41e0886cd4af5643fef",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/17/e3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz",
+        "sha512": "161f6b18dd0ca08e191543727c554d538cbd2d4cfddeef7fd0afb22e00366f04688f133c254d43cafbcc05a6e764f060316444009bd4da38d5ceaf8bac552097",
+        "dest-filename": "6b18dd0ca08e191543727c554d538cbd2d4cfddeef7fd0afb22e00366f04688f133c254d43cafbcc05a6e764f060316444009bd4da38d5ceaf8bac552097",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/16/1f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz",
+        "sha512": "cf87aa26f7e236714c1c822f5cfdc2639ef2d9626ce60dafdd7d339bd984264ae436fe2b0f1bbeb20f4987c1245f27aa06407b48e71ba28f5d315aa1cab00222",
+        "dest-filename": "aa26f7e236714c1c822f5cfdc2639ef2d9626ce60dafdd7d339bd984264ae436fe2b0f1bbeb20f4987c1245f27aa06407b48e71ba28f5d315aa1cab00222",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/87"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz",
+        "sha512": "3bc9a8ac1116f87b151b6f2060364f4eb4fd514a2f414949b9ee583bcdfab624c986e216066ff340773b8f7f3cb075ad747ff1519bab2bda250f6fa972ac79c3",
+        "dest-filename": "a8ac1116f87b151b6f2060364f4eb4fd514a2f414949b9ee583bcdfab624c986e216066ff340773b8f7f3cb075ad747ff1519bab2bda250f6fa972ac79c3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3b/c9"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz",
+        "sha512": "8c28bf40a50cdabd49bb96b727ae131f60394a9280821d0ba649f2a9d4389ba0c2574c49d871b5c40451c0d18f41f8b548b74b599d4e273e85e0e30104d88624",
+        "dest-filename": "bf40a50cdabd49bb96b727ae131f60394a9280821d0ba649f2a9d4389ba0c2574c49d871b5c40451c0d18f41f8b548b74b599d4e273e85e0e30104d88624",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8c/28"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz",
+        "sha512": "89e20500274ca587cc123174ac47f928bbdf5722243b3e8f0c6c8d9cffaefb8c50ea39f2dd50a00383a05cec0dc766949319fccf1f5f89570cf027c562ff4bc7",
+        "dest-filename": "0500274ca587cc123174ac47f928bbdf5722243b3e8f0c6c8d9cffaefb8c50ea39f2dd50a00383a05cec0dc766949319fccf1f5f89570cf027c562ff4bc7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/89/e2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz",
+        "sha512": "4c2825551b7395f7d137144c132477e831812c9a5ebac15c80c543f4f644cc02a752cd65282817e6ef41982d9883e2cbf4c8190ee80516cd5597e269e2dfcf1b",
+        "dest-filename": "25551b7395f7d137144c132477e831812c9a5ebac15c80c543f4f644cc02a752cd65282817e6ef41982d9883e2cbf4c8190ee80516cd5597e269e2dfcf1b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4c/28"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz",
+        "sha512": "d54116457ea39ce036cb81f959ccd9e3880e3a34c49a5aafd6e356e0600910ee7e6dab82061bfcb2763ae48c39fd5392fe084a37d82bd8a8e72cac6bb2fa0c57",
+        "dest-filename": "16457ea39ce036cb81f959ccd9e3880e3a34c49a5aafd6e356e0600910ee7e6dab82061bfcb2763ae48c39fd5392fe084a37d82bd8a8e72cac6bb2fa0c57",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/41"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz",
+        "sha512": "36a729fade5c4c1f018a71646605e23099e2407d0fb14b76939d455216dd7de2af738002706dae427898ffcfa1d58bfa2b36b843b943ecf415d33d2889c13432",
+        "dest-filename": "29fade5c4c1f018a71646605e23099e2407d0fb14b76939d455216dd7de2af738002706dae427898ffcfa1d58bfa2b36b843b943ecf415d33d2889c13432",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/36/a7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+        "sha512": "d4f2c6404ca723fdce5ff7ed579e023a7fb74ae77f327f2f00b836ad69c12e745a1ad24376e356ff6d978e51a03dda5c21b890c632ad6fb0647233f4d27a9f27",
+        "dest-filename": "c6404ca723fdce5ff7ed579e023a7fb74ae77f327f2f00b836ad69c12e745a1ad24376e356ff6d978e51a03dda5c21b890c632ad6fb0647233f4d27a9f27",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d4/f2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
+        "sha512": "d2b160fd18f643ad8d0a6eb68d9c34417edadeccfa402414d0ba5974dac95fc6f2446686553a9bad6f630282001f2310aac369799f356204a2cceb79597ab43f",
+        "dest-filename": "60fd18f643ad8d0a6eb68d9c34417edadeccfa402414d0ba5974dac95fc6f2446686553a9bad6f630282001f2310aac369799f356204a2cceb79597ab43f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d2/b1"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz",
+        "sha512": "b763839645c14329fb8e497a4cd6b0fccb55115bc819e9490c21b8d4e92afcac14b090704385d566c1c055490ae2606fddec22012dcf1ae516b98d81a0ae1953",
+        "dest-filename": "839645c14329fb8e497a4cd6b0fccb55115bc819e9490c21b8d4e92afcac14b090704385d566c1c055490ae2606fddec22012dcf1ae516b98d81a0ae1953",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b7/63"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz",
+        "sha512": "9069067a0608750b0e6f85e3b1f33deeb5ec887681c1ca3e84523aea83b8b3d2d4f8f2c00b9a09ee485d395171921b2695ba54a8302f5f0d750a5b973fe8e41e",
+        "dest-filename": "067a0608750b0e6f85e3b1f33deeb5ec887681c1ca3e84523aea83b8b3d2d4f8f2c00b9a09ee485d395171921b2695ba54a8302f5f0d750a5b973fe8e41e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/90/69"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.8.tgz",
+        "sha512": "1665ecdfb23a8520550e53b8cbbeb84cdcf5acb80ac2324c434106b5ee85dc26f77f86c8b8707f88b6bff08f552a498ecbe80d1eaf2baa5de3ebce80095576d4",
+        "dest-filename": "ecdfb23a8520550e53b8cbbeb84cdcf5acb80ac2324c434106b5ee85dc26f77f86c8b8707f88b6bff08f552a498ecbe80d1eaf2baa5de3ebce80095576d4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/16/65"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+        "sha512": "ef61764fe3cb96986ba8b700a2d60fa74b8932be528cfe522f4d707c4b2925baeee59b39bd06921dbe1507764c24f8a68071c21c6ee030e78e07d1f71dd9adc6",
+        "dest-filename": "764fe3cb96986ba8b700a2d60fa74b8932be528cfe522f4d707c4b2925baeee59b39bd06921dbe1507764c24f8a68071c21c6ee030e78e07d1f71dd9adc6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/61"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz",
+        "sha512": "d0d250e0b14552e5a413b3b17f486d04a4baccb9248c11fe84cd6e93b360ef4e51791f26fee7a576ecb50c1a343f20573ca567040e9806553de0c0465eb4810b",
+        "dest-filename": "50e0b14552e5a413b3b17f486d04a4baccb9248c11fe84cd6e93b360ef4e51791f26fee7a576ecb50c1a343f20573ca567040e9806553de0c0465eb4810b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d0/d2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz",
+        "sha512": "6e9231bead3789fe943705d9f874caef524b87800fbe75e7b4373a5ce5fc515ab85d039597b970a24d00bc897e6fcce00b0ddf49a55364ca403cf6a05db2a61d",
+        "dest-filename": "31bead3789fe943705d9f874caef524b87800fbe75e7b4373a5ce5fc515ab85d039597b970a24d00bc897e6fcce00b0ddf49a55364ca403cf6a05db2a61d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6e/92"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz",
+        "sha512": "fe37c4c0d0dd41504236f8e41a2b7887aa4c3b3abc6c7928a6ae39f1d3edda5323c7e781414a2164d1bd03b0ed3bf3b9ba449bc6e68d1973231e2720c32eab41",
+        "dest-filename": "c4c0d0dd41504236f8e41a2b7887aa4c3b3abc6c7928a6ae39f1d3edda5323c7e781414a2164d1bd03b0ed3bf3b9ba449bc6e68d1973231e2720c32eab41",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fe/37"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz",
+        "sha512": "9bd813c11921cb696f08f7ba409a787771b54d81141e7fc5cc952dabd3231f8e9a9f5c0953e19da060b954ba1ff115fc16dfc3969b21029921b300cb6731c871",
+        "dest-filename": "13c11921cb696f08f7ba409a787771b54d81141e7fc5cc952dabd3231f8e9a9f5c0953e19da060b954ba1ff115fc16dfc3969b21029921b300cb6731c871",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9b/d8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz",
+        "sha512": "f6141ce3e18d56d2402043c4aa562a5b946261daebf1e6b95d0d193a70fa7e0aeefbcde4a93d799aad8e09c6def0a9e3459979bc5de4b3af402b3de48758eb86",
+        "dest-filename": "1ce3e18d56d2402043c4aa562a5b946261daebf1e6b95d0d193a70fa7e0aeefbcde4a93d799aad8e09c6def0a9e3459979bc5de4b3af402b3de48758eb86",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f6/14"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.8.tgz",
+        "sha512": "fa02121dc48f509ee4b41cbd4674ea6dd296efc6dc1a47b7b7ab5a6b0c99ef5a62a3525ec30192262cf272ceeb2e1193bcc2580900750c12b8290b31b3b53c74",
+        "dest-filename": "121dc48f509ee4b41cbd4674ea6dd296efc6dc1a47b7b7ab5a6b0c99ef5a62a3525ec30192262cf272ceeb2e1193bcc2580900750c12b8290b31b3b53c74",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fa/02"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz",
+        "sha512": "ec0e92f634a09bf4beecc76d34349bf8853ce7dbd0a89fd002d71841c7c50ba5bc452e08c4864395d2d1d31a82159e830b2ad02e32cfb31b5335c8798d503894",
+        "dest-filename": "92f634a09bf4beecc76d34349bf8853ce7dbd0a89fd002d71841c7c50ba5bc452e08c4864395d2d1d31a82159e830b2ad02e32cfb31b5335c8798d503894",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ec/0e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz",
+        "sha512": "b405c86b5837b0ce421a9553d2e21b531fd4dc6b3937c4f9d88202b82b4e6daa2cd52f1fcecacf5c6e5639b9103774ba35597ac0a80f8402220466d69ef73dec",
+        "dest-filename": "c86b5837b0ce421a9553d2e21b531fd4dc6b3937c4f9d88202b82b4e6daa2cd52f1fcecacf5c6e5639b9103774ba35597ac0a80f8402220466d69ef73dec",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b4/05"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+        "sha512": "69e3661e70716e2d92b746aee950550bb25716584b94e9ef20895e3cd9e2c943400a5ce6b4050463cfe90622b78878ee7ce97003e736d3ff239e0a3bc5cae0f0",
+        "dest-filename": "661e70716e2d92b746aee950550bb25716584b94e9ef20895e3cd9e2c943400a5ce6b4050463cfe90622b78878ee7ce97003e736d3ff239e0a3bc5cae0f0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/69/e3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz",
+        "sha512": "265f9b0aff07c4a9e54cb56b70313ccd3309d3d47dfee930e2a06cfe864294e7e8424fdc3936c39fe35c7977d5ee3d3d60f55052bc893c7bab69f71283a11528",
+        "dest-filename": "9b0aff07c4a9e54cb56b70313ccd3309d3d47dfee930e2a06cfe864294e7e8424fdc3936c39fe35c7977d5ee3d3d60f55052bc893c7bab69f71283a11528",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/26/5f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz",
+        "sha512": "ef175c6ad83bfd4fbbf94772a23db3a1db48f47fc8228a6aa3e60e21c64eab59c9c1758167da7cc62bb99655e57a40db66471aefd6bf7e8cc46105c8038b16e8",
+        "dest-filename": "5c6ad83bfd4fbbf94772a23db3a1db48f47fc8228a6aa3e60e21c64eab59c9c1758167da7cc62bb99655e57a40db66471aefd6bf7e8cc46105c8038b16e8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/17"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz",
+        "sha512": "b58eec56dd722fda33231be66ed379aad987da4ad770109f8c488280a18baae9c91ef82f646d8f725da843791b7190116f50461077642f371818ef329d59627a",
+        "dest-filename": "ec56dd722fda33231be66ed379aad987da4ad770109f8c488280a18baae9c91ef82f646d8f725da843791b7190116f50461077642f371818ef329d59627a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b5/8e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
+        "sha512": "16404cc03faa6c641e32ed5c3879ee181eb1e32ccf8e1a3c6a9e56b5b109dbaba6860a955db85e90a5103be85910bd6f53dd9adf01f0769d0701ca80505e620e",
+        "dest-filename": "4cc03faa6c641e32ed5c3879ee181eb1e32ccf8e1a3c6a9e56b5b109dbaba6860a955db85e90a5103be85910bd6f53dd9adf01f0769d0701ca80505e620e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/16/40"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz",
+        "sha512": "0636ac5238b13c5752f8d2a4ca9732c8de4f9a0f373a5b2dd3e73abc6a2fd1d8b04c4a3a9a076a551ea1c5c12016e87842b02ced173ef4ab8627d4d50a3d19ce",
+        "dest-filename": "ac5238b13c5752f8d2a4ca9732c8de4f9a0f373a5b2dd3e73abc6a2fd1d8b04c4a3a9a076a551ea1c5c12016e87842b02ced173ef4ab8627d4d50a3d19ce",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/06/36"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz",
+        "sha512": "429f166d93817be6e5829b944fe970db185e2cff2ad286ad73d5299a27a61080b11af14b6261e6f50a30559187b499466d2e80eb227789589a77fd9c5639ce88",
+        "dest-filename": "166d93817be6e5829b944fe970db185e2cff2ad286ad73d5299a27a61080b11af14b6261e6f50a30559187b499466d2e80eb227789589a77fd9c5639ce88",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/42/9f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz",
+        "sha512": "225d3e6e813bc3f5de6d41f2063ae813e0db072391191f4a2a6213cdb47b3324386a4a4e4583ff6666e102bd031bb466981aa83a765dcb6425bda8c9d90039f6",
+        "dest-filename": "3e6e813bc3f5de6d41f2063ae813e0db072391191f4a2a6213cdb47b3324386a4a4e4583ff6666e102bd031bb466981aa83a765dcb6425bda8c9d90039f6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/22/5d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz",
+        "sha512": "45b2514b85164059331d34f057298c4d4bfc12a6213a9f1d38ebe22e3dae82d4e25d1691412ec62c6c594cb2f58d684c7a84827f9ce671992a4e5f488987d771",
+        "dest-filename": "514b85164059331d34f057298c4d4bfc12a6213a9f1d38ebe22e3dae82d4e25d1691412ec62c6c594cb2f58d684c7a84827f9ce671992a4e5f488987d771",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/b2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz",
+        "sha512": "41362e0deb12d15b6e1cd36f321f828e5289e0b26272408c500aa3944dfe8fcc3e465469c325f76a91102861736d919da3b5cd1b5b576be6d0a8813b1c85d3db",
+        "dest-filename": "2e0deb12d15b6e1cd36f321f828e5289e0b26272408c500aa3944dfe8fcc3e465469c325f76a91102861736d919da3b5cd1b5b576be6d0a8813b1c85d3db",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/41/36"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz",
+        "sha512": "7b0ad74434c0a805e5925eadfdf91758d021157f48f8290a970eb38c4c24f3a4523cac19af7c69051b28eb9e5aa9869fc2d9dba472e3eada05ce677ac5d569b5",
+        "dest-filename": "d74434c0a805e5925eadfdf91758d021157f48f8290a970eb38c4c24f3a4523cac19af7c69051b28eb9e5aa9869fc2d9dba472e3eada05ce677ac5d569b5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7b/0a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+        "sha512": "a7326ad76b4469a221aa36f3a42baffceca9258fc13dabcea1f9be75b69bf8c1cb6a3cb6efbfb594b9ba245706805e5eb2427a9aab868ab857636183ffcbbc52",
+        "dest-filename": "6ad76b4469a221aa36f3a42baffceca9258fc13dabcea1f9be75b69bf8c1cb6a3cb6efbfb594b9ba245706805e5eb2427a9aab868ab857636183ffcbbc52",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a7/32"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz",
+        "sha512": "1cfc29188ce4976f265b266a1b9da38aa0c9d76c1a3f5d4f6b5946a22c9490812e30b04fd2878afc2f3d7ac6d7af1b24cb9c1eedd7ddf14e7c9e6d128005a957",
+        "dest-filename": "29188ce4976f265b266a1b9da38aa0c9d76c1a3f5d4f6b5946a22c9490812e30b04fd2878afc2f3d7ac6d7af1b24cb9c1eedd7ddf14e7c9e6d128005a957",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1c/fc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+        "sha512": "f9dd05e0c28c09b795509c06f7ab90e12800ce764d4aaf7723757ef4d1c0e0ea6fa86f26442a4674a98af25fdd974da1d820831f05b616a8a59d3c837009ea8c",
+        "dest-filename": "05e0c28c09b795509c06f7ab90e12800ce764d4aaf7723757ef4d1c0e0ea6fa86f26442a4674a98af25fdd974da1d820831f05b616a8a59d3c837009ea8c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f9/dd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+        "sha512": "767969ebd79f3cf83a51ac36755ab35917c05919d855bd5727c0b2ca121b65e6aae02039fe62de675204b7d42a43199b76f6a08cb226d992fc0715efe651f863",
+        "dest-filename": "69ebd79f3cf83a51ac36755ab35917c05919d855bd5727c0b2ca121b65e6aae02039fe62de675204b7d42a43199b76f6a08cb226d992fc0715efe651f863",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/76/79"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+        "sha512": "3aa653c034437211911c79bf8702ce2fbb953c1f5a52f2346a6fde42e58c3721477f93d21109b211e61885e03410f3ca50efe5d2e8a00a9fa26938e82e35681e",
+        "dest-filename": "53c034437211911c79bf8702ce2fbb953c1f5a52f2346a6fde42e58c3721477f93d21109b211e61885e03410f3ca50efe5d2e8a00a9fa26938e82e35681e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3a/a6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+        "sha512": "530444ec21a9bd2544412f2050c05ed6e0035a33675603f722eb3275ad67491c0d0c2b118e719cef0e8497a58b42c5e66536cb671f5c79c7a0ba6722b4d7e998",
+        "dest-filename": "44ec21a9bd2544412f2050c05ed6e0035a33675603f722eb3275ad67491c0d0c2b118e719cef0e8497a58b42c5e66536cb671f5c79c7a0ba6722b4d7e998",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/53/04"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+        "sha512": "82312d51128b082e555e6d48fb68b5bbd3a1c45b0a01024a4d507c5af0c01c5fa8665ab41935453a54e53b5ab702509313f0c5df6735e844af7e0a91ef7e37fe",
+        "dest-filename": "2d51128b082e555e6d48fb68b5bbd3a1c45b0a01024a4d507c5af0c01c5fa8665ab41935453a54e53b5ab702509313f0c5df6735e844af7e0a91ef7e37fe",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/82/31"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+        "sha512": "05c97a0980de02013bd1ca9968ca233a2fde2bade1e4c7bded9a8042887bed53e3332b00ff8391401446a37ad1cb8e71e0ccd5954f6e671b3c530cbb65a2a707",
+        "dest-filename": "7a0980de02013bd1ca9968ca233a2fde2bade1e4c7bded9a8042887bed53e3332b00ff8391401446a37ad1cb8e71e0ccd5954f6e671b3c530cbb65a2a707",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/c9"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+        "sha512": "2d4f933dd6b7980136401d3f1e9e55c9e2898afa42ebeb6539777554ca1757f60532f93f30d9398977817c1e0c406456c8e615274d7adb9be392bd00cfdf0e25",
+        "dest-filename": "933dd6b7980136401d3f1e9e55c9e2898afa42ebeb6539777554ca1757f60532f93f30d9398977817c1e0c406456c8e615274d7adb9be392bd00cfdf0e25",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2d/4f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+        "sha512": "d90c50accf8a43b0c05b8a36da3f9767a44a7718cb0fb04e5933f406fd2d9a37728574acaf6525d6824342a87d65fe6a3b04ee4dcec493cde638568a9e874f8e",
+        "dest-filename": "50accf8a43b0c05b8a36da3f9767a44a7718cb0fb04e5933f406fd2d9a37728574acaf6525d6824342a87d65fe6a3b04ee4dcec493cde638568a9e874f8e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d9/0c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+        "sha512": "4dbce212ed8356c4c438f89fda629690c78330ba188f1f79a0449af5f91040aeebfceaed6b482791c0e9cf0b9f11c00ed812c1b03ee66645c616a11d3114707f",
+        "dest-filename": "e212ed8356c4c438f89fda629690c78330ba188f1f79a0449af5f91040aeebfceaed6b482791c0e9cf0b9f11c00ed812c1b03ee66645c616a11d3114707f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4d/bc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+        "sha512": "6cefeb54388352e33661fb82530675b7570ffbfcaa8eacfe5dfd95b64769a5e7ee3854b63927807e069f687364167d2dd36844c979e0664c6d1aa5dc5f03bc46",
+        "dest-filename": "eb54388352e33661fb82530675b7570ffbfcaa8eacfe5dfd95b64769a5e7ee3854b63927807e069f687364167d2dd36844c979e0664c6d1aa5dc5f03bc46",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6c/ef"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+        "sha512": "86bdbaa7b7bddd197465af89c16ec4027c00bca91e861d76054d4b966f5892289b838b88af6adba711bd5827f9e86baf89d9531bd2a28904ff4d74f5c805b14c",
+        "dest-filename": "baa7b7bddd197465af89c16ec4027c00bca91e861d76054d4b966f5892289b838b88af6adba711bd5827f9e86baf89d9531bd2a28904ff4d74f5c805b14c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/bd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+        "sha512": "a4e8c1fee488c83b7ea30de4fd170bbd400e1a9cac4f6a610e7ed34d40779fbe52948819ccce8d280aa512b3e1a0553e9e9818dff9fed876084156c5ef43fdfc",
+        "dest-filename": "c1fee488c83b7ea30de4fd170bbd400e1a9cac4f6a610e7ed34d40779fbe52948819ccce8d280aa512b3e1a0553e9e9818dff9fed876084156c5ef43fdfc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a4/e8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+        "sha512": "dbfc3eabc8ecceff56c3573eeae253dcec2a85d9863f6ff84f5edcbbc5aec3252eb9a0830c9da88ddc98c19cc2c71d0672c6418738b71e61fe279a593579ddf9",
+        "dest-filename": "3eabc8ecceff56c3573eeae253dcec2a85d9863f6ff84f5edcbbc5aec3252eb9a0830c9da88ddc98c19cc2c71d0672c6418738b71e61fe279a593579ddf9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/db/fc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+        "sha512": "d75f9a2f9bca85e620733c6d3d555185da6d00cd87edf7034791b0e3f6d372d7ae641947e283fd7f9b3dcd83bd68666fa06781a6a5c8ffd4d9662859eb4f702b",
+        "dest-filename": "9a2f9bca85e620733c6d3d555185da6d00cd87edf7034791b0e3f6d372d7ae641947e283fd7f9b3dcd83bd68666fa06781a6a5c8ffd4d9662859eb4f702b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d7/5f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+        "sha512": "8b5e9fa240062b8e88559b95f0b208c0c76daa18a7f617d890287ca5ff220b7414dcba702fed4548519e8fe3bb97713f0289272fa0dc961da84dd9d13294f315",
+        "dest-filename": "9fa240062b8e88559b95f0b208c0c76daa18a7f617d890287ca5ff220b7414dcba702fed4548519e8fe3bb97713f0289272fa0dc961da84dd9d13294f315",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8b/5e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+        "sha512": "e3d164292e91190a2b88348affa1361a402c02e5399044c50a1ee91b8c83ff2963f6b2a14e63b77a5b27981bd10f83e024f76ce56d8f9210bcd9a570994709ec",
+        "dest-filename": "64292e91190a2b88348affa1361a402c02e5399044c50a1ee91b8c83ff2963f6b2a14e63b77a5b27981bd10f83e024f76ce56d8f9210bcd9a570994709ec",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e3/d1"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+        "sha512": "9a360d9073df1a9511d340ee335659220b3ae07a5fe1b59ccfd678d7ee10fa9803c7bdd4c167406327fa106fe544595d99d1c7ce0ad8ca07b96a41545b40f799",
+        "dest-filename": "0d9073df1a9511d340ee335659220b3ae07a5fe1b59ccfd678d7ee10fa9803c7bdd4c167406327fa106fe544595d99d1c7ce0ad8ca07b96a41545b40f799",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9a/36"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+        "sha512": "00bcaf273f7ae41424f04f4097f24328a0cb1f691f2852d318c9609006db62d66e26df4b53c0d6dd9a03302b50a57025b59c700477af5f3e6efa07f4c80d18a0",
+        "dest-filename": "af273f7ae41424f04f4097f24328a0cb1f691f2852d318c9609006db62d66e26df4b53c0d6dd9a03302b50a57025b59c700477af5f3e6efa07f4c80d18a0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/00/bc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+        "sha512": "5108eb908756aca23adba0eef25090e8c269ffa5752c0a366ce2bd393bb89929fc1865c890f5e4fd5b29e1b2c709df59f48cf639311aa24504f7457078980861",
+        "dest-filename": "eb908756aca23adba0eef25090e8c269ffa5752c0a366ce2bd393bb89929fc1865c890f5e4fd5b29e1b2c709df59f48cf639311aa24504f7457078980861",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/51/08"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+        "sha512": "6d3b111a3e95952767fd70f8086cb3327cda06cf5bb11c72efd793a93081b00f13308124cbbaa0e3c68f92f26f15ed47cb3439a0c65d83b02756559048a2d39f",
+        "dest-filename": "111a3e95952767fd70f8086cb3327cda06cf5bb11c72efd793a93081b00f13308124cbbaa0e3c68f92f26f15ed47cb3439a0c65d83b02756559048a2d39f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6d/3b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+        "sha512": "e9de19df9df8c62b5a03515c3163fb9903eae731b006619b869861d83c1a03568d21752edca4ce7f0ad6a5bc08e3f1abd2e00da3b353b5aca41723b684fb852e",
+        "dest-filename": "19df9df8c62b5a03515c3163fb9903eae731b006619b869861d83c1a03568d21752edca4ce7f0ad6a5bc08e3f1abd2e00da3b353b5aca41723b684fb852e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e9/de"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+        "sha512": "35eb4083988edae37b781f33139aab6770928a5fbb209b7858314b702ef9626cb0ab5559543eaa27a12f34b8d9deb126ea007b5d6e49753eb473a30ddf967ce5",
+        "dest-filename": "4083988edae37b781f33139aab6770928a5fbb209b7858314b702ef9626cb0ab5559543eaa27a12f34b8d9deb126ea007b5d6e49753eb473a30ddf967ce5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/35/eb"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+        "sha512": "3426213a8b6981667991dc4266cbfa22e771d305fcf7cd10fe85b8a4d14d8a1a412ac0db100d73a647f12460b4cae82c52ec8367b80bdfb75bcf0851d1523ba5",
+        "dest-filename": "213a8b6981667991dc4266cbfa22e771d305fcf7cd10fe85b8a4d14d8a1a412ac0db100d73a647f12460b4cae82c52ec8367b80bdfb75bcf0851d1523ba5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/34/26"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+        "sha512": "457b1a3aa5f17e85014283a0be69a28d5c499d6d88181d1ea0c3bb17c1408da8f4513cb050efe5b92aa29960499f4e1636052478d861edfb3ba444976a35a692",
+        "dest-filename": "1a3aa5f17e85014283a0be69a28d5c499d6d88181d1ea0c3bb17c1408da8f4513cb050efe5b92aa29960499f4e1636052478d861edfb3ba444976a35a692",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/7b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+        "sha512": "a9d0331142c3fbf87339b79db6657a881a5d2f94c86ca573b4688aecedff29849ff87233536e7bf8c5f511725cc888836cc02a99bc1ab9f7183efc91af2799b4",
+        "dest-filename": "331142c3fbf87339b79db6657a881a5d2f94c86ca573b4688aecedff29849ff87233536e7bf8c5f511725cc888836cc02a99bc1ab9f7183efc91af2799b4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a9/d0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+        "sha512": "35dfd2806dbb5a803d7befd374aef82a71f3f39d932daf78a2f398c92a3fc8c3ee4e6a5c90afe3205da34b04b783b10b48a5cad77fdc55d9a0d59fc368258ac4",
+        "dest-filename": "d2806dbb5a803d7befd374aef82a71f3f39d932daf78a2f398c92a3fc8c3ee4e6a5c90afe3205da34b04b783b10b48a5cad77fdc55d9a0d59fc368258ac4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/35/df"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+        "sha512": "68826fcf9392921348859229622bebc6b3d3298b235bd533cbeb0ffe6c744b7b1ebf61f2bcf6fbc668db62fa24cc4a5f8181f2fc78f3276cc50044ee51f802a6",
+        "dest-filename": "6fcf9392921348859229622bebc6b3d3298b235bd533cbeb0ffe6c744b7b1ebf61f2bcf6fbc668db62fa24cc4a5f8181f2fc78f3276cc50044ee51f802a6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/68/82"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+        "sha512": "24b00da86cbf0fa9385239a1f13af6e651a29ae397362695c976820194b45bed77f74b000dd1a7c9475258d21f778f6079bb48c463228f8224b51573addaf5d9",
+        "dest-filename": "0da86cbf0fa9385239a1f13af6e651a29ae397362695c976820194b45bed77f74b000dd1a7c9475258d21f778f6079bb48c463228f8224b51573addaf5d9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/24/b0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+        "sha512": "aa8429ad9bf3e70405270303a9eb1e4575afdeba8cbe18296d715f5725a16f1f57e3b3ce200ea2ffe75779f12664aa0080e69375a22035232a30853ad72472cc",
+        "dest-filename": "29ad9bf3e70405270303a9eb1e4575afdeba8cbe18296d715f5725a16f1f57e3b3ce200ea2ffe75779f12664aa0080e69375a22035232a30853ad72472cc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/84"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+        "sha512": "b9f15dd978bdd8e0153d8b32f8fe27eff53b7baf1f7b1d3e11ef20486f4a5fb7a8d3ce025a2438b1dc64b6f765d1b38fba95ed5493d8d7dce4e84c16a9443c96",
+        "dest-filename": "5dd978bdd8e0153d8b32f8fe27eff53b7baf1f7b1d3e11ef20486f4a5fb7a8d3ce025a2438b1dc64b6f765d1b38fba95ed5493d8d7dce4e84c16a9443c96",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b9/f1"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+        "sha512": "87f354692c86e44cb1048a7c611c68e1131edbfa9082fca8c11c1533385884108e35b5bc3d4b20e2590532b86066151ee73dcbdcc88b0eebf227f09a3dad80f0",
+        "dest-filename": "54692c86e44cb1048a7c611c68e1131edbfa9082fca8c11c1533385884108e35b5bc3d4b20e2590532b86066151ee73dcbdcc88b0eebf227f09a3dad80f0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/87/f3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+        "sha512": "f0fbdc5dfef48130d9060b7da6dc49f1e9417818dc2ce01c3ada0efe63c98ed8e2d7e09d19b1e09bbee89b51abb0fc6c884fae5c8a4d48aeb8518688c105dde1",
+        "dest-filename": "dc5dfef48130d9060b7da6dc49f1e9417818dc2ce01c3ada0efe63c98ed8e2d7e09d19b1e09bbee89b51abb0fc6c884fae5c8a4d48aeb8518688c105dde1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f0/fb"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+        "sha512": "7561f31dad96a845c8fced44f4e8eba1c313289976992ac4a258752289abbfa53e26e3706875ec5f1f5b2eee601bb05458520dd2c90840943f2f5ac87b1e17eb",
+        "dest-filename": "f31dad96a845c8fced44f4e8eba1c313289976992ac4a258752289abbfa53e26e3706875ec5f1f5b2eee601bb05458520dd2c90840943f2f5ac87b1e17eb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/61"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+        "sha512": "e7e7cff0ff0c14d0be0326420f1ac1da991914f1b3a90594ce949ebae54bbe6f1531ca2b3586af06aa057312bc6d0cf842c6e7e2850411e9b8c032df732b061c",
+        "dest-filename": "cff0ff0c14d0be0326420f1ac1da991914f1b3a90594ce949ebae54bbe6f1531ca2b3586af06aa057312bc6d0cf842c6e7e2850411e9b8c032df732b061c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/e7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+        "sha512": "faa21844a74d609c18def44264c7496cf2c902d1a3401b9dcd9cddcf04189043d077e3c91a2c542f941fbc22c36942e82eff91853dcb0e4c047ca6809204a635",
+        "dest-filename": "1844a74d609c18def44264c7496cf2c902d1a3401b9dcd9cddcf04189043d077e3c91a2c542f941fbc22c36942e82eff91853dcb0e4c047ca6809204a635",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fa/a2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+        "sha512": "17a6c4c9a995f632860050449a54277ac44f18e42a4b6f94c22d049b5e717a73b11da7f686fe8bf180959f7acf74f24e8897cf8829cb211cafc156aa318dcc23",
+        "dest-filename": "c4c9a995f632860050449a54277ac44f18e42a4b6f94c22d049b5e717a73b11da7f686fe8bf180959f7acf74f24e8897cf8829cb211cafc156aa318dcc23",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/17/a6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+        "sha512": "3047b751ea043585455f3a17116b2f72983a66f96b14d94e43b10eb2f848dc27c05f0ccf7cef10c2ec5de349dea6c60aab2c954274dd11fbfaf2af75c8b70aad",
+        "dest-filename": "b751ea043585455f3a17116b2f72983a66f96b14d94e43b10eb2f848dc27c05f0ccf7cef10c2ec5de349dea6c60aab2c954274dd11fbfaf2af75c8b70aad",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/30/47"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
+        "sha512": "cfd557a42ecc5ab85f5a2a62b6335d8026aea0c2d174820b42c00457e65eb08cc1abfa149719349b702966e3050977674b853b2ab23e977591504190f0ad502b",
+        "dest-filename": "57a42ecc5ab85f5a2a62b6335d8026aea0c2d174820b42c00457e65eb08cc1abfa149719349b702966e3050977674b853b2ab23e977591504190f0ad502b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/d5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz",
+        "sha512": "911cf4544909a962dfd4b2d5378a53d5c83567dc00baf23a2fded5de6d9fe41efa4e0f1de35ddd76f2c13d31070192659e7e174afbb416466d562090195cab5d",
+        "dest-filename": "f4544909a962dfd4b2d5378a53d5c83567dc00baf23a2fded5de6d9fe41efa4e0f1de35ddd76f2c13d31070192659e7e174afbb416466d562090195cab5d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/91/1c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz",
+        "sha512": "73600abc34fc4e8c4b20e525379d604e21d77e5b1f2058ac4b8a4eee90cfa0aa2e242112921667132eb6de0c0ff65682cb99672c3030d6f033bb6bccd982ceac",
+        "dest-filename": "0abc34fc4e8c4b20e525379d604e21d77e5b1f2058ac4b8a4eee90cfa0aa2e242112921667132eb6de0c0ff65682cb99672c3030d6f033bb6bccd982ceac",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/73/60"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+        "sha512": "4e1545e83095840f24506cbe69acc543891743b1354f2ec0df2a4539ed0870957c3bf339d751bdf405b6e22acaad6e7a5ade38c86f7e8a3f056aaa011a4b815e",
+        "dest-filename": "45e83095840f24506cbe69acc543891743b1354f2ec0df2a4539ed0870957c3bf339d751bdf405b6e22acaad6e7a5ade38c86f7e8a3f056aaa011a4b815e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/15"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
+        "sha512": "8ff6f09a406f1d4b4f371cee59ee73e81124deae78611c869415e44ac99fa2287bccdac1be5e40f40f7c6a7969ffb25bc99716209f0a5e8ff74eafc38c52edb9",
+        "dest-filename": "f09a406f1d4b4f371cee59ee73e81124deae78611c869415e44ac99fa2287bccdac1be5e40f40f7c6a7969ffb25bc99716209f0a5e8ff74eafc38c52edb9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/f6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
+        "sha512": "a65477a69e83f924949f51ccef1bd2931d76fc38681c89c8d98177e4a01c545359be50b482dad6ab1ed0ab5a07d92b208b4be51510936cff8365cec1f7e4edb1",
+        "dest-filename": "77a69e83f924949f51ccef1bd2931d76fc38681c89c8d98177e4a01c545359be50b482dad6ab1ed0ab5a07d92b208b4be51510936cff8365cec1f7e4edb1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a6/54"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
+        "sha512": "fb686abc491ec9fff4141a2bebb76e1742e5eceb7c8f22b30d0392af16b317f75a9e296546ad83c11f5d2e9b6c5e9a1942ac44d548ac4a6a197b0ae53dab3d57",
+        "dest-filename": "6abc491ec9fff4141a2bebb76e1742e5eceb7c8f22b30d0392af16b317f75a9e296546ad83c11f5d2e9b6c5e9a1942ac44d548ac4a6a197b0ae53dab3d57",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/68"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
+        "sha512": "2737f212912d394f3d09c152c32352de6bb830bbcb497aa7997d39f9a2810ccf93751e63cdc18e101c31c06371ac443ba7fcfa90ad96ca2a021817f6cd9067be",
+        "dest-filename": "f212912d394f3d09c152c32352de6bb830bbcb497aa7997d39f9a2810ccf93751e63cdc18e101c31c06371ac443ba7fcfa90ad96ca2a021817f6cd9067be",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/27/37"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
+        "sha512": "04a2b86a537ba22e02ff3bf856a1d0fae454fa54dae8918867bb358eec3b6f7447a3d39f281f9b297deed225597ad76c5020419126dd59b6ab25b98dd1f4de4b",
+        "dest-filename": "b86a537ba22e02ff3bf856a1d0fae454fa54dae8918867bb358eec3b6f7447a3d39f281f9b297deed225597ad76c5020419126dd59b6ab25b98dd1f4de4b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/a2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
+        "sha512": "9e1a9a8f59e64dd55597f04fe6899735118edfc8e7e62a2c8acdaf6dd9aea45dadc427fcca5593f25c7e265bcc61856acc654ab63a23505a10dc94562be99fcd",
+        "dest-filename": "9a8f59e64dd55597f04fe6899735118edfc8e7e62a2c8acdaf6dd9aea45dadc427fcca5593f25c7e265bcc61856acc654ab63a23505a10dc94562be99fcd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9e/1a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
+        "sha512": "7bcd8654e13c3ecdc4fbe120bdbe98dc3c344b5d2ef0d910f4a5e6b5184258927c90384e253bed3005a714bd7a901d79f378280965ecaf436278a09932cdbfd1",
+        "dest-filename": "8654e13c3ecdc4fbe120bdbe98dc3c344b5d2ef0d910f4a5e6b5184258927c90384e253bed3005a714bd7a901d79f378280965ecaf436278a09932cdbfd1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7b/cd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
+        "sha512": "a345cf18dc1c5b0f852304ad3969fe07006e1262fa4173f4aecbc0160ec44f575ecb536be966f569cf29e4712c2b4ca03bfea6531964f985900fdc5c6ff9e75e",
+        "dest-filename": "cf18dc1c5b0f852304ad3969fe07006e1262fa4173f4aecbc0160ec44f575ecb536be966f569cf29e4712c2b4ca03bfea6531964f985900fdc5c6ff9e75e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a3/45"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
+        "sha512": "26ec371229e45ea8da7dfc73eaba28c2f57b1994ff9044f9bd228a653eaea65e535dd5a42e462634f5f00c32f6564b760cf9f49ce0c84b87a00bfd001b12a8fd",
+        "dest-filename": "371229e45ea8da7dfc73eaba28c2f57b1994ff9044f9bd228a653eaea65e535dd5a42e462634f5f00c32f6564b760cf9f49ce0c84b87a00bfd001b12a8fd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/26/ec"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
+        "sha512": "3708cb5271b2f3f65fc76ddf979d2d442f2b61a627339db1351605017be68a297dca1d7e2ba691550327cd6ea0401ff50cb816b7defb958427ec2fb0b605d988",
+        "dest-filename": "cb5271b2f3f65fc76ddf979d2d442f2b61a627339db1351605017be68a297dca1d7e2ba691550327cd6ea0401ff50cb816b7defb958427ec2fb0b605d988",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/37/08"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+        "sha512": "814bbd8707d6bef1030419a0b40a30402a23c19989e6670b9f76ae7de0ac8ad8a3b37f9fd8db2b3ed94058847a38f8aa96397de8654251b2ded07caa22955aa0",
+        "dest-filename": "bd8707d6bef1030419a0b40a30402a23c19989e6670b9f76ae7de0ac8ad8a3b37f9fd8db2b3ed94058847a38f8aa96397de8654251b2ded07caa22955aa0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/81/4b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+        "sha512": "50908891305e9c778a4f54d394a3095b2d656997b0b11233622821c98889299adeaad7714a8b3f4b5b7e92d44c416bb608aa9a6abae47accc9c757200b9b4667",
+        "dest-filename": "8891305e9c778a4f54d394a3095b2d656997b0b11233622821c98889299adeaad7714a8b3f4b5b7e92d44c416bb608aa9a6abae47accc9c757200b9b4667",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/50/90"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+        "sha512": "b552fab8982851d8ba89ca7199dae7e58368de0dc3c6ff881c906bd065c7684753730dc5f9c3ca9ec5c58658ba9cef9fffa48328f1c42b550dfa4f9342fd0486",
+        "dest-filename": "fab8982851d8ba89ca7199dae7e58368de0dc3c6ff881c906bd065c7684753730dc5f9c3ca9ec5c58658ba9cef9fffa48328f1c42b550dfa4f9342fd0486",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b5/52"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+        "sha512": "2a144874657653d1ce533c5f887998f081474ddaad3a12330a977c591749884ec3fc751c6550f41204025639be43d8245175a006f3264ed660206e3cc2aeec39",
+        "dest-filename": "4874657653d1ce533c5f887998f081474ddaad3a12330a977c591749884ec3fc751c6550f41204025639be43d8245175a006f3264ed660206e3cc2aeec39",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2a/14"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+        "sha512": "657492a93148af376e0faddbb487c4c8e98d701990be0395b0f34f7b48d8b444a25e485df2ed9eac32e7331986ac30b01c208713b871c110c24f7a6dd1eb13e2",
+        "dest-filename": "92a93148af376e0faddbb487c4c8e98d701990be0395b0f34f7b48d8b444a25e485df2ed9eac32e7331986ac30b01c208713b871c110c24f7a6dd1eb13e2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/65/74"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+        "sha512": "a013bcdab123b312cd2629dc5612e16b1c59744b55d0414730ae4a9b1e6c27a1fd2f5f377471028e279f380767aa92204f9799c13d383e88205275bcf2f38135",
+        "dest-filename": "bcdab123b312cd2629dc5612e16b1c59744b55d0414730ae4a9b1e6c27a1fd2f5f377471028e279f380767aa92204f9799c13d383e88205275bcf2f38135",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/13"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+        "sha512": "135077e45c335d74ecf451cd2ba6c3b33b3b9adc9d362e4c21f516a5c789f176df6f580132c7009f02db12ef81e3879de96dd78cbf7f7a12cf1d1d5f91fd4a2d",
+        "dest-filename": "77e45c335d74ecf451cd2ba6c3b33b3b9adc9d362e4c21f516a5c789f176df6f580132c7009f02db12ef81e3879de96dd78cbf7f7a12cf1d1d5f91fd4a2d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/13/50"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+        "sha512": "bf4a6c68c4a4349dc0d8d32b5041c547326d0cf167fbf5566795b1226076d53f5f8ee7094664bbc424b7a691270116fdcb5d4e033683f8fd8fb3e6fe0465f989",
+        "dest-filename": "6c68c4a4349dc0d8d32b5041c547326d0cf167fbf5566795b1226076d53f5f8ee7094664bbc424b7a691270116fdcb5d4e033683f8fd8fb3e6fe0465f989",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bf/4a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+        "sha512": "aeaf6cf893617f4202863b435f196527b838d68664e52957b69d0b1f0c80e5c7a3c27eef2a62a9e293eb8ba60478fbf63d4eb9b00b1e81b5ed2229e60c50d781",
+        "dest-filename": "6cf893617f4202863b435f196527b838d68664e52957b69d0b1f0c80e5c7a3c27eef2a62a9e293eb8ba60478fbf63d4eb9b00b1e81b5ed2229e60c50d781",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ae/af"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+        "sha512": "51527213d32db4eb014080cac35b246fd9c0c10b91e70b860f7fbcd8ae89809966fd8f8a23dda836c30d199098743b15b511d26a4d29715e439e8e7ee2387db3",
+        "dest-filename": "7213d32db4eb014080cac35b246fd9c0c10b91e70b860f7fbcd8ae89809966fd8f8a23dda836c30d199098743b15b511d26a4d29715e439e8e7ee2387db3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/51/52"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
+        "sha512": "216ae8b26ff2ae7e377a22aa91f9078aced08a80e579a5d01dd0d53ca834152c3077f0eebf25fbf5366714e9d8a41edd72c140326b45ced66e5cf0ef49e3e417",
+        "dest-filename": "e8b26ff2ae7e377a22aa91f9078aced08a80e579a5d01dd0d53ca834152c3077f0eebf25fbf5366714e9d8a41edd72c140326b45ced66e5cf0ef49e3e417",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/6a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+        "sha512": "4e16e58be3a53a3fa230f60505505f2773a60809da4b2367e0cd6fcfd4fa1a46b926df5b6bf1c8479ea3a32eb9b58ea4c7f142179557341f35f58eff194ac118",
+        "dest-filename": "e58be3a53a3fa230f60505505f2773a60809da4b2367e0cd6fcfd4fa1a46b926df5b6bf1c8479ea3a32eb9b58ea4c7f142179557341f35f58eff194ac118",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/16"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+        "sha512": "06f53c9d8806401c5c98cb84794126353beb3158c93521fb4605b6e2f5dec4de157a7eaa0afcb84e7b67be59f09cc2d356571141075b458f0d2a7688a1e58336",
+        "dest-filename": "3c9d8806401c5c98cb84794126353beb3158c93521fb4605b6e2f5dec4de157a7eaa0afcb84e7b67be59f09cc2d356571141075b458f0d2a7688a1e58336",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/06/f5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+        "sha512": "aae2505e54d25062f62c7f52517a3c570b18e2ca1a9e1828e8b3529bce04d4b05c13cb373b4c29762473c91f73fd9649325316bf7eea38e6fda5d26531410a15",
+        "dest-filename": "505e54d25062f62c7f52517a3c570b18e2ca1a9e1828e8b3529bce04d4b05c13cb373b4c29762473c91f73fd9649325316bf7eea38e6fda5d26531410a15",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/e2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+        "sha512": "06add2992a721476968cf93c21ff7273ab2f33c739e9d079040b56e106f0e631d3c305d77132e844c9290c9a7a54bd17ce559a0874d7ae415444c6260f4b0baa",
+        "dest-filename": "d2992a721476968cf93c21ff7273ab2f33c739e9d079040b56e106f0e631d3c305d77132e844c9290c9a7a54bd17ce559a0874d7ae415444c6260f4b0baa",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/06/ad"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+        "sha512": "cdb07dac22404f5adb8e25436f686a2851cd60bc60b64f0d511c59dc86700f717a36dc5b5d94029e74a2d4b931f880e885d3e5169db6db05402c885e64941212",
+        "dest-filename": "7dac22404f5adb8e25436f686a2851cd60bc60b64f0d511c59dc86700f717a36dc5b5d94029e74a2d4b931f880e885d3e5169db6db05402c885e64941212",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cd/b0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+        "sha512": "e038fa336f0907ea001fc9059132d4a3e6b68f038592ea9bdf2b9c53408035c45151bc52d1c3f49d96021a371cdc1357c1122c5159831a0cdac267bbcef247be",
+        "dest-filename": "fa336f0907ea001fc9059132d4a3e6b68f038592ea9bdf2b9c53408035c45151bc52d1c3f49d96021a371cdc1357c1122c5159831a0cdac267bbcef247be",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e0/38"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz",
+        "sha512": "ed4be629a95646dd708232f546b1b1a12256ff44191487a0a5e1af646f648e9f2fad1bb9e574c76f09eaab61a95e6f6e2db72e8719b722a5fd381e0c651d5bd8",
+        "dest-filename": "e629a95646dd708232f546b1b1a12256ff44191487a0a5e1af646f648e9f2fad1bb9e574c76f09eaab61a95e6f6e2db72e8719b722a5fd381e0c651d5bd8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ed/4b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+        "sha512": "28c45e154af4078b7e0fe381923477298aafa1ca765da4b33b9e54701ea681031ddca6dc13e9964f2bd557b0ffcec7446cd9d5e9a71952eb64887417bd3af547",
+        "dest-filename": "5e154af4078b7e0fe381923477298aafa1ca765da4b33b9e54701ea681031ddca6dc13e9964f2bd557b0ffcec7446cd9d5e9a71952eb64887417bd3af547",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/28/c4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
+        "sha512": "3d88f214e2ca43dcb9ec9bd0e902e8f1d02036ab3087c33544c25875076e4fac5b59280adfa3ff67fbfea7cf3ca4cebd8cc31f4bc5ddf05e88d6443f23d1d41a",
+        "dest-filename": "f214e2ca43dcb9ec9bd0e902e8f1d02036ab3087c33544c25875076e4fac5b59280adfa3ff67fbfea7cf3ca4cebd8cc31f4bc5ddf05e88d6443f23d1d41a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3d/88"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+        "sha512": "f3ef56a9e6db173a57f4e47e59ae8edbd6ac22881e44ccdc1ad00835da4c1c7c80835d1fd3969215505b704a867ff3d7c35123019faadbf6c4060dc3beeacadd",
+        "dest-filename": "56a9e6db173a57f4e47e59ae8edbd6ac22881e44ccdc1ad00835da4c1c7c80835d1fd3969215505b704a867ff3d7c35123019faadbf6c4060dc3beeacadd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f3/ef"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+        "sha512": "8a4dd9802f5d63f95855533ef8e212b1a6037a0d6d6f456d3f9b8bde8ba1d64a0639a50c0cfa5b1487a2e099058a659414f9fdd2c6cc34c5d000854e96760a24",
+        "dest-filename": "d9802f5d63f95855533ef8e212b1a6037a0d6d6f456d3f9b8bde8ba1d64a0639a50c0cfa5b1487a2e099058a659414f9fdd2c6cc34c5d000854e96760a24",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8a/4d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+        "sha512": "1c6cb1a0e4d853208ceacb547ba1098277781287b0008ef331d7ea3be9068e79599810f3fdc479a5ff2bfdc4785aaeb4b0bfe9d0891c8d41043f04b7185ac8cb",
+        "dest-filename": "b1a0e4d853208ceacb547ba1098277781287b0008ef331d7ea3be9068e79599810f3fdc479a5ff2bfdc4785aaeb4b0bfe9d0891c8d41043f04b7185ac8cb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1c/6c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+        "sha512": "2338bc45071f7ea09e3558058a02a58b5b2c92521ba479c261ce809275c662807a82b26ac9e6f2ee3bf5d895108264c09c80e76dc935bb192c4f87733773d604",
+        "dest-filename": "bc45071f7ea09e3558058a02a58b5b2c92521ba479c261ce809275c662807a82b26ac9e6f2ee3bf5d895108264c09c80e76dc935bb192c4f87733773d604",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/23/38"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz",
+        "sha512": "67bb4cc35cad4d7b798ea31c38ff8e42d794d55b8d2bd634daeb89b4a4354afebd8d740a2a0e5c89b2f0189a30f32cd93fe780735f0498b18f6a5d1ba77eabbd",
+        "dest-filename": "4cc35cad4d7b798ea31c38ff8e42d794d55b8d2bd634daeb89b4a4354afebd8d740a2a0e5c89b2f0189a30f32cd93fe780735f0498b18f6a5d1ba77eabbd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/67/bb"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
+        "sha512": "86d0940e5c72c822cc81a337c578340b42d6db1a9fb90ea9d39a42108b17bb243e6b592860a4ee04ccd13709b26df2e0bc90cc774af52d39f8f84d138ba0b600",
+        "dest-filename": "940e5c72c822cc81a337c578340b42d6db1a9fb90ea9d39a42108b17bb243e6b592860a4ee04ccd13709b26df2e0bc90cc774af52d39f8f84d138ba0b600",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/d0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+        "sha512": "14c84ea19578faa47a6935002ca5f6ac4a861bea32013bf006df48233551e6b31ad874563e4c5ff8ff8f0092c3d48fc7e7f208f87b99701258105069ab7f689e",
+        "dest-filename": "4ea19578faa47a6935002ca5f6ac4a861bea32013bf006df48233551e6b31ad874563e4c5ff8ff8f0092c3d48fc7e7f208f87b99701258105069ab7f689e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/c8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+        "sha512": "de849e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f",
+        "dest-filename": "9e50ed13315ebb84dd4099b5ec2b8c9aa94eed8e21e56f144364ea47d0a5bdf82797e1b440697d009f1b74b71d8cae94695b041a3f02252121098585393f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/de/84"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz",
+        "sha512": "d6e8144abf011d74672b6dca7ee612fa054c0b72c1f10187f56d621ad0cfb0d5a841b82d5d2131901bb66834787a98865993a366c8fa94397f37f02aa930b750",
+        "dest-filename": "144abf011d74672b6dca7ee612fa054c0b72c1f10187f56d621ad0cfb0d5a841b82d5d2131901bb66834787a98865993a366c8fa94397f37f02aa930b750",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d6/e8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+        "sha512": "04bae011c453c17da8ea01b118e08dc8cbc64a9df96287ee633c3d87520c4d198aaadb40659554ebb6dd6fd3ebdaf50703cfa3de2dad25f8cee82ebee26c864c",
+        "dest-filename": "e011c453c17da8ea01b118e08dc8cbc64a9df96287ee633c3d87520c4d198aaadb40659554ebb6dd6fd3ebdaf50703cfa3de2dad25f8cee82ebee26c864c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/ba"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
+        "sha512": "d40697c443df5d3f86bd304916ecb8c975475890576b839d6c879b18dff05f90e5b08914d3ec331a777694ece8912939d5de4b526aa38012d12e5ca92d4a889d",
+        "dest-filename": "97c443df5d3f86bd304916ecb8c975475890576b839d6c879b18dff05f90e5b08914d3ec331a777694ece8912939d5de4b526aa38012d12e5ca92d4a889d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d4/06"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+        "sha512": "09e87eee8c79a9eecb26e2c7a18d1f7a1de91ee5031c071151ec8bd95620859c1fa64348cbffbc39c8346b752e4a86336af9b2970b8b59039fde19748e330c23",
+        "dest-filename": "7eee8c79a9eecb26e2c7a18d1f7a1de91ee5031c071151ec8bd95620859c1fa64348cbffbc39c8346b752e4a86336af9b2970b8b59039fde19748e330c23",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/09/e8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
+        "sha512": "3163c67c3c67cb3294eeb34e5bd48ffdce74be2df1ae6aee6bffba85f3db092d8004d59fc76e2f3e2773bc2ee4ae353f453a36df9b15efbeb29a5b0cb462a3f2",
+        "dest-filename": "c67c3c67cb3294eeb34e5bd48ffdce74be2df1ae6aee6bffba85f3db092d8004d59fc76e2f3e2773bc2ee4ae353f453a36df9b15efbeb29a5b0cb462a3f2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/31/63"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+        "sha512": "559ce72e0b70867f8c69cb7db5f8b0c7ae1f03d7ab1c7fcc0971147c1ff46d7ffa173ea7cb91064d7625b4ca1caa0e31140419b673b70c75965e2f118ae37b71",
+        "dest-filename": "e72e0b70867f8c69cb7db5f8b0c7ae1f03d7ab1c7fcc0971147c1ff46d7ffa173ea7cb91064d7625b4ca1caa0e31140419b673b70c75965e2f118ae37b71",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/55/9c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+        "sha512": "c906d780efce499543d88b222e5ae8fbb1dfe90d7c109aca484b1da0ccca78f29772dde0bc3f282dc390748cc6ba9af9163f840def203bf9717350737cca71bc",
+        "dest-filename": "d780efce499543d88b222e5ae8fbb1dfe90d7c109aca484b1da0ccca78f29772dde0bc3f282dc390748cc6ba9af9163f840def203bf9717350737cca71bc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c9/06"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
+        "sha512": "e3cc52ae2658620fbca979daf64c2a8c8573b90c62f8a616a76fb99c262760a3d3af42ef0fcf49aa4d8eaf9a20c73d0d50c7c88e1876948517fcbc97f41e2822",
+        "dest-filename": "52ae2658620fbca979daf64c2a8c8573b90c62f8a616a76fb99c262760a3d3af42ef0fcf49aa4d8eaf9a20c73d0d50c7c88e1876948517fcbc97f41e2822",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e3/cc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+        "sha512": "6fa225bacf9cdd1add0e4f8984b2940107f3ce02c43f2eb0717a92edfff17b51044efb033fa18e446ed216e3ace9c203e5892a7215bf2d765b5f96dcf23ed971",
+        "dest-filename": "25bacf9cdd1add0e4f8984b2940107f3ce02c43f2eb0717a92edfff17b51044efb033fa18e446ed216e3ace9c203e5892a7215bf2d765b5f96dcf23ed971",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/a2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cacheable/-/cacheable-2.3.4.tgz",
+        "sha512": "763831c9b0dbc3d7cbfd958c237f8213c66294dc5cc05915b43735809f8894e4925a448c3d069b855fd70874d0ea9c3037a6a2bd73d9e37a264e8a19897d3a13",
+        "dest-filename": "31c9b0dbc3d7cbfd958c237f8213c66294dc5cc05915b43735809f8894e4925a448c3d069b855fd70874d0ea9c3037a6a2bd73d9e37a264e8a19897d3a13",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/76/38"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+        "sha512": "3fc06302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69",
+        "dest-filename": "6302c5ef652f95203508d7584709012fef8613ebb6148b924914d588a8bdb7e6c0668d7e3eab1f4cbaf96ce62bf234435cb71e3ac502d0dda4ee13bb2c69",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3f/c0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz",
+        "sha512": "40e4af7af86c9628e0630471e91bfbcca74c17c95b466c7eb901b1dbebc373e288fde067b32f648ade5a8f6dc0806bb7a5ae2df408306e75d6a92fa2398fb668",
+        "dest-filename": "af7af86c9628e0630471e91bfbcca74c17c95b466c7eb901b1dbebc373e288fde067b32f648ade5a8f6dc0806bb7a5ae2df408306e75d6a92fa2398fb668",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/40/e4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
+        "sha512": "eaaf07169fa5390b5c7fbc012beb847a7c729955a418a9231690afc395b6e5c98cc040d4e39a75c5014142ff090e530caf2ede371c81691faac6099351990845",
+        "dest-filename": "07169fa5390b5c7fbc012beb847a7c729955a418a9231690afc395b6e5c98cc040d4e39a75c5014142ff090e530caf2ede371c81691faac6099351990845",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ea/af"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+        "sha512": "e333617490ff88e8d21f4034e5e6be29ee8c5399a6a5071b42c48e92075a50c27dcd39434c3fc6625c28866204daed206b11d88951c49f5170f6667f92d25683",
+        "dest-filename": "617490ff88e8d21f4034e5e6be29ee8c5399a6a5071b42c48e92075a50c27dcd39434c3fc6625c28866204daed206b11d88951c49f5170f6667f92d25683",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e3/33"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+        "sha512": "a0a9db845c91217a54b9ecfc881326c846b89db8f820e432ba173fc32f6463bfd654f73020ef5503aebc3eef1190eefed06efa48b44e7b2c3d0a9434eb58b898",
+        "dest-filename": "db845c91217a54b9ecfc881326c846b89db8f820e432ba173fc32f6463bfd654f73020ef5503aebc3eef1190eefed06efa48b44e7b2c3d0a9434eb58b898",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/a9"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+        "sha512": "3c025d0c9baca319f09b55705b4ed55b050dd6c97bb26982dce2a082f9dd24569dc710d1c852415ff8209eefca138910001edadc3a7c7ff6170b5165529ad698",
+        "dest-filename": "5d0c9baca319f09b55705b4ed55b050dd6c97bb26982dce2a082f9dd24569dc710d1c852415ff8209eefca138910001edadc3a7c7ff6170b5165529ad698",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3c/02"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+        "sha512": "ed54f5ddf9a3a2d2a91a2a425bd244400bac10f13e122f2797afe0e050409889b418e38b32e6bd3430e8fc35a9d190310abddc3eae59a41aa63c04200dd6b63f",
+        "dest-filename": "f5ddf9a3a2d2a91a2a425bd244400bac10f13e122f2797afe0e050409889b418e38b32e6bd3430e8fc35a9d190310abddc3eae59a41aa63c04200dd6b63f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ed/54"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+        "sha512": "29afbd4ebbadbfb1bc33a593e927a2456cfbf762b9a84a881841b35ca84013ac4e58063aa4f1fc53ef48637a0232fea4a9398bb2fed787fdb0d918a091e3ccb2",
+        "dest-filename": "bd4ebbadbfb1bc33a593e927a2456cfbf762b9a84a881841b35ca84013ac4e58063aa4f1fc53ef48637a0232fea4a9398bb2fed787fdb0d918a091e3ccb2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/af"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+        "sha512": "6828f83b9c0acacce33260d3e2d663f77931cb274dfcae733d64827baff4015fc0035a6a7b9641230d1ad997cf415ee52f9ff26f91ec52b789e94140175b4443",
+        "dest-filename": "f83b9c0acacce33260d3e2d663f77931cb274dfcae733d64827baff4015fc0035a6a7b9641230d1ad997cf415ee52f9ff26f91ec52b789e94140175b4443",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/68/28"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+        "sha512": "c51c2f20e306adf3809ccd4962da90226b9a36d0c4bfdbfaa08600b382c81f04e229e7bcbb0bc88b7eb78a0b2c382d0ee54d388b802510db3bf4b40bbbdb4433",
+        "dest-filename": "2f20e306adf3809ccd4962da90226b9a36d0c4bfdbfaa08600b382c81f04e229e7bcbb0bc88b7eb78a0b2c382d0ee54d388b802510db3bf4b40bbbdb4433",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/1c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+        "sha512": "7989b441606d52b0566561b4777f3a386030d7a67df793e2395a3607b6e35926c779d1a5e5ed1959aabae6438681448d7ac1080e407d2126d383f24af5d84264",
+        "dest-filename": "b441606d52b0566561b4777f3a386030d7a67df793e2395a3607b6e35926c779d1a5e5ed1959aabae6438681448d7ac1080e407d2126d383f24af5d84264",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/79/89"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+        "sha512": "4511023ec8fb8aeff16f9a0a61cb051d2a6914d9ec8ffe763954d129be333f9a275f0545df3566993a0d70e7c60be0910e97cafd4e7ce1f320dfc64709a12529",
+        "dest-filename": "023ec8fb8aeff16f9a0a61cb051d2a6914d9ec8ffe763954d129be333f9a275f0545df3566993a0d70e7c60be0910e97cafd4e7ce1f320dfc64709a12529",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/11"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+        "sha512": "74ecbedc0b96ddadb035b64722e319a537208c6b8b53fb812ffb9b71917d3976c3a3c7dfe0ef32569e417f479f4bcb84a18a39ab8171edd63d3a04065e002c40",
+        "dest-filename": "bedc0b96ddadb035b64722e319a537208c6b8b53fb812ffb9b71917d3976c3a3c7dfe0ef32569e417f479f4bcb84a18a39ab8171edd63d3a04065e002c40",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/74/ec"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/colord/-/colord-2.9.3.tgz",
+        "sha512": "8de0b56b15e99dbd3fda79ff6352cfb8b7605c12c7eda0dc1eee0a10a7eac37094857ed9a5f05294f2b2a9713a6ed2201337d6b6b5f7fedc8109a0af5ef3243b",
+        "dest-filename": "b56b15e99dbd3fda79ff6352cfb8b7605c12c7eda0dc1eee0a10a7eac37094857ed9a5f05294f2b2a9713a6ed2201337d6b6b5f7fedc8109a0af5ef3243b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8d/e0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz",
+        "sha512": "21f103c70a1622391e5cbd5e5dc0e2a30e146ca8e12ddabafc4b92551f4630deca547debf6043cddeef786ccf535dd53de28dde71bf5c1c59160ef83ea4088db",
+        "dest-filename": "03c70a1622391e5cbd5e5dc0e2a30e146ca8e12ddabafc4b92551f4630deca547debf6043cddeef786ccf535dd53de28dde71bf5c1c59160ef83ea4088db",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/21/f1"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+        "sha512": "c8f55abdfc82711866a2b0bbad69641e7d796f8c03560566040ee457841506c17b92fffd4ca2406c05d54f1bd39f03fc1c72a34422430a529b7228984bba740d",
+        "dest-filename": "5abdfc82711866a2b0bbad69641e7d796f8c03560566040ee457841506c17b92fffd4ca2406c05d54f1bd39f03fc1c72a34422430a529b7228984bba740d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/f5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/commander/-/commander-14.0.3.tgz",
+        "sha512": "1fecb4268fd3d5167da8f3f8121d6991c41c2d1825ada25a48ba323ad1f1bba01aa648d6542cb64a2b75410e31dc39e0f2a0e54ac6447adee0e4fab4e8cbd383",
+        "dest-filename": "b4268fd3d5167da8f3f8121d6991c41c2d1825ada25a48ba323ad1f1bba01aa648d6542cb64a2b75410e31dc39e0f2a0e54ac6447adee0e4fab4e8cbd383",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1f/ec"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+        "sha512": "34e2a6f31864cc08f3171f01dafe4e0074febb9a5141cd9409ad95abd8d82ffdf5a36c22f66c4103b2c816cdec5795520b8f73ea91217db3142ef4a12a3dba58",
+        "dest-filename": "a6f31864cc08f3171f01dafe4e0074febb9a5141cd9409ad95abd8d82ffdf5a36c22f66c4103b2c816cdec5795520b8f73ea91217db3142ef4a12a3dba58",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/34/e2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+        "sha512": "fd2aefe1db30c903417e8846a73f68e986f71b3dd2ad40ea047e6b4ee84647b6a1b656d82a7571c366c214c4658da03b1171da5d9f30b07768745bdb9212a6aa",
+        "dest-filename": "efe1db30c903417e8846a73f68e986f71b3dd2ad40ea047e6b4ee84647b6a1b656d82a7571c366c214c4658da03b1171da5d9f30b07768745bdb9212a6aa",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fd/2a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+        "sha512": "2afa78e7d1eb576144275080b22d4abbe318de46ac1f5f53172913cf6c5698c7aae9b936354dd75ef7c9f90eb59b4c64b56c2dfb51d261fdc966c4e6b3769126",
+        "dest-filename": "78e7d1eb576144275080b22d4abbe318de46ac1f5f53172913cf6c5698c7aae9b936354dd75ef7c9f90eb59b4c64b56c2dfb51d261fdc966c4e6b3769126",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2a/fa"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+        "sha512": "7a2f00a2cee36b4c1e469173267100f541c9ffb5d09aa8256d1c277f60138dc07d5aaf3be15287f647e38e2acce94854dbf1397c561a77297284595d72a4a275",
+        "dest-filename": "00a2cee36b4c1e469173267100f541c9ffb5d09aa8256d1c277f60138dc07d5aaf3be15287f647e38e2acce94854dbf1397c561a77297284595d72a4a275",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7a/2f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz",
+        "sha512": "86be22870f8306a72faec1038a844edf5675ef1ef5a5462835eff887a674c01ef6a7b314efff601fc437b35d8d1611cf7d8041395deac9f5319abfd89f7b219d",
+        "dest-filename": "22870f8306a72faec1038a844edf5675ef1ef5a5462835eff887a674c01ef6a7b314efff601fc437b35d8d1611cf7d8041395deac9f5319abfd89f7b219d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/be"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+        "sha512": "b95d903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc",
+        "dest-filename": "903963f69d6ceccb668ca7c69189b862f5d9731791e0879487681f4e893184c834e2249cb1d2ecb9d505ddc966ed00736e6b85c9cd429c6b73b3294777bc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b9/5d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz",
+        "sha512": "f0714404f2a13a924f10fbbbd302497ad8cab5af3a1b0f7e082c829c1decba2daa41f3af472a81cb820a2ca280c1d32959bda51d75a4f566f867a0266944f53e",
+        "dest-filename": "4404f2a13a924f10fbbbd302497ad8cab5af3a1b0f7e082c829c1decba2daa41f3af472a81cb820a2ca280c1d32959bda51d75a4f566f867a0266944f53e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f0/71"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+        "sha512": "5fbb2343371e521bb5bbb63fca5ad1645536152e8b462155a7aaca2cf836df2df1ddcdc338a030b97183a7e3c01a387a0929c28d8780ba5f29713f1b025fa548",
+        "dest-filename": "2343371e521bb5bbb63fca5ad1645536152e8b462155a7aaca2cf836df2df1ddcdc338a030b97183a7e3c01a387a0929c28d8780ba5f29713f1b025fa548",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5f/bb"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+        "sha512": "fd36ff25c8cad75d67352706a1be4c36db27b4d3356823540e2a41fd39306458720ebac4e3b48ec7fd7cc05d9b6e381cdd9cc248a5b54f99ede446c5a00cff56",
+        "dest-filename": "ff25c8cad75d67352706a1be4c36db27b4d3356823540e2a41fd39306458720ebac4e3b48ec7fd7cc05d9b6e381cdd9cc248a5b54f99ede446c5a00cff56",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fd/36"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+        "sha512": "cf51c629c632db103c00641fc2b9f43c0cbe3c1ed7fc64a3dd45495bda8aca7e37c566be825e675e6538aaa2cc4735952c50bc2aeb145fc4ffd240a2398a4021",
+        "dest-filename": "c629c632db103c00641fc2b9f43c0cbe3c1ed7fc64a3dd45495bda8aca7e37c566be825e675e6538aaa2cc4735952c50bc2aeb145fc4ffd240a2398a4021",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/51"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+        "sha512": "446c305a7c10be455f6af295b76d8518bc3ec5849dcc04709b4aeee83853540dee994e6165cdbc57790ee2cb6062bcab4e52e9baf808f468a28e5b408cd6dca8",
+        "dest-filename": "305a7c10be455f6af295b76d8518bc3ec5849dcc04709b4aeee83853540dee994e6165cdbc57790ee2cb6062bcab4e52e9baf808f468a28e5b408cd6dca8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/6c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+        "sha512": "87993fe54e74209245a737cbea73bd8da6ae99f8cefdfd8d8cafe8601d838f39b8a7d2fedd3f6a5a966a6768406cb3eeb98abdc2b534f164320532f919b3e4e5",
+        "dest-filename": "3fe54e74209245a737cbea73bd8da6ae99f8cefdfd8d8cafe8601d838f39b8a7d2fedd3f6a5a966a6768406cb3eeb98abdc2b534f164320532f919b3e4e5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/87/99"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
+        "sha512": "a083f392c993838fccae289a6063bea245c34fbced9ffc37129b6fffe81221d31d2ac268d2ee027d834524fcbee1228cb82a86c36c319c0f9444c837b7c6bf6d",
+        "dest-filename": "f392c993838fccae289a6063bea245c34fbced9ffc37129b6fffe81221d31d2ac268d2ee027d834524fcbee1228cb82a86c36c319c0f9444c837b7c6bf6d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/83"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+        "sha512": "ca9766254fd36c16f2d83c626eebfb64b5b706cd5012633b9c78c400d7e88492ef1345d5ba38ac9f5a8f25c67183ea83b9cb2bf9b3fa7cb0f5acf4b702127b11",
+        "dest-filename": "66254fd36c16f2d83c626eebfb64b5b706cd5012633b9c78c400d7e88492ef1345d5ba38ac9f5a8f25c67183ea83b9cb2bf9b3fa7cb0f5acf4b702127b11",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ca/97"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz",
+        "sha512": "831b727ea320ec62b285099bd39e8aeccdf1b33cbf9b21fcc3e078453f905c142cbc039d7375f29aa0c33c7c750603e0b1d000e522227e89daf3d62d4404c3cf",
+        "dest-filename": "727ea320ec62b285099bd39e8aeccdf1b33cbf9b21fcc3e078453f905c142cbc039d7375f29aa0c33c7c750603e0b1d000e522227e89daf3d62d4404c3cf",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/83/1b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+        "sha512": "5a4ad6a7d191e0a5df28663338b993b86562d545857f0b37efb9fd71ce79fed6fa0eeab217aa5c43901b88712c85a0e963dbfaa1a4abd9708389d1a633077320",
+        "dest-filename": "d6a7d191e0a5df28663338b993b86562d545857f0b37efb9fd71ce79fed6fa0eeab217aa5c43901b88712c85a0e963dbfaa1a4abd9708389d1a633077320",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5a/4a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz",
+        "sha512": "f87972b728e53ca9c81bc5ee446f16be604ff31b3c3fbd72f9228a4ba6575a81202ee78fc6d0e8504887ed691d78f5ab439241a44e9aa15a9f65f2544248d7c0",
+        "dest-filename": "72b728e53ca9c81bc5ee446f16be604ff31b3c3fbd72f9228a4ba6575a81202ee78fc6d0e8504887ed691d78f5ab439241a44e9aa15a9f65f2544248d7c0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f8/79"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
+        "sha512": "f74f2a6a1386a1c44c8a74f69ccdda8c210cf7d1f888f76ff3879a80f3f715f672ff564678ecb60996338e19acf3572438f0973e55bb2e46385e9c43f2bd43ac",
+        "dest-filename": "2a6a1386a1c44c8a74f69ccdda8c210cf7d1f888f76ff3879a80f3f715f672ff564678ecb60996338e19acf3572438f0973e55bb2e46385e9c43f2bd43ac",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f7/4f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+        "sha512": "b68508f38612e589b15b6d7d7ab9e2583d022153a8e3ac46282a2578d41180ecc3a2b8018b5bf80fbd7f385ce00fd18ed9418a22fd42dd2a7c0c09f4fa3e70ec",
+        "dest-filename": "08f38612e589b15b6d7d7ab9e2583d022153a8e3ac46282a2578d41180ecc3a2b8018b5bf80fbd7f385ce00fd18ed9418a22fd42dd2a7c0c09f4fa3e70ec",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b6/85"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+        "sha512": "3128d8cdc58d380d1ec001e9cf4331a5816fc20eb28f2d4d1b7c6d7a8ab3eb8e150a8fd13e09ebd7f186b7e89cde2253cd0f04bb74dd335e126b09d5526184e8",
+        "dest-filename": "d8cdc58d380d1ec001e9cf4331a5816fc20eb28f2d4d1b7c6d7a8ab3eb8e150a8fd13e09ebd7f186b7e89cde2253cd0f04bb74dd335e126b09d5526184e8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/31/28"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+        "sha512": "4d6ae02ce1544131fdf78614ca5d724f8bb26af6399cd0799ae7dff91b566aa3550802b8d3c6f96679db34050458b4c2a6e9bdc3a6ab4fbd22d57750e1478e3c",
+        "dest-filename": "e02ce1544131fdf78614ca5d724f8bb26af6399cd0799ae7dff91b566aa3550802b8d3c6f96679db34050458b4c2a6e9bdc3a6ab4fbd22d57750e1478e3c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4d/6a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+        "sha512": "fa1d6590b2a164c4d88e8835544a49346ecd64959cb9cd830e4feab2a49345108e5e22e3790d5dd7fb9dad41a1a8cc5480097028d67471fdaea9a9f918bb92d8",
+        "dest-filename": "6590b2a164c4d88e8835544a49346ecd64959cb9cd830e4feab2a49345108e5e22e3790d5dd7fb9dad41a1a8cc5480097028d67471fdaea9a9f918bb92d8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fa/1d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+        "sha512": "c54b683e432081bcf430fc8f8885abd4aa7869e5898c367a48cbd44618a68dd660b11b83a65179fecf617201a1c97321b3eeafa67ba8899da4162bb714c9d2f1",
+        "dest-filename": "683e432081bcf430fc8f8885abd4aa7869e5898c367a48cbd44618a68dd660b11b83a65179fecf617201a1c97321b3eeafa67ba8899da4162bb714c9d2f1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/4b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz",
+        "sha512": "b2a41a9809d1d785600abd40eb5f00dec1abca07292be1c46de9c0fc7884024914c1c648201fed816a871715a03b20e1e270782424629a1efd751e58c1cf4c0d",
+        "dest-filename": "1a9809d1d785600abd40eb5f00dec1abca07292be1c46de9c0fc7884024914c1c648201fed816a871715a03b20e1e270782424629a1efd751e58c1cf4c0d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b2/a4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+        "sha512": "65fe47d8ac6ddb18d3bdb26f3f66562c4202c40ea3fa1026333225ca9cb8c5c060d6f2959f1f3d5b2d066d2fa47f9730095145cdd0858765d20853542d2e9cb3",
+        "dest-filename": "47d8ac6ddb18d3bdb26f3f66562c4202c40ea3fa1026333225ca9cb8c5c060d6f2959f1f3d5b2d066d2fa47f9730095145cdd0858765d20853542d2e9cb3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/65/fe"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+        "sha512": "8c44280b093c8726f6019ce220e2e10eaa66e7edb0c39b8813a9643bfea370e0aeb1f93a2e1307a575df04b5d367b61dcadd23e15a1442feae18d61b756fa404",
+        "dest-filename": "280b093c8726f6019ce220e2e10eaa66e7edb0c39b8813a9643bfea370e0aeb1f93a2e1307a575df04b5d367b61dcadd23e15a1442feae18d61b756fa404",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8c/44"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+        "sha512": "9a0dce3cc578857cb0c29a03c6edd075ae7108a422faf09366af12f49fc4a64841d87cca5eae12345644dfe34af77258c5cf153127a9fa5394482fd154a681ab",
+        "dest-filename": "ce3cc578857cb0c29a03c6edd075ae7108a422faf09366af12f49fc4a64841d87cca5eae12345644dfe34af77258c5cf153127a9fa5394482fd154a681ab",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9a/0d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+        "sha512": "5948f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c",
+        "dest-filename": "f6aa5c5a42d3b883a3eae5cdbd193716183c9df22b4bf334e58a98040b3dc97ac02288e2a8b5df0953aa2d0773c00a01bac64254c9585ba0c4be6e37bf8c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/59/48"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+        "sha512": "4eda5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80",
+        "dest-filename": "5c349dd7033c771aaf2c591cc96956a346cd2e57103660091d6f58e6d9890fcf81ba7a05050320379f9bed10865e7cf93959ae145db2ae4b97ca90959d80",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4e/da"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
+        "sha512": "f36199523452d29fe381a9dfeaad6b10edb9552a071f484a3c24eb8229653e3748ff76e0061004d50cc7ac74e2ce3a51bf2ea9180bca8c326d936a45f4d0eaf3",
+        "dest-filename": "99523452d29fe381a9dfeaad6b10edb9552a071f484a3c24eb8229653e3748ff76e0061004d50cc7ac74e2ce3a51bf2ea9180bca8c326d936a45f4d0eaf3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f3/61"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
+        "sha512": "f9fd7915f2bae1843065d24d10b113767e626d71144265b50d92fa29784d9dcda17a8cbfb20f55249793ee7f1394c5a8bb35aa4966af1642211f221b20011aa6",
+        "dest-filename": "7915f2bae1843065d24d10b113767e626d71144265b50d92fa29784d9dcda17a8cbfb20f55249793ee7f1394c5a8bb35aa4966af1642211f221b20011aa6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f9/fd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.2.tgz",
+        "sha512": "8668131f9ec67f3a1316354dd320704e0827b15505dad72a8bb449647aa2f6521ecd2b38785c80324b40ebc603e2be64370d66c72638766932a050dbdc522aac",
+        "dest-filename": "131f9ec67f3a1316354dd320704e0827b15505dad72a8bb449647aa2f6521ecd2b38785c80324b40ebc603e2be64370d66c72638766932a050dbdc522aac",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/68"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+        "sha512": "b0d5ce7ca0a7ef8aedf1120228cbc94bb5ca57f5e4f6403b0f226bf262629374bb0b0832dea964926c92dae401de388983a54d75977fa43049bb49ef1b63654e",
+        "dest-filename": "ce7ca0a7ef8aedf1120228cbc94bb5ca57f5e4f6403b0f226bf262629374bb0b0832dea964926c92dae401de388983a54d75977fa43049bb49ef1b63654e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b0/d5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+        "sha512": "c2973e2d77a2ca28acc4f944914cd4eacbf24b57eb20edcc8318f57ddcbb3e6f1883382e6b1d8ddc56bf0ff6a0d56a9b3a9add23eb98eb031497cfdad86fa26a",
+        "dest-filename": "3e2d77a2ca28acc4f944914cd4eacbf24b57eb20edcc8318f57ddcbb3e6f1883382e6b1d8ddc56bf0ff6a0d56a9b3a9add23eb98eb031497cfdad86fa26a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c2/97"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+        "sha512": "521764e6c7ea71e7bff47feb08e262918cfaee8d1ad93c3684644f386d98d51d9d83b6eb45ed6e1b4c9a3500c7bbe4cefee40f17fe5e09aa6f612987523b7b25",
+        "dest-filename": "64e6c7ea71e7bff47feb08e262918cfaee8d1ad93c3684644f386d98d51d9d83b6eb45ed6e1b4c9a3500c7bbe4cefee40f17fe5e09aa6f612987523b7b25",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/52/17"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+        "sha512": "b43e34787c40df98743c421935e223907a034786238c9a77e1b88cd260efa6505efff981f881c2a870c657ba7117eecc9254ef8a085c08f3d90bbca75b28dd4c",
+        "dest-filename": "34787c40df98743c421935e223907a034786238c9a77e1b88cd260efa6505efff981f881c2a870c657ba7117eecc9254ef8a085c08f3d90bbca75b28dd4c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b4/3e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+        "sha512": "5e83237413b07bf7ac56012f2e636c0f72111e49bb7db288506beb95e9682575198031e283620f58d9e2bfe1b08f2257cee36a56396be7ee32554663c9c2707d",
+        "dest-filename": "237413b07bf7ac56012f2e636c0f72111e49bb7db288506beb95e9682575198031e283620f58d9e2bfe1b08f2257cee36a56396be7ee32554663c9c2707d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5e/83"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+        "sha512": "8fa3c0436b94afbf4f6610633f90b97e197c7b7f459919ce8ec0f99469d6ac553c8b61bbefab412bbfa73fc2ae4144d3c80654c1f42a5c082b547e4c6c7f4261",
+        "dest-filename": "c0436b94afbf4f6610633f90b97e197c7b7f459919ce8ec0f99469d6ac553c8b61bbefab412bbfa73fc2ae4144d3c80654c1f42a5c082b547e4c6c7f4261",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8f/a3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz",
+        "sha512": "029e86d16430714fcb1ecbcbc0e3757c0417f59a7403663a63f709065f6bfc96d6f74672838ff36c6eb3cca6b639300b10b6ab60798abb41a1a4ce443beed3d2",
+        "dest-filename": "86d16430714fcb1ecbcbc0e3757c0417f59a7403663a63f709065f6bfc96d6f74672838ff36c6eb3cca6b639300b10b6ab60798abb41a1a4ce443beed3d2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/02/9e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+        "sha512": "2a67ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a",
+        "dest-filename": "ca2f76fa1be457bcff0dd6faf74ead642ffa021609f63585c4b6a3fcfcbde929aa540381bc70555aa05dd2537db7083e17ca947f7df8a81e692d8bafd36a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2a/67"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
+        "sha512": "30c74046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004",
+        "dest-filename": "4046e54443388d4de243f0380caa6870475d41450fdc04ffa92ed61d4939dfdcc20ef1f15e8883446d7dfa65d3657d4ffb03d7f7814c38f41de842cbf004",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/30/c7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+        "sha512": "ed150a7d781230c933b7a66e5e6a9aa4ebab2c63cf7e08fa97db9167b9511a896f934cb6ca871cdf92dd731282e4f419767d8332a8a8010d8da1672b4ca9a6ea",
+        "dest-filename": "0a7d781230c933b7a66e5e6a9aa4ebab2c63cf7e08fa97db9167b9511a896f934cb6ca871cdf92dd731282e4f419767d8332a8a8010d8da1672b4ca9a6ea",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ed/15"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
+        "sha512": "915b1ca97938382a7af126747648042958baffc8a3df4d0a0564c9ab7d8ffdd61e5934b02b8d56c93c5a94dd5e46603967d514fcb5fd0fb1564a657d480631ea",
+        "dest-filename": "1ca97938382a7af126747648042958baffc8a3df4d0a0564c9ab7d8ffdd61e5934b02b8d56c93c5a94dd5e46603967d514fcb5fd0fb1564a657d480631ea",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/91/5b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+        "sha512": "9a5b1347219a3c18cf79d93a06fc3e6aa6ec5c3b680320339b930eec9814fb2551c8c4393bc6c3e0a71c8bb052f397fddef79e81e08f90bf11e062c29678cb17",
+        "dest-filename": "1347219a3c18cf79d93a06fc3e6aa6ec5c3b680320339b930eec9814fb2551c8c4393bc6c3e0a71c8bb052f397fddef79e81e08f90bf11e062c29678cb17",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9a/5b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+        "sha512": "927bf279ab9886a8ce62f43ae8cce748cb3cdf0987ac2c9c34437a028fb601e6047f150892e895c5d11ad6a94610f2be59ede7d131e20dc8984ac09c816fc3a0",
+        "dest-filename": "f279ab9886a8ce62f43ae8cce748cb3cdf0987ac2c9c34437a028fb601e6047f150892e895c5d11ad6a94610f2be59ede7d131e20dc8984ac09c816fc3a0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/92/7b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-average-color/-/fast-average-color-9.5.2.tgz",
+        "sha512": "15b694f223d33e58cfeed9a75615db0b2012370ff3c6799a3437fcf209f9a535e536f7a397dc3815aa5e58c87a50d0f0223849254dbc10f7d05b05b4df66203c",
+        "dest-filename": "94f223d33e58cfeed9a75615db0b2012370ff3c6799a3437fcf209f9a535e536f7a397dc3815aa5e58c87a50d0f0223849254dbc10f7d05b05b4df66203c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/15/b6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+        "sha512": "7f7a90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1",
+        "dest-filename": "90f68432f63d808417bf1fd542f75c0b98a042094fe00ce9ca340606e61b303bb04b2a3d3d1dce4760dcfd70623efb19690c22200da8ad56cd3701347ce1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7f/7a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+        "sha512": "ecca6d2fc53472a705773233c0e4c7a22957f71e41acdab27bb67f2ee0bb9023118a8d44312caa44adc1100503eec5d1ab8893e00cd356e65d8604364c2bd82e",
+        "dest-filename": "6d2fc53472a705773233c0e4c7a22957f71e41acdab27bb67f2ee0bb9023118a8d44312caa44adc1100503eec5d1ab8893e00cd356e65d8604364c2bd82e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ec/ca"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+        "sha512": "96177fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f",
+        "dest-filename": "7fc05f8b93df076684c2b6556b687b5f8795d88a32236a55dc93bb1a52db9a9d20f22ccc671e149710326a1f10fb9ac47c0f4b829aa964c23095f31bf01f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/96/17"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+        "sha512": "0c25eee887e1a9c92ced364a6371f1a77cbaaa9858e522599ab58c0eb29c11148e5d641d32153d220fcf62bcf2c3fba5f63388ca1d0de0cd2d6c2e61a1d83c77",
+        "dest-filename": "eee887e1a9c92ced364a6371f1a77cbaaa9858e522599ab58c0eb29c11148e5d641d32153d220fcf62bcf2c3fba5f63388ca1d0de0cd2d6c2e61a1d83c77",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0c/25"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+        "sha512": "88f79e0ca25259fe0810e6ac555ae49d7a5a055d08029cff829ed2d9b6fb6782e58db976306251a889d9894ad0c15d7a729cf0fc3dd2e63e49ba58ff813e7600",
+        "dest-filename": "9e0ca25259fe0810e6ac555ae49d7a5a055d08029cff829ed2d9b6fb6782e58db976306251a889d9894ad0c15d7a729cf0fc3dd2e63e49ba58ff813e7600",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/88/f7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz",
+        "sha512": "7919c2b534ed199169402c2126250ebb13d05915d52980e7d1bd8f7877d72fafd98b9dd22c0cc01df5615562b602bc82fd61f4e6419fc611483ef4c5d125d0ce",
+        "dest-filename": "c2b534ed199169402c2126250ebb13d05915d52980e7d1bd8f7877d72fafd98b9dd22c0cc01df5615562b602bc82fd61f4e6419fc611483ef4c5d125d0ce",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/79/19"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+        "sha512": "1864e8c49ff0d71df6b3f0f610a343ee44e29789fc39593ff66c9c4dce150f36b5de53afa54653197de61520ad57d92c746055cefb320152ccea61c54e1c57c7",
+        "dest-filename": "e8c49ff0d71df6b3f0f610a343ee44e29789fc39593ff66c9c4dce150f36b5de53afa54653197de61520ad57d92c746055cefb320152ccea61c54e1c57c7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/18/64"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+        "sha512": "b486d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e",
+        "dest-filename": "d8b596ee70eb340511aa3c992c84951874bf920c7edd54cf208f2f84469dd60148cb105244fb4da46a7c87b708d63a7c2b298062c0098cd29e242c90275e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b4/86"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz",
+        "sha512": "3765857cad76826acad5cd465ceaa2009d6d739604f91e77cef43eb793fc4b95e19e6298541e5e64488b3592834a6a06f30aaa6c5f445d80415bf9de7f5f65a2",
+        "dest-filename": "857cad76826acad5cd465ceaa2009d6d739604f91e77cef43eb793fc4b95e19e6298541e5e64488b3592834a6a06f30aaa6c5f445d80415bf9de7f5f65a2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/37/65"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+        "sha512": "5d74d4c02be2b1ae6869c34644ff527cdb5804d00c8be44fc011666e564417b37bb301d8412ebf65f93b491c31e03e63dc21f6d7560d45ca350c430d55f6429d",
+        "dest-filename": "d4c02be2b1ae6869c34644ff527cdb5804d00c8be44fc011666e564417b37bb301d8412ebf65f93b491c31e03e63dc21f6d7560d45ca350c430d55f6429d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5d/74"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+        "sha512": "62c1a97b75872caf19622e2d583836272dde6d1cf6ad7a300f19e57786e4401d3471cff5670f405a70b48bdced0c98ad8afb50bda23d29a2f22ab73e8415b4ca",
+        "dest-filename": "a97b75872caf19622e2d583836272dde6d1cf6ad7a300f19e57786e4401d3471cff5670f405a70b48bdced0c98ad8afb50bda23d29a2f22ab73e8415b4ca",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/62/c1"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
+        "sha512": "efcfcf5d3d7094b2c3813cc3b3bb23abd873cf4bd70fece7fbbc32a447b87d74310a6766a9f1ac10f4319a2092408dda8c557dd5b552b2f36dac94625ba9c69e",
+        "dest-filename": "cf5d3d7094b2c3813cc3b3bb23abd873cf4bd70fece7fbbc32a447b87d74310a6766a9f1ac10f4319a2092408dda8c557dd5b552b2f36dac94625ba9c69e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/cf"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+        "sha512": "7fb71c14f2b7497147a71d795081b2449fc525072db8a674cd5b8dddfac1a381e72b771acbd5445b447ac8f6051c2d0082a86e90fcca8eadb6b790e6032a86cb",
+        "dest-filename": "1c14f2b7497147a71d795081b2449fc525072db8a674cd5b8dddfac1a381e72b771acbd5445b447ac8f6051c2d0082a86e90fcca8eadb6b790e6032a86cb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7f/b7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz",
+        "sha512": "376767cd5248a619cdb231dcaf1196ec378f72427a85a3eb485aa9b015211d8830b4a195ab826b04689e944183d9f0959ec1a6d73941559f301a1932b9eb60ba",
+        "dest-filename": "67cd5248a619cdb231dcaf1196ec378f72427a85a3eb485aa9b015211d8830b4a195ab826b04689e944183d9f0959ec1a6d73941559f301a1932b9eb60ba",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/37/67"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+        "sha512": "3e30ec7bb47385c3e4209c32e6deca3d641267d7006f341771a7ec7ad4280fbb0e2514251a290d6f1ef2669d8ea2d0e7272ac371bc91ab74ed6f5f2260eaa4c4",
+        "dest-filename": "ec7bb47385c3e4209c32e6deca3d641267d7006f341771a7ec7ad4280fbb0e2514251a290d6f1ef2669d8ea2d0e7272ac371bc91ab74ed6f5f2260eaa4c4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3e/30"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+        "sha512": "d57d4d4ed889a61af29ffb8b433df086d63a8caddf4eaa04de884ab34b53f948ebd56e7da28a719a8121ecbbb9a7abc168f6e0a0cd1bcef7805b8422e51c960d",
+        "dest-filename": "4d4ed889a61af29ffb8b433df086d63a8caddf4eaa04de884ab34b53f948ebd56e7da28a719a8121ecbbb9a7abc168f6e0a0cd1bcef7805b8422e51c960d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/7d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz",
+        "sha512": "0935ddeab93f337fd42cd423f0506a0561d80556326d0dd53c1c34c462857b7b6e1fbcad4fa0029efce9210dd466d07ccaf50a0b67179f56bec7ee445502e8bc",
+        "dest-filename": "ddeab93f337fd42cd423f0506a0561d80556326d0dd53c1c34c462857b7b6e1fbcad4fa0029efce9210dd466d07ccaf50a0b67179f56bec7ee445502e8bc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/09/35"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+        "sha512": "e71a037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43",
+        "dest-filename": "037d7f9f2fb7da0139da82658fa5b16dc21fd1efb5a630caaa1c64bae42defbc1d181eb805f81d58999df8e35b4c8f99fade4d36d765cda09c339617df43",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e7/1a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+        "sha512": "ed71cdc47eea5fdc46e66230c6486e993a31fcc21135c3a00ebc56b0cb76a40af6dd61e9e8cad194dec50521690a9afea153b417be38894811f369c931f1b648",
+        "dest-filename": "cdc47eea5fdc46e66230c6486e993a31fcc21135c3a00ebc56b0cb76a40af6dd61e9e8cad194dec50521690a9afea153b417be38894811f369c931f1b648",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ed/71"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+        "sha512": "de137b35ab2462f3032d0639e609d6dcd43e99eb0401ea53aa583e5446e3ef3cea10c055361cdc19861ea85a3f4e5633e9e42215ca751dcb0264efa71a04bcce",
+        "dest-filename": "7b35ab2462f3032d0639e609d6dcd43e99eb0401ea53aa583e5446e3ef3cea10c055361cdc19861ea85a3f4e5633e9e42215ca751dcb0264efa71a04bcce",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/de/13"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
+        "sha512": "090f9b10ef93bdafea966c36e1d09e8ee94ae6933356750e14e8a356881ddca42cd3b1e7448829f131a2a6f082453d3ac5e6046e96e0c1a0b18251728ae21c98",
+        "dest-filename": "9b10ef93bdafea966c36e1d09e8ee94ae6933356750e14e8a356881ddca42cd3b1e7448829f131a2a6f082453d3ac5e6046e96e0c1a0b18251728ae21c98",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/09/0f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+        "sha512": "1498584680da89ab5f12450af072a589c9aeff7486143e75ab78ad2831a8493cac4090677ce7315391b19e113513ab2807be8c6d3d0c06d9ca26e5f2031fbde9",
+        "dest-filename": "584680da89ab5f12450af072a589c9aeff7486143e75ab78ad2831a8493cac4090677ce7315391b19e113513ab2807be8c6d3d0c06d9ca26e5f2031fbde9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/14/98"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+        "sha512": "00e22049009ea62258c0fdc04671b1fb95674eed870587736c63f8e5e2f0d6faf7cc1def64b7b279dd6c0bd8676dc39cf7f4ab33233944f42b906cf8692f59a3",
+        "dest-filename": "2049009ea62258c0fdc04671b1fb95674eed870587736c63f8e5e2f0d6faf7cc1def64b7b279dd6c0bd8676dc39cf7f4ab33233944f42b906cf8692f59a3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/00/e2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
+        "sha512": "5f1c08f043a1550816a7a8832feddbd2bf3a7f877a017eb3494e791df078c9d084b972d773915c61e3aefa79c67ed4b84c48eeff5d6bb782893d33206df9afe0",
+        "dest-filename": "08f043a1550816a7a8832feddbd2bf3a7f877a017eb3494e791df078c9d084b972d773915c61e3aefa79c67ed4b84c48eeff5d6bb782893d33206df9afe0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5f/1c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
+        "sha512": "5a3972ae89669bcb83a66fe8806c976576f567e09ad81f0d6c9c2a0558346b12bd19b05ea12ef2195eaf8d79d87469ba5f9de27a112ec716f288aa7c42637857",
+        "dest-filename": "72ae89669bcb83a66fe8806c976576f567e09ad81f0d6c9c2a0558346b12bd19b05ea12ef2195eaf8d79d87469ba5f9de27a112ec716f288aa7c42637857",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5a/39"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz",
+        "sha512": "3466df989069f71f08c722527753fea2d60af2fa27a0969cb4ea20ad57c5448004635ba48a5f1148a0f3d98a3bc21d688a1979d65febe96e1ea6478a247a8bf0",
+        "dest-filename": "df989069f71f08c722527753fea2d60af2fa27a0969cb4ea20ad57c5448004635ba48a5f1148a0f3d98a3bc21d688a1979d65febe96e1ea6478a247a8bf0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/34/66"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz",
+        "sha512": "6b00a89c9495087546343eb1ded98c68a710bf05cb8637649a89b2d96f86a1aba2f183e06205c965ec218377d60be0e57eaa90b9683c030aa31930f69c03d55a",
+        "dest-filename": "a89c9495087546343eb1ded98c68a710bf05cb8637649a89b2d96f86a1aba2f183e06205c965ec218377d60be0e57eaa90b9683c030aa31930f69c03d55a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6b/00"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+        "sha512": "a1a846bee3064253f0fe2bc86018d54ab5807d62c17a4bb9b693c4d9f38f2e2f961df7c859bba1dad0a38724214c13cc7f913d8c3107e053a64d8818c1b2b0b5",
+        "dest-filename": "46bee3064253f0fe2bc86018d54ab5807d62c17a4bb9b693c4d9f38f2e2f961df7c859bba1dad0a38724214c13cc7f913d8c3107e053a64d8818c1b2b0b5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a1/a8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+        "sha512": "b1ea5f7e44fcb2dc272186ec301a6808726e24ce65f7c154176027134ee17ef1349bfaa9dd1e7cea1c388c5e2e69d6e1be0d68a08773baeec2b1f0f68f309a34",
+        "dest-filename": "5f7e44fcb2dc272186ec301a6808726e24ce65f7c154176027134ee17ef1349bfaa9dd1e7cea1c388c5e2e69d6e1be0d68a08773baeec2b1f0f68f309a34",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b1/ea"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+        "sha512": "8e121768ecf2d6c6fc232a1c6abb964a7d538e69c156cf00ca1732f37ae6c4d27cab6b96282023dc29c963e2a91925c2b9e00f7348b4e6456f54ab4fd6df52de",
+        "dest-filename": "1768ecf2d6c6fc232a1c6abb964a7d538e69c156cf00ca1732f37ae6c4d27cab6b96282023dc29c963e2a91925c2b9e00f7348b4e6456f54ab4fd6df52de",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8e/12"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz",
+        "sha512": "c587e7c3ad82286f272e46417d66e15b00f0d36087b72f3a8df3dc73672bdd97deb8af72b2854f3c45317f6d5b003feb580824e764ae06b2c995e7cdcbc9af16",
+        "dest-filename": "e7c3ad82286f272e46417d66e15b00f0d36087b72f3a8df3dc73672bdd97deb8af72b2854f3c45317f6d5b003feb580824e764ae06b2c995e7cdcbc9af16",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/87"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+        "sha512": "45b279fe398570d342703579a3d7939c12c9fc7b33595d0fef76dcf857f89d2feb263f98692e881b288e2f45680585fe9755ab97793ade1fcaac7fa7849d17bd",
+        "dest-filename": "79fe398570d342703579a3d7939c12c9fc7b33595d0fef76dcf857f89d2feb263f98692e881b288e2f45680585fe9755ab97793ade1fcaac7fa7849d17bd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/b2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz",
+        "sha512": "19967d98a7bcafae3a35401fff37a69c66e3621e01b7cfcca8048963ea529b9643b5cdd8428c7ee20b0b23bca2d616daea8f9e0ac1b1a479f9fa21159f7d7f15",
+        "dest-filename": "7d98a7bcafae3a35401fff37a69c66e3621e01b7cfcca8048963ea529b9643b5cdd8428c7ee20b0b23bca2d616daea8f9e0ac1b1a479f9fa21159f7d7f15",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/19/96"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+        "sha512": "1329094ff4352a34d672da698080207d23b4b4a56e6548e180caf5ee4a93ba6325e807efdc421295e53ba99533a170c54c01d30c2e0d3a81bf67153712f94c3d",
+        "dest-filename": "094ff4352a34d672da698080207d23b4b4a56e6548e180caf5ee4a93ba6325e807efdc421295e53ba99533a170c54c01d30c2e0d3a81bf67153712f94c3d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/13/29"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz",
+        "sha512": "899c8a1bdebf2703f3d4de79be3d887b6bd76e1bb8e34cdf51f26f4b012a11b78b96e93b3676a97c6a9aecb1f498eb270f14c5f39331f3f77247a1dfa9c6e66d",
+        "dest-filename": "8a1bdebf2703f3d4de79be3d887b6bd76e1bb8e34cdf51f26f4b012a11b78b96e93b3676a97c6a9aecb1f498eb270f14c5f39331f3f77247a1dfa9c6e66d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/89/9c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+        "sha512": "7a3e0085f85f2f6436ce93262e8ed4d54bfdf8fca1219a6040b193d45f668881a6882248a0281299ccc576b73dee6593e24558ef6280f969e7849e698214af4a",
+        "dest-filename": "0085f85f2f6436ce93262e8ed4d54bfdf8fca1219a6040b193d45f668881a6882248a0281299ccc576b73dee6593e24558ef6280f969e7849e698214af4a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/7a/3e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz",
+        "sha512": "552211a4b7d1c250007462f8c224ee731d927118a9a3479dd4505ab56932b7cdf68c2e0245e2acb606bac888585701aef4b3818ee5fdc3399131e41d049b7310",
+        "dest-filename": "11a4b7d1c250007462f8c224ee731d927118a9a3479dd4505ab56932b7cdf68c2e0245e2acb606bac888585701aef4b3818ee5fdc3399131e41d049b7310",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/55/22"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz",
+        "sha512": "32f1bf725b000ead463ccd8a1a8da7c9f6965729fd9da3e25eba887b88d88d735942ddb7f245b2386aecc9cfc3991010f917bac9ea3ac97ff2a0d086e4a00456",
+        "dest-filename": "bf725b000ead463ccd8a1a8da7c9f6965729fd9da3e25eba887b88d88d735942ddb7f245b2386aecc9cfc3991010f917bac9ea3ac97ff2a0d086e4a00456",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/32/f1"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+        "sha512": "a7f2e017344de457a80f70cb4ba6e451aa5ec9ee84e1223ac89b3a29eb4435dd7c4be141b61a98ab66a62545a9b79cf4110c301de9a27636393aa24610a9b9b8",
+        "dest-filename": "e017344de457a80f70cb4ba6e451aa5ec9ee84e1223ac89b3a29eb4435dd7c4be141b61a98ab66a62545a9b79cf4110c301de9a27636393aa24610a9b9b8",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a7/f2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz",
+        "sha512": "cedab20b790bb68d1ef566cda7469e3fe337913b7e9db688bde1a653102d65afbc88580a2d4383e1828ce63f9fdd00fcf5badaed47ae9a89591cab8e5e74e679",
+        "dest-filename": "b20b790bb68d1ef566cda7469e3fe337913b7e9db688bde1a653102d65afbc88580a2d4383e1828ce63f9fdd00fcf5badaed47ae9a89591cab8e5e74e679",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ce/da"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/htmlhint/-/htmlhint-1.9.2.tgz",
+        "sha512": "3f079648f0353dbf8054520e4a9206bb92a12dd9ad93fb9fff40a98efac37fa5d45a6753caa5258e5ca5c12c50d0058bbcf19c0712b69fcb884ac2389423a405",
+        "dest-filename": "9648f0353dbf8054520e4a9206bb92a12dd9ad93fb9fff40a98efac37fa5d45a6753caa5258e5ca5c12c50d0058bbcf19c0712b69fcb884ac2389423a405",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3f/07"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+        "sha512": "e60b39cad68d8c1ae1e4ec37cebbdd51463ed15c48b9654be22f62aede9fae257e06a7427e6575d4241358c8816161db5e1728f89d641df4ce52478f8420ef30",
+        "dest-filename": "39cad68d8c1ae1e4ec37cebbdd51463ed15c48b9654be22f62aede9fae257e06a7427e6575d4241358c8816161db5e1728f89d641df4ce52478f8420ef30",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e6/0b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+        "sha512": "86c053354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa",
+        "dest-filename": "53354a904c3c245ad71d608da2d3a63f9d4044b0d10324a8d676280bbde832f240ee2404bcb91969924710a721172f467fa630f2e4706632344227682afa",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/c0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+        "sha512": "1ece7dc4135f508ba730581601b197e5cabaf3ddc86d68382a7ae36d8c17dedc74ceda2b5604c303a076b317fc7a31c9e30cfc06a194318967ccd05eaf936f1a",
+        "dest-filename": "7dc4135f508ba730581601b197e5cabaf3ddc86d68382a7ae36d8c17dedc74ceda2b5604c303a076b317fc7a31c9e30cfc06a194318967ccd05eaf936f1a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1e/ce"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+        "sha512": "4d1dca7eb4d94d82cf07a8d48dfc7a305f56716ac72fdb2ee5339b2b866462005d58a3ce1684a8408744b93b91f36a66b711f6b29586f61e9eb707ebd692c1a9",
+        "dest-filename": "ca7eb4d94d82cf07a8d48dfc7a305f56716ac72fdb2ee5339b2b866462005d58a3ce1684a8408744b93b91f36a66b711f6b29586f61e9eb707ebd692c1a9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4d/1d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+        "sha512": "2665cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c",
+        "dest-filename": "cc67ac2ebc398b88712697dca4cea3ba97015ba1fd061b822470668435d0910c398c5679f2eece47b0880709b6aad30d8cc8f843aa48535204b62d4d8f1c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/26/65"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+        "sha512": "255ff2ba0576bb35b988c4528990320ed41dfa7c6d5278de2edd1a70d770f7c90a2ebbee455c81f34b6c444384ef2bc65606a5859e913570a61079142812b17b",
+        "dest-filename": "f2ba0576bb35b988c4528990320ed41dfa7c6d5278de2edd1a70d770f7c90a2ebbee455c81f34b6c444384ef2bc65606a5859e913570a61079142812b17b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/25/5f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+        "sha512": "cf3d3a4bcb74a33a035cc1beb9b7b6eb37824cd5dc2883c96498bc841ac5e227422e6b38086f50b4aeea065d5ba22e4e0f31698ecc1be493e61c26cca63698ce",
+        "dest-filename": "3a4bcb74a33a035cc1beb9b7b6eb37824cd5dc2883c96498bc841ac5e227422e6b38086f50b4aeea065d5ba22e4e0f31698ecc1be493e61c26cca63698ce",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/3d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+        "sha512": "64c11161eb3aa43c9dcae1a276c7bb3ac1f1b5b23b595794128ce047f83baddd31522998365bd9444fcad8c8194e35b2ef6e487de94b79570433dee69ad4465f",
+        "dest-filename": "1161eb3aa43c9dcae1a276c7bb3ac1f1b5b23b595794128ce047f83baddd31522998365bd9444fcad8c8194e35b2ef6e487de94b79570433dee69ad4465f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/64/c1"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+        "sha512": "51fa1e300e9f209f304d81445237a59da188ebbbfaf8deea5c912f42e2066bdf65e31b02aee498395490d2e3c0367e1d0339bc96460f68a2ebae28cbabbc76df",
+        "dest-filename": "1e300e9f209f304d81445237a59da188ebbbfaf8deea5c912f42e2066bdf65e31b02aee498395490d2e3c0367e1d0339bc96460f68a2ebae28cbabbc76df",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/51/fa"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+        "sha512": "49b29b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1",
+        "dest-filename": "9b00d90deb4dd58b88c466fe3d2de549327e321b0b1bcd9c28ac4a32122badb0dde725875b3b7eb37e1189e90103a4e6481640ed9eae494719af9778eca1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/49/b2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+        "sha512": "cf29a6e7ebbeb02b125b20fda8d69e8d5dc316f84229c94a762cd868952e1c0f3744b8dbee74ae1a775d0871afd2193e298ec130096c59e2b851e83a115e9742",
+        "dest-filename": "a6e7ebbeb02b125b20fda8d69e8d5dc316f84229c94a762cd868952e1c0f3744b8dbee74ae1a775d0871afd2193e298ec130096c59e2b851e83a115e9742",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/29"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+        "sha512": "e571d8692ca2a800dbe119d9d4175a77a70fa7c4e88ac7b84f312370e6031d991309b2a089497b593502a4d587bb1983b7dd709ec64173dc629cdce8a6fdc931",
+        "dest-filename": "d8692ca2a800dbe119d9d4175a77a70fa7c4e88ac7b84f312370e6031d991309b2a089497b593502a4d587bb1983b7dd709ec64173dc629cdce8a6fdc931",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e5/71"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+        "sha512": "c5e9526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a",
+        "dest-filename": "526b21c7dfa66013b6568658bba56df884d6cd97c3a3bf92959a4243e2105d0f7b61f137e4f6f61ab0b33e99758e6611648197f184b4a7af046be1e9524a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/e9"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+        "sha512": "e350a27e483a7bc4f2952a5db53a5e2d532abd20445734edb47bc4443ef8d7ea6767c00dbf4d34e0c44be3740a3c394af5c1af369e8d6566540656c65d8c719e",
+        "dest-filename": "a27e483a7bc4f2952a5db53a5e2d532abd20445734edb47bc4443ef8d7ea6767c00dbf4d34e0c44be3740a3c394af5c1af369e8d6566540656c65d8c719e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e3/50"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+        "sha512": "5514b32a46cc9b98cc0e828b6e5b4090543942bed50e24c5197c581575e8c158f7f3b19e18d382b0e1fa32ccb4d12199dc5a7ce1bd4d69ad69b2a81c08810fe5",
+        "dest-filename": "b32a46cc9b98cc0e828b6e5b4090543942bed50e24c5197c581575e8c158f7f3b19e18d382b0e1fa32ccb4d12199dc5a7ce1bd4d69ad69b2a81c08810fe5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/55/14"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+        "sha512": "447c4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23",
+        "dest-filename": "4c2e9f659ca1c61d19e0f5016144231b600715a67ebdb2648672addfdfac638155564e18f8aaa2db4cb96aed2b23f01f9f210d44b8210623694ab3241e23",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/7c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
+        "sha512": "fe298a346e046d636b563a0d0bfd47e7ff46172fadaa31811c2692b0df8fd919cfaa3b0b9afe940f7123f8a8fc9c159a440c3293b90ae5951cf8e11ab674d1dc",
+        "dest-filename": "8a346e046d636b563a0d0bfd47e7ff46172fadaa31811c2692b0df8fd919cfaa3b0b9afe940f7123f8a8fc9c159a440c3293b90ae5951cf8e11ab674d1dc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fe/29"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+        "sha512": "45d2547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29",
+        "dest-filename": "547e5704ddc5332a232a420b02bb4e853eef5474824ed1b7986cf84737893a6a9809b627dca02b53f5b7313a9601b690f690233a49bce0e026aeb16fcf29",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/d2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+        "sha512": "a90293e334315e5f252f006d1cc5b06937067c5399be23897addcecbfc661a4da0647ebbec224cf44bed7dd4a48167004d9863ff9e49674ae6cb79b2093e65b0",
+        "dest-filename": "93e334315e5f252f006d1cc5b06937067c5399be23897addcecbfc661a4da0647ebbec224cf44bed7dd4a48167004d9863ff9e49674ae6cb79b2093e65b0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a9/02"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+        "sha512": "fec33774ed853b35e3290849ba8d10d7bdf07f628ea3cb7823cbc7cba945f69a14a7b6ca4f4fcd1c4f1f3d7db73f07e19f291faa70b6c51c4e9d5c395ee18868",
+        "dest-filename": "3774ed853b35e3290849ba8d10d7bdf07f628ea3cb7823cbc7cba945f69a14a7b6ca4f4fcd1c4f1f3d7db73f07e19f291faa70b6c51c4e9d5c395ee18868",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fe/c3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+        "sha512": "e1b57905f4769aa7d04c99be579b4f3dd7fe669ba1888bd3b8007983c91cad7399a534ff430c15456072c17d68cebea512e3dd6c7c70689966f46ea6236b1f49",
+        "dest-filename": "7905f4769aa7d04c99be579b4f3dd7fe669ba1888bd3b8007983c91cad7399a534ff430c15456072c17d68cebea512e3dd6c7c70689966f46ea6236b1f49",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e1/b5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+        "sha512": "c72170ca1ae8fc91287fa1a17b68b3d8d717a23dac96836c5abfd7b044432bfa223c27da36197938d7e9fa341d01945043420958dcc7f7321917b962f75921db",
+        "dest-filename": "70ca1ae8fc91287fa1a17b68b3d8d717a23dac96836c5abfd7b044432bfa223c27da36197938d7e9fa341d01945043420958dcc7f7321917b962f75921db",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c7/21"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+        "sha512": "c5b6c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756",
+        "dest-filename": "c21f9742614e53f0b704861ba1ec727cf075ee5b7aac237634cce64529f6441dca5688753f271ce4eb6f41aec69bfe63221d0b62f7030ffbce3944f7b756",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/b6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+        "sha512": "34cf3f3fd9f75e35e12199f594b86415a0024ce5114178d6855e0103f4673aff31be0aadaa9017f483b89914314b1d51968e2dab37aa6f4b0e96bb9a3b2dddba",
+        "dest-filename": "3f3fd9f75e35e12199f594b86415a0024ce5114178d6855e0103f4673aff31be0aadaa9017f483b89914314b1d51968e2dab37aa6f4b0e96bb9a3b2dddba",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/34/cf"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+        "sha512": "05d6e8cbe97bb40dce196e858f21475a43f92ee0728f54e4df72e3caad1ac72cdd93dfff2528b6bb77cfd504a677528dc2ae9538a606940bbcec28ac562afa3f",
+        "dest-filename": "e8cbe97bb40dce196e858f21475a43f92ee0728f54e4df72e3caad1ac72cdd93dfff2528b6bb77cfd504a677528dc2ae9538a606940bbcec28ac562afa3f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/d6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+        "sha512": "5e63967bb7b21d81f5e1c2dd54fa3283e18e1f7ad85fef8aa73af2949c125bdf2ddcd93e53c5ce97c15628e830b7375bf255c67facd8c035337873167f16acca",
+        "dest-filename": "967bb7b21d81f5e1c2dd54fa3283e18e1f7ad85fef8aa73af2949c125bdf2ddcd93e53c5ce97c15628e830b7375bf255c67facd8c035337873167f16acca",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5e/63"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+        "sha512": "cf039374bdeb150fe545d0679ed295397ea4e5c289c047351dd8a54fbd41584bbb278d605c8076311a7ebf176e3d2c1924f581c44cefe321f5c182c91941d7e1",
+        "dest-filename": "9374bdeb150fe545d0679ed295397ea4e5c289c047351dd8a54fbd41584bbb278d605c8076311a7ebf176e3d2c1924f581c44cefe321f5c182c91941d7e1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/03"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
+        "sha512": "a3154790747f1097f608d5e75b144b5ba9a0ec9c82094706d03b441a62f672d528d4f3538a7d4f52297eafffb8af93295600bf7e7d648ecc7b9a34ae8caa88a7",
+        "dest-filename": "4790747f1097f608d5e75b144b5ba9a0ec9c82094706d03b441a62f672d528d4f3538a7d4f52297eafffb8af93295600bf7e7d648ecc7b9a34ae8caa88a7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a3/15"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
+        "sha512": "0980c3dd23adb07b725de10e458471daa06da432458d14c65d4b66344306cb360e2a3d53137b7271d961a3b900d547f1f4e616673839d901411802d38abcc34b",
+        "dest-filename": "c3dd23adb07b725de10e458471daa06da432458d14c65d4b66344306cb360e2a3d53137b7271d961a3b900d547f1f4e616673839d901411802d38abcc34b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/09/80"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+        "sha512": "75c4b5ba5fbdb66783f794fec76f3f7a12e077d98435adcbb2f0d3b739b7bf20443bb44fa6dbc00feb78e165576948d305172ba45785942f160abb94478e7a87",
+        "dest-filename": "b5ba5fbdb66783f794fec76f3f7a12e077d98435adcbb2f0d3b739b7bf20443bb44fa6dbc00feb78e165576948d305172ba45785942f160abb94478e7a87",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/75/c4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz",
+        "sha512": "2420ebb0fe19d526fd2701b4689f04a36afb9383aee4cc264e14bfea57087b5202c9bed404928644851476a736012744ff8da5833eb31549f300886d5e7055ad",
+        "dest-filename": "ebb0fe19d526fd2701b4689f04a36afb9383aee4cc264e14bfea57087b5202c9bed404928644851476a736012744ff8da5833eb31549f300886d5e7055ad",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/24/20"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
+        "sha512": "f9b4f6b87e04e4b184ee1fe7ddebdc4bfb109495c2a48a7aca6f0e589e5e57afbaec3b2a97f2da693eea24102ddabcdfa1aff94011818710e2c7574cb7691029",
+        "dest-filename": "f6b87e04e4b184ee1fe7ddebdc4bfb109495c2a48a7aca6f0e589e5e57afbaec3b2a97f2da693eea24102ddabcdfa1aff94011818710e2c7574cb7691029",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f9/b4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz",
+        "sha512": "fef945280a07e4282ddc87be24b8516f03ac09078f001894ded2757a01afc90fb7dd1fef730336665d9047f2f38ec05e22d3edde84955daa67fa6e27403be9cf",
+        "dest-filename": "45280a07e4282ddc87be24b8516f03ac09078f001894ded2757a01afc90fb7dd1fef730336665d9047f2f38ec05e22d3edde84955daa67fa6e27403be9cf",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fe/f9"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+        "sha512": "ef297295eb1943f3d5dbd8e110397751f8e8e995fb802a89af917b3caaea73ddefedfcd2ca6b75069c0453c9c0517b3cab3cefaa16e384ae50660e8cb7f1e406",
+        "dest-filename": "7295eb1943f3d5dbd8e110397751f8e8e995fb802a89af917b3caaea73ddefedfcd2ca6b75069c0453c9c0517b3cab3cefaa16e384ae50660e8cb7f1e406",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/29"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz",
+        "sha512": "9415adf21ba387f0a3cacc391985666691475c30a067386b3a6f2f6dc51da1b00364d38afdb46c86bda43370df82baed4750d085fba95bd82721739f8858be6f",
+        "dest-filename": "adf21ba387f0a3cacc391985666691475c30a067386b3a6f2f6dc51da1b00364d38afdb46c86bda43370df82baed4750d085fba95bd82721739f8858be6f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/94/15"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz",
+        "sha512": "304e056fcdcb804830370f7a44a36f295e154cbb977e82ae7409a6da53fc2a4f3b29a30ad3f5ebc7f68090c5a64fc9836fedcc9450eca5f6c2b3b69d8d1c40da",
+        "dest-filename": "056fcdcb804830370f7a44a36f295e154cbb977e82ae7409a6da53fc2a4f3b29a30ad3f5ebc7f68090c5a64fc9836fedcc9450eca5f6c2b3b69d8d1c40da",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/30/4e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
+        "sha512": "88f64ae9e6236f146edee078fd667712c10830914ca80a28a65dd1fb3baad148dc026fcc3ba282c1e0e03df3f77a54f3b6828fdcab67547c539f63470520d553",
+        "dest-filename": "4ae9e6236f146edee078fd667712c10830914ca80a28a65dd1fb3baad148dc026fcc3ba282c1e0e03df3f77a54f3b6828fdcab67547c539f63470520d553",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/88/f6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
+        "sha512": "d0aa63a97455beb6320ac5f5b3047f5d32b4bdae9542440ce8c368ecfa96efb0728c086801103c11facfd4de3e2a52a3f184b46540ad453fd852e872603ba321",
+        "dest-filename": "63a97455beb6320ac5f5b3047f5d32b4bdae9542440ce8c368ecfa96efb0728c086801103c11facfd4de3e2a52a3f184b46540ad453fd852e872603ba321",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d0/aa"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz",
+        "sha512": "8edb6645eedb46c7b9d8eb1620c0cb697c56a91026b4851c70043781aaef882a898da7d739f34c3b4c8c7cda5d0facdb19a4d4d0fe4dcfb7bb8004fa70a98947",
+        "dest-filename": "6645eedb46c7b9d8eb1620c0cb697c56a91026b4851c70043781aaef882a898da7d739f34c3b4c8c7cda5d0facdb19a4d4d0fe4dcfb7bb8004fa70a98947",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8e/db"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+        "sha512": "f627bc22d3d1ead8d8e6e60987c2bf66bbff44c67954e94e5afb597441d849314a65f2013d06bdb4e0047805a177e02722778b276db0e5f8ce62da2eb695aae7",
+        "dest-filename": "bc22d3d1ead8d8e6e60987c2bf66bbff44c67954e94e5afb597441d849314a65f2013d06bdb4e0047805a177e02722778b276db0e5f8ce62da2eb695aae7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f6/27"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+        "sha512": "972bb13c6aff59f86b95e9b608bfd472751cd7372a280226043cee918ed8e45ff242235d928ebe7d12debe5c351e03324b0edfeb5d54218e34f04b71452a0add",
+        "dest-filename": "b13c6aff59f86b95e9b608bfd472751cd7372a280226043cee918ed8e45ff242235d928ebe7d12debe5c351e03324b0edfeb5d54218e34f04b71452a0add",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/97/2b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+        "sha512": "09dceaa3044909e2d4ef66c7bd6ab04410652dc304b48bc6ae5bde7fbe24327576028952f58f3152fd48d14fcc34058c84194a228cae120a09d2dfdb6f01db2d",
+        "dest-filename": "eaa3044909e2d4ef66c7bd6ab04410652dc304b48bc6ae5bde7fbe24327576028952f58f3152fd48d14fcc34058c84194a228cae120a09d2dfdb6f01db2d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/09/dc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+        "sha512": "371545c0b027addf62eca501c42e03ad4866823cceb3ed509b9d03de8175fe82feaf5369678800ef1bc6d3fcc9f1ebd1ef320a9f8bcb7fba9335db9616d0ab47",
+        "dest-filename": "45c0b027addf62eca501c42e03ad4866823cceb3ed509b9d03de8175fe82feaf5369678800ef1bc6d3fcc9f1ebd1ef320a9f8bcb7fba9335db9616d0ab47",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/37/15"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+        "sha512": "2a9340450037230bfe8d3034bad51555bae1f8996baf516fd1ee7a186cc014e5cdedd93f16f89a0d6f0b1e62b9d8395c1f858fda7ea023cbcdd5a7ac045828f7",
+        "dest-filename": "40450037230bfe8d3034bad51555bae1f8996baf516fd1ee7a186cc014e5cdedd93f16f89a0d6f0b1e62b9d8395c1f858fda7ea023cbcdd5a7ac045828f7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2a/93"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.14.0.tgz",
+        "sha512": "fb599d59c7d225552c69322337dce87b399485f5e8e65d2f3fb7a404c3e8de3712fda224c479d7a803ec072b33319c7f63ca10051271271e7183e447deeaf3c4",
+        "dest-filename": "9d59c7d225552c69322337dce87b399485f5e8e65d2f3fb7a404c3e8de3712fda224c479d7a803ec072b33319c7f63ca10051271271e7183e447deeaf3c4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/fb/59"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+        "sha512": "bddd85e1853211728670b1e8abe4c4c828f1b9e49e1e7171cb28cda7cd328345d5e2f5219c37abfe5bef96a33f6ab0796d740de4adbfde88a7c82472c7c4f609",
+        "dest-filename": "85e1853211728670b1e8abe4c4c828f1b9e49e1e7171cb28cda7cd328345d5e2f5219c37abfe5bef96a33f6ab0796d740de4adbfde88a7c82472c7c4f609",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bd/dd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz",
+        "sha512": "00f30111a9e3c9b68fcd4adfa94d08314e48d00b3028c1fb93c3932ecd2fbd5e0a669131913918f3b9d1ff3a5bb933e3fa0011a29eda1946e5d75a670df5bac6",
+        "dest-filename": "0111a9e3c9b68fcd4adfa94d08314e48d00b3028c1fb93c3932ecd2fbd5e0a669131913918f3b9d1ff3a5bb933e3fa0011a29eda1946e5d75a670df5bac6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/00/f3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+        "sha512": "f58b9b9edddef00d0e2b0c58497ca12f29865b8b02b9f70b1ba55d88375419590f869a8bc65bcfe6f975f7cde0423265deda9baccef7d668da65a3faf00828b1",
+        "dest-filename": "9b9edddef00d0e2b0c58497ca12f29865b8b02b9f70b1ba55d88375419590f869a8bc65bcfe6f975f7cde0423265deda9baccef7d668da65a3faf00828b1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f5/8b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/meow/-/meow-13.2.0.tgz",
+        "sha512": "a7140943307a76318f5e1d3c75a704968305a29b0ea865512853d8bcf3adf570d9d476ac6e00d903be02246ade494e06dc093b105246a221f66aeabec9721280",
+        "dest-filename": "0943307a76318f5e1d3c75a704968305a29b0ea865512853d8bcf3adf570d9d476ac6e00d903be02246ade494e06dc093b105246a221f66aeabec9721280",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a7/14"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+        "sha512": "f2aed51203095b827cb5c7d53f2f20d3d35c43065d6f0144aa17bf5999282338e7ff74c60f0b4e098b571b10373bcb4fce97330820e0bfe3f63f9cb4d1924e3a",
+        "dest-filename": "d51203095b827cb5c7d53f2f20d3d35c43065d6f0144aa17bf5999282338e7ff74c60f0b4e098b571b10373bcb4fce97330820e0bfe3f63f9cb4d1924e3a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f2/ae"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+        "sha512": "3d7c1f06162ed210423f0f039f413e58361beda7f77522d558a8b71c6bfce08745e13c85a02d32b3115dd06a31c3b9d2bf84ff3f3109431b18b0488508aa3604",
+        "dest-filename": "1f06162ed210423f0f039f413e58361beda7f77522d558a8b71c6bfce08745e13c85a02d32b3115dd06a31c3b9d2bf84ff3f3109431b18b0488508aa3604",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3d/7c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+        "sha512": "54fefd5d43f15760a28183f78d6c005054a4bb668aa811fbb9301aa4558206abadb1b983a3de8a639a3cba1e94fbf612227e4ec499d7a7bddb795929a8c20684",
+        "dest-filename": "fd5d43f15760a28183f78d6c005054a4bb668aa811fbb9301aa4558206abadb1b983a3de8a639a3cba1e94fbf612227e4ec499d7a7bddb795929a8c20684",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/54/fe"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+        "sha512": "3142e454b7ca1980c561e8cfd3b40ebab0cb2d0a5c8e4ec5c3eee35d2d91d9ccd1433479eb21d1bde5393432443af887fa111364a4a4224e5cf93db71a315432",
+        "dest-filename": "e454b7ca1980c561e8cfd3b40ebab0cb2d0a5c8e4ec5c3eee35d2d91d9ccd1433479eb21d1bde5393432443af887fa111364a4a4224e5cf93db71a315432",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/31/42"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+        "sha512": "5608d652c9e74fa9fe35493a799abbef37857695b62d60f33facc51ab09b1d789836e9790f3aa4d871d0e6e147d83356e576e9f3e8d5cda78db7de2cb04125e3",
+        "dest-filename": "d652c9e74fa9fe35493a799abbef37857695b62d60f33facc51ab09b1d789836e9790f3aa4d871d0e6e147d83356e576e9f3e8d5cda78db7de2cb04125e3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/56/08"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+        "sha512": "b44047a839c8a0cff5ad7304d738246bd83a43695ca029311cbb9cece0c9e41c5b3f977873667970682d5c092ee7ddb4d02c7b762b874ce61f4810fc9fa9a6f0",
+        "dest-filename": "47a839c8a0cff5ad7304d738246bd83a43695ca029311cbb9cece0c9e41c5b3f977873667970682d5c092ee7ddb4d02c7b762b874ce61f4810fc9fa9a6f0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b4/40"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+        "sha512": "e85973b9b4cb646dc9d9afcd542025784863ceae68c601f268253dc985ef70bb2fa1568726afece715c8ebf5d73fab73ed1f7100eb479d23bfb57b45dd645394",
+        "dest-filename": "73b9b4cb646dc9d9afcd542025784863ceae68c601f268253dc985ef70bb2fa1568726afece715c8ebf5d73fab73ed1f7100eb479d23bfb57b45dd645394",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e8/59"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+        "sha512": "cfcd4634eee79d830486b1a1f4b7b29a8138f98af45a7e4c70721930ae5c7d00a5f8d0d7d3cb0266051cf7fe8c1e78bd216b852e6d59dc74c25eedb3f5f37ad9",
+        "dest-filename": "4634eee79d830486b1a1f4b7b29a8138f98af45a7e4c70721930ae5c7d00a5f8d0d7d3cb0266051cf7fe8c1e78bd216b852e6d59dc74c25eedb3f5f37ad9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/cd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+        "sha512": "37c4a97cf527529d5b2be3cc616f2a496765f54fb0c0d588e102b13980f2f4902ba3758c5fba7639e55117dbfedf8ee99da90d7af3e688784d999d876c503beb",
+        "dest-filename": "a97cf527529d5b2be3cc616f2a496765f54fb0c0d588e102b13980f2f4902ba3758c5fba7639e55117dbfedf8ee99da90d7af3e688784d999d876c503beb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/37/c4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+        "sha512": "396343f1e8b756d342f61ed5eb4a9f7f7495a1b1ebf7de824f0831b9b832418129836f7487d2746eec8408d3497b19059b9b0e6a38791b5d7a45803573c64c4b",
+        "dest-filename": "43f1e8b756d342f61ed5eb4a9f7f7495a1b1ebf7de824f0831b9b832418129836f7487d2746eec8408d3497b19059b9b0e6a38791b5d7a45803573c64c4b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/39/63"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
+        "sha512": "d61e60299085fa93bfa3722ab79269ef073dac7dde249d3e9e1fc2228891c2347175efe1007c8b3d760de15dc2a8a01b8993d2789152587989b1b92272d6b412",
+        "dest-filename": "60299085fa93bfa3722ab79269ef073dac7dde249d3e9e1fc2228891c2347175efe1007c8b3d760de15dc2a8a01b8993d2789152587989b1b92272d6b412",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d6/1e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.2.0.tgz",
+        "sha512": "91520e7729eb176091a1d1d978fffded1875b324d41c1362c35ee1502215865844b1695f266d7d32e3b9eace0c74a6ebdb6c56c7a9b3327340817cd594860cf5",
+        "dest-filename": "0e7729eb176091a1d1d978fffded1875b324d41c1362c35ee1502215865844b1695f266d7d32e3b9eace0c74a6ebdb6c56c7a9b3327340817cd594860cf5",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/91/52"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+        "sha512": "e9e66ce4bb375ad0a2b075a9f52d86532f1daa4a468b80554b3dc66aa884e9ecee6f4e75d844b3b57530501e82e8829b4246363e76ff983e166288c24707302c",
+        "dest-filename": "6ce4bb375ad0a2b075a9f52d86532f1daa4a468b80554b3dc66aa884e9ecee6f4e75d844b3b57530501e82e8829b4246363e76ff983e166288c24707302c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e9/e6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+        "sha512": "ac98134279149c7d6c170f324fa552537cc3dec5a6bbab19848b1e63c557f8646edcfe85ec5bbe24d0e85df9251256cb2529dcdc55101d57b8714e618fe05c52",
+        "dest-filename": "134279149c7d6c170f324fa552537cc3dec5a6bbab19848b1e63c557f8646edcfe85ec5bbe24d0e85df9251256cb2529dcdc55101d57b8714e618fe05c52",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ac/98"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz",
+        "sha512": "4529fd17af0f8c7f47aad96db129ea602d575e859ef418eee7edb5dd1f7c70d1adb5a83dabdc80393cdd6ecaaf21aeda366e567df059169598af6696ae495603",
+        "dest-filename": "fd17af0f8c7f47aad96db129ea602d575e859ef418eee7edb5dd1f7c70d1adb5a83dabdc80393cdd6ecaaf21aeda366e567df059169598af6696ae495603",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/29"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+        "sha512": "55726373cec549c17cf2e69f4b726594382f026f9cfd295fcf4ea5a2b8f6b80637e2b954bb436dfaff30ade88899cae00238c81e9d6b5e94c394b386c36f56c1",
+        "dest-filename": "6373cec549c17cf2e69f4b726594382f026f9cfd295fcf4ea5a2b8f6b80637e2b954bb436dfaff30ade88899cae00238c81e9d6b5e94c394b386c36f56c1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/55/72"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+        "sha512": "e88a50ee6294c5171934b20e6d1d21cfb971b1aa5248860d649c173c6785d264d5a862852178f50d070ca13db64b744e70bc98febcf43d669667d6b25a669df6",
+        "dest-filename": "50ee6294c5171934b20e6d1d21cfb971b1aa5248860d649c173c6785d264d5a862852178f50d070ca13db64b744e70bc98febcf43d669667d6b25a669df6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e8/8a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+        "sha512": "4d839a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945",
+        "dest-filename": "9a9ccdf01b0346b193767154d83c0af0e39e319d78f9aa6585d5b12801ce3e714fe897b19587ba1d7af8e9d4534776e1dcdca64c70576ec54e5773ab8945",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4d/83"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+        "sha512": "2da363b51594058fbecc1e6713f37071aa0cca548f93e4be647341d53cdd6cc24c9f2e9dca7a401aded7fed97f418ab74c8784ea7c47a696e8d8b1b29ab1b93f",
+        "dest-filename": "63b51594058fbecc1e6713f37071aa0cca548f93e4be647341d53cdd6cc24c9f2e9dca7a401aded7fed97f418ab74c8784ea7c47a696e8d8b1b29ab1b93f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2d/a3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+        "sha512": "190d84591a5057cfe8f80c3c62ab5f6593df3515996246e2744f64e6ba65fe10b7bed1c705f1a6d887e2eaa595f9ca031a4ad42990311372e8b7991cb11961fa",
+        "dest-filename": "84591a5057cfe8f80c3c62ab5f6593df3515996246e2744f64e6ba65fe10b7bed1c705f1a6d887e2eaa595f9ca031a4ad42990311372e8b7991cb11961fa",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/19/0d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+        "sha512": "6b208abe6fe98421b13a461148233cda20f072df3f1289d2120092c56c43eef7ba8c7820b059787d955004f44d810a0a8ae57fa1d845ac6cd05d9c1b89f0bc46",
+        "dest-filename": "8abe6fe98421b13a461148233cda20f072df3f1289d2120092c56c43eef7ba8c7820b059787d955004f44d810a0a8ae57fa1d845ac6cd05d9c1b89f0bc46",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6b/20"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+        "sha512": "6a4f50cb943b8d86f65b071ecb9169be0d8aa0073f64884b48b392066466ca03ec1b091556dd1f65ad2aaed333fa6ead2530077d943c167981e0c1b82d6cbbff",
+        "dest-filename": "50cb943b8d86f65b071ecb9169be0d8aa0073f64884b48b392066466ca03ec1b091556dd1f65ad2aaed333fa6ead2530077d943c167981e0c1b82d6cbbff",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6a/4f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+        "sha512": "a2399e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9",
+        "dest-filename": "9e374a9dfb2d23b3312da18e3caf43deab97703049089423aee90e5fe3595f92cc17b8ab58ae18284e92e7c887079b6e1486ac7ee53aa6d889d2c0b844e9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/39"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+        "sha512": "2c32733d510410f47ecb8f33f7703411dd325dbf29001c865a8fe4e5861d620a58dbfd84b0eb24b09aeaee5387c6bcab54e9f57a31baa00a7c6a1bce2100fcb3",
+        "dest-filename": "733d510410f47ecb8f33f7703411dd325dbf29001c865a8fe4e5861d620a58dbfd84b0eb24b09aeaee5387c6bcab54e9f57a31baa00a7c6a1bce2100fcb3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/2c/32"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
+        "sha512": "dcefe2555b0900fb0e9e9c1621e0fe77acffecf9aa029c9078f52d0a77636ad8fff48e4bca51efb79aa5b856814f7239877af57a37d1d39e9cf850aff8d9cd5e",
+        "dest-filename": "e2555b0900fb0e9e9c1621e0fe77acffecf9aa029c9078f52d0a77636ad8fff48e4bca51efb79aa5b856814f7239877af57a37d1d39e9cf850aff8d9cd5e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/dc/ef"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+        "sha512": "80329bf1a64c0de0ffb595acf4febeab427d33091d97ac4c57c4e39c63f7a89549d3a6dd32091b0652d4f0875f3ac22c173d815b5acd553dd7b8d125f333c0bf",
+        "dest-filename": "9bf1a64c0de0ffb595acf4febeab427d33091d97ac4c57c4e39c63f7a89549d3a6dd32091b0652d4f0875f3ac22c173d815b5acd553dd7b8d125f333c0bf",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/80/32"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+        "sha512": "c212dd58c60bd93c08d3c867f3f66a01bad57a6bb42cd68d349657ef73baa9a21d0937d7badb0b84c923744357d2a86c43db888a6a38fda40e997928a27da70d",
+        "dest-filename": "dd58c60bd93c08d3c867f3f66a01bad57a6bb42cd68d349657ef73baa9a21d0937d7badb0b84c923744357d2a86c43db888a6a38fda40e997928a27da70d",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c2/12"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+        "sha512": "fff9ec8660f9e5ce3a16e170dbac55ff1140681e4717d5dd6a9ec7241067aca74077afc6c4305a340d7cef43bbf7ef6e7a0eb57192d255cf8e68595f98e6d855",
+        "dest-filename": "ec8660f9e5ce3a16e170dbac55ff1140681e4717d5dd6a9ec7241067aca74077afc6c4305a340d7cef43bbf7ef6e7a0eb57192d255cf8e68595f98e6d855",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ff/f9"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+        "sha512": "c5c787dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454",
+        "dest-filename": "87dac9e1b5be4cf658aa0ec984c39ea57b7efa993664117fe311bfd1c4d1727a036e97b78db250973fd1438ff2dcbb45fc284c8c71e3f69eda5a1eb0c454",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c5/c7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+        "sha512": "57bfaf404274e99f9ce6d4b27bc4be9c751f239d71a172178c743df5c42d294910aaa3b590efca08951f657b81e3b87f60194385a8761f785d5065e7f227b4a0",
+        "dest-filename": "af404274e99f9ce6d4b27bc4be9c751f239d71a172178c743df5c42d294910aaa3b590efca08951f657b81e3b87f60194385a8761f785d5065e7f227b4a0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/57/bf"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+        "sha512": "40ff3c0402af31a9bfdcdc47eaf8f6a36d51e8c8f165401dea7970012fe99c6bcdf4854ba1c2c7c46608cc5860e9f510fb9b61e8fe1dbf8796f635f70d2223ec",
+        "dest-filename": "3c0402af31a9bfdcdc47eaf8f6a36d51e8c8f165401dea7970012fe99c6bcdf4854ba1c2c7c46608cc5860e9f510fb9b61e8fe1dbf8796f635f70d2223ec",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/40/ff"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+        "sha512": "b9d82c018f9f4e7befee423b69ac5bab058d6f4007881d2a04ef3d3d928f9284e618e81d6eb1c3283fb40765f8b937c9fc54f5474f6bf604ec8d48cd268b6ea2",
+        "dest-filename": "2c018f9f4e7befee423b69ac5bab058d6f4007881d2a04ef3d3d928f9284e618e81d6eb1c3283fb40765f8b937c9fc54f5474f6bf604ec8d48cd268b6ea2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b9/d8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz",
+        "sha512": "4dfc92aecff99e6f1f4090dc043b949e0dd53942ac77b4beceabdb3938865c77f15f8c0adf56ab77e86836ebe489c33fd981739690e000139ebca4ac0781bf14",
+        "dest-filename": "92aecff99e6f1f4090dc043b949e0dd53942ac77b4beceabdb3938865c77f15f8c0adf56ab77e86836ebe489c33fd981739690e000139ebca4ac0781bf14",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4d/fc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz",
+        "sha512": "869afe274e41d855585005c778ad58c88dbaec9fdd0c384c53a07a722be6f21498d636099c15f1cca0ca0ecc33266b4b1ebcab8e19c38eaaa9ff8f6df0500b7b",
+        "dest-filename": "fe274e41d855585005c778ad58c88dbaec9fdd0c384c53a07a722be6f21498d636099c15f1cca0ca0ecc33266b4b1ebcab8e19c38eaaa9ff8f6df0500b7b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/9a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz",
+        "sha512": "a0800e4ea808a3bab610ec1b85bf146a561e3ccbd8a0879163660a9ed7691505cda2c4aedef2eb9e21a0987f4e2acfea0247e88f9a01de57bfee620d5b52c27f",
+        "dest-filename": "0e4ea808a3bab610ec1b85bf146a561e3ccbd8a0879163660a9ed7691505cda2c4aedef2eb9e21a0987f4e2acfea0247e88f9a01de57bfee620d5b52c27f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/80"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz",
+        "sha512": "a0fb53338a1eacbf945e6c7ef77cad65537cd91ae563fc0f515f08783c45af32235ce2c5d6937e12628f2dbb9bbca1d3d870b6d315ec0801f667e08a57a3b3fe",
+        "dest-filename": "53338a1eacbf945e6c7ef77cad65537cd91ae563fc0f515f08783c45af32235ce2c5d6937e12628f2dbb9bbca1d3d870b6d315ec0801f667e08a57a3b3fe",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/fb"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz",
+        "sha512": "1d06eddbc2ae942e402731be719b63f64bca07ddc214274bbe88355852dfd43fb198cbcf1a506cb64a531197cae7e00df617c9a1cc81142362ab24b8f1ba60cd",
+        "dest-filename": "eddbc2ae942e402731be719b63f64bca07ddc214274bbe88355852dfd43fb198cbcf1a506cb64a531197cae7e00df617c9a1cc81142362ab24b8f1ba60cd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1d/06"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz",
+        "sha512": "d2c82522cf569a4cdbafc950c04c88ce50ce382f5b1a67d529c2536b1bf7bcc99ddeea38a380deac2dc49f46e79a071e7aa97d05f0bc851929edc8347e3755ab",
+        "dest-filename": "2522cf569a4cdbafc950c04c88ce50ce382f5b1a67d529c2536b1bf7bcc99ddeea38a380deac2dc49f46e79a071e7aa97d05f0bc851929edc8347e3755ab",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d2/c8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz",
+        "sha512": "d008a8342259d833d8cf90014fa6dd748aa5860c21a4767f97ae58018a34042227d31883a6c9d31f3d209e84c6934397656d0946cf9c0f02fcbbfb5e45dcfef0",
+        "dest-filename": "a8342259d833d8cf90014fa6dd748aa5860c21a4767f97ae58018a34042227d31883a6c9d31f3d209e84c6934397656d0946cf9c0f02fcbbfb5e45dcfef0",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d0/08"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz",
+        "sha512": "43ca907cf899f931ceff766b3ab3b470924a7e96026a0b4c5245db9c47e68148f05e0eb3fd605e3b24bd00f0413c24d288357eb384b0406bbcc85b2231122e76",
+        "dest-filename": "907cf899f931ceff766b3ab3b470924a7e96026a0b4c5245db9c47e68148f05e0eb3fd605e3b24bd00f0413c24d288357eb384b0406bbcc85b2231122e76",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/43/ca"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz",
+        "sha512": "a2b46cb98a49570f0b740c2aa8bca4063f5e712e7f7111e5239fa7bd3a3c2dc08a9b30e6a953915ed388604110b8bf43e01c6d035966e62b00ab34190a843a12",
+        "dest-filename": "6cb98a49570f0b740c2aa8bca4063f5e712e7f7111e5239fa7bd3a3c2dc08a9b30e6a953915ed388604110b8bf43e01c6d035966e62b00ab34190a843a12",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/b4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+        "sha512": "d4d342b3abaeadf9156de5c6e12f09153f6dd7d9b8e480a789ff3358b779a0f499e74427c0c7caf87de3bf8d3c7788f0ffb06db6fe5ac52e48887a0b69534779",
+        "dest-filename": "42b3abaeadf9156de5c6e12f09153f6dd7d9b8e480a789ff3358b779a0f499e74427c0c7caf87de3bf8d3c7788f0ffb06db6fe5ac52e48887a0b69534779",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d4/d3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+        "sha512": "4a848be3e39212d47df4b1c56508892e44f9f42e41d5a9863b53734f08fb4d3d6a0948143ba8713afce4398c43faf32b5c13375c920ace892811176a42afd99a",
+        "dest-filename": "8be3e39212d47df4b1c56508892e44f9f42e41d5a9863b53734f08fb4d3d6a0948143ba8713afce4398c43faf32b5c13375c920ace892811176a42afd99a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4a/84"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
+        "sha512": "be47033eb459a354192db9f944b18fa60fd698843ae6aa165a170629ffdbe5ea659246ab5f49bdcfca6909ab789a53aa52c5a9c8db9880edd5472ad81d2cd7e6",
+        "dest-filename": "033eb459a354192db9f944b18fa60fd698843ae6aa165a170629ffdbe5ea659246ab5f49bdcfca6909ab789a53aa52c5a9c8db9880edd5472ad81d2cd7e6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/be/47"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz",
+        "sha512": "ee280f4cce777061cc5bcc56b954f2762d8a3b6df754589337217984b26aa629477e69fc0bc80f7fe3d2edd513eb861c5c56e23066714bda424b12ff0f19bf27",
+        "dest-filename": "0f4cce777061cc5bcc56b954f2762d8a3b6df754589337217984b26aa629477e69fc0bc80f7fe3d2edd513eb861c5c56e23066714bda424b12ff0f19bf27",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ee/28"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+        "sha512": "bd8b7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16",
+        "dest-filename": "7b503d54f5683ad77f2c84bb4b3af740bbef03b02fe2945b44547707fb0c9d712a4d136d007d239db9fe8c91115a84be4563b5f5a14ee7295645b5fabc16",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bd/8b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/qified/-/qified-0.9.1.tgz",
+        "sha512": "9fb99aaf84f4c50fb7f5d136bc64c095bc541299ddc0f00d1f490379fd7f318b01f016daf70b219326c8471ef8aa072f2903c4584adff40a807588e1cd8d8896",
+        "dest-filename": "9aaf84f4c50fb7f5d136bc64c095bc541299ddc0f00d1f490379fd7f318b01f016daf70b219326c8471ef8aa072f2903c4584adff40a807588e1cd8d8896",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9f/b9"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+        "sha512": "36e68d49ae9f94a4f925a498433268934e09cd32f5080e9a1a1bf9adf2d6dcf82a03e3360a1a59427002f21f22e19164052f17e51aa40c11c0eebe217a3dcaf4",
+        "dest-filename": "8d49ae9f94a4f925a498433268934e09cd32f5080e9a1a1bf9adf2d6dcf82a03e3360a1a59427002f21f22e19164052f17e51aa40c11c0eebe217a3dcaf4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/36/e6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+        "sha512": "e66e2740aa7ead945bd3d2cd1f9f463380714e1f76e75ff295b2886e97bb4e91b17c9fbd92fe812e42c15c88e3b296e06e720136a948db7b519d3593d2c9d423",
+        "dest-filename": "2740aa7ead945bd3d2cd1f9f463380714e1f76e75ff295b2886e97bb4e91b17c9fbd92fe812e42c15c88e3b296e06e720136a948db7b519d3593d2c9d423",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e6/6e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+        "sha512": "cfa17b2bd6d5f3911fb1e442a766f3ae9c90d06930d6e2e809e97d5c15563e0fd38d18fde12909cd44c67ce6b86ecee226f056b501b45aaef09c8d2ccb0dc405",
+        "dest-filename": "7b2bd6d5f3911fb1e442a766f3ae9c90d06930d6e2e809e97d5c15563e0fd38d18fde12909cd44c67ce6b86ecee226f056b501b45aaef09c8d2ccb0dc405",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cf/a1"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+        "sha512": "f6bfb28bdfa6814df700a723e886d3f684423bbf16ae24a3eadfdc17c0d605927d68e18f393103bdd503cf51702a29bb4175b0987aad7479d125f840c441b8e9",
+        "dest-filename": "b28bdfa6814df700a723e886d3f684423bbf16ae24a3eadfdc17c0d605927d68e18f393103bdd503cf51702a29bb4175b0987aad7479d125f840c441b8e9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f6/bf"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+        "sha512": "22a6fd3630824ede877febce74d21919d4e21f5412aabdbb1ff124f6cbff6bdee07ee788ff9875b37c918b59e783331468e393a229f9748d5d5ca757885faed1",
+        "dest-filename": "fd3630824ede877febce74d21919d4e21f5412aabdbb1ff124f6cbff6bdee07ee788ff9875b37c918b59e783331468e393a229f9748d5d5ca757885faed1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/22/a6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
+        "sha512": "61970ce444bc8c948cf8aac9f4176f1c7aa59c64e0e6d1f7b02e42845463e229e8b0a72d772cc10e13b2c87746939f7bab6393e8d4eb080d4ebc1fd80f07de91",
+        "dest-filename": "0ce444bc8c948cf8aac9f4176f1c7aa59c64e0e6d1f7b02e42845463e229e8b0a72d772cc10e13b2c87746939f7bab6393e8d4eb080d4ebc1fd80f07de91",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/61/97"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
+        "sha512": "c82a8d9dee88f0807aad5087ed752f9412bbfd02b2ab2a41146bfef1d8f84011498a2457f851bbfe791d02f184972bd567f1d03f9375f70ced7ae4c04578b91b",
+        "dest-filename": "8d9dee88f0807aad5087ed752f9412bbfd02b2ab2a41146bfef1d8f84011498a2457f851bbfe791d02f184972bd567f1d03f9375f70ced7ae4c04578b91b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/2a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+        "sha512": "6fa8d2bf1bd59f2a6d0222e36e458b13f94e9d1e257d3b43025f9e502ed1672f9041673ac11cc8576084eb106e3260f1736a888a1b430990f934f38597b7d105",
+        "dest-filename": "d2bf1bd59f2a6d0222e36e458b13f94e9d1e257d3b43025f9e502ed1672f9041673ac11cc8576084eb106e3260f1736a888a1b430990f934f38597b7d105",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/a8"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+        "sha512": "c12fa1020252851d0a844bcf240adfb8f54dd7e1f3d6dd18ea7e632eb1906e46f8bab80f13fd11bdefb590c075bffa16807826e1621c57e8bb176a53563fb689",
+        "dest-filename": "a1020252851d0a844bcf240adfb8f54dd7e1f3d6dd18ea7e632eb1906e46f8bab80f13fd11bdefb590c075bffa16807826e1621c57e8bb176a53563fb689",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c1/2f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
+        "sha512": "3b076ffc5b7b2233a09bf8b4c6f3436752eb4403517dec386f6a6b1773963102f12dfbb76d2f055610acad208c2b8951e7a63dc9af804e1a13a43093c429a944",
+        "dest-filename": "6ffc5b7b2233a09bf8b4c6f3436752eb4403517dec386f6a6b1773963102f12dfbb76d2f055610acad208c2b8951e7a63dc9af804e1a13a43093c429a944",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/3b/07"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+        "sha512": "84e4b4f3da27f1176ea9d6e1bd0e59dfb0341128ecab3eaa9d171f7ec314df8f7916e4dda929beedb849dbd26f20eb010c41276a7e433eef6ddd3a3d55194ccc",
+        "dest-filename": "b4f3da27f1176ea9d6e1bd0e59dfb0341128ecab3eaa9d171f7ec314df8f7916e4dda929beedb849dbd26f20eb010c41276a7e433eef6ddd3a3d55194ccc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/84/e4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+        "sha512": "5dfd2759ee91b1ece214cbbe029f5b8a251b9a996ae92f7fa7eef0ed85cffc904786b5030d48706bebc0372b9bbaa7d9593bde53ffc36151ac0c6ed128bfef13",
+        "dest-filename": "2759ee91b1ece214cbbe029f5b8a251b9a996ae92f7fa7eef0ed85cffc904786b5030d48706bebc0372b9bbaa7d9593bde53ffc36151ac0c6ed128bfef13",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5d/fd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+        "sha512": "a5bfcc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2",
+        "dest-filename": "cc6265ecb40932b11171f2988d235b4614d408140def904dc6ab812e035745ea01e9ffebe066ab021896a9bf2f0ddd0fb8a3b170beab8f25c9d9ed1632e2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a5/bf"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+        "sha512": "a9883d28fdb8743e6a91af49e3b774695932d0df9be1f4d4f3d2cdf620e78c1e706a4b220b8f6bbcc0743eb509406a13987e745cf8aa3af0230df6a28c6c5867",
+        "dest-filename": "3d28fdb8743e6a91af49e3b774695932d0df9be1f4d4f3d2cdf620e78c1e706a4b220b8f6bbcc0743eb509406a13987e745cf8aa3af0230df6a28c6c5867",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a9/88"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz",
+        "sha512": "4f2789d7389fe7704f7c7a28b411b03d1613d5152dea8196b1a42bf14c995bf7809bd6caa228edbebb920c49991e6f760b04bd9e3eff7d6b6da8f0a0cdea7c08",
+        "dest-filename": "89d7389fe7704f7c7a28b411b03d1613d5152dea8196b1a42bf14c995bf7809bd6caa228edbebb920c49991e6f760b04bd9e3eff7d6b6da8f0a0cdea7c08",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/4f/27"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+        "sha512": "a0c03675caf0eaed187f12505e6df8d9b14a5ff138b06f6b6d3ccef69b54711fdef00df7707baf4ad8983b01fb7ecce4665675cffb5af400283e4d85e2a20e1c",
+        "dest-filename": "3675caf0eaed187f12505e6df8d9b14a5ff138b06f6b6d3ccef69b54711fdef00df7707baf4ad8983b01fb7ecce4665675cffb5af400283e4d85e2a20e1c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/c0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+        "sha512": "83a4147dfd38a19a47b34786e69f37ac52e11de574d2e83f61ff6764ce9f2de52b3e0b814e44d039da40596b29321e794d97d54033da37735025f6d5440c5d23",
+        "dest-filename": "147dfd38a19a47b34786e69f37ac52e11de574d2e83f61ff6764ce9f2de52b3e0b814e44d039da40596b29321e794d97d54033da37735025f6d5440c5d23",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/83/a4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+        "sha512": "ab56f737942445459497b8b2ca569a8f790ea484f43768bd32a2044173fbdc656c37d730ddf771f17eb77049968491a2d8f3c2176dc88e9ee4b66777f6b6b020",
+        "dest-filename": "f737942445459497b8b2ca569a8f790ea484f43768bd32a2044173fbdc656c37d730ddf771f17eb77049968491a2d8f3c2176dc88e9ee4b66777f6b6b020",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ab/56"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+        "sha512": "27da99c96fbe40aff4f4dc8dff378ed1d1bfd467467f2a7d955f1a8c79d154b7e8fee16c6e38b99879c3827fea61d507c8290cd8dfbc572b298197257c087479",
+        "dest-filename": "99c96fbe40aff4f4dc8dff378ed1d1bfd467467f2a7d955f1a8c79d154b7e8fee16c6e38b99879c3827fea61d507c8290cd8dfbc572b298197257c087479",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/27/da"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+        "sha512": "e65e15c9947ce8b67f943c594d1ea3a8bf00144d92d0814b30fdba01b8ec2d5003c4776107f734194b07fb2dfd51f0a2dddcf3f0e950b8f9a768938ca031d004",
+        "dest-filename": "15c9947ce8b67f943c594d1ea3a8bf00144d92d0814b30fdba01b8ec2d5003c4776107f734194b07fb2dfd51f0a2dddcf3f0e950b8f9a768938ca031d004",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e6/5e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+        "sha512": "50e4a1b0fc33ecdacc52a851eadd215a315dbaf3b36edbfbb680c7d7f848adf44d2030679c159dd02c094c6bd3a67815966c0609d3fdfd997fb55ac3a9cb98cd",
+        "dest-filename": "a1b0fc33ecdacc52a851eadd215a315dbaf3b36edbfbb680c7d7f848adf44d2030679c159dd02c094c6bd3a67815966c0609d3fdfd997fb55ac3a9cb98cd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/50/e4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+        "sha512": "051ed5bc30951cefaadb10445ac9314ba0c9135a919dbec3c7352ba206fbd425a849f89c07162c88019df8a9749a6abf329ac6f7202b464cab4314cee978cccc",
+        "dest-filename": "d5bc30951cefaadb10445ac9314ba0c9135a919dbec3c7352ba206fbd425a849f89c07162c88019df8a9749a6abf329ac6f7202b464cab4314cee978cccc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/05/1e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+        "sha512": "bc5282d8812d427561a53efc875629f30cf0adff0233e33328c1c62597c1b738593727111675ec1e4e84e53c4892432c80d4bb99d5f700607bc7640cd9d8b894",
+        "dest-filename": "82d8812d427561a53efc875629f30cf0adff0233e33328c1c62597c1b738593727111675ec1e4e84e53c4892432c80d4bb99d5f700607bc7640cd9d8b894",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bc/52"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+        "sha512": "a1e33596953f52f853c70fa0ddc21fc571f225173fba275ddf22b53f6e368331ddb34b9d401633b37cbc8f8802096f9927b69dd3272d95df1160ef9b76eae5bf",
+        "dest-filename": "3596953f52f853c70fa0ddc21fc571f225173fba275ddf22b53f6e368331ddb34b9d401633b37cbc8f8802096f9927b69dd3272d95df1160ef9b76eae5bf",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a1/e3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+        "sha512": "907c6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c",
+        "dest-filename": "6bdb366962d766acdd6a0e3aeb5ff675ad1d641bc0f1fa09292b51b87979af5ecc26704d614d6056614ce5ada630d7fc99a7a62e0d8efb62dbdb3747660c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/90/7c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+        "sha512": "efef9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4",
+        "dest-filename": "9d161b5cc77df9dee05aabc0c347836ec417ad0730bb6503a19934089c711de9b4ab5dd884cb30af1b4ed9e3851874b4a1594c97b7933fca1cfc7a471bd4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ef/ef"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+        "sha512": "c9bc7458ed7ff1b4812c459766f11dee0316dd29f7245956dd3bd7d674446c32d135035a78d37c58ad26781c0f74068e23b4ed4514499ff12cd7386bac21eeee",
+        "dest-filename": "7458ed7ff1b4812c459766f11dee0316dd29f7245956dd3bd7d674446c32d135035a78d37c58ad26781c0f74068e23b4ed4514499ff12cd7386bac21eeee",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c9/bc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+        "sha512": "6f3c99d5ef3cc3d3b588d25b2a73a5bd84eb58f0e5e3a3b56c6d03dd7227bfef6d90faf1acdf235144e21650e4926296827d4ce827c8035dd2b86a8e6bd2a8af",
+        "dest-filename": "99d5ef3cc3d3b588d25b2a73a5bd84eb58f0e5e3a3b56c6d03dd7227bfef6d90faf1acdf235144e21650e4926296827d4ce827c8035dd2b86a8e6bd2a8af",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6f/3c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+        "sha512": "83d43585a79bcb7e8e492b706f89ed08618668ab1a5528d0ebc7c1c6841cbad9797d2d6fb98d7c1f7c12b778c5c85b6b931f8acf45751bce40e0cc80743322d9",
+        "dest-filename": "3585a79bcb7e8e492b706f89ed08618668ab1a5528d0ebc7c1c6841cbad9797d2d6fb98d7c1f7c12b778c5c85b6b931f8acf45751bce40e0cc80743322d9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/83/d4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz",
+        "sha512": "a8c08c7e1634e347151d3e372bd045ca0a986d43c564a1ce83b2bbde6b5358945bf29c8fddfcdfe08c5de52cdd10943a311520fd606738bc60859b4a2aeac435",
+        "dest-filename": "8c7e1634e347151d3e372bd045ca0a986d43c564a1ce83b2bbde6b5358945bf29c8fddfcdfe08c5de52cdd10943a311520fd606738bc60859b4a2aeac435",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a8/c0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+        "sha512": "88e056160517edc688662baeb480b15605f549dc700151452b0b7512f31861e73f3563b999e389e8ae6e43186b6017502677b82b18aa65cf8aa6d14e585488f7",
+        "dest-filename": "56160517edc688662baeb480b15605f549dc700151452b0b7512f31861e73f3563b999e389e8ae6e43186b6017502677b82b18aa65cf8aa6d14e585488f7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/88/e0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+        "sha512": "b2dc41cabd76a1e78ec98d8196f893350958579c4e8f8ec68ab3ebe32035844f490adc5f40dd3eb556e4c700ad603416844296147b042b8f0e460e63ae8b8202",
+        "dest-filename": "41cabd76a1e78ec98d8196f893350958579c4e8f8ec68ab3ebe32035844f490adc5f40dd3eb556e4c700ad603416844296147b042b8f0e460e63ae8b8202",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b2/dc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+        "sha512": "51758c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40",
+        "dest-filename": "8c2a12cec1529bef6f0852d40f5f17d853ebac7726ed52b2bff2e184f0240cbeb84ea70bf30c1c23d108522fb31073bbc8b084811bc550f3e203431a5f40",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/51/75"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+        "sha512": "d573091397d0a358c61fa63fede6e7c0f3811242049d3e10177d9de51d7e557757bde334201309b7ccdf6b15f53f7421570ad87bee7bebe8e400db524b69816f",
+        "dest-filename": "091397d0a358c61fa63fede6e7c0f3811242049d3e10177d9de51d7e557757bde334201309b7ccdf6b15f53f7421570ad87bee7bebe8e400db524b69816f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d5/73"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+        "sha512": "e464b5d8574e64d9623399803b115183b22bd295b3f0c769626e8063a54f906a5b03b67399bccd701250d063efbf25a0718ed00210a07fd532f3d234ddf68b92",
+        "dest-filename": "b5d8574e64d9623399803b115183b22bd295b3f0c769626e8063a54f906a5b03b67399bccd701250d063efbf25a0718ed00210a07fd532f3d234ddf68b92",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e4/64"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+        "sha512": "6aa0f6434d78e19fbf46a1b9d8d78712465ab930145893bc73ac937ed18928edd38dae6d52021f98897a904c6f86dc520cfedf5c1e83bf391f32909dfc5dc6f9",
+        "dest-filename": "f6434d78e19fbf46a1b9d8d78712465ab930145893bc73ac937ed18928edd38dae6d52021f98897a904c6f86dc520cfedf5c1e83bf391f32909dfc5dc6f9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6a/a0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+        "sha512": "c0ac90450a63274b08a7ad84ad265d1ac8cc256b1aa79a1136284786ee86ec954effd8c807a5327af2feb57b8eaab9e0f23fdcc4a4d6c96530bd24eb8a2673fe",
+        "dest-filename": "90450a63274b08a7ad84ad265d1ac8cc256b1aa79a1136284786ee86ec954effd8c807a5327af2feb57b8eaab9e0f23fdcc4a4d6c96530bd24eb8a2673fe",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c0/ac"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+        "sha512": "b6c693224296f5be0df80123f92540f96849cd5effccc85c4aeefc98b2964a4edc5cc3921ec04a15652cd1f5b0abc4322b73202414115fa19b8b89186ddbc691",
+        "dest-filename": "93224296f5be0df80123f92540f96849cd5effccc85c4aeefc98b2964a4edc5cc3921ec04a15652cd1f5b0abc4322b73202414115fa19b8b89186ddbc691",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b6/c6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+        "sha512": "20868fd20de2cbd0b2cb5f30dccf5871a0ee76e8c40151cab776b7409835facaffa17f7a4db68652e6c6d212720a30814e1147fad169708ca8507527d6881a2c",
+        "dest-filename": "8fd20de2cbd0b2cb5f30dccf5871a0ee76e8c40151cab776b7409835facaffa17f7a4db68652e6c6d212720a30814e1147fad169708ca8507527d6881a2c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/20/86"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+        "sha512": "637f153d21dcaa416b0a916743dbee4979aabaebf9a1738aa46793e9a1abaf7a3719cf409556ba2417d448e0a76f1186645fbfd28a08ecaacfb944b3b54754e4",
+        "dest-filename": "153d21dcaa416b0a916743dbee4979aabaebf9a1738aa46793e9a1abaf7a3719cf409556ba2417d448e0a76f1186645fbfd28a08ecaacfb944b3b54754e4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/63/7f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+        "sha512": "c833cc363a785b27d80641e78c844b7dc6b58ba28cc860adb1582829eff3d7eeafba481a10d76018166df9998a3dce206afbc46793a01df1ddadace180dc86ef",
+        "dest-filename": "cc363a785b27d80641e78c844b7dc6b58ba28cc860adb1582829eff3d7eeafba481a10d76018166df9998a3dce206afbc46793a01df1ddadace180dc86ef",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c8/33"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+        "sha512": "e9f3dcf91e22870a8fe8dfda22fd9fd60307f25395b56407a2a0b8c8aea8483555a1cba602c7c2aa39179ea89832198cc12fe61072e9ed57a196ddea97a9448a",
+        "dest-filename": "dcf91e22870a8fe8dfda22fd9fd60307f25395b56407a2a0b8c8aea8483555a1cba602c7c2aa39179ea89832198cc12fe61072e9ed57a196ddea97a9448a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e9/f3"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz",
+        "sha512": "6cbbdcd563b3ff5e1a3c89aefdcb9f2806587d7b3f03fa3065f48c67837ed7a5865cba17e653a2af9dccea8741c6f8609a07710959cdc9226664ac7bdd3f7772",
+        "dest-filename": "dcd563b3ff5e1a3c89aefdcb9f2806587d7b3f03fa3065f48c67837ed7a5865cba17e653a2af9dccea8741c6f8609a07710959cdc9226664ac7bdd3f7772",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6c/bb"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-36.0.1.tgz",
+        "sha512": "f1a5fc993cc9e9cb8ef26983e72a27eb5096b88338503f10e5a05c58a1927fa920f840b7ba107e88ecb0a532b871ae992fb078f5e9fcc9a9ce16d516d2a373cb",
+        "dest-filename": "fc993cc9e9cb8ef26983e72a27eb5096b88338503f10e5a05c58a1927fa920f840b7ba107e88ecb0a532b871ae992fb078f5e9fcc9a9ce16d516d2a373cb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f1/a5"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz",
+        "sha512": "bf6d15e7dfdcadf73cb154c0b607b499d69f23701d9f34362ac59eeafe76dcbe0e0356c93b4d92ecc3b6a325c3092ea259bf5c9083e7a8015522da92050afb8f",
+        "dest-filename": "15e7dfdcadf73cb154c0b607b499d69f23701d9f34362ac59eeafe76dcbe0e0356c93b4d92ecc3b6a325c3092ea259bf5c9083e7a8015522da92050afb8f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/bf/6d"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz",
+        "sha512": "0e1b939af656bb1e07d543a758c077b24d2c6da0953a84198eff2ed6b0e84d5d074dd19e9bd864019b65e09672f0fdb3e018349d3f9831e385c95af8cdc1b94f",
+        "dest-filename": "939af656bb1e07d543a758c077b24d2c6da0953a84198eff2ed6b0e84d5d074dd19e9bd864019b65e09672f0fdb3e018349d3f9831e385c95af8cdc1b94f",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/0e/1b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+        "sha512": "aa9080bd197db2db8e1ef78ab27ec79dc251befe74d6a21a70acd094effe2f0c5cf7ed2adb02f2bf80dfbedf34fc33e7da9a8e06c25d0e2a205c647df8ebf047",
+        "dest-filename": "80bd197db2db8e1ef78ab27ec79dc251befe74d6a21a70acd094effe2f0c5cf7ed2adb02f2bf80dfbedf34fc33e7da9a8e06c25d0e2a205c647df8ebf047",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/aa/90"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
+        "sha512": "cc539b2ccc99784c33028282caed41f7553bf4adadec0a57b907e8f0ebb1c172c381c2b1bb033e62f71b2219ba416ab3ee61d41f54d5cad4753f05558c4b8c8a",
+        "dest-filename": "9b2ccc99784c33028282caed41f7553bf4adadec0a57b907e8f0ebb1c172c381c2b1bb033e62f71b2219ba416ab3ee61d41f54d5cad4753f05558c4b8c8a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/cc/53"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+        "sha512": "a2dd169d74bd7e076480871e3dee911cd935580f3e9ae3dae9c4a3791dd5f0adbbabd041d6b4c4dd1d69ec7bf4cf567201cf2ce95beff0323259febcd4c02dd3",
+        "dest-filename": "169d74bd7e076480871e3dee911cd935580f3e9ae3dae9c4a3791dd5f0adbbabd041d6b4c4dd1d69ec7bf4cf567201cf2ce95beff0323259febcd4c02dd3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/dd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz",
+        "sha512": "a2fb2ccac4136be96e87b03959ebb746d6ba1499450416c89e33a1ef6d8b22dea4969536fc7b5d51bb338eefc6e1d7af72f93c3c6b7b1422efe707edbb74c750",
+        "dest-filename": "2ccac4136be96e87b03959ebb746d6ba1499450416c89e33a1ef6d8b22dea4969536fc7b5d51bb338eefc6e1d7af72f93c3c6b7b1422efe707edbb74c750",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a2/fb"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/table/-/table-6.9.0.tgz",
+        "sha512": "f6463e0b283260cea3d36b796051db373d85379426606bfdcc08d5a789420e3942c3b6a675c917944b7f6e33215087e3e13846444e200941f9fb21a736e3e8e4",
+        "dest-filename": "3e0b283260cea3d36b796051db373d85379426606bfdcc08d5a789420e3942c3b6a675c917944b7f6e33215087e3e13846444e200941f9fb21a736e3e8e4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f6/46"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz",
+        "sha512": "23c2bdc1ec2754390bd4d4c6a2a5a654422551c07d805ae200491791f0a35f989bf1ecc6c6d477c43ee2648c6b7c0ae312c1fb1750870f844552dc5e7dda95fc",
+        "dest-filename": "bdc1ec2754390bd4d4c6a2a5a654422551c07d805ae200491791f0a35f989bf1ecc6c6d477c43ee2648c6b7c0ae312c1fb1750870f844552dc5e7dda95fc",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/23/c2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz",
+        "sha512": "6e5ea6a47dd3ec8dd4171baf0c45cbc72fd5b85c419396dbce9961eed5c8ebc9b032890d61dd6df6a3c11e59f24f07dae09182e333f9d7a23585862d43fbeca4",
+        "dest-filename": "a6a47dd3ec8dd4171baf0c45cbc72fd5b85c419396dbce9961eed5c8ebc9b032890d61dd6df6a3c11e59f24f07dae09182e333f9d7a23585862d43fbeca4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6e/5e"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz",
+        "sha512": "de87e9f8b2fc13ea4afc9b8f2cf82054021a12e86f233e2a35c7f79c0d579f6a3fedf6fbb3f4d8a47870183bf5654dcf90196e515685f0fc821dc9b8f1c28b59",
+        "dest-filename": "e9f8b2fc13ea4afc9b8f2cf82054021a12e86f233e2a35c7f79c0d579f6a3fedf6fbb3f4d8a47870183bf5654dcf90196e515685f0fc821dc9b8f1c28b59",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/de/87"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz",
+        "sha512": "44dc501ffa88f3fb77b615c90f072cb543b8cdeaa8eb8f94cbffac355441c785e7d8e5fe399f683fe8899cd16aa6516b6b665455e28249ada85568b74f8b9598",
+        "dest-filename": "501ffa88f3fb77b615c90f072cb543b8cdeaa8eb8f94cbffac355441c785e7d8e5fe399f683fe8899cd16aa6516b6b665455e28249ada85568b74f8b9598",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/44/dc"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
+        "sha512": "455652215e481b5d079377a7a2dae1bf3d13f5e9ba7321c12e41ff60066e2aa77c85190a8527c218870fd8a518d043f19ddcc034198d965cd63f06a4f9b85e4b",
+        "dest-filename": "52215e481b5d079377a7a2dae1bf3d13f5e9ba7321c12e41ff60066e2aa77c85190a8527c218870fd8a518d043f19ddcc034198d965cd63f06a4f9b85e4b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/45/56"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+        "sha512": "d3e0d4bea58c55a94b9a16ba96be240fc88030ad47cd5d3f68a9c2b566fdbfdeb8d539cffcc15becf7366f1a314234d7004aebc9756050e7efd98a8d965a867a",
+        "dest-filename": "d4bea58c55a94b9a16ba96be240fc88030ad47cd5d3f68a9c2b566fdbfdeb8d539cffcc15becf7366f1a314234d7004aebc9756050e7efd98a8d965a867a",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/d3/e0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+        "sha512": "290411f7237b479f8e4b068ad174288f6da9c07a1396062a994b1c3d8a249cea160967e3ff9fc00533118baf45aca5397df3d587941c16292958923f3f5a1c1c",
+        "dest-filename": "11f7237b479f8e4b068ad174288f6da9c07a1396062a994b1c3d8a249cea160967e3ff9fc00533118baf45aca5397df3d587941c16292958923f3f5a1c1c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/29/04"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+        "sha512": "54a4bf65a42186428530036600e8615d5a087c15db950c465f59b2090d9f690adf9a86cc7ed5de24f7191a9d204b4ee872f1895832d91b23990da74306a60826",
+        "dest-filename": "bf65a42186428530036600e8615d5a087c15db950c465f59b2090d9f690adf9a86cc7ed5de24f7191a9d204b4ee872f1895832d91b23990da74306a60826",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/54/a4"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+        "sha512": "a67f7d561a0009847c9c51e1c6a8b1faebec6d78a77806ac5a6e688d7a0df311302b929ddff4eb84d9f5c01cae0f9d94c5644bcbca6efa444c9e2122e84abd66",
+        "dest-filename": "7d561a0009847c9c51e1c6a8b1faebec6d78a77806ac5a6e688d7a0df311302b929ddff4eb84d9f5c01cae0f9d94c5644bcbca6efa444c9e2122e84abd66",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a6/7f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+        "sha512": "65b6bcdacf3b205abd03d5e68e25f9b9903f011583ac1d3738796af95c357d276dd08fb8fcabadc32f013f863fcbf68e44ca3ad45434bc86f98f8e2f4a8e4f92",
+        "dest-filename": "bcdacf3b205abd03d5e68e25f9b9903f011583ac1d3738796af95c357d276dd08fb8fcabadc32f013f863fcbf68e44ca3ad45434bc86f98f8e2f4a8e4f92",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/65/b6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+        "sha512": "c1e10312aed9e5e4c73c3878c635fbf3df9f1df17e3fc6e888507ed2f6d6ce96e76ec12bfc645aa218bfb8c2b183c4593179e5d48b408bf2141d632c8c357b91",
+        "dest-filename": "0312aed9e5e4c73c3878c635fbf3df9f1df17e3fc6e888507ed2f6d6ce96e76ec12bfc645aa218bfb8c2b183c4593179e5d48b408bf2141d632c8c357b91",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/c1/e1"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+        "sha512": "9f5730f24d64d31e29800dbef57ace905c9d4deacd709d735823b9367f6c7161d30fee6da7c760853db1d6e76e41e3d94d981ddd3ba97fec7d0712637898bbed",
+        "dest-filename": "30f24d64d31e29800dbef57ace905c9d4deacd709d735823b9367f6c7161d30fee6da7c760853db1d6e76e41e3d94d981ddd3ba97fec7d0712637898bbed",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9f/57"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+        "sha512": "eb93fb8b3e97e7212bd5cc1c82f4316db230ed493780ecb974876d678ac3bde2ea86b7493fe2e2fc7c7ab722b43446fed860b29de08c2621aaac00c248d93cb1",
+        "dest-filename": "fb8b3e97e7212bd5cc1c82f4316db230ed493780ecb974876d678ac3bde2ea86b7493fe2e2fc7c7ab722b43446fed860b29de08c2621aaac00c248d93cb1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/eb/93"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+        "sha512": "389fe26f184f96aacc33452234727fd02290928285db8dff0049a996ddeaa518245bc546ec87ce4b8d61ed5f138c84ea741c87ceb8dc4bfdac8becb894887c34",
+        "dest-filename": "e26f184f96aacc33452234727fd02290928285db8dff0049a996ddeaa518245bc546ec87ce4b8d61ed5f138c84ea741c87ceb8dc4bfdac8becb894887c34",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/38/9f"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
+        "sha512": "63f6abbdb9feaebcf72422a5f42e2454d7d37d29b6fe6129e454b3e44b194803463d2950ae9448e4ce0f285fa6267139da338ef743e73d273752bddb4d0c3480",
+        "dest-filename": "abbdb9feaebcf72422a5f42e2454d7d37d29b6fe6129e454b3e44b194803463d2950ae9448e4ce0f285fa6267139da338ef743e73d273752bddb4d0c3480",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/63/f6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+        "sha512": "a0916ef781d06fe29576e49440bef09e99aa9df98bb0e03f9c087a6fa107d30084a0ad3f98f79753a737c0a0d5f373243ae1cf447b525ca294f7d2016b34bfdb",
+        "dest-filename": "6ef781d06fe29576e49440bef09e99aa9df98bb0e03f9c087a6fa107d30084a0ad3f98f79753a737c0a0d5f373243ae1cf447b525ca294f7d2016b34bfdb",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a0/91"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
+        "sha512": "5e5794a1cf6ec065ea8d6c176944d9026ccc705679f39f10036befc7552be7121c8b15c83fef0b9c50e0469954df4bacead7aa765b2415fbbe69ee0aefd3a87b",
+        "dest-filename": "94a1cf6ec065ea8d6c176944d9026ccc705679f39f10036befc7552be7121c8b15c83fef0b9c50e0469954df4bacead7aa765b2415fbbe69ee0aefd3a87b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/5e/57"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
+        "sha512": "a49c34e75ba899bdd9782cc64e945bf116c4a81e58e1659eb7c825fc6713954df9052c743d5759f3afdbaa4402c8a2aeada55010aeebea404741717e7c1864a1",
+        "dest-filename": "34e75ba899bdd9782cc64e945bf116c4a81e58e1659eb7c825fc6713954df9052c743d5759f3afdbaa4402c8a2aeada55010aeebea404741717e7c1864a1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a4/9c"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
+        "sha512": "863712d6685fbb28b8596f085ad8cfedbac3ac6d9cb8366e932ad8ad26aea1718d831d12ef371e3f4eda758909c9c12be7a04e51334fcdb227a2888dddf9f5ab",
+        "dest-filename": "12d6685fbb28b8596f085ad8cfedbac3ac6d9cb8366e932ad8ad26aea1718d831d12ef371e3f4eda758909c9c12be7a04e51334fcdb227a2888dddf9f5ab",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/37"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+        "sha512": "a985675793849b6016f1c24c0a9755db4083c9a3778340230e53867f5396e22683131f0cc1db42854a78ceee07d153f79c3445ffc44a587f883e9f6e5b460666",
+        "dest-filename": "675793849b6016f1c24c0a9755db4083c9a3778340230e53867f5396e22683131f0cc1db42854a78ceee07d153f79c3445ffc44a587f883e9f6e5b460666",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a9/85"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+        "sha512": "829b4735082120d9dcfef4c6224d12385185357c3b255ae5454b42a2725196f6b0e83b97d303b925e928f6c5ab301861f8fb18019ee85c088e9dffd42a88328b",
+        "dest-filename": "4735082120d9dcfef4c6224d12385185357c3b255ae5454b42a2725196f6b0e83b97d303b925e928f6c5ab301861f8fb18019ee85c088e9dffd42a88328b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/82/9b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+        "sha512": "26cd26f5cc7ea8e803c68d1e32214612e796cedcfe778f8cdeb1a598a3d3f93e084bf8cfe32970dcdc29bba7294d33fc4753000b5905e156dd2eddc045fdb4f7",
+        "dest-filename": "26f5cc7ea8e803c68d1e32214612e796cedcfe778f8cdeb1a598a3d3f93e084bf8cfe32970dcdc29bba7294d33fc4753000b5905e156dd2eddc045fdb4f7",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/26/cd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
+        "sha512": "eeb294cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06",
+        "dest-filename": "94cb2df7435c9cf7ca50d430262edc17d74f45ed321f5a55b561da3c5a5d628b549e1e279e8741c77cf78bd9f3172bacf4b3c79c2acf5fac2b8b26f9dd06",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ee/b2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+        "sha512": "8d02f79519e871a16dbb7574d094e8633ff8424356b30c628c368254d6518914cedc74032ec76ed59b66214bd5e323e9fabbd69b98f4cb44c6fd2eb572e8a34e",
+        "dest-filename": "f79519e871a16dbb7574d094e8633ff8424356b30c628c368254d6518914cedc74032ec76ed59b66214bd5e323e9fabbd69b98f4cb44c6fd2eb572e8a34e",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/8d/02"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+        "sha512": "15e770d1a66f921ca7a0f625039597acc080326fa7496759b7a973250ece93c4ba43e56c1e61e94569dd55127c05ed196e47cf7392d1607fb95ebcd770478b45",
+        "dest-filename": "70d1a66f921ca7a0f625039597acc080326fa7496759b7a973250ece93c4ba43e56c1e61e94569dd55127c05ed196e47cf7392d1607fb95ebcd770478b45",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/15/e7"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+        "sha512": "10f0f9ab5b97c85c49a42acb9c27359c79eade039ae83641a1c008888d93692080ed5089d5424331a802cc891736c5187c3d5d68afff2d3110f318886eb1ed73",
+        "dest-filename": "f9ab5b97c85c49a42acb9c27359c79eade039ae83641a1c008888d93692080ed5089d5424331a802cc891736c5187c3d5d68afff2d3110f318886eb1ed73",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/10/f0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+        "sha512": "00cf5a43f20fad6ffa10d2d08370066382b53764c665d4797b882efcc9a6476c51dcb975f9d89bfa7a2893dda0e135773d75727b2c5d5b0b5a0808942f484cc4",
+        "dest-filename": "5a43f20fad6ffa10d2d08370066382b53764c665d4797b882efcc9a6476c51dcb975f9d89bfa7a2893dda0e135773d75727b2c5d5b0b5a0808942f484cc4",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/00/cf"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+        "sha512": "a396bdc4a8dbb6e858e818b94b7f87bdb444466a2e69b59bc947295d7500d6ef863542a844e8bd6f2389f0cd271db1d81e46080a2325ab1920d4a9189a6db94b",
+        "dest-filename": "bdc4a8dbb6e858e818b94b7f87bdb444466a2e69b59bc947295d7500d6ef863542a844e8bd6f2389f0cd271db1d81e46080a2325ab1920d4a9189a6db94b",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/a3/96"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+        "sha512": "31298f33d44462a0c6048f38dfd980e265a1579b0a9839412962186c0de545bd8f4c70021349a02b003cc90db1abdbf10d3ba4e223eb102040116d9aa055d8d1",
+        "dest-filename": "8f33d44462a0c6048f38dfd980e265a1579b0a9839412962186c0de545bd8f4c70021349a02b003cc90db1abdbf10d3ba4e223eb102040116d9aa055d8d1",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/31/29"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz",
+        "sha512": "9edf8dd9dcc8bad551c40471d678213ca1afd711e2914ec729d7da7ca90b34b8a77663d4fdc877537d4d38218603f7663dc99bd559687ced2f9ca01cb26d28fd",
+        "dest-filename": "8dd9dcc8bad551c40471d678213ca1afd711e2914ec729d7da7ca90b34b8a77663d4fdc877537d4d38218603f7663dc99bd559687ced2f9ca01cb26d28fd",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/9e/df"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+        "sha512": "1f125d616ab53132106c9de7c3472ab2c1e84cd536ebb2a5ac3b866755989710d2b54b4a52139a266875d76fd36661f1c547ee26a3d748e9bbb43c9ab3439221",
+        "dest-filename": "5d616ab53132106c9de7c3472ab2c1e84cd536ebb2a5ac3b866755989710d2b54b4a52139a266875d76fd36661f1c547ee26a3d748e9bbb43c9ab3439221",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/1f/12"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+        "sha512": "04b2374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c",
+        "dest-filename": "374e5d535b73ef97bd25df2ab763ae22f9ac29c17aac181616924a8cb676d782b303fb28fbae15b492e103c7325a6171a3116e6881aa4a34c10a34c8e26c",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/b2"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+        "sha512": "854ae669605d543731bd8aa7ca1d3dcee9cacd13968db65388dcbc741123912ede8440d089b5c9ed7be59ad6f0b9372552223237e0b25d00f8566928f1f366f3",
+        "dest-filename": "e669605d543731bd8aa7ca1d3dcee9cacd13968db65388dcbc741123912ede8440d089b5c9ed7be59ad6f0b9372552223237e0b25d00f8566928f1f366f3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/85/4a"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+        "sha512": "04ddb607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970",
+        "dest-filename": "b607979a30c23d50cb63ac677983978260fa423c3532d052576d8b1a4f9cd8c6314e7244b9dd2403137a56915a16a475d56f706b61c10de13c1ae7907970",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/04/dd"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+        "sha512": "e3602d9a0aa357e5f556974e7f24c6398462d3fceca0baad5d07244e6a937b26d3f810c86ccfc6bb1a3bc77a44dafb69af5a24eb146a33d3a905ef89ca8ab2c3",
+        "dest-filename": "2d9a0aa357e5f556974e7f24c6398462d3fceca0baad5d07244e6a937b26d3f810c86ccfc6bb1a3bc77a44dafb69af5a24eb146a33d3a905ef89ca8ab2c3",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/e3/60"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz",
+        "sha512": "f90536cdde8e4c3f175882426df7da890787f54ef7a88a9a7e8d71e95d6c9c25981897fa7151347034780fcc51cdc1277c8db5205ad43f33c6b5c3dff000be47",
+        "dest-filename": "36cdde8e4c3f175882426df7da890787f54ef7a88a9a7e8d71e95d6c9c25981897fa7151347034780fcc51cdc1277c8db5205ad43f33c6b5c3dff000be47",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/f9/05"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+        "sha512": "b00b7c06180d6f30ad8066edd8ec66a6eaf23badd9a0393fb2a681ff39d09bde13e1f084b32ff257eec2742d64261394f656e800453b47792abaec9c0e889b54",
+        "dest-filename": "7c06180d6f30ad8066edd8ec66a6eaf23badd9a0393fb2a681ff39d09bde13e1f084b32ff257eec2742d64261394f656e800453b47792abaec9c0e889b54",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/b0/0b"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
+        "sha512": "86e0aff481fd4dc7fde73b980ac42b699b569c9bc1b4b544d101cc3acf1b5b26401593437188ec3ead67131f23280f72f817a8f6ffbb3813d18ac4138e29d033",
+        "dest-filename": "aff481fd4dc7fde73b980ac42b699b569c9bc1b4b544d101cc3acf1b5b26401593437188ec3ead67131f23280f72f817a8f6ffbb3813d18ac4138e29d033",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/86/e0"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+        "sha512": "6b850641a58f1f9f663975189c01b67b09dc412e22e05e374efdc9a0033eb365430264bd36c2bc1a90cc2eb0873e4b054fb8772ba4cea14367da96fb4685f1e2",
+        "dest-filename": "0641a58f1f9f663975189c01b67b09dc412e22e05e374efdc9a0033eb365430264bd36c2bc1a90cc2eb0873e4b054fb8772ba4cea14367da96fb4685f1e2",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/6b/85"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz",
+        "sha512": "02f6da08b38ed8eb70fe55b96e687d77f58475c0c5750a766766541f7a57f54da2872518d27bcbbfb27a4eb5a8c2495118f61b07f22e20c7d88316823e0e41a6",
+        "dest-filename": "da08b38ed8eb70fe55b96e687d77f58475c0c5750a766766541f7a57f54da2872518d27bcbbfb27a4eb5a8c2495118f61b07f22e20c7d88316823e0e41a6",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/02/f6"
+    },
+    {
+        "type": "file",
+        "url": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+        "sha512": "ad592cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9",
+        "dest-filename": "2cbec9cd09d27fa2119ceb180fc3237c7a1782c6c88b33c9b1b84fedfe6395a897b03ee3b59a22e94c74224604ca08b7b12f831e00555a82db3b1e6359d9",
+        "dest": "flatpak-node/npm-cache/_cacache/content-v2/sha512/ad/59"
+    },
+    {
+        "type": "inline",
+        "contents": "00757fc67357b280a9001e22a8ec30185c63af3b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz\", \"integrity\": \"sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==\", \"time\": 0, \"size\": 17360, \"metadata\": {\"url\": \"https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f45e412c29aacbb328f9d4d864101d74f4ed118dfdb7fbf9054ad9586eac",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3b/17"
+    },
+    {
+        "type": "inline",
+        "contents": "0128fa55617d9a65272cf81ed1030bcf7ddc06d1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz\", \"integrity\": \"sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==\", \"time\": 0, \"size\": 857913, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a572853469e16dffcaa3e17c6e84cd41b313c34eb5af1f2679febb41dc72",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/e0"
+    },
+    {
+        "type": "inline",
+        "contents": "01e46bc0dc92759455dae23fe49151b09cd35346\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz\", \"integrity\": \"sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==\", \"time\": 0, \"size\": 3884794, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "135fdff79235b08198cd4cb78de9deb671d31d6835d0e4e7f6008e178c33",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/03/e6"
+    },
+    {
+        "type": "inline",
+        "contents": "022fac9995aecf3907dab7eb5b15ac0716152e60\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ini/-/ini-1.3.8.tgz\", \"integrity\": \"sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==\", \"time\": 0, \"size\": 3998, \"metadata\": {\"url\": \"https://registry.npmjs.org/ini/-/ini-1.3.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8c5e2a2dc539f4e1bf163b03e6f9bf63cf830db894a07035fe82fa207aea",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/15/71"
+    },
+    {
+        "type": "inline",
+        "contents": "02aa9e4ae90fc2379abd967ab8894b52ab6351fc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz\", \"integrity\": \"sha512-JCDrsP4Z1Sb9JwG0aJ8Eo2r7k4Ou5MwmThS/6lcIe1ICyb7UBJKGRIUUdqc2ASdE/42lgz6zFUnzAIhtXnBVrQ==\", \"time\": 0, \"size\": 8476, \"metadata\": {\"url\": \"https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.37.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "14ee0e76ce0d3739e34575fd168503fc1fe0e30375db71acc9bd813af401",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/da/10"
+    },
+    {
+        "type": "inline",
+        "contents": "0327dcda608a0fabe8a4796c9768c79aa5dad397\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz\", \"integrity\": \"sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==\", \"time\": 0, \"size\": 1089001, \"metadata\": {\"url\": \"https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4244544732d3e784c8fd360e0ea256a943488c53a834da3d0ddf3e83af9b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6f/9f"
+    },
+    {
+        "type": "inline",
+        "contents": "037421341f9e83e517c3908af8047d3ae20ee615\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz\", \"integrity\": \"sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==\", \"time\": 0, \"size\": 9705, \"metadata\": {\"url\": \"https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "243136ed99c82696e8d0da7ee6748305d1815b0c884838b842d58c2f811e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f4/08"
+    },
+    {
+        "type": "inline",
+        "contents": "0423fa4ea62c79bdeb0a89746049426f372460ad\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz\", \"integrity\": \"sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==\", \"time\": 0, \"size\": 5333, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2e5e443fa7532f3ec903a0b1165cd01e0d792ea9f50f24f6b510ed808116",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/23/81"
+    },
+    {
+        "type": "inline",
+        "contents": "0456daee298e058b05964f8c9d89b17d649af337\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz\", \"integrity\": \"sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==\", \"time\": 0, \"size\": 3730, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3f5b8e1c4db46b2c24d0264a2bb8ab473f22a4f13707d911085e0a717fb7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/28/af"
+    },
+    {
+        "type": "inline",
+        "contents": "046742ddcf7a9dd650a67a25492f7b42043fec75\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz\", \"integrity\": \"sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==\", \"time\": 0, \"size\": 2017, \"metadata\": {\"url\": \"https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ca47ff09ac9d048c991a5d94c9ef412ffa5496c2ab672947137bfb61e829",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/18/69"
+    },
+    {
+        "type": "inline",
+        "contents": "04a6aafa64549a6cc59c0747744c35cb2f6eca35\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz\", \"integrity\": \"sha512-0sglIs9Wmkzbr8lQwEyIzlDOOC9bGmfVKcJTaxv3vMmd3uo4o4DerC3En0bnmgceeql9BfC8hRkp7cg0fjdVqw==\", \"time\": 0, \"size\": 2594, \"metadata\": {\"url\": \"https://registry.npmjs.org/postcss-resolve-nested-selector/-/postcss-resolve-nested-selector-0.1.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a774b56d8d77aafc2833743c445d4ebf541a311c75d508eba89c9105f85d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/81/3a"
+    },
+    {
+        "type": "inline",
+        "contents": "04d4fe9336273610d75ba840d667ff9cc8c75ee3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz\", \"integrity\": \"sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==\", \"time\": 0, \"size\": 2433, \"metadata\": {\"url\": \"https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "199329b02915572faa5ff439b52c860d19665f3c62c1faac64ab534f02db",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cf/26"
+    },
+    {
+        "type": "inline",
+        "contents": "05e25d6ffcd6e0c271012943396b661f6fe361e2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz\", \"integrity\": \"sha512-ME4Fb83LgEgwNw96RKNvKV4VTLuXfoKudAmm2lP8Kk87KaMK0/Xrx/aAkMWmT8mDb+3MlFDspfbCs7adjRxA2g==\", \"time\": 0, \"size\": 58071, \"metadata\": {\"url\": \"https://registry.npmjs.org/listr2/-/listr2-9.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4f2b95f6bf308d967f065fb135d2192befa9ae95fe0eadd01494f6bbbbf2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1c/d0"
+    },
+    {
+        "type": "inline",
+        "contents": "062c157a258c356eb5d0ff406805815d4fbd2c7b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz\", \"integrity\": \"sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==\", \"time\": 0, \"size\": 8996, \"metadata\": {\"url\": \"https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "453bd89145eccf9d67f5797fb09e5a017b5b13f1ac45cb7b70bda45940ec",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/e7"
+    },
+    {
+        "type": "inline",
+        "contents": "067fbc2fc960f70859479dbcb175ef9d7e4f1292\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz\", \"integrity\": \"sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==\", \"time\": 0, \"size\": 6074, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "18f75527ac37299e70f06aad31fb38c55d9ffb7d576a3961d46b9f85720a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2d/ea"
+    },
+    {
+        "type": "inline",
+        "contents": "08feceb25c44c3acb21b39c988472901d8508491\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/commander/-/commander-11.1.0.tgz\", \"integrity\": \"sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==\", \"time\": 0, \"size\": 45767, \"metadata\": {\"url\": \"https://registry.npmjs.org/commander/-/commander-11.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e5eadb31edb99a328216181baebf4ace396ad067d3ccecc837f4e04cfd91",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b0/fa"
+    },
+    {
+        "type": "inline",
+        "contents": "096d1566b7f61516c64fb803189646379ec8a614\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/chai/-/chai-5.3.3.tgz\", \"integrity\": \"sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==\", \"time\": 0, \"size\": 80499, \"metadata\": {\"url\": \"https://registry.npmjs.org/chai/-/chai-5.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e675bfb2e26b51b7a2201957dde3f796ef84cf2c4999c18d3ee06ba85991",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/65/02"
+    },
+    {
+        "type": "inline",
+        "contents": "09703db43afc3cf82c342e891402c22bb9b56fe6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz\", \"integrity\": \"sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==\", \"time\": 0, \"size\": 4408, \"metadata\": {\"url\": \"https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-5.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1d947b01fae736cd50442f7e58f6889762608107934417e262d386b4083b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/05/41"
+    },
+    {
+        "type": "inline",
+        "contents": "09f93a8e5d91e9e9e14b44e1709f2c9214ada5c6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz\", \"integrity\": \"sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==\", \"time\": 0, \"size\": 4301, \"metadata\": {\"url\": \"https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "77e106cf4fe6cf8a1950447ebaf67c41ca77bf45543dc959cd8dff8abcee",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e3/fd"
+    },
+    {
+        "type": "inline",
+        "contents": "0a078b0c48359b4c20385f2a37290e977d0df120\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz\", \"integrity\": \"sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==\", \"time\": 0, \"size\": 2675, \"metadata\": {\"url\": \"https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "21f3b978a3a22da2c741a07872da75d54875dd2620f1fbe58f0b0f9d92a9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ed/b8"
+    },
+    {
+        "type": "inline",
+        "contents": "0a568af90ae4039722c18f16fbabe501d60b09ac\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz\", \"integrity\": \"sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==\", \"time\": 0, \"size\": 4174590, \"metadata\": {\"url\": \"https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "80ddbe68b148e60513d5a1ca0817d8c00016ff90fcd5899a164af9b14ed2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5d/3f"
+    },
+    {
+        "type": "inline",
+        "contents": "0aad5abf59165a5658660124746df3c1c1f8b3f4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz\", \"integrity\": \"sha512-O8morBEW+HsVG28gYDZPTrT9UUovQUlJue5YO836tiTJhuIWBm/zQHc7j388sHWtdH/xUZurK9olD2+pcqx5ww==\", \"time\": 0, \"size\": 13310, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-context-menu/-/react-context-menu-2.2.16.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0274d7c68832b4c3521f5d1820c605f9e436505e309cb7a0a219e06f922c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/02/de"
+    },
+    {
+        "type": "inline",
+        "contents": "0b7b2dc8fb1e72638fff7638e0879ad78429f9fa\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz\", \"integrity\": \"sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==\", \"time\": 0, \"size\": 5928, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "419224f61b4dee999548d94866a6d4732a1305a497db0e78f5af71aad359",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/85/e3"
+    },
+    {
+        "type": "inline",
+        "contents": "0c0dc5c51ba0703dfa8d4b34bdb8b6c6a67e4848\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz\", \"integrity\": \"sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==\", \"time\": 0, \"size\": 3849556, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7ff78a06c8555d1e363864d4e9cfa847d64d072cce3774fe36721aa8885b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/00/6f"
+    },
+    {
+        "type": "inline",
+        "contents": "0c7a7a0cfc46f96d55ba2f63b5f42ede13c6f9c4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz\", \"integrity\": \"sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==\", \"time\": 0, \"size\": 52722, \"metadata\": {\"url\": \"https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "63480143ccb5d6e489ad2487ed3782550dfb0ef213105a1fc5c3b33121cc",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1f/eb"
+    },
+    {
+        "type": "inline",
+        "contents": "0de79bd3d2979d8373bdf1b5aab02a32641d8e51\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz\", \"integrity\": \"sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==\", \"time\": 0, \"size\": 330532, \"metadata\": {\"url\": \"https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4ae60f8c0864c6f22cb6ee68b3f8867fb1813732f1e10e071e938ee26fe7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fe/8e"
+    },
+    {
+        "type": "inline",
+        "contents": "0e59844e5b609f7c714da16cd1eecb9b256d1782\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz\", \"integrity\": \"sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==\", \"time\": 0, \"size\": 2842, \"metadata\": {\"url\": \"https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "452a94b385f28d524a6fd9178863fe32cc70bc3d94033a3dda9c91b2e128",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/ef"
+    },
+    {
+        "type": "inline",
+        "contents": "0f51513ae948ec73a369aeda6fb57779e188ac51\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz\", \"integrity\": \"sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==\", \"time\": 0, \"size\": 14663, \"metadata\": {\"url\": \"https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "cb27353e382265f8f1860479d989b960c3a951132d731e6cd55a4656aece",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/25/2d"
+    },
+    {
+        "type": "inline",
+        "contents": "10aecaeead6bca8b1264e8501307a3d40b8333f1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz\", \"integrity\": \"sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==\", \"time\": 0, \"size\": 26671, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b8e11cad828856c49e6dff904d3d2475e8e8d43c77af996376940cd65454",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/aa/9e"
+    },
+    {
+        "type": "inline",
+        "contents": "10cf0621845d92152b90ef61830789d6206b35ce\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz\", \"integrity\": \"sha512-CYDD3SOtsHtyXeEORYRx2qBtpDJFjRTGXUtmNEMGyzYOKj1TE3tycdlho7kA1Ufx9OYWZzg52QFBGALTirzDSw==\", \"time\": 0, \"size\": 25027, \"metadata\": {\"url\": \"https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "02b650807e84145edf8db12bbdd8853c09b425b8208e5fed686bab563382",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7b/a9"
+    },
+    {
+        "type": "inline",
+        "contents": "11b758212ff22c713fa53c29124ff87b79144d60\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react/-/react-18.3.1.tgz\", \"integrity\": \"sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==\", \"time\": 0, \"size\": 81751, \"metadata\": {\"url\": \"https://registry.npmjs.org/react/-/react-18.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "434e6cce71a37629e1945f6d35d5e52c1e34aa88ef24d1915846c72775f1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/73/e2"
+    },
+    {
+        "type": "inline",
+        "contents": "11f5159fcd3208e5547f62162b84094881de5515\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz\", \"integrity\": \"sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==\", \"time\": 0, \"size\": 6969, \"metadata\": {\"url\": \"https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7dfc9eddd7fa68ce162b1c8969851a9534036a8ce85a9f3360aff789fc68",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/60/2e"
+    },
+    {
+        "type": "inline",
+        "contents": "124f6d5624f08322aedc7556fc1a15f9535a49c6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/globals/-/globals-17.6.0.tgz\", \"integrity\": \"sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==\", \"time\": 0, \"size\": 29802, \"metadata\": {\"url\": \"https://registry.npmjs.org/globals/-/globals-17.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "37c5a9aa3695ed176e70c8ae35f7597743748480dd910026b1d23f09d99e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/06/81"
+    },
+    {
+        "type": "inline",
+        "contents": "133b172d4ded9067e47efcd846831de4f532a4b6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz\", \"integrity\": \"sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==\", \"time\": 0, \"size\": 23662, \"metadata\": {\"url\": \"https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5041c4a1b2ff1b52a6e1b0bf859ef4e62186411afad0bf31e91b55417780",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2b/a4"
+    },
+    {
+        "type": "inline",
+        "contents": "136da76d0c67c55e25926bd14f065ccd0da3a811\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz\", \"integrity\": \"sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==\", \"time\": 0, \"size\": 15961, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ef30fa51cda1f7fec7431ff72e4dceadd4c8c12da056e18c4a3a6335cbf4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/21/1e"
+    },
+    {
+        "type": "inline",
+        "contents": "1399cbea7cbee96ca6e336db354601859c14ebc6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz\", \"integrity\": \"sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==\", \"time\": 0, \"size\": 17273, \"metadata\": {\"url\": \"https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fbb20dd7b54a8a059e8b5fb24f6a9bab83cf36e50b4b3961fcb6e82a9ae9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f2/a6"
+    },
+    {
+        "type": "inline",
+        "contents": "13e82e2e2e81ee1b1ac20e12af802949ea13ff07\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz\", \"integrity\": \"sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==\", \"time\": 0, \"size\": 11241, \"metadata\": {\"url\": \"https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b739b1f6f936987c26973cec93f36482ed240ab90158c0d04899bab0de13",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a3/50"
+    },
+    {
+        "type": "inline",
+        "contents": "142e75d1f4eaa070ffc73e8a98d74b54bc959b0a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/globby/-/globby-11.1.0.tgz\", \"integrity\": \"sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==\", \"time\": 0, \"size\": 6381, \"metadata\": {\"url\": \"https://registry.npmjs.org/globby/-/globby-11.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b63b3cfc48d8daee892b18f66369c3115a356c3119d5117d91bc958b8b47",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/06/0b"
+    },
+    {
+        "type": "inline",
+        "contents": "147da7df82bfe6e40dc61e99cd341f79e1444c76\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz\", \"integrity\": \"sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==\", \"time\": 0, \"size\": 6268, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2b0123c780f4536fbd0b803d54bb573a256230046b95fd342da9df92dc8d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/47/12"
+    },
+    {
+        "type": "inline",
+        "contents": "157b64b930487212ac4085378b510bb5d047d0ce\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz\", \"integrity\": \"sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==\", \"time\": 0, \"size\": 4119987, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2d55f9a41c57244e431b96db470a19fead478df12c5f3a962e96832d9fae",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/30/af"
+    },
+    {
+        "type": "inline",
+        "contents": "1670a5266f043a51fcda8d007e955cbd74d50e11\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz\", \"integrity\": \"sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==\", \"time\": 0, \"size\": 7121, \"metadata\": {\"url\": \"https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-6.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "04dcc124b868fe72a53e629c46cb25375815712232a39ec6b7b1adf56e20",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/63/ad"
+    },
+    {
+        "type": "inline",
+        "contents": "17676c2221e327e77a57bf256ca31fa61ccc7fa1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz\", \"integrity\": \"sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==\", \"time\": 0, \"size\": 842179, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0eb31100bb369ae9b95c4ebb30ddebb4ace99df79cce931a1cf6edccab6f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b4/d6"
+    },
+    {
+        "type": "inline",
+        "contents": "17750c64ee03cc51ab1b800e33b90310c44618cb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz\", \"integrity\": \"sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==\", \"time\": 0, \"size\": 343589, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b0c7d5ccb68b34a2ba4447bf16fc47ab7e818b1fbc21acf353f01a8c5283",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e0/2b"
+    },
+    {
+        "type": "inline",
+        "contents": "17d7ecb9f5e37d87d20daada3b175c3a9806a4be\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz\", \"integrity\": \"sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==\", \"time\": 0, \"size\": 19779, \"metadata\": {\"url\": \"https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "55a9d8d32b5679c9b7eb6e790c2ccd0839caeb5408eaee9d02321ef9ab53",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/42/13"
+    },
+    {
+        "type": "inline",
+        "contents": "1878a4e65cb76e4793db3aa0ae00a59c684801da\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz\", \"integrity\": \"sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==\", \"time\": 0, \"size\": 3072, \"metadata\": {\"url\": \"https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c08c5902d481154f472b2c4d2433878c5e74cd459450eeff8dbd41c88fc2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/19/a7"
+    },
+    {
+        "type": "inline",
+        "contents": "189923a805ddcb90f67f62119aa4d909ade3d475\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz\", \"integrity\": \"sha512-xYfnw62CKG8nLkZBfWbhWwDw02CHty86jfPcc2cr3ZfeuK9ysoVPPEUxf21bAD/rWAgk52SuBrLJlefNy8mvFg==\", \"time\": 0, \"size\": 2309, \"metadata\": {\"url\": \"https://registry.npmjs.org/globjoin/-/globjoin-0.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "389b9b232408d97ae1a970b4f99cfe1374c916033e0a36d6ccc3d8f23497",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b2/57"
+    },
+    {
+        "type": "inline",
+        "contents": "18e3a14bba5f4bc46c6564521d42d72aef564245\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz\", \"integrity\": \"sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==\", \"time\": 0, \"size\": 3525, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c56cdb49f40694dc6b984bd43ff53d96f6ea1dbb06ee467a00e4a697e664",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1d/59"
+    },
+    {
+        "type": "inline",
+        "contents": "18fc2ea40b601a2d797e05ba78604f527336100d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz\", \"integrity\": \"sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==\", \"time\": 0, \"size\": 7479, \"metadata\": {\"url\": \"https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "dc4d09c078e5fda1ffd8fe6224f320d36d4c62060b195159c328acfed935",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/42/01"
+    },
+    {
+        "type": "inline",
+        "contents": "192db0460e43c4ce9e1f2ade8e4edab33e4f2f48\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz\", \"integrity\": \"sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==\", \"time\": 0, \"size\": 12742, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "00c0d4b873bba9e76b10270189c03ed0a83bb47982991526853e685e1a81",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0d/1e"
+    },
+    {
+        "type": "inline",
+        "contents": "197f173b8cf5d4b96ddc9384b9c65c25ba7e62ed\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz\", \"integrity\": \"sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==\", \"time\": 0, \"size\": 9998, \"metadata\": {\"url\": \"https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3849f3c1fa39383ce61dfadb908796c9646f9a97f258c3ed9322170e28cb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/18/70"
+    },
+    {
+        "type": "inline",
+        "contents": "199d43553adc2a33ea21ef6b6a1a3bb6135f7b29\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz\", \"integrity\": \"sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==\", \"time\": 0, \"size\": 963050, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f63fb3c92ff50cf9779c30d9e565ca86d07ec75bf1fafa765cd864d572fa",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1b/a2"
+    },
+    {
+        "type": "inline",
+        "contents": "1a2a7e484b6e1f091fe7b2918909d337b489e5af\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz\", \"integrity\": \"sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==\", \"time\": 0, \"size\": 4496, \"metadata\": {\"url\": \"https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "56d3868cdb645b2dd09110debc35e2e7b4e26d0210d08755dce2a8cd9ae8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/27/26"
+    },
+    {
+        "type": "inline",
+        "contents": "1a38da4a5a3e362701d028114f01e7eb80bbfd2b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz\", \"integrity\": \"sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==\", \"time\": 0, \"size\": 824228, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "47dd2c5eb5f0f07c850d7ab2688ae78f7b61400b8c2d69a80ab475c8ec18",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/05/a1"
+    },
+    {
+        "type": "inline",
+        "contents": "1a8cac540dd9b2f7d0ae8d499842458a49dc8ed3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz\", \"integrity\": \"sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==\", \"time\": 0, \"size\": 4237, \"metadata\": {\"url\": \"https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3d92b01370613c71f3a974a835ef92cc79ed6d3bf63089f97396056e585c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/62/24"
+    },
+    {
+        "type": "inline",
+        "contents": "1ad5e60331f6634b7da563e23a5182bdd0f46183\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz\", \"integrity\": \"sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==\", \"time\": 0, \"size\": 3656, \"metadata\": {\"url\": \"https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "aefda99ca03a1004596e312ea5d597c682502fb85fe4283d6c1079cacd8f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8d/f8"
+    },
+    {
+        "type": "inline",
+        "contents": "1b543fe4148c1f5eaf7aa6b2793df85e26e518c2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz\", \"integrity\": \"sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==\", \"time\": 0, \"size\": 42928, \"metadata\": {\"url\": \"https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f64e55889c24b95ae1a41df23ab129d0f33551831210bcec228fbe08bc70",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f4/e8"
+    },
+    {
+        "type": "inline",
+        "contents": "1d60404b3281c92034abd12e57aa0af0e64aa315\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz\", \"integrity\": \"sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==\", \"time\": 0, \"size\": 22808, \"metadata\": {\"url\": \"https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c98f1cdf494d5afde6448966f8b5b9ae83d1b42c6702670e15e8a7f68552",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/49/61"
+    },
+    {
+        "type": "inline",
+        "contents": "1df7627de7f4fb2e1c1eb4f3331917c7c152d944\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz\", \"integrity\": \"sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==\", \"time\": 0, \"size\": 3572, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4a6b7b0714b6f1c94fff48ad31ee18cb6aa93ed63612067b4de30efd43f8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f3/8b"
+    },
+    {
+        "type": "inline",
+        "contents": "1e222f5401aeccee6428fcfa3ba317c812f1fd62\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ws/-/ws-8.20.0.tgz\", \"integrity\": \"sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==\", \"time\": 0, \"size\": 34449, \"metadata\": {\"url\": \"https://registry.npmjs.org/ws/-/ws-8.20.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "aed4a1fdca70ef9121f0a689e3a44f1799df36e485b24e118a49905d7fcd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/fb"
+    },
+    {
+        "type": "inline",
+        "contents": "1f00a148568369ebe861d3225db2c24cbdd7fd51\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz\", \"integrity\": \"sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==\", \"time\": 0, \"size\": 9799, \"metadata\": {\"url\": \"https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "af28f1133468f98432a0caf94d8a9e1a4f1bcd830398a06a4e51d9d17bcd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/87/da"
+    },
+    {
+        "type": "inline",
+        "contents": "1fc86368ec00423b0e014283dbcc18beb9842a4a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz\", \"integrity\": \"sha512-8HFEBPKhOpJPEPu70wJJetjKta86Gw9+CCyCnB3sui2qQfOvRyqBy4IKLKKAwdMpWb2lHXWk9Wb4Z6AmaUT1Pg==\", \"time\": 0, \"size\": 6479, \"metadata\": {\"url\": \"https://registry.npmjs.org/css-functions-list/-/css-functions-list-3.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0afb0b32f8f09e50c8d2b46f691715db45e9c45dfdf2864a478ba7cb6acd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/aa/9e"
+    },
+    {
+        "type": "inline",
+        "contents": "209a03d0e799b3874e59bceb75b43bbdc3cbd5a9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz\", \"integrity\": \"sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==\", \"time\": 0, \"size\": 3936, \"metadata\": {\"url\": \"https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b968e19e42cda755b43c4bd1e354056b2be0e8ff44896e82e4bc9fdb6322",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/69/33"
+    },
+    {
+        "type": "inline",
+        "contents": "20d71fa835c8a99dc14d6f879c787dd80b999618\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/qified/-/qified-0.9.1.tgz\", \"integrity\": \"sha512-n7mar4T0xQ+39dE2vGTAlbxUEpndwPANH0kDef1/MYsB8Bba9wshkybIRx74qgcvKQPEWErf9AqAdYjhzY2Ilg==\", \"time\": 0, \"size\": 18937, \"metadata\": {\"url\": \"https://registry.npmjs.org/qified/-/qified-0.9.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a8f76e839fb2953a5d24621b2140713fc0e5fad63f11eb48864e2565e0d2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2f/21"
+    },
+    {
+        "type": "inline",
+        "contents": "21a078d17c0a02739c2957317e209105eb618a03\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz\", \"integrity\": \"sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==\", \"time\": 0, \"size\": 14245, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "021ecffe3a6a03d09df754d273271105bfc55d701d3afa3f04d70bbee723",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/37/a0"
+    },
+    {
+        "type": "inline",
+        "contents": "21d9e1ee2c0b4100b5cd1ec0a2414a452d2e44e0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz\", \"integrity\": \"sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==\", \"time\": 0, \"size\": 3389, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9b2e81a9ef349bd31c3c94f1c2d4040643ee96b8128c972db597415d555c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d2/3c"
+    },
+    {
+        "type": "inline",
+        "contents": "227a59a890df443a12409d5cd52cfb58f6dcd161\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz\", \"integrity\": \"sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==\", \"time\": 0, \"size\": 6838, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "983b2a8f75359a5ef5034843700932f77eecd10a41efecd6be51e99c606e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2f/d6"
+    },
+    {
+        "type": "inline",
+        "contents": "241efa24721cdb89baecd10ce5f71a06aedc564d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz\", \"integrity\": \"sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==\", \"time\": 0, \"size\": 3165, \"metadata\": {\"url\": \"https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7e2f7ad9dbe684c39fe2dcdc0b17715b6cacde8589f358591df2d12e911c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/86/bb"
+    },
+    {
+        "type": "inline",
+        "contents": "244036e4362860dbf936e83073280bef4a5e4045\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz\", \"integrity\": \"sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==\", \"time\": 0, \"size\": 4312, \"metadata\": {\"url\": \"https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e444d001268ef2d4c2a6c96efcf4cbe9d51fdc9008329f7956b60986aef9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/64/28"
+    },
+    {
+        "type": "inline",
+        "contents": "255595f4ff5243016255e589d9661b953c583cb2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz\", \"integrity\": \"sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==\", \"time\": 0, \"size\": 3507038, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7bf704b620a95281ac3e0ce6487e2cb33c1def7a88c53bfdc1997791de79",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5b/75"
+    },
+    {
+        "type": "inline",
+        "contents": "25aae8418b6db1b1dba7bb1312fa5fcd1b46d3d9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz\", \"integrity\": \"sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==\", \"time\": 0, \"size\": 899587, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8500800c1d157bcf9650d1412cee2376d4b37c2a9f70dcf1bd8f84afb1c0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/02/69"
+    },
+    {
+        "type": "inline",
+        "contents": "261760e151d8d001952dfa7dc5124084ff598aee\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz\", \"integrity\": \"sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==\", \"time\": 0, \"size\": 80321, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "65fe6aec50e6ca1c411ea339a5cb928a34a889783d2a617f9257ef499b25",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7e/07"
+    },
+    {
+        "type": "inline",
+        "contents": "2674a9e34f4cd2e8d77bef743cb7fe905e5844f7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz\", \"integrity\": \"sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==\", \"time\": 0, \"size\": 570769, \"metadata\": {\"url\": \"https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "77787b349a5134c90916f2ca95e27cded52bc9037dfd94a97a97336e9b4d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/53"
+    },
+    {
+        "type": "inline",
+        "contents": "26f3e541eabc021c2d2e8586c2c68fcfab5dfb20\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz\", \"integrity\": \"sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==\", \"time\": 0, \"size\": 2270, \"metadata\": {\"url\": \"https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7cedabc2e6a505dca3109032357d135bb901c6fe15b7142b0b79ec09c9f3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8a/d6"
+    },
+    {
+        "type": "inline",
+        "contents": "27367a2db849fddd727605fa14cafc1d5c7baf9d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz\", \"integrity\": \"sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==\", \"time\": 0, \"size\": 3180, \"metadata\": {\"url\": \"https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ee063debd53dc122426b227cb91b1fd4b2207a02282e0d79e4906a405162",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6d/9f"
+    },
+    {
+        "type": "inline",
+        "contents": "283bdb03755b37a1b233533f18ae7a3fd9a52de9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz\", \"integrity\": \"sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==\", \"time\": 0, \"size\": 2979, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "dd11aca2ddd3aeb854849cd81cab78174fc5ea935c0fd552de94684f90a8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/34"
+    },
+    {
+        "type": "inline",
+        "contents": "283fdf2844afe3036bdc7e4afc1079d1f673ee54\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz\", \"integrity\": \"sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==\", \"time\": 0, \"size\": 5309, \"metadata\": {\"url\": \"https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d5492d209a15a4c78e9e02abacbf2dfca909ee66881a6f37075d9b29c405",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/eb/69"
+    },
+    {
+        "type": "inline",
+        "contents": "28985d61bd4a882a1a7861c931e0fffbda065b6c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz\", \"integrity\": \"sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==\", \"time\": 0, \"size\": 6779, \"metadata\": {\"url\": \"https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fefef5c06cc570a726f66b226d6abde231b9f5de2ae35354240c598b5518",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/75/17"
+    },
+    {
+        "type": "inline",
+        "contents": "28ac940e78a53e00aa2e5bd01ddab6fc86b5fb4a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz\", \"integrity\": \"sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==\", \"time\": 0, \"size\": 301773, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "418df36f08d77db3d8e9bc6b4f37ace935b3618fd6b94e74736e8cbbb3cc",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/64/60"
+    },
+    {
+        "type": "inline",
+        "contents": "28d80aa638fc054661ae3e0b3f54d25a024e6456\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz\", \"integrity\": \"sha512-eiFgzCbIneyMlLOmNG4g9xzF7Hv3Mga4LjxjcSC/ues6VYq2+gUbQI8JqNuw/ZM8tJIeIaBGpswAsqV2V7ApgA==\", \"time\": 0, \"size\": 15988, \"metadata\": {\"url\": \"https://registry.npmjs.org/@cacheable/utils/-/utils-2.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "86c37b6c04a635939cfc9b3fa9ece31af89570b2bf0d51229f8ed684c124",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/67/01"
+    },
+    {
+        "type": "inline",
+        "contents": "2987c07d1a5b79f836c71b34ae6521480ba60ee8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz\", \"integrity\": \"sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==\", \"time\": 0, \"size\": 7328, \"metadata\": {\"url\": \"https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b770aa000f755eaa35f914a7fa516956cb339f419e0da287c2f2e4313e47",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1f/7b"
+    },
+    {
+        "type": "inline",
+        "contents": "2a1f6cd986880d49683db738f725d15344e211ef\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz\", \"integrity\": \"sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==\", \"time\": 0, \"size\": 9370, \"metadata\": {\"url\": \"https://registry.npmjs.org/postcss-import/-/postcss-import-15.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3b06ed2602a1e10b48be3a921b2ffbccf28e9450d8205112d4795ccfe3b7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/65/6a"
+    },
+    {
+        "type": "inline",
+        "contents": "2b47ef0ce630833c58bd59ddbc5ee006df1b0dc0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz\", \"integrity\": \"sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==\", \"time\": 0, \"size\": 3548, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c68a85433f7c743aa9b9427fb21be6fd8c25f9e7893bd5cf65537496008d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/fe"
+    },
+    {
+        "type": "inline",
+        "contents": "2b997b800c792cecb38e6868d3071f5e8ddda3f1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz\", \"integrity\": \"sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==\", \"time\": 0, \"size\": 13764, \"metadata\": {\"url\": \"https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a95f6ee3665f1b7c89de9e104ea60b0cd9674bcdbb621b1fa57880ab8c07",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/93/eb"
+    },
+    {
+        "type": "inline",
+        "contents": "2bdce8df684ee52d8c05d99d5fff92811e9c54cb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz\", \"integrity\": \"sha512-0AioNCJZ2DPYz5ABT6bddIqlhgwhpHZ/l65YAYo0BCIn0xiDpsnTHz0gnoTGk0OXZW0JRs+cDwL8u/teRdz+8A==\", \"time\": 0, \"size\": 2635, \"metadata\": {\"url\": \"https://registry.npmjs.org/postcss-safe-parser/-/postcss-safe-parser-7.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b7d1ff95b606e4e1ba8bf82ba65ae1c884216e6eccf4bda0053d746bd300",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/52/25"
+    },
+    {
+        "type": "inline",
+        "contents": "2cd0509e38f8b358c6e50a526803f3cdb45160b7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz\", \"integrity\": \"sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==\", \"time\": 0, \"size\": 6219, \"metadata\": {\"url\": \"https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "29ae16b7b413d7a609c6beba2ab22ac51a8f88aa3c3a36759292907ce3ac",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ca/98"
+    },
+    {
+        "type": "inline",
+        "contents": "2d656f4a4ba9d0302a365f8255219f5edc7fbd10\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz\", \"integrity\": \"sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==\", \"time\": 0, \"size\": 11398, \"metadata\": {\"url\": \"https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e236d9a349e738c8841f9d14a32f0d4d269da22830565d660e941dc2ff4e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e6/45"
+    },
+    {
+        "type": "inline",
+        "contents": "2eaa3f70b58d9f15e5118fda2479bcefdfa1583a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz\", \"integrity\": \"sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==\", \"time\": 0, \"size\": 796108, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "611504a1080def1cb652fce49e117a92e7ebcf3bb95361d4e987ced957a8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/88/c6"
+    },
+    {
+        "type": "inline",
+        "contents": "300c21295b3649cf4aafff1127d04308ce7b571f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz\", \"integrity\": \"sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==\", \"time\": 0, \"size\": 31183, \"metadata\": {\"url\": \"https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fa719068f546ebc8cc40f64e2b6d2920f55693622f88b7fe92318eed4f79",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/32/6f"
+    },
+    {
+        "type": "inline",
+        "contents": "304d9ee74926876341188fe133afbf7331ca8a90\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz\", \"integrity\": \"sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==\", \"time\": 0, \"size\": 15295, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "064f622dc2b521763857528fa1e46d598a083d7c42096c4915582372e8e6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b4/78"
+    },
+    {
+        "type": "inline",
+        "contents": "30f01b03978797b027cf34d7e1c45500dc84bff2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz\", \"integrity\": \"sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==\", \"time\": 0, \"size\": 4234, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "96cd808473396fb088e2ec729674e5f39275b060f4bc94a4d49736b2bbaf",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d8/0c"
+    },
+    {
+        "type": "inline",
+        "contents": "310e57d660c185b82c055aac80c968d75cda4315\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz\", \"integrity\": \"sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==\", \"time\": 0, \"size\": 4876, \"metadata\": {\"url\": \"https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "143ae50ba22ddec235347ed6a62762b673eddb52cb1939aea401679de36b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9a/bc"
+    },
+    {
+        "type": "inline",
+        "contents": "3136b560cca5c82f186e1ae23500ebab963b27a1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz\", \"integrity\": \"sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==\", \"time\": 0, \"size\": 10026, \"metadata\": {\"url\": \"https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e413b98fb9dd3106e44211c7e85f5ef5dacedbbae40ba9d3db496aec3ad4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/40/c4"
+    },
+    {
+        "type": "inline",
+        "contents": "31466c0d59b629646e9abc1227dab28b1875b9da\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz\", \"integrity\": \"sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==\", \"time\": 0, \"size\": 3862529, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6d8f1954e21e9af42908a4e84ef47f2f63556562197f14a0c901301da9f8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c8/64"
+    },
+    {
+        "type": "inline",
+        "contents": "31714b035025b28986fdf9f0244b3cdd2dc379d9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz\", \"integrity\": \"sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==\", \"time\": 0, \"size\": 56842, \"metadata\": {\"url\": \"https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9f69780ca63c5abcd306054cce0d8e83552bd14adbf3d31ff9cf8595b313",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d9/53"
+    },
+    {
+        "type": "inline",
+        "contents": "334402dbda547b6984c0c352f99bfc0bb54c6f9d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz\", \"integrity\": \"sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==\", \"time\": 0, \"size\": 30513, \"metadata\": {\"url\": \"https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4770783f9e8a04dc1981e9b336245aa81e7c44c38754a79c812ab556e605",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e3/fd"
+    },
+    {
+        "type": "inline",
+        "contents": "33d608cefb32f6e9f798adb52d2e50b864740acc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz\", \"integrity\": \"sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==\", \"time\": 0, \"size\": 366888, \"metadata\": {\"url\": \"https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fb838d6218acbdee79a5976f39bee21bb54120dccf8dff9e29209ac9b2b8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4e/b5"
+    },
+    {
+        "type": "inline",
+        "contents": "3562d18d82eb1fbe1fc4ae8370a27f7b35bd8652\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz\", \"integrity\": \"sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==\", \"time\": 0, \"size\": 13358, \"metadata\": {\"url\": \"https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "53b66cd301f9a22d216cf30ba987eaf569b028dcca22223bb25b4ab86664",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d9/59"
+    },
+    {
+        "type": "inline",
+        "contents": "362736a9ea21ef01f209a8fafa7ce2fcc4a0e031\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz\", \"integrity\": \"sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==\", \"time\": 0, \"size\": 4231, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fb94be01bf9c91518c0d48881333eedb389a7eeceaa41b9e3bb9322b463b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/33"
+    },
+    {
+        "type": "inline",
+        "contents": "37ac74353a309e87b2f5c6b0db121e2dc1e11039\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz\", \"integrity\": \"sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==\", \"time\": 0, \"size\": 785413, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fb246b618873930cf2c2f1f20b90d5fbd32394646dce1100f597cd5ff8ff",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5e/4c"
+    },
+    {
+        "type": "inline",
+        "contents": "38174a7b444b5c5de6a90d25b4ae53a3cf76fdbf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz\", \"integrity\": \"sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==\", \"time\": 0, \"size\": 14260, \"metadata\": {\"url\": \"https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "aed451e167a5b0a6599321bfc9dccaa481334065ca397082e26598c17294",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/82/d4"
+    },
+    {
+        "type": "inline",
+        "contents": "3a2cf8ba70c468343bfdd6cda9c012f955b07bb1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz\", \"integrity\": \"sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==\", \"time\": 0, \"size\": 2880, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f26dea52f5e17e7686475713bb1059b055da65c0aa1c9b779c4e21cfcff8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/e5"
+    },
+    {
+        "type": "inline",
+        "contents": "3a8ce92eb49585f36641676947ba502181e6d2e9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz\", \"integrity\": \"sha512-v20V59/crfc8sVTAtge0mdafI3AdnzQ2KsWe6v523L4OA1bJO02S7MO2oyXDCS6iWb9ckIPnqAFVItqSBQr7jw==\", \"time\": 0, \"size\": 346940, \"metadata\": {\"url\": \"https://registry.npmjs.org/stylelint/-/stylelint-16.26.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "236f319e44c1673fb2ba2c17b2ac83182d794accd1deef0c44142298499d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b0/27"
+    },
+    {
+        "type": "inline",
+        "contents": "3ae349c081d103357d8912b6a54a399180748476\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz\", \"integrity\": \"sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==\", \"time\": 0, \"size\": 3652, \"metadata\": {\"url\": \"https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f74042740cf491b55667cf1a269361282f02fa1c0ae653bffc8ea4b9e242",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/36/a5"
+    },
+    {
+        "type": "inline",
+        "contents": "3b3d2b72f64e01f47ec77ed0f741b9814f9d08c1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/glob/-/glob-13.0.6.tgz\", \"integrity\": \"sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==\", \"time\": 0, \"size\": 364690, \"metadata\": {\"url\": \"https://registry.npmjs.org/glob/-/glob-13.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "05ac7d875ebb50cfbe305d609680a0132171f6cf277f002b5d27f4e98b82",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3f/77"
+    },
+    {
+        "type": "inline",
+        "contents": "3b547c36d6a101f1f00b6bc9f3b418763197a950\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz\", \"integrity\": \"sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==\", \"time\": 0, \"size\": 7782, \"metadata\": {\"url\": \"https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e8bc27510c4d79a1e1ea8154a02ae29d70cdb92077213ec966a298832d6c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d6/9a"
+    },
+    {
+        "type": "inline",
+        "contents": "3d779defe561890e2a1b77ee7aa2c389777e975c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz\", \"integrity\": \"sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==\", \"time\": 0, \"size\": 3064, \"metadata\": {\"url\": \"https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c74a5eaa2413b99f506d2259afd0e40a20bcd5325bcf008422955af7a017",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6c/0b"
+    },
+    {
+        "type": "inline",
+        "contents": "3df0f5cd5d640b8ab71abf4d3586909667d9e89f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz\", \"integrity\": \"sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==\", \"time\": 0, \"size\": 38897, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e615d98bed8665bc7b64b3a7a47bbdee31e0fb72246b22f485936c457f13",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/65/29"
+    },
+    {
+        "type": "inline",
+        "contents": "3e4930055828420c8d9aa5e4003fd9c615a013e8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz\", \"integrity\": \"sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==\", \"time\": 0, \"size\": 10600, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "528c5445a438483b66270e6a4dddfa6e9bdcceb2b998cb6f7580d23ceb1b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/60"
+    },
+    {
+        "type": "inline",
+        "contents": "3ede7701913c95e9c12564a2e000b8d8e63bd59a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz\", \"integrity\": \"sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==\", \"time\": 0, \"size\": 51162, \"metadata\": {\"url\": \"https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9efa8f0b245f2045eaff573eabbeb66fc3680690cf2d1ccec61b94fb0d24",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/de/44"
+    },
+    {
+        "type": "inline",
+        "contents": "3f5bb7ea9b419aeefa9668debcb0de6968a0eeb1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz\", \"integrity\": \"sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==\", \"time\": 0, \"size\": 26452, \"metadata\": {\"url\": \"https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "85e57baa9d925eb439766658c7cd72d41dfbdff23d9608399d25cb93b50e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/01/7a"
+    },
+    {
+        "type": "inline",
+        "contents": "3f75dcd8395c00123f2751290cf554a151f365c5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz\", \"integrity\": \"sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==\", \"time\": 0, \"size\": 4199, \"metadata\": {\"url\": \"https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "71b2d1452a6c218b9b534041f2e2b4b9ce6235c552e2515e16f03820d00e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/12/80"
+    },
+    {
+        "type": "inline",
+        "contents": "3fc1ea29664bf349635d3095d387d467161f16a3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz\", \"integrity\": \"sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==\", \"time\": 0, \"size\": 639638, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "60c97d564c437a0ef7eef0b6ce52fde3be5aa7df983d26113927468c2a64",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d5/08"
+    },
+    {
+        "type": "inline",
+        "contents": "429e33ba1c7b03eb4ba7f94299301ded63b2da5b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz\", \"integrity\": \"sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==\", \"time\": 0, \"size\": 7997, \"metadata\": {\"url\": \"https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "11559ac769e79e13cbc493b7586224212c15b07c9d3c4787777408a5767b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8a/35"
+    },
+    {
+        "type": "inline",
+        "contents": "43440e09bd79a8cc6f4dfb968dc5fe2d560f15ad\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz\", \"integrity\": \"sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==\", \"time\": 0, \"size\": 5240, \"metadata\": {\"url\": \"https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b179097bf33c30fcd5322583f45c0ffe91cb5b4b04eba298df4fb2468743",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b1/90"
+    },
+    {
+        "type": "inline",
+        "contents": "44441ce58112b1fcf29d0314ab050ff037fb6e0b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz\", \"integrity\": \"sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==\", \"time\": 0, \"size\": 27914, \"metadata\": {\"url\": \"https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b21b9f6e6b6e337727cbf65e9b3126885bf502b8ad1df9f8c1ec18450c1b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5c/f8"
+    },
+    {
+        "type": "inline",
+        "contents": "444ef1c491d4674fdd04410a54eca46cc7267ad4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz\", \"integrity\": \"sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==\", \"time\": 0, \"size\": 4080074, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "de13673d9ce0488425116cb65f9de1532751c13ed0efecd75b7db795da1b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/00/0d"
+    },
+    {
+        "type": "inline",
+        "contents": "446b35b3c1cca675ef33b5a9b83570761fc83646\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz\", \"integrity\": \"sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==\", \"time\": 0, \"size\": 841017, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "df78612da586ec1a8fc8c036ca223bba130c4f6692aa052f21b3ecaf765f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/13/17"
+    },
+    {
+        "type": "inline",
+        "contents": "47accc6bc32ddcef3f28c609a57c76eb26106f5c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz\", \"integrity\": \"sha512-ovssysQTa+luh7A5Weu3Rta6FJlFBBbInjOh722LIt6klpU2/HtdUbszju/G4devcvk8PGt7FCLv5wftu3THUA==\", \"time\": 0, \"size\": 2718, \"metadata\": {\"url\": \"https://registry.npmjs.org/svg-tags/-/svg-tags-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6ca891d81f0217adf18ffe8cb643a8e14506d30d3b3dc31a816e7639d7ec",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/89/43"
+    },
+    {
+        "type": "inline",
+        "contents": "4853ca6e8a1f234c765bb5ed85507251f9ed7484\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz\", \"integrity\": \"sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==\", \"time\": 0, \"size\": 54865, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6a7f0b9a683ffdec0b3364ad04b951effd6524a2e1323afccdd48228be92",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ee/86"
+    },
+    {
+        "type": "inline",
+        "contents": "489170ac9d6da8aee424195e200c33041e4844d4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz\", \"integrity\": \"sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==\", \"time\": 0, \"size\": 2258, \"metadata\": {\"url\": \"https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f5251e6ff87ae95f404dbe68861990a90dface0d95d807752acae3154dd5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b0/cc"
+    },
+    {
+        "type": "inline",
+        "contents": "48dc4d76c4a7f300145aeb87365e507e2559f503\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz\", \"integrity\": \"sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==\", \"time\": 0, \"size\": 4853, \"metadata\": {\"url\": \"https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a7bd89d5e50b639d5d8ce521aa97b6d3195447b72a7ff9d2c0d1812f7be0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/95/0b"
+    },
+    {
+        "type": "inline",
+        "contents": "49874de63f3bdfd637c16453fe8977a9eadfcc64\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz\", \"integrity\": \"sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==\", \"time\": 0, \"size\": 3009, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9ddc9f878c52039554fd9be6ee3852f10163225591207069618d4544e7b8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4d/f4"
+    },
+    {
+        "type": "inline",
+        "contents": "49cdfad06c9b603d8e800338b110210d2818067b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cac/-/cac-6.7.14.tgz\", \"integrity\": \"sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==\", \"time\": 0, \"size\": 21928, \"metadata\": {\"url\": \"https://registry.npmjs.org/cac/-/cac-6.7.14.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ba715ab03e09151e592cad6fa262d10f5d9bffaeb7406108b3cc42b99417",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c1/43"
+    },
+    {
+        "type": "inline",
+        "contents": "4acb9875ebc56c671c2d12c12823a5852ddc90f5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz\", \"integrity\": \"sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==\", \"time\": 0, \"size\": 5141, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "570007f66e0a594c21201eb3e8f15d7a4d92bcb97b59246e5b7194b3b290",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/f3"
+    },
+    {
+        "type": "inline",
+        "contents": "4af858e54f176d620493f73fee5ba33974c95a9e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz\", \"integrity\": \"sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==\", \"time\": 0, \"size\": 4053, \"metadata\": {\"url\": \"https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3b5c4878bcc451766f7bcf5df7d2a4999739fcb2e30c1dcf6d759fbf963e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/79/23"
+    },
+    {
+        "type": "inline",
+        "contents": "4b104b03bdca31c19caade83c443fe4d4a4c0726\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz\", \"integrity\": \"sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==\", \"time\": 0, \"size\": 168465, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7e6bf68e985e99da651cab0d850eaeff1cee7376435a6fc5ffc00fde028b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/f3"
+    },
+    {
+        "type": "inline",
+        "contents": "4cc903fd2d546e506b77bba8c64d4d13bec7e193\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz\", \"integrity\": \"sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==\", \"time\": 0, \"size\": 18158, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "bac56552c297c7629e0376e89839d6a33001452285e699707cb6b7bef1c6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c8/29"
+    },
+    {
+        "type": "inline",
+        "contents": "4d8a9b5a2e2ff3323d8587eb864c41f27cd9ec70\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz\", \"integrity\": \"sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==\", \"time\": 0, \"size\": 3551, \"metadata\": {\"url\": \"https://registry.npmjs.org/error-ex/-/error-ex-1.3.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c4027722fd67e7be89e5fad69c0d838f4ddc3dab0adfe8b2371f12b125bd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c1/ea"
+    },
+    {
+        "type": "inline",
+        "contents": "4e40e703b6cecd2cafa74bfa6095e001074c9f9b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/globals/-/globals-14.0.0.tgz\", \"integrity\": \"sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==\", \"time\": 0, \"size\": 17235, \"metadata\": {\"url\": \"https://registry.npmjs.org/globals/-/globals-14.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "aa8a49a64aa50b6965e5452104c55b9f97fec3e5c280a171bbc0021410e3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8f/3e"
+    },
+    {
+        "type": "inline",
+        "contents": "4e48ae14edb0982f1463fea22636c3221941e89e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz\", \"integrity\": \"sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==\", \"time\": 0, \"size\": 1854, \"metadata\": {\"url\": \"https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "946df9356ae372c19a7700e322d8d0276a406143c7375ce22124fad7dfcd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3a/21"
+    },
+    {
+        "type": "inline",
+        "contents": "4f45cbed01ac23ddddc5e51589a4bfb33c4367e0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz\", \"integrity\": \"sha512-tAXIa1g3sM5CGpVT0uIbUx/U3Gs5N8T52IICuCtObaos1S8fzsrPXG5WObkQN3S6NVl6wKgPhAIiBGbWnvc97A==\", \"time\": 0, \"size\": 39112, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-scroll-area/-/react-scroll-area-1.2.10.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e2bd6d8ba2108ee96c05875911ce547ac068370beb32393dc1fb35ffffb5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/28/14"
+    },
+    {
+        "type": "inline",
+        "contents": "4f532eeaf4e8a7932a11507ceb3c1677e42f53de\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz\", \"integrity\": \"sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==\", \"time\": 0, \"size\": 15266, \"metadata\": {\"url\": \"https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6fd694af3f2a77a99b7f63d7eeca0a3d895a46536c015370e462365772e9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/58/85"
+    },
+    {
+        "type": "inline",
+        "contents": "4f5de37149940548a5c72d73a4a16e6a8a3c2c4a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz\", \"integrity\": \"sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==\", \"time\": 0, \"size\": 30747, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "be954aca6e8bac59ed3f9aeedddfb27aff4451daf808e122d86491a37f77",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f6/44"
+    },
+    {
+        "type": "inline",
+        "contents": "500a86d2d37be84ad19b8c07881dacfde3ffcc5e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz\", \"integrity\": \"sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==\", \"time\": 0, \"size\": 18477, \"metadata\": {\"url\": \"https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "238807144536cb82d714f2a1374ef3c3a03fbbfd4fa234ff083114a25f63",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b6/63"
+    },
+    {
+        "type": "inline",
+        "contents": "504056813db7bb8855d67373cb79f0a4b8d14b39\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz\", \"integrity\": \"sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==\", \"time\": 0, \"size\": 3882784, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "80ebb8908c357227759202290a2cf797e22754ec23c5a7d620de590395b4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3d/9b"
+    },
+    {
+        "type": "inline",
+        "contents": "509ee31b664d299e20bb37b2d8c1dc6d6aceb9cd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-36.0.1.tgz\", \"integrity\": \"sha512-8aX8mTzJ6cuO8mmD5yon61CWuIM4UD8Q5aBcWKGSf6kg+EC3uhB+iOywpTK4ca6ZL7B49en8yanOFtUW0qNzyw==\", \"time\": 0, \"size\": 3567, \"metadata\": {\"url\": \"https://registry.npmjs.org/stylelint-config-standard/-/stylelint-config-standard-36.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2feeeb3fafb47f5bd7e5f763e4b700e9eaedf96bf35da745c973f6c77c8a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1c/94"
+    },
+    {
+        "type": "inline",
+        "contents": "5148e76a98ebca0061a0013fe83122bbdd2b0636\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/async/-/async-3.2.6.tgz\", \"integrity\": \"sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==\", \"time\": 0, \"size\": 150393, \"metadata\": {\"url\": \"https://registry.npmjs.org/async/-/async-3.2.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2ef4d8877589473848fd9bf548c44e0a4b9e0b52f57d138c51b77a9fe6c8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b6/2d"
+    },
+    {
+        "type": "inline",
+        "contents": "5162cf333e11d3e7838c46fa834f53acc1ce69cf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz\", \"integrity\": \"sha512-id+7YRUgoUX6CgV0DtuhirQWodeeA7Lf4i2x71JS/vtA5pRb/hIGWlw+G6MeXvsM+MXrz0VAydTGElX1rAfgPg==\", \"time\": 0, \"size\": 31402, \"metadata\": {\"url\": \"https://registry.npmjs.org/@dual-bundle/import-meta-resolve/-/import-meta-resolve-4.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "47a94c10b694a04e9877b43a03606ef8d07cdf49ea6ad55f5b0b3eac47b3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/51/20"
+    },
+    {
+        "type": "inline",
+        "contents": "51e0a2015c4bad4dc9d5f6576fc7196fab5df094\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz\", \"integrity\": \"sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==\", \"time\": 0, \"size\": 4195965, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2ba7247c5b8508fdb00c2b69a6dfed2e27d0bac54c0e780ad1c0de281f4e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e4/5c"
+    },
+    {
+        "type": "inline",
+        "contents": "52063d107f8e763c7db1583c5ed71592db21a25c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz\", \"integrity\": \"sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==\", \"time\": 0, \"size\": 4068, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "064ac66040d7820a41b4342f9685c2ed6b4556989cc76cf89118dd265f79",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1e/59"
+    },
+    {
+        "type": "inline",
+        "contents": "520f750fbf9dad26bbb37826a079ad360866e2f7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz\", \"integrity\": \"sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==\", \"time\": 0, \"size\": 953419, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "db7475c99a8af74516668665b873b014949d563f1f3060036e9b1d436dbb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4e/c6"
+    },
+    {
+        "type": "inline",
+        "contents": "5275296959f0beb34d155efbfc74cb60589b7467\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz\", \"integrity\": \"sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==\", \"time\": 0, \"size\": 2073, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "470c9cbb447615faafb6dfdf54632831f7f96c77771ea06a1eeffba41373",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cd/d3"
+    },
+    {
+        "type": "inline",
+        "contents": "54bd6383e30e0be816a17a306383c5fbe5c2bf8e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz\", \"integrity\": \"sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==\", \"time\": 0, \"size\": 24986, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2a12420aab34889ed2c64b80f9b722e2e90e139a130f13e34a1c7a0e1e29",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2f/2c"
+    },
+    {
+        "type": "inline",
+        "contents": "54eb53989c86e83530171f22ff731b7292f78036\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz\", \"integrity\": \"sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==\", \"time\": 0, \"size\": 17469, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b53660a6bedeb14f8bf9b40272b72516049c051ad67f47e108579dbc0a9d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/89/48"
+    },
+    {
+        "type": "inline",
+        "contents": "554b70e5dd9db701adef36f64df42134efd7b190\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/xml/-/xml-1.0.1.tgz\", \"integrity\": \"sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==\", \"time\": 0, \"size\": 6809, \"metadata\": {\"url\": \"https://registry.npmjs.org/xml/-/xml-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3f497efcb1f561f2e35f128fec8ee3271f5f785c09ebb2b20530f06c8416",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cd/f9"
+    },
+    {
+        "type": "inline",
+        "contents": "5631bc8360c25b8f2f6065c37610aef3d1fb69f3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz\", \"integrity\": \"sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==\", \"time\": 0, \"size\": 4683, \"metadata\": {\"url\": \"https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9b1b5aa5889844cd472441c0c1f23172a8dfb7c90ff4d55a8de845646955",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/34/9e"
+    },
+    {
+        "type": "inline",
+        "contents": "56692c4b9ad2f80f57a269675c8c24cc4ed0affe\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz\", \"integrity\": \"sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==\", \"time\": 0, \"size\": 3681, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1ea8e1c5735aa7333775abaea09cba50e98296556053fba7d4dd227c6732",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/91"
+    },
+    {
+        "type": "inline",
+        "contents": "571adcaa95c2a1a84d281fbb51a88c0ce074d036\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz\", \"integrity\": \"sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==\", \"time\": 0, \"size\": 9146, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e29fc6e888e285300467cc4224ea6fb974ed531347d52d7eeb3c9632099f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/92/38"
+    },
+    {
+        "type": "inline",
+        "contents": "571d2ddd9ee432035a8a115b57ae9869c12b1d22\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz\", \"integrity\": \"sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==\", \"time\": 0, \"size\": 6573, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ed9e9efea9640d672a8754bfa79884ad37e401e4eef3d7633118cbc58795",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/50/40"
+    },
+    {
+        "type": "inline",
+        "contents": "5786c04680341cfb4beea954c0a4f3f2924ad818\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz\", \"integrity\": \"sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==\", \"time\": 0, \"size\": 3850679, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "65d2c134c6ff109aa75543b9f34975f18821703a6b9f3fa0ff6651b9bc55",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ef/36"
+    },
+    {
+        "type": "inline",
+        "contents": "57db739517593eea357e05426331cbee6a60457e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz\", \"integrity\": \"sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==\", \"time\": 0, \"size\": 2008, \"metadata\": {\"url\": \"https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2cbc18156d0b5bd45d43608718e4abeac731fab0a1e48d628756e2cae0e8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/12/40"
+    },
+    {
+        "type": "inline",
+        "contents": "58883094c2f975105838a8b639e5060a3e43eb8e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz\", \"integrity\": \"sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==\", \"time\": 0, \"size\": 874014, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "bd4ae3a2cd0ed4db4c690b881f863e6ef8c38f23270c5451f0ae104059c8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f2/f7"
+    },
+    {
+        "type": "inline",
+        "contents": "5935b0004e69442b354101b1a8fbb9eb7459b991\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz\", \"integrity\": \"sha512-dXn3FZhPv0US+7dtJsIi2R+c7qWYiReoEh5zUntWCf4oSpMNib8FDhSoed6m3QyZdx5hK7iLFkYk3rNxwt8vTA==\", \"time\": 0, \"size\": 2937, \"metadata\": {\"url\": \"https://registry.npmjs.org/@keyv/serialize/-/serialize-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a8ae92e55173bf37984847abd9668945b8bc848e6cf6e7a850fe603a3e0d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/37/e7"
+    },
+    {
+        "type": "inline",
+        "contents": "59c9e50e387d0dd1e8141e3371932d65ae75fba2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz\", \"integrity\": \"sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==\", \"time\": 0, \"size\": 9742, \"metadata\": {\"url\": \"https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7bd13a4fbca4723a579cab6019efcd5e03ff32581fd276a8f79738dc7a68",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b0/18"
+    },
+    {
+        "type": "inline",
+        "contents": "5a8da8312f4f805be44ecadba1007084d24aec23\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/vite/-/vite-5.4.21.tgz\", \"integrity\": \"sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==\", \"time\": 0, \"size\": 760049, \"metadata\": {\"url\": \"https://registry.npmjs.org/vite/-/vite-5.4.21.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "446856e2adb28de3b02a5e5f396a79399380f2c39ce620c3e58951730f91",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/48/01"
+    },
+    {
+        "type": "inline",
+        "contents": "5ad1478c49b8ecf0a909c5d677929d36985bc127\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz\", \"integrity\": \"sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==\", \"time\": 0, \"size\": 132003, \"metadata\": {\"url\": \"https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a81ec09ff8849df96b20fa9c869a01023fc35e39a6fe539bee503fd77a00",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/30"
+    },
+    {
+        "type": "inline",
+        "contents": "5ad7fdf03b3977fba5a4d7a6ed7fd58ff7b0193c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz\", \"integrity\": \"sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==\", \"time\": 0, \"size\": 6101, \"metadata\": {\"url\": \"https://registry.npmjs.org/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c561cd4ce5d6a5a2845920607bd21b6b4c35e9262a397af57741af09c5ad",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ec/47"
+    },
+    {
+        "type": "inline",
+        "contents": "5b47f212fe504b3658e482fb881c82c2016419c3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz\", \"integrity\": \"sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==\", \"time\": 0, \"size\": 9804, \"metadata\": {\"url\": \"https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b2ef5a84c2eaaa7d05e56b8cf6c031a281ad250ad82994ffd1323d790201",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2c/a1"
+    },
+    {
+        "type": "inline",
+        "contents": "5bcd3ba9a33394bce4cd0877e4786a52f2ba31eb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/commander/-/commander-14.0.3.tgz\", \"integrity\": \"sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==\", \"time\": 0, \"size\": 53293, \"metadata\": {\"url\": \"https://registry.npmjs.org/commander/-/commander-14.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a1341f553e55ce7c5f65a6af6639838475601422a045b14723220bc1bd35",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/90/fc"
+    },
+    {
+        "type": "inline",
+        "contents": "5c2daaa21e43d1f7be77d2e83fc50fc0880d3368\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz\", \"integrity\": \"sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==\", \"time\": 0, \"size\": 83605, \"metadata\": {\"url\": \"https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c43cb43d33c94194830f62decc25626d377ceda4183614d4743fb9ffd7ee",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7e/d8"
+    },
+    {
+        "type": "inline",
+        "contents": "5d63dfcd70177e58da22ba07e62fdf62c98b959e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz\", \"integrity\": \"sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==\", \"time\": 0, \"size\": 795847, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "25cd7867d5de7eebe9e90200d10a14e10b4fc1ec384b652f937e689fed35",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/39/35"
+    },
+    {
+        "type": "inline",
+        "contents": "5e621ade89e852910872fb351d7f3083c1bcb416\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz\", \"integrity\": \"sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==\", \"time\": 0, \"size\": 2668, \"metadata\": {\"url\": \"https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "be90b3954e2f6e7b35b521e65a5016fd963aa11c3d6c88ccd9e0b61c069e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7d/ad"
+    },
+    {
+        "type": "inline",
+        "contents": "5ec7c359c0b85c76a4044e368d387348de9f8ced\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz\", \"integrity\": \"sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==\", \"time\": 0, \"size\": 5512, \"metadata\": {\"url\": \"https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6d5c2061312fdd689bcc92e60ccf2b2e72bc15b7e22453f3a8680f491803",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ee/2c"
+    },
+    {
+        "type": "inline",
+        "contents": "5eeba38c32699bfe5489c58d29ded948619a20bb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz\", \"integrity\": \"sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==\", \"time\": 0, \"size\": 2263, \"metadata\": {\"url\": \"https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "87042931e5944467d47331c350feb4384bf9143ab6ceebf7108a55905843",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/f7"
+    },
+    {
+        "type": "inline",
+        "contents": "5f8120abd516a06436803aa0768139a346a864cd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz\", \"integrity\": \"sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==\", \"time\": 0, \"size\": 4521, \"metadata\": {\"url\": \"https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5f01dce87163b20c9c209fd3a3a1c9bf6c3f7de4a63436be40e76d952ebf",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/03/58"
+    },
+    {
+        "type": "inline",
+        "contents": "60c3c20e861fd0e6997075e2e391ec83ce85555b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz\", \"integrity\": \"sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==\", \"time\": 0, \"size\": 6483, \"metadata\": {\"url\": \"https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "946b615093c0934b0885f755ce9896b1659ae82a6d29fdb3bf5508540f8d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/16/57"
+    },
+    {
+        "type": "inline",
+        "contents": "60f81decb0ef2499846809011578faf8768bab34\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz\", \"integrity\": \"sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==\", \"time\": 0, \"size\": 22400, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a825ea2c84ffbf55ba64f8df536ac984957d23e7273a8d5f50aa69e91a25",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e3/c8"
+    },
+    {
+        "type": "inline",
+        "contents": "6141e29e0b0925bb3a5a52ebfabd692651857890\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz\", \"integrity\": \"sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==\", \"time\": 0, \"size\": 3990163, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "43daf96c217a2aacf85ddcd30768c6e65bf8a56b5aa6eb678ef99a4274d0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2a/7a"
+    },
+    {
+        "type": "inline",
+        "contents": "61b44b257048d421c5d3308e7af5f869a2c16c8a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz\", \"integrity\": \"sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==\", \"time\": 0, \"size\": 3446, \"metadata\": {\"url\": \"https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4e020eef80700cb3f93d867eba934f2b586e90d19ab0707fd54abc8ff7e9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/03/3a"
+    },
+    {
+        "type": "inline",
+        "contents": "64166cead9a3e1cad56e89250f42e85ce7cc4dce\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz\", \"integrity\": \"sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==\", \"time\": 0, \"size\": 2956, \"metadata\": {\"url\": \"https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "43bf6734f1580c73673e7bb9f58d51f653c7acd60564758a602b5806f39e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3a/c9"
+    },
+    {
+        "type": "inline",
+        "contents": "645b6e572c017f4ac37b66f694c3a6c98da473f3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz\", \"integrity\": \"sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==\", \"time\": 0, \"size\": 44438, \"metadata\": {\"url\": \"https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3a35c272cae9f0f48d769aa94e6fc87308a8e34f29c8bfac12c2f2725f68",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6e/03"
+    },
+    {
+        "type": "inline",
+        "contents": "64cfabbb15b13f84dfdbfb74cf7f874fdf66a7aa\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz\", \"integrity\": \"sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==\", \"time\": 0, \"size\": 2067, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "488f71f39bc65742422faf2c74e3b330852ef2192dbb3198fed044e60c20",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c2/a4"
+    },
+    {
+        "type": "inline",
+        "contents": "6517f39b21e46514f6a3882938a842237a854702\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/environment/-/environment-1.1.0.tgz\", \"integrity\": \"sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==\", \"time\": 0, \"size\": 2766, \"metadata\": {\"url\": \"https://registry.npmjs.org/environment/-/environment-1.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8e7ff11dd0fe25b7d40c7f2721c5c2d99d60b0990695b20923170f8eec18",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e1/87"
+    },
+    {
+        "type": "inline",
+        "contents": "65390b461ed15ed4a0722fa5cbf0dac29cac1b54\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz\", \"integrity\": \"sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==\", \"time\": 0, \"size\": 6666, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "dfae46bf14b9cbd9c6befc444d36babb398a78500f653e49682e36f6b0d1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e7/58"
+    },
+    {
+        "type": "inline",
+        "contents": "65c23b3b88f5a8f8152a585b2290fcac83b9881e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz\", \"integrity\": \"sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==\", \"time\": 0, \"size\": 15149, \"metadata\": {\"url\": \"https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "496e961e4bdc855b1ed54d1b8b683df7f0af0064514517f634da3143aa18",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9a/e3"
+    },
+    {
+        "type": "inline",
+        "contents": "65c91f6d3bc8bd33987915a29fe7ea7b35005dc0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz\", \"integrity\": \"sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==\", \"time\": 0, \"size\": 4437, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e09607cab9ed86d1eaba2facfc3c4b0abe81568c9ad9916c858add870bf6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/c3"
+    },
+    {
+        "type": "inline",
+        "contents": "65cbd9f1326eea0ce6f219a0e3a7adb6b5a5ae6f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.8.tgz\", \"integrity\": \"sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==\", \"time\": 0, \"size\": 5638, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "eb81d4a696c90de2697c6abebf541e947d1599fc2ebd6c7236fd91ccae9f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7d/51"
+    },
+    {
+        "type": "inline",
+        "contents": "6627399e509e7fa6ef22698aec31a7cacbacf863\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/htmlhint/-/htmlhint-1.9.2.tgz\", \"integrity\": \"sha512-PweWSPA1Pb+AVFIOSpIGu5KhLdmtk/uf/0CpjvrDf6XUWmdTyqUljlylwSxQ0AWLvPGcBxK2n8uISsI4lCOkBQ==\", \"time\": 0, \"size\": 97420, \"metadata\": {\"url\": \"https://registry.npmjs.org/htmlhint/-/htmlhint-1.9.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6ada6e53420bbaab22766b7bf40f3182be1f8bcf3995d289267431b62c2b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/85/5d"
+    },
+    {
+        "type": "inline",
+        "contents": "66d79aa566b36dc58236d000c0ff7aeb6ac493e3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz\", \"integrity\": \"sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==\", \"time\": 0, \"size\": 2366, \"metadata\": {\"url\": \"https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "dac130a6e73bad4d60937014d9324e1adb2d7b984911bb12a73df78f2411",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0d/f5"
+    },
+    {
+        "type": "inline",
+        "contents": "66f1d25d4368c8fa7d3e089d0cbb333f1409703c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz\", \"integrity\": \"sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==\", \"time\": 0, \"size\": 2454, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0b57f65571788559ed93ba6d26cacaac21da8e4adfe374787669e431e875",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e4/f2"
+    },
+    {
+        "type": "inline",
+        "contents": "6795c0c84c6a04697d3efe79e25fab31b121f163\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz\", \"integrity\": \"sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==\", \"time\": 0, \"size\": 6145, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "29a46658abf61c9719df02da136c280351a126f4bf1dfded33238ec0f0f5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/77/6b"
+    },
+    {
+        "type": "inline",
+        "contents": "67fac2afde1b0a9ca4e2b87c709af312b084515a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/table/-/table-6.9.0.tgz\", \"integrity\": \"sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==\", \"time\": 0, \"size\": 48504, \"metadata\": {\"url\": \"https://registry.npmjs.org/table/-/table-6.9.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "cccd77f2c3b102dc33910bf5ad24aeb9fe5b32fac5dfbb11e5ed98ecd49d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/65/23"
+    },
+    {
+        "type": "inline",
+        "contents": "697961e898753c08313f6ab9060d7bd068ac8fe9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.2.0.tgz\", \"integrity\": \"sha512-kVIOdynrF2CRodHZeP/97Rh1syTUHBNiw17hUCIVhlhEsWlfJm19MuO56s4MdKbr22xWx6mzMnNAgXzVlIYM9Q==\", \"time\": 0, \"size\": 145682, \"metadata\": {\"url\": \"https://registry.npmjs.org/node-sarif-builder/-/node-sarif-builder-3.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "931df1b780f5fb3a7e7fc925acbf3c6c8a42a4a44bcd9bf045bc912a4642",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/45/f7"
+    },
+    {
+        "type": "inline",
+        "contents": "6a0500f484e8159e2f8c20ee43fe81db5bfafb25\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz\", \"integrity\": \"sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==\", \"time\": 0, \"size\": 383410, \"metadata\": {\"url\": \"https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9bf100b48aea77d9a3d0c1e4441927474592452251f523894ea9be6834ae",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e0/e6"
+    },
+    {
+        "type": "inline",
+        "contents": "6a9b5770720a4d6e733745e55ed124f9e8dc51cf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz\", \"integrity\": \"sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==\", \"time\": 0, \"size\": 1684, \"metadata\": {\"url\": \"https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8d77072374a0022204f7ed0c1aa73ee351cb74e16430f44d44f29b0cd918",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9a/11"
+    },
+    {
+        "type": "inline",
+        "contents": "6acde1f2b0be18e3a5cb4563e8482ffb71b7dd9c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz\", \"integrity\": \"sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==\", \"time\": 0, \"size\": 2362, \"metadata\": {\"url\": \"https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "09319958990cf29548f3d94275674b4b96127bf2f4aca28775a64a95d00c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/eb/61"
+    },
+    {
+        "type": "inline",
+        "contents": "6b84b8f37c618e3624796e18c35d85e15b6f7d98\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz\", \"integrity\": \"sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==\", \"time\": 0, \"size\": 5338, \"metadata\": {\"url\": \"https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c2c4e4cf88f6f5a26a474eec1eb28a1a0c087f156fa82df974013a50081f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7d/65"
+    },
+    {
+        "type": "inline",
+        "contents": "6ba2457b357be31c5921b8760eb186a14e43a3df\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz\", \"integrity\": \"sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==\", \"time\": 0, \"size\": 3102, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "500f6d65c0cf35c0f7c0635f953b37393168aa27cb55c7b0ce3399c0d7f2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e9/df"
+    },
+    {
+        "type": "inline",
+        "contents": "6c16c219cfe0f39f6e907722105894dfae0a5028\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz\", \"integrity\": \"sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==\", \"time\": 0, \"size\": 853362, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "10cdc36302d1c245a7cfa2a19235d2ff266f9dc2ae5a1ce168ee90b6d746",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/a9"
+    },
+    {
+        "type": "inline",
+        "contents": "6c207587cf34c6eae0632aacbc4b71b0645df26e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz\", \"integrity\": \"sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==\", \"time\": 0, \"size\": 8903, \"metadata\": {\"url\": \"https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0184937fde98938cb062ec8293fb6a17fcb7da8963a6d525de3f86b642e5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/47/6e"
+    },
+    {
+        "type": "inline",
+        "contents": "6c650084b97ca839d8e466b5ad79e496bfe37c7d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz\", \"integrity\": \"sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==\", \"time\": 0, \"size\": 3676, \"metadata\": {\"url\": \"https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "55345d3cba5b3c5650abf3687718415cbc865505089a50a09e96fb8cd897",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/18/ce"
+    },
+    {
+        "type": "inline",
+        "contents": "6d0e1f3e525aa486a806d900a1105c9f3c40c82e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz\", \"integrity\": \"sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==\", \"time\": 0, \"size\": 58102, \"metadata\": {\"url\": \"https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c8a7e7fa7c14ef4395b5cf40f6d347e468c9ab6cc2534ec382bb3e9f3c8b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/0a"
+    },
+    {
+        "type": "inline",
+        "contents": "6d59684f2045d6d209fe93ffc2fb7ec662adf4cc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz\", \"integrity\": \"sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==\", \"time\": 0, \"size\": 6495, \"metadata\": {\"url\": \"https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d9d201a5b440cf5e3d9fe4fd277d173efc5975b1a84bfc4f5eec4cb9da6f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d9/12"
+    },
+    {
+        "type": "inline",
+        "contents": "6e079a7c6f156f4e92326b465c8132f88cc3485e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz\", \"integrity\": \"sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==\", \"time\": 0, \"size\": 6515, \"metadata\": {\"url\": \"https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7abfe22978059281588faea7f535ded2928b235f6b15bd778baec1001220",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cd/95"
+    },
+    {
+        "type": "inline",
+        "contents": "6e193b40bc844e54c05f9a194177336c815b9978\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz\", \"integrity\": \"sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==\", \"time\": 0, \"size\": 3203, \"metadata\": {\"url\": \"https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5a0d78b90af65c20d4ba7a0707179aaef1af848134d9dcb828150b331a72",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d8/98"
+    },
+    {
+        "type": "inline",
+        "contents": "6e6cb181797b0667513cb0e46f631211fd3eb343\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz\", \"integrity\": \"sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==\", \"time\": 0, \"size\": 3411, \"metadata\": {\"url\": \"https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5e4a83442d291d5de897ec5988a37d07269e97c52ea66182b3be08b6b990",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fd/0f"
+    },
+    {
+        "type": "inline",
+        "contents": "6f1c382b7724303ceb95973a9e18c005c2f20ec6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz\", \"integrity\": \"sha512-lBWt8hujh/Cjysw5GYVmZpFHXDCgZzhrOm8vbcUdobADZNOK/bRshr2kM3DfgrrtR1DQhfupW9gnIXOfiFi+bw==\", \"time\": 0, \"size\": 45107, \"metadata\": {\"url\": \"https://registry.npmjs.org/lint-staged/-/lint-staged-16.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a832fec87b276ebb1a02ec454daf283d740c6341b85bdd7f93655814c2c3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d6/70"
+    },
+    {
+        "type": "inline",
+        "contents": "703b37325686939400c3cf83ea90a99003c4af7d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz\", \"integrity\": \"sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==\", \"time\": 0, \"size\": 939054, \"metadata\": {\"url\": \"https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "dc686502b2b362d9db0876c4850033f737266bf558ebc15c4ba45515f823",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/30/a1"
+    },
+    {
+        "type": "inline",
+        "contents": "7048733c9a707d3193713e71a986331b7a11dc13\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz\", \"integrity\": \"sha512-bLvc1WOz/14aPImu/cufKAZYfXs/A/owZfSMZ4N+16WGXLoX5lOir53M6odBxvhgmgdxCVnNySJmZKx73T93cg==\", \"time\": 0, \"size\": 2617, \"metadata\": {\"url\": \"https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-14.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8a0a8a7ab67c9aa29ba74f984d30c78204570ebe523d1b99ccd608a842cb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/76/40"
+    },
+    {
+        "type": "inline",
+        "contents": "70c045733e867699008c05c97d0364a67dd5aa26\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz\", \"integrity\": \"sha512-CQ+bEO+Tva/qlmw24dCejulK5pMzVnUOFOijVogd3KQs07HnRIgp8TGipvCCRT06xeYEbpbgwaCxglFyiuIcmA==\", \"time\": 0, \"size\": 5269, \"metadata\": {\"url\": \"https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b70f2acc5163064b73cfb72546c7e0d89ef302abb2ee5cf66fef96919433",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/eb"
+    },
+    {
+        "type": "inline",
+        "contents": "719ea523cc47269953393542ba84568bc220dac4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz\", \"integrity\": \"sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==\", \"time\": 0, \"size\": 35340, \"metadata\": {\"url\": \"https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1018bd2617c9bf8a0c2742b8d6db95d9995670b0e195cb06cfea9d61c009",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/69/e3"
+    },
+    {
+        "type": "inline",
+        "contents": "71b4737a75ddbb7d661fe86b37ee0e88219084c4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fast-average-color/-/fast-average-color-9.5.2.tgz\", \"integrity\": \"sha512-FbaU8iPTPljP7tmnVhXbCyASNw/zxnmaNDf88gn5pTXlNvejl9w4FapeWMh6UNDwIjhJJU28EPfQWwW032YgPA==\", \"time\": 0, \"size\": 12181, \"metadata\": {\"url\": \"https://registry.npmjs.org/fast-average-color/-/fast-average-color-9.5.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "893d349e547919f0e19cb597dd43adc7ddb3dd67dbea826167df4f9b1540",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e6/d4"
+    },
+    {
+        "type": "inline",
+        "contents": "724978b9cf0dc59ff4e2159d3543a6eb9e71094d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz\", \"integrity\": \"sha512-VSIRpLfRwlAAdGL4wiTucx2ScRipo0ed1FBatWkyt832jC4CReKstga6yIhYVwGu9LOBjuX9wzmRMeQdBJtzEA==\", \"time\": 0, \"size\": 5871993, \"metadata\": {\"url\": \"https://registry.npmjs.org/hls.js/-/hls.js-1.6.16.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c222e0cf64c5ce25f0cf9b01a12d0a523e6d6c161e7d1a5ac5d5bdd9789e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bc/16"
+    },
+    {
+        "type": "inline",
+        "contents": "72740ff614ad0f1b1f29de5756cee6890193606a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz\", \"integrity\": \"sha512-FvEb29x5wVwu/Kf93IWwsOOEuhHh6dYCJF3vcKLzXc0KXIW181AOzv6ceT4ZpBHDvAfG60eqb+ekmrnLHIy+jw==\", \"time\": 0, \"size\": 18005, \"metadata\": {\"url\": \"https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4f824b75c08ade59a6e4e439461aaf09f22b7b56bdad20ca9afc81027e3e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c5/d6"
+    },
+    {
+        "type": "inline",
+        "contents": "73a683a98d60c604f7b9ee25958a8024c6887790\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz\", \"integrity\": \"sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==\", \"time\": 0, \"size\": 2720, \"metadata\": {\"url\": \"https://registry.npmjs.org/balanced-match/-/balanced-match-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "214450a55323150959707659d9ec4e17731f6ff49a15ff625266d887d1eb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c9/62"
+    },
+    {
+        "type": "inline",
+        "contents": "74e36af51693b3563004c7b151b2373a6c9e2f4f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz\", \"integrity\": \"sha512-GZZ9mKe8r646NUAf/zemnGbjYh4Bt8/MqASJY+pSm5ZDtc3YQox+4gsLI7yi1hba6o+eCsGxpHn5+iEVn31/FQ==\", \"time\": 0, \"size\": 1204808, \"metadata\": {\"url\": \"https://registry.npmjs.org/happy-dom/-/happy-dom-20.9.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "000a6055cc69ecec904c6f00adb017625f11447cf719b68fb110e1e36b12",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/dd/ca"
+    },
+    {
+        "type": "inline",
+        "contents": "7590d644854430ceb3d166d6a10b762f962fd1f1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz\", \"integrity\": \"sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==\", \"time\": 0, \"size\": 1506, \"metadata\": {\"url\": \"https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0ff11cd5c49f9abb3792227a2806421aeb4003688278322146dd805a2cea",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/31"
+    },
+    {
+        "type": "inline",
+        "contents": "75d932ac20f4d6e79ae1b5a95a4c46abfbb70484\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz\", \"integrity\": \"sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==\", \"time\": 0, \"size\": 6586, \"metadata\": {\"url\": \"https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "14cbab914a1f63d40eb9e86f6c8bbfdc77e802c37cb36c66a8d86735d313",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/82/9b"
+    },
+    {
+        "type": "inline",
+        "contents": "763581e9c630fa5d969e57574916c4fd2d975ea5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json5/-/json5-2.2.3.tgz\", \"integrity\": \"sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==\", \"time\": 0, \"size\": 50318, \"metadata\": {\"url\": \"https://registry.npmjs.org/json5/-/json5-2.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e89f8bf36bf4f4865512579b711f7cba1f7f3a4cc4d8b133abb9793b0ea9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2c/24"
+    },
+    {
+        "type": "inline",
+        "contents": "7641368474869040e3961b45f849d8efca03e063\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz\", \"integrity\": \"sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==\", \"time\": 0, \"size\": 39740, \"metadata\": {\"url\": \"https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "339b9832e323abb280eb874ec64f59486423026430be7b1c2ec42ca7e1b7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9d/6b"
+    },
+    {
+        "type": "inline",
+        "contents": "76c97314f6fafb53dbdf6b412e62a7e3a3e674ce\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz\", \"integrity\": \"sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==\", \"time\": 0, \"size\": 12234, \"metadata\": {\"url\": \"https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "51d5590effeaf15b72fd4702168fa6343fd71188c1016e2e173a9062f2fd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/53/62"
+    },
+    {
+        "type": "inline",
+        "contents": "77029c495e22db94691e530b0901a24ef1909fd7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz\", \"integrity\": \"sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==\", \"time\": 0, \"size\": 13081, \"metadata\": {\"url\": \"https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2491a48f50be25a8213ee0a1186e48b2141688c4b926158ec064dbee258c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/3f"
+    },
+    {
+        "type": "inline",
+        "contents": "773bfcd7d71b6a903a86b19e6b3e299042181a70\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz\", \"integrity\": \"sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==\", \"time\": 0, \"size\": 18238, \"metadata\": {\"url\": \"https://registry.npmjs.org/object-hash/-/object-hash-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f096fae19d8a3df86b113bbd6e3fad4b2beae9893b4410ad87d2db681270",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/5c"
+    },
+    {
+        "type": "inline",
+        "contents": "77c33f91345f902b6a68bf11144fbcef07b8f095\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz\", \"integrity\": \"sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==\", \"time\": 0, \"size\": 905208, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "496db97a69c2988ba50cae81e3d8ba40630a5bc5668793fba3763c071f55",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/70/ab"
+    },
+    {
+        "type": "inline",
+        "contents": "781438b94cd4a64254e15b9a96f5c6540d58e7e5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz\", \"integrity\": \"sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==\", \"time\": 0, \"size\": 6013, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "07b02a93b8d7573ed9ba644c3e99de3db9615f3f1caba0dc9b9d102deb4e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/50/1f"
+    },
+    {
+        "type": "inline",
+        "contents": "783d6392ea9b8c77a7744132b8618223d1be176c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz\", \"integrity\": \"sha512-N2dnzVJIphnNsjHcrxGW7DePckJ6haPrSFqpsBUhHYgwtKGVq4JrBGielEGD2fCVnsGm1zlBVZ8wGhkyuetgug==\", \"time\": 0, \"size\": 11010, \"metadata\": {\"url\": \"https://registry.npmjs.org/flat-cache/-/flat-cache-6.1.22.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "77797bcfebc71f48299c03a08ca93b6054de2f0cdf3bcfd7c660c748f104",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f8/89"
+    },
+    {
+        "type": "inline",
+        "contents": "786aa2884a39f6ee594c2af39b0a45da145cc069\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz\", \"integrity\": \"sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==\", \"time\": 0, \"size\": 9622, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "58cbe482acb2f4e2b961dfc2cdd7143d35b8f091f18831fcdcf72dc7cd4f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0d/01"
+    },
+    {
+        "type": "inline",
+        "contents": "796a7c6f0da3c604d33eecfbeac9b1442c1ffb21\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz\", \"integrity\": \"sha512-zFObLMyZeEwzAoKCyu1B91U79K2t7ApXuQfo8OuxwXLDgcKxuwM+YvcbIhm6QWqz7mHUH1TVytR1PwVVjEuMig==\", \"time\": 0, \"size\": 3235, \"metadata\": {\"url\": \"https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2c31390d2b35477dce03c5b5fb79d91e27b9be9f2fc2d2e906f29dece4cc",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a5/3f"
+    },
+    {
+        "type": "inline",
+        "contents": "7a6508c547e933cc44fa3ebc1888c8eec0f0dae3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz\", \"integrity\": \"sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==\", \"time\": 0, \"size\": 5063, \"metadata\": {\"url\": \"https://registry.npmjs.org/colorette/-/colorette-2.0.20.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "82dba49db442debbbfe81175a6e1504dfcb526af05d7f4661f5835a056b2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f4/df"
+    },
+    {
+        "type": "inline",
+        "contents": "7a96398bcb23418943af4f6b2a22a767399e981b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/debug/-/debug-4.4.3.tgz\", \"integrity\": \"sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==\", \"time\": 0, \"size\": 13449, \"metadata\": {\"url\": \"https://registry.npmjs.org/debug/-/debug-4.4.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e25f670d26bc26d1cb236efef449fc8718223fd484c4107ba797934cb10c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c9/1f"
+    },
+    {
+        "type": "inline",
+        "contents": "7b0b0bb6734d586f5114d88649952bb872482039\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz\", \"integrity\": \"sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==\", \"time\": 0, \"size\": 28354, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2f9f9df8a204a306e5baed8f658a43e437792315d561c5eb0315c7a97d50",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/11/d4"
+    },
+    {
+        "type": "inline",
+        "contents": "7c1d0d444443347c6cbd04e2715745591e976f47\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz\", \"integrity\": \"sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==\", \"time\": 0, \"size\": 2333, \"metadata\": {\"url\": \"https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0b92e01b7ab1456bd06f5ccfd852fb1432f57fcf62be62d5036f9e14698f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ef/56"
+    },
+    {
+        "type": "inline",
+        "contents": "7c442e6fcb2e842a764f9b558be2907f1e4db8d3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz\", \"integrity\": \"sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==\", \"time\": 0, \"size\": 8620, \"metadata\": {\"url\": \"https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "35cb8b23ae64f5467e4748e13214ac6208cf6c4330e3bc5a2a28b7b96aac",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/ed"
+    },
+    {
+        "type": "inline",
+        "contents": "7d6894659f6ad016c7b20292511e8a203ae66d02\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz\", \"integrity\": \"sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==\", \"time\": 0, \"size\": 5223, \"metadata\": {\"url\": \"https://registry.npmjs.org/lilconfig/-/lilconfig-3.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "bc5fdc7cd0a8d1167bf80eb528874a6405e3f171e49e9610f99acd4b74d1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ca/12"
+    },
+    {
+        "type": "inline",
+        "contents": "7ddafcb73a2e6f9bf126cdb16c87735c6e4dc015\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz\", \"integrity\": \"sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==\", \"time\": 0, \"size\": 4621, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f7c9e3404de9212aefe3706d0ad202a663b6af36dcd7532e19428d480a26",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/02"
+    },
+    {
+        "type": "inline",
+        "contents": "7e21cdacfa720f6176d4ebcbade7887f4677a142\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz\", \"integrity\": \"sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==\", \"time\": 0, \"size\": 6026, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "110819c5903563df1824b2214749ef7781289e80d4a600347e3901aac1c4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/43/5f"
+    },
+    {
+        "type": "inline",
+        "contents": "7e2a22a1dc1bde1f24ae9dc32cb4b615355a77f2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz\", \"integrity\": \"sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==\", \"time\": 0, \"size\": 217611, \"metadata\": {\"url\": \"https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f3e26b8c50880e9350336dbc39f707c1ba35f75dbadc9598933ea528a990",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/e9"
+    },
+    {
+        "type": "inline",
+        "contents": "8160de1b9302ac804b554764c02a4850945d28da\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pify/-/pify-2.3.0.tgz\", \"integrity\": \"sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==\", \"time\": 0, \"size\": 2793, \"metadata\": {\"url\": \"https://registry.npmjs.org/pify/-/pify-2.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "04b563f9f41a3ba3b7df4541c2da4dc131b47234e904a7eebf0037238c08",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6d/83"
+    },
+    {
+        "type": "inline",
+        "contents": "81a63232d6f2bbce4bb40fee99d2517c12026d1f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz\", \"integrity\": \"sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==\", \"time\": 0, \"size\": 3409, \"metadata\": {\"url\": \"https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "873bbccc3b70b17e1c1fbddbda99b69f0d507fd8d12442008ee2f2518c1f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/ac"
+    },
+    {
+        "type": "inline",
+        "contents": "82d09144fc440ea901f33d2f5d60f765edcf4ddf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz\", \"integrity\": \"sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==\", \"time\": 0, \"size\": 2510, \"metadata\": {\"url\": \"https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9bf57dceb99b6a930d3ad84cbe70e19fad1250d13e828e2b3c4c491b3994",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0c/11"
+    },
+    {
+        "type": "inline",
+        "contents": "84d37d466c2ae956d5f5403e891553b67c9eaf23\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz\", \"integrity\": \"sha512-7A6S9jSgm/S+7MdtNDSb+IU859vQqJ/QAtcYQcfFC6W8RS4IxIZDldLR0xqCFZ6DCyrQLjLPsxtTNch5jVA4lA==\", \"time\": 0, \"size\": 11339, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "dcecd9ea33544599eb1e71ac0fd23e843f4caf0dd35ae634e5a1e2bca450",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d4/42"
+    },
+    {
+        "type": "inline",
+        "contents": "8541e65519e46dc8ff00fcc318bb2d37f16a930e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz\", \"integrity\": \"sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==\", \"time\": 0, \"size\": 4199, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "904a5c549d54613c85d48b46a1439b5e5454edcd8a8a473e651a4ab467d4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/20/f7"
+    },
+    {
+        "type": "inline",
+        "contents": "86109bffb8661f32d357b72ab5cde4a83492880d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz\", \"integrity\": \"sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==\", \"time\": 0, \"size\": 7556, \"metadata\": {\"url\": \"https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b1ccc6576fd094e8ad4e6eef40ae1b375cc30655523ae64966330c83cfa7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b6/ec"
+    },
+    {
+        "type": "inline",
+        "contents": "86191d50fa12c69315e24f66071d88697c555851\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz\", \"integrity\": \"sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==\", \"time\": 0, \"size\": 4383, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "986a984b5f35ab2d37137aaa7fa8e905cccd2f9614d45637750dcbedca8e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c2/ba"
+    },
+    {
+        "type": "inline",
+        "contents": "87114ba233a2f390dad2ea779bb91aa8f1cc9931\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz\", \"integrity\": \"sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==\", \"time\": 0, \"size\": 7635, \"metadata\": {\"url\": \"https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5b88cf3c6125d3f0a83e08d7fc6bc3848a7da209ed87f32d58376e0c2224",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e9/a9"
+    },
+    {
+        "type": "inline",
+        "contents": "874a9b5e899290ea79c643a3ef26c9e1ccbc68a3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz\", \"integrity\": \"sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==\", \"time\": 0, \"size\": 3810, \"metadata\": {\"url\": \"https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "40122c5cee651bb244e17448855ba7beb1ffc43ef9d58d74671626ebedb0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/20/e0"
+    },
+    {
+        "type": "inline",
+        "contents": "89ca1de22079ddc5d1b3155c892f571016a886b6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz\", \"integrity\": \"sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==\", \"time\": 0, \"size\": 927454, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2babddf6b8750984ceb4cd25d52e5bff9d35564905eed2db47876d109593",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/52/5e"
+    },
+    {
+        "type": "inline",
+        "contents": "8a1f89faa4a8589d128a6272743122bce16c0582\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz\", \"integrity\": \"sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==\", \"time\": 0, \"size\": 3386, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "071d7d949ade71febc395082397753f9a225031462df3ac9c8ff4104bbad",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/33/f9"
+    },
+    {
+        "type": "inline",
+        "contents": "8aee2567d947c3a939b939923b3e49bdd2810f38\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz\", \"integrity\": \"sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==\", \"time\": 0, \"size\": 15193, \"metadata\": {\"url\": \"https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f4754ecba45983ae5f78ce876450285d661dc7989afc3e5d075dda33874c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/15/44"
+    },
+    {
+        "type": "inline",
+        "contents": "8b00384f8258352f1cb5f3f07943ba08d985d11d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz\", \"integrity\": \"sha512-1UEWRX6jnOA2y4H5WczZ44gOOjTEmlqv1uNW4GAJEO5+bauCBhv8snY65Iw5/VOS/ghKN9gr2KjnLKxrsvoMVw==\", \"time\": 0, \"size\": 2435, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0423c306fc66318eb336eeb4033781a7b495f0aa3ba92eec00f34069f13e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d2/53"
+    },
+    {
+        "type": "inline",
+        "contents": "8b7c7f1eb5c25323af0ed1df782ebb0d4190cf52\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz\", \"integrity\": \"sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==\", \"time\": 0, \"size\": 3545, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "56fc6b8aa67287e6e60a90a5e8bd6500ef9e97a317a38b324cca616a7d25",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/91/08"
+    },
+    {
+        "type": "inline",
+        "contents": "8b803f7bd2896dcc2a4d51166dad8535838fbd8f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz\", \"integrity\": \"sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==\", \"time\": 0, \"size\": 95174, \"metadata\": {\"url\": \"https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "487c86743ff85773f81174888b881f6646009713a7e92294daac8eda4c73",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/99/f8"
+    },
+    {
+        "type": "inline",
+        "contents": "8c9b477af0084b3e4b0fdce366762ed11ab0e69e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz\", \"integrity\": \"sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==\", \"time\": 0, \"size\": 13369, \"metadata\": {\"url\": \"https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0380559f2aa3f48d6733aadf8843d8e3d9f1b92eaaa125de918fc91bbe9b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7c/e2"
+    },
+    {
+        "type": "inline",
+        "contents": "8cb8eac33b4007f31330ca8151416ba5ff02337f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz\", \"integrity\": \"sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==\", \"time\": 0, \"size\": 3456, \"metadata\": {\"url\": \"https://registry.npmjs.org/postcss-js/-/postcss-js-4.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a24dabc79158d070f1d3300bd2c396eed95cd588f3024e3c563bcc8ea9da",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6f/e1"
+    },
+    {
+        "type": "inline",
+        "contents": "8d3082d98c60a63d1dd2c5d643d5ff6440f4da18\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz\", \"integrity\": \"sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==\", \"time\": 0, \"size\": 101468, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2492c2b5f85238bd02623aca1b85b0bb220bf72ad455ce3759a176860a58",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/77/5d"
+    },
+    {
+        "type": "inline",
+        "contents": "8e35cb1dbcb55dbd8bcce7ed3c10308b220f245f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz\", \"integrity\": \"sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==\", \"time\": 0, \"size\": 22477, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "70f2d09e88b52e50b4f2f83eb4d09a8274b46984806a4934f47e709dcf86",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/32/a5"
+    },
+    {
+        "type": "inline",
+        "contents": "8e70c1566d2a126d311d3224316e888924d7606c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz\", \"integrity\": \"sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==\", \"time\": 0, \"size\": 3265, \"metadata\": {\"url\": \"https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8a67a6a69c573e507dac8723fa56c0451c1ebb42aa08925c3bd37a8435c3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/75/e3"
+    },
+    {
+        "type": "inline",
+        "contents": "8f4f3e7b194f6ece910b9370c539139e83130835\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz\", \"integrity\": \"sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==\", \"time\": 0, \"size\": 5032, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "39e2ac79093ba6379dc15592b32ac1a19e63cde8792e874535a13fb90c5c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1b/ac"
+    },
+    {
+        "type": "inline",
+        "contents": "8feb84efdda9ebff1755d81f98b1d7ed6702bd9c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz\", \"integrity\": \"sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==\", \"time\": 0, \"size\": 839309, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1fec7ed4603fed826a0036a449d6509511210db01e41e1c2dca77df1ed61",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ae/64"
+    },
+    {
+        "type": "inline",
+        "contents": "902b69d3360a262cbd9d2ee97faadbcffc136bcc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz\", \"integrity\": \"sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==\", \"time\": 0, \"size\": 3768056, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "974ef046f769da36693d5d6a38f98646e6dd0adc620308999c6bc5158791",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/82/59"
+    },
+    {
+        "type": "inline",
+        "contents": "90fc7ecf7274ddf541e452c1f9b936bc17df7238\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz\", \"integrity\": \"sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==\", \"time\": 0, \"size\": 7603, \"metadata\": {\"url\": \"https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7f7a0679c52edb767a55df3d93f847884d7909cf16c2f148ba11d53e9f7c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fb/ea"
+    },
+    {
+        "type": "inline",
+        "contents": "912805456ee0fff3bbf2e21f6854da729a60e61c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz\", \"integrity\": \"sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==\", \"time\": 0, \"size\": 5824, \"metadata\": {\"url\": \"https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8c061789582f306e5cd49035ee51582e6495bd621f643d2451345dc3b3dc",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/90/53"
+    },
+    {
+        "type": "inline",
+        "contents": "91a4e47fb432967e78a9014ff9b420c64dce42f9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz\", \"integrity\": \"sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==\", \"time\": 0, \"size\": 7611, \"metadata\": {\"url\": \"https://registry.npmjs.org/any-promise/-/any-promise-1.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "356c5215c5306570d50eb1cb3f2f89e7af7fdc22b26fc5bf32ef13e56887",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c7/a4"
+    },
+    {
+        "type": "inline",
+        "contents": "91bf02aec3385683eeda8802ad993e19f711624e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/commander/-/commander-4.1.1.tgz\", \"integrity\": \"sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==\", \"time\": 0, \"size\": 27190, \"metadata\": {\"url\": \"https://registry.npmjs.org/commander/-/commander-4.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4cc18d3de16a2f6fe4449e87b0e7c0d8b49272a49bf150863714d78d0052",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/70/42"
+    },
+    {
+        "type": "inline",
+        "contents": "91cf859a57821d613590397910a610fa21e3daec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz\", \"integrity\": \"sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==\", \"time\": 0, \"size\": 6255, \"metadata\": {\"url\": \"https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e41f2c2713684e6e809753f5b2a642d98d5d19a1c17c03d0788531cebf88",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/35/7f"
+    },
+    {
+        "type": "inline",
+        "contents": "9256c05809b130d5104ba822f57e889480cd5e45\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz\", \"integrity\": \"sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg==\", \"time\": 0, \"size\": 43182, \"metadata\": {\"url\": \"https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fdd901bf99d7fe725a565c4454f0b7ee6dc3b3fc9babcb0f77ab8498cfa0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/28/58"
+    },
+    {
+        "type": "inline",
+        "contents": "930387d79476e1d64618e708bbc3a4dbe32114ad\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz\", \"integrity\": \"sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==\", \"time\": 0, \"size\": 3566, \"metadata\": {\"url\": \"https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8a41fc808dc3a75f728fad90921316b23f9325e5b104e74921762846f141",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/31"
+    },
+    {
+        "type": "inline",
+        "contents": "9304f537cebdf5e5bcd55b4ea0af193a1b198b1d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz\", \"integrity\": \"sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==\", \"time\": 0, \"size\": 3751, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1b06241dca05cc2c2e892ff340b199de6286d22ee730339e6bcad25cfadd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/08/c7"
+    },
+    {
+        "type": "inline",
+        "contents": "93f4819a59cf7011497d5ad686f2e5a8f3c9c470\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz\", \"integrity\": \"sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==\", \"time\": 0, \"size\": 3205, \"metadata\": {\"url\": \"https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "eacf1bc6656c90469010990afa8d3eea7e8c2154b0ee8b7217123eb2ac45",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6c/d1"
+    },
+    {
+        "type": "inline",
+        "contents": "94157a609fe722c2ce8e371484bd9efe98ff2efd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz\", \"integrity\": \"sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==\", \"time\": 0, \"size\": 9542, \"metadata\": {\"url\": \"https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "db09e99d2fc4b9d471366260d48b659687fefb56966562f29c82112f99a9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4a/f9"
+    },
+    {
+        "type": "inline",
+        "contents": "94523fbd3f83689586d2617e884f38dca91d79a1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz\", \"integrity\": \"sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==\", \"time\": 0, \"size\": 3982493, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c35f135ee87267b7c80b09e75f31c4cae6d867637ad18932c4469c5e1735",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/12/1b"
+    },
+    {
+        "type": "inline",
+        "contents": "946780d348e3e23ea30ecc7da704838050e8c73f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz\", \"integrity\": \"sha512-hr4ihw+DBqcvrsEDioRO31Z17x71pUYoNe/4h6Z0wB72p7MU7/9gH8Q3s12NFhHPfYBBOV3qyfUxmr/Yn3shnQ==\", \"time\": 0, \"size\": 19628, \"metadata\": {\"url\": \"https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9b2caca6a42699734092261a6a6ef9653bacea4a50d16239d09065ebaeb4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bb/d2"
+    },
+    {
+        "type": "inline",
+        "contents": "94b8d6a4c5f1545ef6e579d9f7fde82cc95af232\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz\", \"integrity\": \"sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==\", \"time\": 0, \"size\": 3756, \"metadata\": {\"url\": \"https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f7afbc9eb60823c417e5dd1dd2f56b61e1b85cdd840120ff5644e6b03358",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/23/76"
+    },
+    {
+        "type": "inline",
+        "contents": "94d364f29b64cdf403b5b6ab287958c5cbfcd568\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz\", \"integrity\": \"sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==\", \"time\": 0, \"size\": 11266, \"metadata\": {\"url\": \"https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3b39289cebf40a8594d69713501d2f3f55dd9f6593f918d4d98e58bf776c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/80/4c"
+    },
+    {
+        "type": "inline",
+        "contents": "9505582169afa087cafcc2b6af21c1db7561e833\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz\", \"integrity\": \"sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==\", \"time\": 0, \"size\": 1606, \"metadata\": {\"url\": \"https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a6e1de377bb0cea25c497401195206c2774c2d4388eeaa6313079f05eafa",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4a/db"
+    },
+    {
+        "type": "inline",
+        "contents": "954e4b3ca6b48c76e475208bffd1862e71aa6c36\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz\", \"integrity\": \"sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==\", \"time\": 0, \"size\": 4131044, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "27a6c561329523b7a65321d67edb2bafe1455e1e75cfa90ab16e957bab16",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1c/d9"
+    },
+    {
+        "type": "inline",
+        "contents": "9599017eca488754d3be557bbe04cabf07992795\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz\", \"integrity\": \"sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==\", \"time\": 0, \"size\": 14017, \"metadata\": {\"url\": \"https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "03efc199c2b017a7533cc730722dec616ebc1b3be56bda4c0a85c7f71fa6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/10/01"
+    },
+    {
+        "type": "inline",
+        "contents": "95ba94be0b9548a89b45623fe74df3ba55f80bc5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz\", \"integrity\": \"sha512-NGbfmJBp9x8IxyJSd1P+otYK8vonoJactOogrVfFRIAEY1ukil8RSKDz2Yo7wh1oihl51l/r6W4epkeKJHqL8A==\", \"time\": 0, \"size\": 2775, \"metadata\": {\"url\": \"https://registry.npmjs.org/global-modules/-/global-modules-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2c9efb727ce3ff9e6f2e8cc34fe0fe6b41bd59361964261f2674991068d1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/fc/78"
+    },
+    {
+        "type": "inline",
+        "contents": "960ab89ec886cf6d6b5c72ac3b63261711d0e432\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz\", \"integrity\": \"sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==\", \"time\": 0, \"size\": 2586, \"metadata\": {\"url\": \"https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b63698b307024058da762d69517e68a93c003a2ffbef26cf95298422d445",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/60/1a"
+    },
+    {
+        "type": "inline",
+        "contents": "969f25d89b8c33f956d24a6dbc6d60094810c42b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz\", \"integrity\": \"sha512-awConJSVCHVGND6x3tmMaKcQvwXLhjdkmomy2W+Goaui8YPgYgXJZewhg3fWC+DlfqqQuWg8AwqjGTD2nAPVWg==\", \"time\": 0, \"size\": 3423, \"metadata\": {\"url\": \"https://registry.npmjs.org/global-prefix/-/global-prefix-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "56b10f54ef7faa1f67bc201895b02611765a3e1cac3d1082b0dd2d20e997",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/30/72"
+    },
+    {
+        "type": "inline",
+        "contents": "97ec14b3e701b108a9acd07cf7245691f952a74d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz\", \"integrity\": \"sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==\", \"time\": 0, \"size\": 270941, \"metadata\": {\"url\": \"https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "201041f51e29437bf7e8130f606a6fb606be022966e86b42a41fc3f8945b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/58/1a"
+    },
+    {
+        "type": "inline",
+        "contents": "9802034775339b9e374b8705bcd145f841655231\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz\", \"integrity\": \"sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==\", \"time\": 0, \"size\": 3866, \"metadata\": {\"url\": \"https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c99fe20ee8c4a489636364819eeba7691d224f93b56f13b9d5cfd1943647",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7a/da"
+    },
+    {
+        "type": "inline",
+        "contents": "98ccaee5f8ce2817a09b90e28ebe806a75f4a606\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz\", \"integrity\": \"sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==\", \"time\": 0, \"size\": 2868, \"metadata\": {\"url\": \"https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d04e75208dec117f72a95a5989f81fac7565a530fd22f70ea5e3abc377c3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/40/62"
+    },
+    {
+        "type": "inline",
+        "contents": "98f30b1c3073008956461f29d2ea2f3e6a226e2f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz\", \"integrity\": \"sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==\", \"time\": 0, \"size\": 10693, \"metadata\": {\"url\": \"https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "25a4d3ecb0818d3e6dd60b9f05612cc6efb08f88e7b765eaaebb33fc0f85",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e8/8b"
+    },
+    {
+        "type": "inline",
+        "contents": "99af7e50e243de3fff165b5a8575a491f1e79a51\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz\", \"integrity\": \"sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==\", \"time\": 0, \"size\": 7894, \"metadata\": {\"url\": \"https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "06c21f3b1d5a519ada4a723ced880e4775ff60567f6861fbb597ce7d1a8b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bc/f4"
+    },
+    {
+        "type": "inline",
+        "contents": "99b16aa5fb9ac928f556ddd0e49c76c5f4f7116a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz\", \"integrity\": \"sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==\", \"time\": 0, \"size\": 89981, \"metadata\": {\"url\": \"https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "64b96cec0914bacadaca2548c2c6e32b7eb715cf0cc5193e6b96c5a25a5b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/be/72"
+    },
+    {
+        "type": "inline",
+        "contents": "99f070baeb3c44344b1dbe79145f835215ea0262\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz\", \"integrity\": \"sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==\", \"time\": 0, \"size\": 1679, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "51bdb2a4f8e62d44922a0ff258d8cc3adf38d06f4dbc590dcaeb32cd130b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c8/3d"
+    },
+    {
+        "type": "inline",
+        "contents": "99f33a1b3ef828bb1235579b53137ad2aafcf1fd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz\", \"integrity\": \"sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==\", \"time\": 0, \"size\": 3187571, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "291c332f083c6019a62f21452f27ac3829a9e8dd260bd5c7f36bf059a2a1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/66/7d"
+    },
+    {
+        "type": "inline",
+        "contents": "9a5d14dbe3e630da975780b32ba4676d050ac4d4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz\", \"integrity\": \"sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==\", \"time\": 0, \"size\": 2160, \"metadata\": {\"url\": \"https://registry.npmjs.org/dlv/-/dlv-1.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "29a0208c073447be0af35c79e18b8b2edb9642b3fd2605c0d2329626575d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/1a"
+    },
+    {
+        "type": "inline",
+        "contents": "9b100bcc4f83a9c928ceb71298dd21c88b606364\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz\", \"integrity\": \"sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==\", \"time\": 0, \"size\": 32961, \"metadata\": {\"url\": \"https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "dba699dd89a2f5ee5c5d6077f3ddc207a1f432e22c06e7f03ecf00c388a1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/24/ca"
+    },
+    {
+        "type": "inline",
+        "contents": "9b1438b77a5162a10a7a830d56bd181cfeb21a03\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz\", \"integrity\": \"sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==\", \"time\": 0, \"size\": 33879, \"metadata\": {\"url\": \"https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fa8761e8d61cc8be2919af736040c7049784899abd5a9dd58738d6dc9833",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e4/c7"
+    },
+    {
+        "type": "inline",
+        "contents": "9b3db7663ab552843367229679d3fbb9c4dd6ebe\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz\", \"integrity\": \"sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==\", \"time\": 0, \"size\": 4251628, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ba8c2a08eac7f24554a57a495f95f4c0a1e19f8768417dd5fea07931bb16",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1a/7f"
+    },
+    {
+        "type": "inline",
+        "contents": "9c8a850b9eef6b34ef0ed7687dee7ce92ac997b7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ms/-/ms-2.1.3.tgz\", \"integrity\": \"sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==\", \"time\": 0, \"size\": 2967, \"metadata\": {\"url\": \"https://registry.npmjs.org/ms/-/ms-2.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "bd8af8e4938b9fee217abddb09ce52db330434e323c828aeabe5bd909ae7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/21/a7"
+    },
+    {
+        "type": "inline",
+        "contents": "9cfb31fc8113429969ffaf5ceb48aee4c0598d93\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz\", \"integrity\": \"sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==\", \"time\": 0, \"size\": 4182, \"metadata\": {\"url\": \"https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "71d24cf34057d36cf27f9cc782bb6dd446e56a1987513836d5a2681a064d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/62/82"
+    },
+    {
+        "type": "inline",
+        "contents": "9d3fdcde75cc3d44a066499a2dfb2a43a343171e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/arg/-/arg-5.0.2.tgz\", \"integrity\": \"sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==\", \"time\": 0, \"size\": 5620, \"metadata\": {\"url\": \"https://registry.npmjs.org/arg/-/arg-5.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "cb8820da33e4b6b8281e52263db9a95652cdeadc4c913c9381b108fec502",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/22/44"
+    },
+    {
+        "type": "inline",
+        "contents": "9eecf74a710d507edb72891c2d9a1f3b1fb3dc24\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz\", \"integrity\": \"sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==\", \"time\": 0, \"size\": 4129742, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1a865896ac854406e778c64c746b1bbd506befa888d226b99565598f10c8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9f/ed"
+    },
+    {
+        "type": "inline",
+        "contents": "9f42cb7a6be9f70f8c1d94ab105317eeabfeaf2a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz\", \"integrity\": \"sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==\", \"time\": 0, \"size\": 669432, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1585102f8d37043bd00eeb5de48f7eca995ac19adf1c8f8d6e5965a2f035",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/78/37"
+    },
+    {
+        "type": "inline",
+        "contents": "9fc2beaffbfa4a9b5360d797083f4a4104073463\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz\", \"integrity\": \"sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==\", \"time\": 0, \"size\": 4023141, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "319fc3d2774a09d9f434e1cb9a70b0c3bbb58862a757fabf35cbab92dcb9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d5/05"
+    },
+    {
+        "type": "inline",
+        "contents": "a068440026f73736c49a333baec34614a45d3458\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz\", \"integrity\": \"sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==\", \"time\": 0, \"size\": 7898, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d90cfcd33a9895fbbb880406407aee65cd5b37556b94baafb95ba5cb93dd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/af/8a"
+    },
+    {
+        "type": "inline",
+        "contents": "a0be89300eb8ed18b2befa067c479eba68163fb9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz\", \"integrity\": \"sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==\", \"time\": 0, \"size\": 2206, \"metadata\": {\"url\": \"https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f7d95a8e3571758f8b5d095a21909a8f6cdfe7fd2349f7f72b2801eef079",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/d5"
+    },
+    {
+        "type": "inline",
+        "contents": "a13bd049bc9566cc2458717e749af0d63fc097c7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz\", \"integrity\": \"sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==\", \"time\": 0, \"size\": 4129297, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c288142e36eb24df8a73d01898c488dd3785639fb980a0c6ec2ff54bf06a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1a/10"
+    },
+    {
+        "type": "inline",
+        "contents": "a14ac3a7e79dcc0c3be1c1cb13ac91e3a523da05\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz\", \"integrity\": \"sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==\", \"time\": 0, \"size\": 2149, \"metadata\": {\"url\": \"https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "96f9fcc533e049869e9b00ffe42e3b0fa381051c8997cdfeb7bc0d0d843f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f2/a8"
+    },
+    {
+        "type": "inline",
+        "contents": "a15a4179f17b3eade05d289e6e80e75fdd0ea97c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz\", \"integrity\": \"sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==\", \"time\": 0, \"size\": 2429, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1b45d5168ed8296f6d5d5167fe2f8076e2cd5e5d67d2766935784d3e798d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/52/bd"
+    },
+    {
+        "type": "inline",
+        "contents": "a17c43dc7b56a442de20b3d29d4c621d2b5471c3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz\", \"integrity\": \"sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==\", \"time\": 0, \"size\": 33636, \"metadata\": {\"url\": \"https://registry.npmjs.org/resolve/-/resolve-1.22.12.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "97ff179f2c0848443c394cef48b13c3c0972db4d8737a8e03fbf20f262d3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1e/fb"
+    },
+    {
+        "type": "inline",
+        "contents": "a17fc8ce1543a415395fa38baff97c54bc094f0d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz\", \"integrity\": \"sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==\", \"time\": 0, \"size\": 9885, \"metadata\": {\"url\": \"https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "50bd38ff6c87dbfd241ad6e511935b52d9c8d0582f51bc4610eba895906f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9f/5a"
+    },
+    {
+        "type": "inline",
+        "contents": "a1948f6867cebb48c3aafb3dfe959de5e5b4a87c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz\", \"integrity\": \"sha512-N2WFfK12gmrK1c1GXOqiAJ1tc5YE+R53zvQ+t5P8S5XhnmKYVB5eZEiLNZKDSmoG8wqqbF9EXYBBW/nef19log==\", \"time\": 0, \"size\": 16841, \"metadata\": {\"url\": \"https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-11.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c638744e262c6b44887176b9200dab83d43dd833d2b890e11e7300f0d157",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/96/e7"
+    },
+    {
+        "type": "inline",
+        "contents": "a1bbaf79a67661dca41bab0aae37cfcc163aba7b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz\", \"integrity\": \"sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==\", \"time\": 0, \"size\": 1803, \"metadata\": {\"url\": \"https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f7abebb652f68099c4cfd2e267576a78df6b03af55260e847ee9358218b6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ed/c6"
+    },
+    {
+        "type": "inline",
+        "contents": "a2ca864cfaea25699df81e129095316ae07f8956\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz\", \"integrity\": \"sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==\", \"time\": 0, \"size\": 11377, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "211d19f87bd3d47c875f803133fab6d0d895cb6f8284f41b2b3fee63f93d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/da/ec"
+    },
+    {
+        "type": "inline",
+        "contents": "a30c4695b005002601ffe9fd323322ae9f469f35\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz\", \"integrity\": \"sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==\", \"time\": 0, \"size\": 1946, \"metadata\": {\"url\": \"https://registry.npmjs.org/camelcase-css/-/camelcase-css-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a3badf2b8edb4522accc539393250280c89c5322dfc5f85258a570f501cd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/13/49"
+    },
+    {
+        "type": "inline",
+        "contents": "a363815527fcf22af6165cb5518ef43287d080cd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz\", \"integrity\": \"sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==\", \"time\": 0, \"size\": 80631, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d2a7293f4d9df6333dd70614d00bb39f3c403f8ba6ee409f23acbf47f11f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e5/38"
+    },
+    {
+        "type": "inline",
+        "contents": "a373e1e787bf080c9ec7ffb632102c17c586f5b6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz\", \"integrity\": \"sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==\", \"time\": 0, \"size\": 3187578, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "403c95f06d21c4286daeeeb08333a3ddb82ac99d41ce14010587828c91f5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c8/ce"
+    },
+    {
+        "type": "inline",
+        "contents": "a3a5f6c1106f1d5a3e6fa1b5dc174df5bb32a334\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/espree/-/espree-10.4.0.tgz\", \"integrity\": \"sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==\", \"time\": 0, \"size\": 17313, \"metadata\": {\"url\": \"https://registry.npmjs.org/espree/-/espree-10.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "117b08bed4e0eab131e59b5437b3f282263ed761bd544830a76bfb3c37d6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/41/e9"
+    },
+    {
+        "type": "inline",
+        "contents": "a481f9f5caade7d1e25e2005bd586788297ee48b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz\", \"integrity\": \"sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==\", \"time\": 0, \"size\": 2258, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8af21194b7c666dcff699b874730170edc9a2670a4d17bf4186649ee9fa7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6b/96"
+    },
+    {
+        "type": "inline",
+        "contents": "a4fa4bd17c4f4cf372f04fa2c118efcb8749c2a5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz\", \"integrity\": \"sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==\", \"time\": 0, \"size\": 3965, \"metadata\": {\"url\": \"https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5f0f5600d4f6c8cd5287991a72adc9ee514c0139a77a26e8dd6e3ef107fe",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d9/83"
+    },
+    {
+        "type": "inline",
+        "contents": "a55333600ef97e310791198906a11412d4d3b30d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz\", \"integrity\": \"sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==\", \"time\": 0, \"size\": 867768, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "27ce686d48c132adf371d2db66e03aebe5b0ad61b6289c744acc6deb8216",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/25/ae"
+    },
+    {
+        "type": "inline",
+        "contents": "a5c335aa0f624c7c9a54ba7e3d7fccbe87bc9de0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz\", \"integrity\": \"sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==\", \"time\": 0, \"size\": 2954, \"metadata\": {\"url\": \"https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f99ab9b86ec4a9a5033a4b41f687abf6110c7960ef61b601ec5567a38010",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/72"
+    },
+    {
+        "type": "inline",
+        "contents": "a5ca0f78572c64b0d95e7aa0193389ece6d9e22b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz\", \"integrity\": \"sha512-PCqQV3c4CoVm3kdPhyeZ07VmBRdH2EpMFA/pd9OASpOEC3aXNGoqPDAZ80D0cLpMBxnmk0+yNhGsEx31hq7Gtw==\", \"time\": 0, \"size\": 3556, \"metadata\": {\"url\": \"https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e305560b6866750d14f0065ac7d8616a149c6d0165c57231055ac32191c2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/64/b8"
+    },
+    {
+        "type": "inline",
+        "contents": "a5efeed9232891a39c3d8a46d29607ba77edb025\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz\", \"integrity\": \"sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==\", \"time\": 0, \"size\": 5736, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "51099bda25f44e4ab25f542f2829803549000e6ecb3325ed665ce2edf165",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/41/48"
+    },
+    {
+        "type": "inline",
+        "contents": "a618cd4584f109de835b241c86ce2c370220a607\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz\", \"integrity\": \"sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==\", \"time\": 0, \"size\": 7090, \"metadata\": {\"url\": \"https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1d26498054c07107bca5dec3e4c244be0003d52ac2eebc92797ebafba65f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c5/39"
+    },
+    {
+        "type": "inline",
+        "contents": "a62cdb3bbfa2f76aaa282eb4f481579e1fd9c3c3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz\", \"integrity\": \"sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==\", \"time\": 0, \"size\": 4049, \"metadata\": {\"url\": \"https://registry.npmjs.org/tailwindcss-animate/-/tailwindcss-animate-1.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "23574405401dd5740af52bf75b544867c55c9771876ae1a64e650f11417f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/38"
+    },
+    {
+        "type": "inline",
+        "contents": "a65120e9f1e4df892fc00f9c7340ac64212fa775\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz\", \"integrity\": \"sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==\", \"time\": 0, \"size\": 50720, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8e13f049c97f2afa1f6987c55134e8228c4c8692012bb8c4118ba0343e5f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d8/ed"
+    },
+    {
+        "type": "inline",
+        "contents": "a746ddda540c67cf537ff64841b2cc85e7306577\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz\", \"integrity\": \"sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==\", \"time\": 0, \"size\": 2432, \"metadata\": {\"url\": \"https://registry.npmjs.org/thenify-all/-/thenify-all-1.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7a8beb06a8fd4638cdba34925f9f425882003f502b4019194e8df5f5e90a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ac/f0"
+    },
+    {
+        "type": "inline",
+        "contents": "a78fccc060485c7df4f246d73385afc51ea600ed\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz\", \"integrity\": \"sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==\", \"time\": 0, \"size\": 793671, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a9ccf88d3e4375ce00eebe2ff72c6cd7f0092b37acd13864b72a365f46ff",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1c/18"
+    },
+    {
+        "type": "inline",
+        "contents": "a85e0d97f27db24417b6aeb731a5a9621ef929ed\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz\", \"integrity\": \"sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==\", \"time\": 0, \"size\": 9398, \"metadata\": {\"url\": \"https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3297caeecf16808017a479c939430759f9d57eeddc307b56b0995f3af281",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/40/ae"
+    },
+    {
+        "type": "inline",
+        "contents": "a86b7e715412575e628effca8fd1e71caabc6880\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz\", \"integrity\": \"sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==\", \"time\": 0, \"size\": 3408, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2392a2ba8cc0a7070cd3e6d8ad7baadebdbea4955444d611492473e1d53a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c3/24"
+    },
+    {
+        "type": "inline",
+        "contents": "a924325d5a24dd78e9e054568c011d5799cbecf6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz\", \"integrity\": \"sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==\", \"time\": 0, \"size\": 8751, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "44d195bf59b7f71c2a336b826652f3fe5b71a260b8607e4de0b0ab4f6af2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/04/03"
+    },
+    {
+        "type": "inline",
+        "contents": "a95fc26fd78f44983033a0a5be12f58246e5c31e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz\", \"integrity\": \"sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==\", \"time\": 0, \"size\": 10833, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "969e38a2b7dda51f43929a08833ed717a152bd25e963d498eb080a827e25",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5b/1a"
+    },
+    {
+        "type": "inline",
+        "contents": "a9e34a345a0a7d06b2c4e28b412d4587d437be45\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz\", \"integrity\": \"sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==\", \"time\": 0, \"size\": 811358, \"metadata\": {\"url\": \"https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.19.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7ad3e780625e9e2253e8fd66171af8b9391cae1bcaf476e5147be2722dd9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/53/aa"
+    },
+    {
+        "type": "inline",
+        "contents": "aa28ffd220acadd35f1a838551fd3de7c695dc0a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz\", \"integrity\": \"sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==\", \"time\": 0, \"size\": 8109, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "17d5aa3783c612239557f251b2be4fdcb43aec68db7405d1d6b7a9377c5d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/74/8d"
+    },
+    {
+        "type": "inline",
+        "contents": "aa57f3d33c25a9b84310c16d676e1d7b0d3ba041\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz\", \"integrity\": \"sha512-HAYH7d3TLRHDOUQK4mZKf9k9Ph/m8Akstg66ywKR4SFAigjs3yBiUeZtFxywiTm5moZMAp/5W/ZuFnNXXYLuuQ==\", \"time\": 0, \"size\": 18604, \"metadata\": {\"url\": \"https://registry.npmjs.org/@csstools/media-query-list-parser/-/media-query-list-parser-4.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e117df7b34b7c4c9dc7e5796c8f2ed539ef989c18ff051275e1c0d20cc4f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ec/91"
+    },
+    {
+        "type": "inline",
+        "contents": "aad70b1e7e316106b8b1ae07d1902aba06a88ab7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz\", \"integrity\": \"sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==\", \"time\": 0, \"size\": 7127, \"metadata\": {\"url\": \"https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "481959c84d13edab51fdc4f5177ae1c6a8d5245488eb8cc48d2001deef02",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/12/3a"
+    },
+    {
+        "type": "inline",
+        "contents": "aada1f9976b6cc7c928720807250d45687928fbe\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz\", \"integrity\": \"sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==\", \"time\": 0, \"size\": 10079, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a47d5e82891c085f2fa155d225d518fe865af309f3e6890e2b184377dc52",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/37/f9"
+    },
+    {
+        "type": "inline",
+        "contents": "aafa85c56e2ba439e087a83636b70cfc36ac8c38\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz\", \"integrity\": \"sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==\", \"time\": 0, \"size\": 25301, \"metadata\": {\"url\": \"https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6633f1c44e00f62fb33c4ed801fdd7f8ddfd7bbb964c51ab483aa7c06b3b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/c5"
+    },
+    {
+        "type": "inline",
+        "contents": "ab062397e09b60723d715995b0c9d75989ca7d92\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz\", \"integrity\": \"sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==\", \"time\": 0, \"size\": 4597, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "cedd14d309b153583ec33b511626642a5b2cecfae082a664e1e6a368bc97",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ae/78"
+    },
+    {
+        "type": "inline",
+        "contents": "ab93a47f9c735850818809abfd40b68e6ae46771\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz\", \"integrity\": \"sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==\", \"time\": 0, \"size\": 15915, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1da406197170b616eda8e749f38787cc2f6a51a7cc273ecb5c757804513e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ec/52"
+    },
+    {
+        "type": "inline",
+        "contents": "abe45a232d8bbd3528164197e315c12d13b86b0a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz\", \"integrity\": \"sha512-c2AKvDT8ToxLIOUlN51gTiHXflsfIFisS4pO7pDPoKouJCESkhZnEy623gwP9laCy5lnLDAw1vAzu2vM2YLOrA==\", \"time\": 0, \"size\": 3053, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/whatwg-mimetype/-/whatwg-mimetype-3.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4026fb0360c3be6dff3d47d78f614b2ff8389f9d8b86bf19df0e228440ac",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/cf"
+    },
+    {
+        "type": "inline",
+        "contents": "ac29237c2dfc660cea48cff948fa520871bba163\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz\", \"integrity\": \"sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==\", \"time\": 0, \"size\": 11288, \"metadata\": {\"url\": \"https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f478dc1d9f45106f5abc4002e92282a8caf94d32b6f2288756e9c1baa163",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2a/d8"
+    },
+    {
+        "type": "inline",
+        "contents": "aced20ba8ddee977dd56788028a49b766a44c95a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz\", \"integrity\": \"sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==\", \"time\": 0, \"size\": 2939, \"metadata\": {\"url\": \"https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e799b4f4f867c76836f49706783aec8eb075d0081863e7515941c4f53393",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/60/94"
+    },
+    {
+        "type": "inline",
+        "contents": "ad2c41b699ad1d285bdacf4119420f09ab0daffa\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz\", \"integrity\": \"sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==\", \"time\": 0, \"size\": 3519, \"metadata\": {\"url\": \"https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7f2a8bd190f22671c866441ba3c09df2b7cc1088ad65bfa1ff1f42906fe4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a0/bf"
+    },
+    {
+        "type": "inline",
+        "contents": "ad59d1ab5d3882e724d7dd5ea1a2bd4bb1568403\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.2.tgz\", \"integrity\": \"sha512-hmgTH57GfzoTFjVN0yBwTggnsVUF2tcqi7RJZHqi9lIezSs4eFyAMktA68YD4r5kNw1mxyY4dmkyoFDb3FIqrA==\", \"time\": 0, \"size\": 5997, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-plugin-react-refresh/-/eslint-plugin-react-refresh-0.5.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6abad177bba7e16771d34dd7d9dfc5156998aeedb5a5e40d9c345e9f981b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/66/8a"
+    },
+    {
+        "type": "inline",
+        "contents": "ad5ec135c1a441d4f506aaf826afe72da3fb8607\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/braces/-/braces-3.0.3.tgz\", \"integrity\": \"sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==\", \"time\": 0, \"size\": 13972, \"metadata\": {\"url\": \"https://registry.npmjs.org/braces/-/braces-3.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a192012145418d110a524426072bc9265ee2fc93b0a67eb175c371423ae4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/af/bc"
+    },
+    {
+        "type": "inline",
+        "contents": "ae0d27cac64e1a7ff125a7674e51e0b4fc63623d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz\", \"integrity\": \"sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==\", \"time\": 0, \"size\": 4701, \"metadata\": {\"url\": \"https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7cad974fc3c5204ab1101f1718f396785ef13692699159ffad5330214d27",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4c/57"
+    },
+    {
+        "type": "inline",
+        "contents": "af225f27afbdb03cddd7457bb7a29cf7459f469b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz\", \"integrity\": \"sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==\", \"time\": 0, \"size\": 28340, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7692e94a71c732b3dadff9f88aa664f65b14c727e2330fe497dc41eb47a1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7b/4b"
+    },
+    {
+        "type": "inline",
+        "contents": "af94b9a500ee4631018c9a104b5d108b60d4aea7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz\", \"integrity\": \"sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==\", \"time\": 0, \"size\": 4255, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2ac6234e08578459cc70534addafba44ecd5267c7510db659945c34b184d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c3/ea"
+    },
+    {
+        "type": "inline",
+        "contents": "b172e2cd76fb97e0f9f5aa666ff6d4d80bfaa8b1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/levn/-/levn-0.4.1.tgz\", \"integrity\": \"sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==\", \"time\": 0, \"size\": 7465, \"metadata\": {\"url\": \"https://registry.npmjs.org/levn/-/levn-0.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0bd207e4befdc1899d2abf0d3271f34fd6bd81eaaa9e7f4b005488802bb0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ca/de"
+    },
+    {
+        "type": "inline",
+        "contents": "b505fd060ecd5bbc70b1f60ea9868f9b270fd571\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz\", \"integrity\": \"sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==\", \"time\": 0, \"size\": 193967, \"metadata\": {\"url\": \"https://registry.npmjs.org/sucrase/-/sucrase-3.35.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d7752131dc29ed9a3f1b5ed3749f1e346be65b985028600b9da9d8d7182d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6c/65"
+    },
+    {
+        "type": "inline",
+        "contents": "b51782e80ad9887e0a7bc88c4eba2064d72d2d2c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/slash/-/slash-3.0.0.tgz\", \"integrity\": \"sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==\", \"time\": 0, \"size\": 1840, \"metadata\": {\"url\": \"https://registry.npmjs.org/slash/-/slash-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3046a229db5b86e70667caf8a296c942a91249477fb9b1346e3759b79f8b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7d/35"
+    },
+    {
+        "type": "inline",
+        "contents": "b5d16bf14c5b16afbf2e4820d2bfef925dfeb8bc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz\", \"integrity\": \"sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==\", \"time\": 0, \"size\": 3449, \"metadata\": {\"url\": \"https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c7d3cc971492220b7cec031eec035df5e60b61a4319081d0cc87870409b3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1c/a4"
+    },
+    {
+        "type": "inline",
+        "contents": "b61c8219d35ae772dd7417002c0a775113b106fc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/husky/-/husky-9.1.7.tgz\", \"integrity\": \"sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==\", \"time\": 0, \"size\": 2448, \"metadata\": {\"url\": \"https://registry.npmjs.org/husky/-/husky-9.1.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f91f4a30360110c0f4913891a03a2462bee0c184340a48d68d097e1f3d16",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/74/c5"
+    },
+    {
+        "type": "inline",
+        "contents": "b67db885f212ce7ef813b99c26bfc88182ec034d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz\", \"integrity\": \"sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==\", \"time\": 0, \"size\": 17726, \"metadata\": {\"url\": \"https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3aa5d94761ad382e1a1acc61203736494009e20422bce1dd1433666dd012",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/57"
+    },
+    {
+        "type": "inline",
+        "contents": "b6b41c41bb35148054851d2695cf088d06f1f93f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz\", \"integrity\": \"sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==\", \"time\": 0, \"size\": 73417, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7fc8fb088ff37e4ff427d1fec06dd168abfd2fcda2b0ea1489ca5010fb91",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/51/7d"
+    },
+    {
+        "type": "inline",
+        "contents": "b7a209a0abe850d02b9459c1ebbb10eb43f70547\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz\", \"integrity\": \"sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==\", \"time\": 0, \"size\": 316943, \"metadata\": {\"url\": \"https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a1e0372340b9efaac26c39afafd39fa461f7ce18fa266e376867f7569051",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f2/f4"
+    },
+    {
+        "type": "inline",
+        "contents": "b7b2c53e78216e19ccd892db974a1382354d600e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz\", \"integrity\": \"sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==\", \"time\": 0, \"size\": 4483, \"metadata\": {\"url\": \"https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8e01e6bce59ac02f0d20fc97382749190cb73f6006f9526fc7fb1ec79dd4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/26"
+    },
+    {
+        "type": "inline",
+        "contents": "b80b8ae25a2a10c0c5b6691530dbf72e2c5f7a6b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz\", \"integrity\": \"sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==\", \"time\": 0, \"size\": 5849, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c2ea22c4bf9c5ddcd0333850e543442de3364478847c7ebc382b1ff3a70d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8b/ee"
+    },
+    {
+        "type": "inline",
+        "contents": "b8228365de697205533825a30795d19e6be8e10e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz\", \"integrity\": \"sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==\", \"time\": 0, \"size\": 113093, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0fd312def6de344310f1bee3f5675f0cea9565faccfe4349babb249d5402",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e0/9e"
+    },
+    {
+        "type": "inline",
+        "contents": "ba2a346c8877a2bff4f2c6800f63a6c80813dbe4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lucide-react/-/lucide-react-1.14.0.tgz\", \"integrity\": \"sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA==\", \"time\": 0, \"size\": 2688772, \"metadata\": {\"url\": \"https://registry.npmjs.org/lucide-react/-/lucide-react-1.14.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "20ee81384727d7221bf55a655aad3ccd278a7b4c282c0c4d3af8643a9c49",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/58/c9"
+    },
+    {
+        "type": "inline",
+        "contents": "ba975c4d51bb8bbd65610d14e05cb3dc69f155d1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz\", \"integrity\": \"sha512-CTXd6rk/M3/ULNQj8FBqBWHYBVYybQ3VPBw0xGKFe3tuH7ytT6ACnvzpIQ3UZtB8yvUKC2cXn1a+x+5EVQLovA==\", \"time\": 0, \"size\": 16095, \"metadata\": {\"url\": \"https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2c323301791a8b74312a9eaf417c45e67dba8be1c0af8235dadffaab0478",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/69/8e"
+    },
+    {
+        "type": "inline",
+        "contents": "baae82feb47b3bbc3b3d1960900c6d26c0845571\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz\", \"integrity\": \"sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==\", \"time\": 0, \"size\": 816161, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "35b0fccb70c54f40a0faececa63d63d9b95e43545e33f16b4ecd47e71f61",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a6/bc"
+    },
+    {
+        "type": "inline",
+        "contents": "bb40f96286e6f9708156958b92949f987dfacb36\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz\", \"integrity\": \"sha512-ztqyC3kLto0e9WbNp0aeP+M3kTt+nbaIveGmUxAtZa+8iFgKLUOD4YKM5j+f3QD89bra7UeumolZHKuOXnTmeQ==\", \"time\": 0, \"size\": 2637, \"metadata\": {\"url\": \"https://registry.npmjs.org/html-tags/-/html-tags-3.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "823f94d26ecf5c1aead7c9d2ab77c66c559650d9fc588869fa7c4e346582",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7f/d6"
+    },
+    {
+        "type": "inline",
+        "contents": "bb4ece9ac1f1f8eac3b99702780e514fcf4913ed\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.8.tgz\", \"integrity\": \"sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==\", \"time\": 0, \"size\": 3363, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9e05f45ec43113e3f81eae620ab97868a4c25551288a01a9ef131238762d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/28/eb"
+    },
+    {
+        "type": "inline",
+        "contents": "bbdfd43ed128a89cf95fa2073401ec6c06fccaca\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz\", \"integrity\": \"sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==\", \"time\": 0, \"size\": 4937, \"metadata\": {\"url\": \"https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1295af917239a2fbe94404f49d472949b2a2519701a35e8dc9841f02ae34",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c0/83"
+    },
+    {
+        "type": "inline",
+        "contents": "bc071c15d122e841b8ec82fc0e4fb1a870881ff8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz\", \"integrity\": \"sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==\", \"time\": 0, \"size\": 6318, \"metadata\": {\"url\": \"https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "216edd7104928342f4e596f226b589b3733c83a5c056ece5738890de4460",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/95/20"
+    },
+    {
+        "type": "inline",
+        "contents": "bca61143b45e94d18e44556cf413881fe8a8cc51\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz\", \"integrity\": \"sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==\", \"time\": 0, \"size\": 4952, \"metadata\": {\"url\": \"https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "656d08a513cf41cf02f0fcb0e63ba171f108175b3c711837ec0c0f93f955",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0a/d0"
+    },
+    {
+        "type": "inline",
+        "contents": "bd2a610aa5f499723bbf0e1a3d74cd84fa94a7ac\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz\", \"integrity\": \"sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==\", \"time\": 0, \"size\": 2663, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "76c21652f2169a69eaaea1063b83090d4a616b9b952147bafbb6e4588813",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9d/6b"
+    },
+    {
+        "type": "inline",
+        "contents": "bd677871d738cf702e700907dc299adcc38604de\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz\", \"integrity\": \"sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==\", \"time\": 0, \"size\": 37786, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "35a1db3e28833675445dd5070d460a5c2d2f7a04d80bdbff6aad4190b647",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7f/37"
+    },
+    {
+        "type": "inline",
+        "contents": "bd887b02ca3a2c2a2f1614d3c090cd9367877df3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz\", \"integrity\": \"sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==\", \"time\": 0, \"size\": 4571, \"metadata\": {\"url\": \"https://registry.npmjs.org/didyoumean/-/didyoumean-1.2.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5a578c04b206bec88a8d3b6a18f0c6d6b87adb6b3a875bc0666d7997d6d5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cc/0c"
+    },
+    {
+        "type": "inline",
+        "contents": "bdf94d948b168388e33bd2e1d571bad282a23440\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz\", \"integrity\": \"sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==\", \"time\": 0, \"size\": 9408, \"metadata\": {\"url\": \"https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "cc8592ab15d662d89edc5604d9f6347e26fbca3465f5f245b65eefb11d93",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2e/c8"
+    },
+    {
+        "type": "inline",
+        "contents": "be4138fca42ff79ffbe5d869abe9f6b3a52d2259\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz\", \"integrity\": \"sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==\", \"time\": 0, \"size\": 17972, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9672ccd5d1b968aaac0d946fa3edfb7bf457bbf9ea32c1949fbe55b875f4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/07"
+    },
+    {
+        "type": "inline",
+        "contents": "be9e87928b52b63c950694f980ba48fb0be5d179\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz\", \"integrity\": \"sha512-APMBEanjybaPzUrfqU0IMU5I0AswKMH7k8OTLs0vvV4KZpExkTkY87nR/zpbuTPj+gARop7aGUbl11pnDfW6xg==\", \"time\": 0, \"size\": 3106, \"metadata\": {\"url\": \"https://registry.npmjs.org/mathml-tag-names/-/mathml-tag-names-2.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9beba70df585444da3d77cbec63303932ea61eee019b53ebbf60e8c7a4a1",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9f/37"
+    },
+    {
+        "type": "inline",
+        "contents": "beb3581a096857eef74eaedeca49d285be4518ea\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz\", \"integrity\": \"sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==\", \"time\": 0, \"size\": 135815, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c28913cbc3407b3ee6a1dd1f8b3e6a714f62604f554104e211c8c6a58574",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d2/b8"
+    },
+    {
+        "type": "inline",
+        "contents": "bf17bc9feca98e76e2167d1981a076e31663a7c6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz\", \"integrity\": \"sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==\", \"time\": 0, \"size\": 9608, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4022921afad2e38857eb774774f73ce1bd92b1c21069b7125dc7c7578551",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/26/d4"
+    },
+    {
+        "type": "inline",
+        "contents": "bf4a5535c22d7d6da5189b8758e60a4fd5e6684f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz\", \"integrity\": \"sha512-MkKCwxlXTgz6CFoJx3pCwn07GKp36+aZyu/u2Ln2VrA5DcdyCZkASEDBTd8x5whTQQL5CiYf4prXKLcgQdv29g==\", \"time\": 0, \"size\": 1529, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "63f22fbcf0c21b1e268e7098ba936a48f7ddd6c06761a6c5b4a5fe434ebf",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/11/42"
+    },
+    {
+        "type": "inline",
+        "contents": "c0f0065af70a7d0e18983cd7bb6e4b77735e952e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz\", \"integrity\": \"sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==\", \"time\": 0, \"size\": 7360, \"metadata\": {\"url\": \"https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "cece4a065d9009795606216ee3e75501611290013df6fa0039bed9edd10a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/52/1d"
+    },
+    {
+        "type": "inline",
+        "contents": "c265b4c40fee05b42bd21df26a22bf3ab4bc0e32\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz\", \"integrity\": \"sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==\", \"time\": 0, \"size\": 66106, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9add37ab7d1df19464f2de99764e01ea48e71ab20f95ca94d9ce31e1ae7e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/73/bd"
+    },
+    {
+        "type": "inline",
+        "contents": "c2c248d70788d576a590340ad07a700640cc8753\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz\", \"integrity\": \"sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==\", \"time\": 0, \"size\": 5723, \"metadata\": {\"url\": \"https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7ba0b9b690691f421a084eac76303bb06beadc65796c38a94889436512be",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ed/ae"
+    },
+    {
+        "type": "inline",
+        "contents": "c2d0973f62538d0854e3bd8ecf11c841ecce1fa7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz\", \"integrity\": \"sha512-ieIFACdMpYfMEjF0rEf5KLvfVyIkOz6PDGyNnP+u+4xQ6jny3VCgA4OgXOwNx2aUkxn8zx9fiVcM8CfFYv9Lxw==\", \"time\": 0, \"size\": 5255, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4d797505dd86c957fd2449104916d12a5c9401fe448731766e66d8449c48",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ea/cb"
+    },
+    {
+        "type": "inline",
+        "contents": "c304e2836156835170fba74440cfec54b21af4fe\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz\", \"integrity\": \"sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==\", \"time\": 0, \"size\": 5836, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7dc86c802ff8fff670dbcca77371a2964508a335e97204bd469e0a15a72c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2f/b8"
+    },
+    {
+        "type": "inline",
+        "contents": "c32c69ab6c8ba19de74e387e5c163c2520ba8e72\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz\", \"integrity\": \"sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==\", \"time\": 0, \"size\": 2169, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c10bf71d66461aba0899e81d7a146332c45dbbacb1693c38fc2e4e578e39",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8a/c9"
+    },
+    {
+        "type": "inline",
+        "contents": "c36a4344f60f78677eb2a507571ca18431f911b6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz\", \"integrity\": \"sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==\", \"time\": 0, \"size\": 1503, \"metadata\": {\"url\": \"https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b652af7d985d655c33bbc6261689ea2f5a550b485dde76ad3aefbe2591eb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/03/af"
+    },
+    {
+        "type": "inline",
+        "contents": "c375a623b22500e0b5ad9180961e5bc8a1742f6b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz\", \"integrity\": \"sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==\", \"time\": 0, \"size\": 10038, \"metadata\": {\"url\": \"https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1394bfe3119ef9620ccb5d4eb6c4001ab70c64efb55f558a35ad46138686",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a4/96"
+    },
+    {
+        "type": "inline",
+        "contents": "c3821a38078544edb779d2d6f174c21f21984b54\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz\", \"integrity\": \"sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==\", \"time\": 0, \"size\": 19598, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2aee5ac644afd1ccffda411fbb237bf75c89a741fff22979ecc3beab5fe4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/25"
+    },
+    {
+        "type": "inline",
+        "contents": "c3d200949562f80f09b9c6f8a6c5d536f81ce6b9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cacheable/-/cacheable-2.3.4.tgz\", \"integrity\": \"sha512-djgxybDbw9fL/ZWMI3+CE8ZilNxcwFkVtDc1gJ+IlOSSWkSMPQabhV/XCHTQ6pwwN6aivXPZ43omTooZiX06Ew==\", \"time\": 0, \"size\": 31167, \"metadata\": {\"url\": \"https://registry.npmjs.org/cacheable/-/cacheable-2.3.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "36d4047e7b76c2f95e3b53294a5ed947c30106be4bb4bdb5259be753ed9b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f0/8c"
+    },
+    {
+        "type": "inline",
+        "contents": "c41c0429c3b566154ad7d71291cb2dccfaaefcd9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz\", \"integrity\": \"sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==\", \"time\": 0, \"size\": 2989, \"metadata\": {\"url\": \"https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e8166faad33ceb76841ce09c5e5e619d46225021c61320e9f0882993d698",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ae/0b"
+    },
+    {
+        "type": "inline",
+        "contents": "c47d148c639ea5b37c3ab9b01a31fa58d3f3045d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz\", \"integrity\": \"sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==\", \"time\": 0, \"size\": 13098, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.2.8.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "06192603daebdeebec6ad6e070357bb297b864354a3998c359fa50ad570b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9a/76"
+    },
+    {
+        "type": "inline",
+        "contents": "c5b97bc903ed8c3284c4aa7246d5bd6f00aeb26a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz\", \"integrity\": \"sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==\", \"time\": 0, \"size\": 4316, \"metadata\": {\"url\": \"https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "52b1c2943a9a945ffff983101f4282cf512899f2ea417b7a8d877f4c22b7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f8/4a"
+    },
+    {
+        "type": "inline",
+        "contents": "c632a17fd3849e122142b2fa75fa708372e3eff9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz\", \"integrity\": \"sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==\", \"time\": 0, \"size\": 34715, \"metadata\": {\"url\": \"https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "09a653ae745f2a6ce9bc9757f1642f3bc8b27c2f4d328ffaa7d6d190f472",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b7/6c"
+    },
+    {
+        "type": "inline",
+        "contents": "c69ec48edfea5ac0fed154997a5ea1369ef26e32\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz\", \"integrity\": \"sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==\", \"time\": 0, \"size\": 13668, \"metadata\": {\"url\": \"https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6979cd76f3f7c5ce2daa2cc64e01910d200bb244900d065df7a11931cd9c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/16/9a"
+    },
+    {
+        "type": "inline",
+        "contents": "c710a53f835879bb558320917d810dcedd861000\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz\", \"integrity\": \"sha512-MvG/clsADq1GPM2KGo2nyfaWVyn9naPiXrqIe4jYjXNZQt238kWyOGrsyc/DmRAQ+Re6yeo6yX/yoNCG5KAEVg==\", \"time\": 0, \"size\": 32237, \"metadata\": {\"url\": \"https://registry.npmjs.org/hookified/-/hookified-1.15.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "69e27e8ef69c2fec13495b5122a46d9812371a8173e8643b286e0f1f2671",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b5/05"
+    },
+    {
+        "type": "inline",
+        "contents": "c7c68be054424e3388c0b06723565a584ca5b7f3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz\", \"integrity\": \"sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==\", \"time\": 0, \"size\": 73700, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e3c28731fd395c51d360d7299b28b972face0f39c50bdd7da97cf212912e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3b/5e"
+    },
+    {
+        "type": "inline",
+        "contents": "c85412fcb89a8343eacae968a6514fe67818ee63\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz\", \"integrity\": \"sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==\", \"time\": 0, \"size\": 3151, \"metadata\": {\"url\": \"https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7d3c580b65869fc4f55b962ca87f8ed801eeb7d0a568c2b65f39ea2df787",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f1/17"
+    },
+    {
+        "type": "inline",
+        "contents": "c86edfc368e68f5f8d4980a86099d43bbf9162dd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz\", \"integrity\": \"sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==\", \"time\": 0, \"size\": 8383, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d5f8ccfbb62d7e7a7ee4f06ad85054ca2d54ee156eb7eaee541e26d9e288",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3f/db"
+    },
+    {
+        "type": "inline",
+        "contents": "c8a5706006c7272b34109041e53fbf4865386e30\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz\", \"integrity\": \"sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==\", \"time\": 0, \"size\": 11577, \"metadata\": {\"url\": \"https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "375aec77f76404d91225e72006a0105b2a6ec04bb02cfa365ebcd4a0232b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bf/7c"
+    },
+    {
+        "type": "inline",
+        "contents": "c8dc69aa53afdcd39b445f0c8cd5ac47dee550bf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz\", \"integrity\": \"sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==\", \"time\": 0, \"size\": 6664, \"metadata\": {\"url\": \"https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c147816be94e86ed9bbb4b9e20409e4791a8991fcfd41d7a44489dedd29b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0b/90"
+    },
+    {
+        "type": "inline",
+        "contents": "c909b91482ce3a20142f149a79d5b289d6d24b53\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz\", \"integrity\": \"sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==\", \"time\": 0, \"size\": 828482, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7d9ad9785db96c8702546e491bc5ead375ee3ab4cf91fa3e510d7bc71d78",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/be/4a"
+    },
+    {
+        "type": "inline",
+        "contents": "c975a78e0b2d462b150b9a76cd10edb1dc791b26\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/meow/-/meow-13.2.0.tgz\", \"integrity\": \"sha512-pxQJQzB6djGPXh08dacEloMFopsOqGVRKFPYvPOt9XDZ1HasbgDZA74CJGreSU4G3Ak7EFJGoiH2auq+yXISgA==\", \"time\": 0, \"size\": 91037, \"metadata\": {\"url\": \"https://registry.npmjs.org/meow/-/meow-13.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "56f81ead9c0f449bf99b18bb179c8f579ee2b6e894405503b9462c641f25",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a8/ba"
+    },
+    {
+        "type": "inline",
+        "contents": "c9d37758deda0c43b2186bfb14961dd67def1b9d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz\", \"integrity\": \"sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==\", \"time\": 0, \"size\": 2232, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ad2fd86fe0c1b9f233d92c25e56b1a582b8425b52db4767f8d72410c021f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e3/c5"
+    },
+    {
+        "type": "inline",
+        "contents": "c9e3d6e08d73510bffcdcc6883ddeba6a0cd516c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz\", \"integrity\": \"sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==\", \"time\": 0, \"size\": 2068, \"metadata\": {\"url\": \"https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5296f26e207d1371c8f95bf082321237691bc5e5db64b66d0ffd6ffa99ab",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/46/d9"
+    },
+    {
+        "type": "inline",
+        "contents": "c9f3ba02f01317b536c33216c7cd130476594172\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz\", \"integrity\": \"sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==\", \"time\": 0, \"size\": 4553, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "431da6a77bae523c9b8e44218a52c36c1c81fe7d9626698941b8b8787f8d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bb/68"
+    },
+    {
+        "type": "inline",
+        "contents": "caf2cef9e57fd1035961a49a5c778d77a56cc57e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz\", \"integrity\": \"sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==\", \"time\": 0, \"size\": 2618, \"metadata\": {\"url\": \"https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ce47a91aa4c10cda303c5b693122434fcebd897428fb2d4b7b305796453a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/4b/4d"
+    },
+    {
+        "type": "inline",
+        "contents": "cb9f91e1e014cdf964fcc34b36e574f6c4328bb5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz\", \"integrity\": \"sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==\", \"time\": 0, \"size\": 2018, \"metadata\": {\"url\": \"https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2b27069dfecf075bafa065bde7131376f7aaec6e7f6d21859f58a03813cd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/2a/52"
+    },
+    {
+        "type": "inline",
+        "contents": "ccf891d44b5231050430281b8f8b7373dbe1bd23\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz\", \"integrity\": \"sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==\", \"time\": 0, \"size\": 2383, \"metadata\": {\"url\": \"https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4d241faeb3fea9ec8318fd93dd55eb70a87cc8a6e3f849ccef9863882b4b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/31/ac"
+    },
+    {
+        "type": "inline",
+        "contents": "cd73b3160583a51c06d9417fe2252a76a78f5283\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/which/-/which-1.3.1.tgz\", \"integrity\": \"sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==\", \"time\": 0, \"size\": 4174, \"metadata\": {\"url\": \"https://registry.npmjs.org/which/-/which-1.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "24e888de8c94c67026f3974571f3072a9ff5276007cbd45ef80215795ecb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/86/df"
+    },
+    {
+        "type": "inline",
+        "contents": "cd9778c443eb202955f61afde92f0297963d8fcf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz\", \"integrity\": \"sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==\", \"time\": 0, \"size\": 2041, \"metadata\": {\"url\": \"https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c662626ec8eafafa54476678b9f71799a74ee368f2b7845a6ec9f9174a4d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f2/1f"
+    },
+    {
+        "type": "inline",
+        "contents": "cf428a9c70b608b0c86f18b0b208006d8d28c694\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz\", \"integrity\": \"sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==\", \"time\": 0, \"size\": 3868, \"metadata\": {\"url\": \"https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4b4e7b3fafd80561ac59574cbe83d3d4c3ddb6861a0eb3dcf181fb1c399f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ea/91"
+    },
+    {
+        "type": "inline",
+        "contents": "cfd9cafd22770df22314167fdefd2b76c2333767\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz\", \"integrity\": \"sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==\", \"time\": 0, \"size\": 3400, \"metadata\": {\"url\": \"https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "99a7db3a3209b5de2c760de391f5d6844b67a72311c9da9da01366aaa562",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/81/46"
+    },
+    {
+        "type": "inline",
+        "contents": "d0515182a4d32ff4d970def41ccd9eaa6b433ce6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz\", \"integrity\": \"sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==\", \"time\": 0, \"size\": 6828, \"metadata\": {\"url\": \"https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e94403f1afd2fed5b3e826107e8cd76b0c1b10f404aa820f369ed9d7fe52",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6a/09"
+    },
+    {
+        "type": "inline",
+        "contents": "d060a29a24be4e71046cbacaec0066dc83194c7e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz\", \"integrity\": \"sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==\", \"time\": 0, \"size\": 10925, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "715a86aa779da41ab634b8f3191069d4b2966a3c5b47cb739ab6a9b93aec",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d4/8f"
+    },
+    {
+        "type": "inline",
+        "contents": "d1be96154325e5075e4ed09dcc414b8e61a4d934\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz\", \"integrity\": \"sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==\", \"time\": 0, \"size\": 2677, \"metadata\": {\"url\": \"https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "454c882933ab15d532e2493b0bd7ce7019f1caca2abb46f076ca0855330b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a5/b8"
+    },
+    {
+        "type": "inline",
+        "contents": "d21f195d54ac81f6d6b9482133fc0daaf03301c7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz\", \"integrity\": \"sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==\", \"time\": 0, \"size\": 2646, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "cdd6d90f9cc86254b9d817a815ac6df79ca99e76fc8bbcf2ed1a39dd9a1d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/86/d4"
+    },
+    {
+        "type": "inline",
+        "contents": "d267cb77ad5c5bd33be3e6022e784d2e160e0e18\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz\", \"integrity\": \"sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==\", \"time\": 0, \"size\": 3582, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "05573a5fc0e72e0cfb57cbf81cd2187bb54a665efe4c6982168a700ec701",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/69/5f"
+    },
+    {
+        "type": "inline",
+        "contents": "d2da1f6634ec7e4d39df4f509dc8b53fdcd3694a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz\", \"integrity\": \"sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==\", \"time\": 0, \"size\": 2677, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "48011259d0e96d76bb6477a88e2828eb597909fd035b03109bd1f2cc4e3e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e1/13"
+    },
+    {
+        "type": "inline",
+        "contents": "d30edad7233ba379509ac5da170ea13d13b7ecac\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz\", \"integrity\": \"sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==\", \"time\": 0, \"size\": 202714, \"metadata\": {\"url\": \"https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "75b9da89923e80cdca92443f7503f232b0bc30bb859fea34eff5b40f43d2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/bd/93"
+    },
+    {
+        "type": "inline",
+        "contents": "d31c9160378263d3bc01ee81e386c673303cf2d8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz\", \"integrity\": \"sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==\", \"time\": 0, \"size\": 138324, \"metadata\": {\"url\": \"https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "97d2c6e5c772f993e1a5b5fdeae5e52c835ac89d689ba43dbe025d54d880",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/96/e8"
+    },
+    {
+        "type": "inline",
+        "contents": "d32904c7e60ee11a7cc3af0143e5e473c36a9f9d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/semver/-/semver-7.7.4.tgz\", \"integrity\": \"sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==\", \"time\": 0, \"size\": 28442, \"metadata\": {\"url\": \"https://registry.npmjs.org/semver/-/semver-7.7.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c335f15c5e60271d167b8468ee446614a76a1bee37e0fcc08643dc5818a4",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d5/ed"
+    },
+    {
+        "type": "inline",
+        "contents": "d4041d893b59e10016ce118e42c07d3fd3c592c9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz\", \"integrity\": \"sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==\", \"time\": 0, \"size\": 18715, \"metadata\": {\"url\": \"https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "450611954c32e690fc10a43e257795966469c108f5fab11aae27ec07010e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f7/9b"
+    },
+    {
+        "type": "inline",
+        "contents": "d500eea0b57a6ab6c771cf4b89efaa512172a532\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz\", \"integrity\": \"sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==\", \"time\": 0, \"size\": 17339, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "73d44145e779147659bd53b420b3f717946f103bf634edd7dacf0d872a47",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9a/8b"
+    },
+    {
+        "type": "inline",
+        "contents": "d6b3470728ed6256111b27537bd8df7fe186ba09\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz\", \"integrity\": \"sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==\", \"time\": 0, \"size\": 5610, \"metadata\": {\"url\": \"https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "904a49b9061b89b7da89c73e69c176aa9f83737461e1812920e1f4649e63",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/23/dc"
+    },
+    {
+        "type": "inline",
+        "contents": "d6fe2445a6eae6a00d31497db1a9f73dfc553ade\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz\", \"integrity\": \"sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==\", \"time\": 0, \"size\": 2813, \"metadata\": {\"url\": \"https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "297e6081f2050d08959be634218f7dc79469d7a8742e8eb0d087205d0e19",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7e/1e"
+    },
+    {
+        "type": "inline",
+        "contents": "d7081769e438b9b0da0dfe51b8ebe291fa0e22e3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz\", \"integrity\": \"sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==\", \"time\": 0, \"size\": 14536, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.15.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "bf2dd5bf2d9b9006f82aeedaffc7f69ad64358a9a08afe81cbcdca1766f2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c4/11"
+    },
+    {
+        "type": "inline",
+        "contents": "d717883c0a1dde8fad55b0575ae3ed70ea4dc85f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz\", \"integrity\": \"sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==\", \"time\": 0, \"size\": 4638, \"metadata\": {\"url\": \"https://registry.npmjs.org/pirates/-/pirates-4.0.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "64ff17064f8b6d1cba61d90bbd9b83995b6a83c3e2e6619a4cdb7bde67d8",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c1/54"
+    },
+    {
+        "type": "inline",
+        "contents": "d745faf5de1e3a7ff5448731c75f485f675f91b2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz\", \"integrity\": \"sha512-7xdcatg7/U+7+Udyoj2zodtI9H/IIopqo+YOIcZOq1nJwXWBZ9p8xiu5llXlekDbZkca79a/fozEYQXIA4sW6A==\", \"time\": 0, \"size\": 8682, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-tabs/-/react-tabs-1.1.13.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "97eeecddd26637708519813d42ee2a5ec256bd4831ffa02269e8993e19b7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ec/8e"
+    },
+    {
+        "type": "inline",
+        "contents": "d758da460d2138399b64a431ce2617103506c9a8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz\", \"integrity\": \"sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==\", \"time\": 0, \"size\": 190116, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "282a52d7ff98e5c2b63589e7ac3942da557cb7fbf6b14be414452ca7de4d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/00/31"
+    },
+    {
+        "type": "inline",
+        "contents": "d79faf5fb9569efa453f4f4d963806ab445c5bea\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz\", \"integrity\": \"sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==\", \"time\": 0, \"size\": 4296, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a8b30a439dfcf0b09abd5dce256cec215e5094780e39dae9291d68c45eea",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/14/60"
+    },
+    {
+        "type": "inline",
+        "contents": "d8284a7c0249e00e8dbf7ff84a8c592ab8c9a2c0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/colord/-/colord-2.9.3.tgz\", \"integrity\": \"sha512-jeC1axXpnb0/2nn/Y1LPuLdgXBLH7aDcHu4KEKfqw3CUhX7ZpfBSlPKyqXE6btIgEzfWtrX3/tyBCaCvXvMkOw==\", \"time\": 0, \"size\": 32721, \"metadata\": {\"url\": \"https://registry.npmjs.org/colord/-/colord-2.9.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e35d358270ead42e313260feab96e2e9016c4efe62526fefc4ae1031044e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a8/7e"
+    },
+    {
+        "type": "inline",
+        "contents": "d894e9fc5bce1ef420ed9dd664c7ae33004533b9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz\", \"integrity\": \"sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==\", \"time\": 0, \"size\": 7647, \"metadata\": {\"url\": \"https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2058c7dd9c8eafd6bae482d29c84e26280ec20cda6747162efd1748423b0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/28/2e"
+    },
+    {
+        "type": "inline",
+        "contents": "d89eae79cda0bf6857bbdf56c2a400c756fbca9c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz\", \"integrity\": \"sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==\", \"time\": 0, \"size\": 894137, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e54d69009aa6df948c838752210c84c24aa3a51f7bdc76f15f87ba4e0401",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b5/0e"
+    },
+    {
+        "type": "inline",
+        "contents": "d8f9f1c97b3f779998fb83e6e7e37aa98acc52f2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz\", \"integrity\": \"sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==\", \"time\": 0, \"size\": 14064, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d219a86c2dd1e627799e3f884a3850634031990733acec5604fd4424e34d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c0/97"
+    },
+    {
+        "type": "inline",
+        "contents": "d9d308d9a488ff2be7ce561eec05edae6e5aa7ec\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/which/-/which-2.0.2.tgz\", \"integrity\": \"sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==\", \"time\": 0, \"size\": 4496, \"metadata\": {\"url\": \"https://registry.npmjs.org/which/-/which-2.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5a271b1898a503a6f8a6b2361235fd7539e9ae1aa5622d3e78124d1a0c34",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b4/9d"
+    },
+    {
+        "type": "inline",
+        "contents": "daa1a00c8ce50dbe5b1dd794de32f40b4a3ac9e2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz\", \"integrity\": \"sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==\", \"time\": 0, \"size\": 4905, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "eff66b6824615ca63508bdebe2ed78415c5ffd420790a17bdbf5467d5c9a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/86/f9"
+    },
+    {
+        "type": "inline",
+        "contents": "dab22ec156d3b57a12522ece46511443c0500ddb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mz/-/mz-2.7.0.tgz\", \"integrity\": \"sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==\", \"time\": 0, \"size\": 4046, \"metadata\": {\"url\": \"https://registry.npmjs.org/mz/-/mz-2.7.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d7c97e76694e2668372ea24799bda303855bdc25e192bc2a61f2d34c822a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/bf"
+    },
+    {
+        "type": "inline",
+        "contents": "db2b4dc5b53d140452c1320dc4a5f6124f7b8e3b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz\", \"integrity\": \"sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==\", \"time\": 0, \"size\": 4465, \"metadata\": {\"url\": \"https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b5d441067698d74c6f1aede355a770879de88de1319ba75e5ead9d54b854",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/99/e2"
+    },
+    {
+        "type": "inline",
+        "contents": "dbf0edd3af7cad1f781ec392c7773d5bdea666c7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz\", \"integrity\": \"sha512-kRz0VEkJqWLf1LLVN4pT1cg1Z9wAuvI6L97V3m2f5B76Tg8d413ddvLBPTEHAZJlnn4XSvu0FkZtViCQGVyrXQ==\", \"time\": 0, \"size\": 14396, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/sarif/-/sarif-2.1.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "582434be79560ffa1b1155812c9dd4d7d8cf6314be637646942359f5ef09",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d0/6e"
+    },
+    {
+        "type": "inline",
+        "contents": "dc2a73e9e1bc82d6e09a90ab82f54938728dd5d5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz\", \"integrity\": \"sha512-jttmRe7bRse52OsWIMDLaXxWqRAmtIUccAQ3garviCqJjafXOfNMO0yMfNpdD6zbGaTU0P5Nz7e7gAT6cKmJRw==\", \"time\": 0, \"size\": 6255, \"metadata\": {\"url\": \"https://registry.npmjs.org/lodash.truncate/-/lodash.truncate-4.4.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d8c93d198bce545a9cc4ec86978a3bd992c4777a581fa3434985b49a4d81",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ac/05"
+    },
+    {
+        "type": "inline",
+        "contents": "dc7e9ce86762306d3489e9c4b7e8106b0471eb8a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz\", \"integrity\": \"sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==\", \"time\": 0, \"size\": 188861, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "367420e70c3c9a20a84ffa83050f9a20bcb297b7e0f015d3992bdf909158",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/91"
+    },
+    {
+        "type": "inline",
+        "contents": "dc85a7cf3cace26f729f1d745da27b141849c5d4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz\", \"integrity\": \"sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==\", \"time\": 0, \"size\": 59568, \"metadata\": {\"url\": \"https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8aec66ccaf0b0d30ad3e8da7c1fae595b30c2dd5d6e33ae7c6cd921711f7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/87/84"
+    },
+    {
+        "type": "inline",
+        "contents": "dcd3d1528ce74d005e7a0cf06ed8772f5bc1ab78\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz\", \"integrity\": \"sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==\", \"time\": 0, \"size\": 844978, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "88e0becb67383e911252ac9e9f2c0f77620c47c33ebe83cd88f1d262720a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/12/50"
+    },
+    {
+        "type": "inline",
+        "contents": "dd1d573a6cc402d8f2977bef4885245a7d652f1f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz\", \"integrity\": \"sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==\", \"time\": 0, \"size\": 422851, \"metadata\": {\"url\": \"https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "33a7acf0855ec12fd4b2bc61f94aea61c8ad83231f8fb8875350e5479a19",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/95/9c"
+    },
+    {
+        "type": "inline",
+        "contents": "dd73c54c4d6a1e0ce27e7ecf38ae2d01d764513e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz\", \"integrity\": \"sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==\", \"time\": 0, \"size\": 2979, \"metadata\": {\"url\": \"https://registry.npmjs.org/slice-ansi/-/slice-ansi-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b362abb753f81ac562f7dc23f4ae725ece05230fa7e1b43eb87f533205b2",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c6/28"
+    },
+    {
+        "type": "inline",
+        "contents": "dd833bdf578074c1c80640da67e0f9d17407af43\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz\", \"integrity\": \"sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==\", \"time\": 0, \"size\": 3189, \"metadata\": {\"url\": \"https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "67daffbacaa6d2e6f24d61e9f00135a6395a816fd639ed72686a00cf622f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/96/45"
+    },
+    {
+        "type": "inline",
+        "contents": "ddb18874d80de9cf6f921c311c7d0cf2b9d60327\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz\", \"integrity\": \"sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==\", \"time\": 0, \"size\": 2768, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "05a8af0a671c32b41850c1223429fe74449cfcb4c7cac54a9c7c213dfcae",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b3/b3"
+    },
+    {
+        "type": "inline",
+        "contents": "ddd7315d3d2ce860b8086cfcb21d80152b762ab4\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz\", \"integrity\": \"sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==\", \"time\": 0, \"size\": 166185, \"metadata\": {\"url\": \"https://registry.npmjs.org/esquery/-/esquery-1.7.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8f5daa2e963ae7637a4ec1906adb0f59a184aeaff930e427cca84fdb2d25",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/93/69"
+    },
+    {
+        "type": "inline",
+        "contents": "de3bd5668d47a838f942e10e0a2e6540d9a2e721\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz\", \"integrity\": \"sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==\", \"time\": 0, \"size\": 6499, \"metadata\": {\"url\": \"https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "bc4a7e0cb4b181bbb8591b9cc2d834792e975abe8f99d70f808f4857b359",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/10/28"
+    },
+    {
+        "type": "inline",
+        "contents": "de52e8334a66443c36ff7c38b982c3f9db61a767\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz\", \"integrity\": \"sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==\", \"time\": 0, \"size\": 43587, \"metadata\": {\"url\": \"https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "985d91f2cae01f01b9309fcbaee19a7d405ec40d9959c344da21aab939e3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7c/f5"
+    },
+    {
+        "type": "inline",
+        "contents": "deac2ae624ec88cdaf7649cdcdc6950f19244288\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz\", \"integrity\": \"sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==\", \"time\": 0, \"size\": 3690416, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2f4a7fe236605e83980e7ec10d0f4602de4cfc9a2c9cf49fc7e69c16f624",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ed/71"
+    },
+    {
+        "type": "inline",
+        "contents": "dec4fa36f7c4ab7cb0d2f0d60af0fb0f07fb1666\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz\", \"integrity\": \"sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==\", \"time\": 0, \"size\": 2625, \"metadata\": {\"url\": \"https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c9aa1c46bf0c67511379e97bd07fca87532422f2506214f94db8861160d3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a1/5e"
+    },
+    {
+        "type": "inline",
+        "contents": "dedb8e8026406a02b017b0d7b0bae0d996527b16\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz\", \"integrity\": \"sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==\", \"time\": 0, \"size\": 27558, \"metadata\": {\"url\": \"https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "dca74c11e5655a750df5ea5df7d3e30aea946b2bfe7122481ba65c02d479",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/65/e3"
+    },
+    {
+        "type": "inline",
+        "contents": "dfc095b983a77202312a4ce77cc7f9a7b0355b22\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz\", \"integrity\": \"sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==\", \"time\": 0, \"size\": 3210, \"metadata\": {\"url\": \"https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0913a74f5e223a4fe6108493dd3b03c2d47259df459926160659513c9ad3",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d5/f4"
+    },
+    {
+        "type": "inline",
+        "contents": "e074329ee154ca7a413d4ca4af8c89f1b550d009\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz\", \"integrity\": \"sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==\", \"time\": 0, \"size\": 3765769, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5dfa2517bd157c31a86d99c03f6d8683dbbf06b3bf4f22fd4f0a7c713ee5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/15/e7"
+    },
+    {
+        "type": "inline",
+        "contents": "e1cf01dacb4df6c5a402bcdd4957546d03a7c807\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz\", \"integrity\": \"sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==\", \"time\": 0, \"size\": 7016, \"metadata\": {\"url\": \"https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c20239447440069f6870574056c49f6772c56a34aede64919bf47e808b0a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/06/e1"
+    },
+    {
+        "type": "inline",
+        "contents": "e2e5411edfcabb4812ae36a78eccc55ace5d25ff\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz\", \"integrity\": \"sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==\", \"time\": 0, \"size\": 46389, \"metadata\": {\"url\": \"https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9e1f98072240b36b23bd4b0c2851d77c503e802626ed480a926932785b6c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0d/35"
+    },
+    {
+        "type": "inline",
+        "contents": "e338e4ccabc5e3fef1fc65cb4afbafe1a87c6634\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz\", \"integrity\": \"sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==\", \"time\": 0, \"size\": 15375, \"metadata\": {\"url\": \"https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d061f03faba3b3c47f62d0a015be11004e903e73b12c938a858600af050c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/60/5b"
+    },
+    {
+        "type": "inline",
+        "contents": "e3d209deb4977c678c000d2ccc4432d949948b6e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz\", \"integrity\": \"sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==\", \"time\": 0, \"size\": 2847, \"metadata\": {\"url\": \"https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4b439cd530e6a38af802bae49d3069b7907c9a582ea8e49f5b4f5c2fa497",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/25/6e"
+    },
+    {
+        "type": "inline",
+        "contents": "e3d6476396a150247d6e443c79bc259dbda79c53\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz\", \"integrity\": \"sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==\", \"time\": 0, \"size\": 5017, \"metadata\": {\"url\": \"https://registry.npmjs.org/postcss-nested/-/postcss-nested-6.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "4071a40658890d8a5f681076ddd767d6e0c3632b3d1034c91b343e98dcf5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/75/4e"
+    },
+    {
+        "type": "inline",
+        "contents": "e3dcc64bc8de892e882ef15fc11a750b1e8e6ffb\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz\", \"integrity\": \"sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==\", \"time\": 0, \"size\": 1927, \"metadata\": {\"url\": \"https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "279e8188ca0f6ffefda0f94dc97a8ff608b71872a5f99a2783484b081e46",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0c/31"
+    },
+    {
+        "type": "inline",
+        "contents": "e48349573ff5a82adda552c6a7eb3fb44e10f5ac\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz\", \"integrity\": \"sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==\", \"time\": 0, \"size\": 57432, \"metadata\": {\"url\": \"https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fd14b0c4983ed8715106632628717ec301144a764615ae7f40ddcd6f9111",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/98/b7"
+    },
+    {
+        "type": "inline",
+        "contents": "e4e158335954b80c9b625ce53150c82a77fda801\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz\", \"integrity\": \"sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==\", \"time\": 0, \"size\": 4424, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "93406ea1adf5e177b609f739dda6d432205e1670f3d4400370fd7b648e88",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/80/b4"
+    },
+    {
+        "type": "inline",
+        "contents": "e583aabb34c520614dac5300b677abecddb7eee3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz\", \"integrity\": \"sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==\", \"time\": 0, \"size\": 2117, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "14653864a77b7c8644710834018401ea9fd5653744bbbea2201a6af48a9f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6a/86"
+    },
+    {
+        "type": "inline",
+        "contents": "e5c6fd4970c5bb2cfa66591526bda8218098d1d1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/entities/-/entities-7.0.1.tgz\", \"integrity\": \"sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==\", \"time\": 0, \"size\": 113587, \"metadata\": {\"url\": \"https://registry.npmjs.org/entities/-/entities-7.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a2435483a93b96a0f34458e113c5e07866d100f76c29ee03eb5da9c2576e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/74/7b"
+    },
+    {
+        "type": "inline",
+        "contents": "e5c8d688b6f4deb438d53af0e0f8186131929506\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz\", \"integrity\": \"sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==\", \"time\": 0, \"size\": 2246, \"metadata\": {\"url\": \"https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8e7e8934679b7b49b8240b1f2dcb66c25a5bd17f9629f8fe0ea634cab93c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/6c/6f"
+    },
+    {
+        "type": "inline",
+        "contents": "e6e3f7e0a8eb63d937fc495d6f2e86865c37c729\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz\", \"integrity\": \"sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==\", \"time\": 0, \"size\": 9288, \"metadata\": {\"url\": \"https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5799a11997482f78a71307f2134a84b508b74d7faa3535d40d26c6261638",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/58/92"
+    },
+    {
+        "type": "inline",
+        "contents": "e7229a0eab285506cd79e91b6bc79eb92cb9b452\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz\", \"integrity\": \"sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==\", \"time\": 0, \"size\": 14868, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5f76d9dbd32f944f6293ac2dbbe02b0789c323f64cc4104a9e020557c4fd",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/96/77"
+    },
+    {
+        "type": "inline",
+        "contents": "e7ae49edbfad7522461737524f3d0d54eb882751\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz\", \"integrity\": \"sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==\", \"time\": 0, \"size\": 2410, \"metadata\": {\"url\": \"https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9c99122e7249037717e57101e31f890ba71beada83674fb60859f01b33dc",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/44/20"
+    },
+    {
+        "type": "inline",
+        "contents": "e7d96a6dd75c1843ffafc0885495e6a44104e06e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz\", \"integrity\": \"sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==\", \"time\": 0, \"size\": 1925, \"metadata\": {\"url\": \"https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b740a9a80e5550356f6d262f934c142247144736e799b0258ea752d46b6a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/74/54"
+    },
+    {
+        "type": "inline",
+        "contents": "e8d62b5b9d60c0cd5d2692f1d1dea7786190d8d0\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz\", \"integrity\": \"sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==\", \"time\": 0, \"size\": 6513, \"metadata\": {\"url\": \"https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "3faad2c88a66a554f262e6f9be13c1136475bf87f819b06f3ff0daa67359",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/ff"
+    },
+    {
+        "type": "inline",
+        "contents": "eb2e7cc7c27b088084e6759b3be15c759f694a48\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz\", \"integrity\": \"sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==\", \"time\": 0, \"size\": 6542, \"metadata\": {\"url\": \"https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "df2b2137355548fc0e2edd8c75e03ade0d1036d9466886d3c4f7ea6248af",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/5a/48"
+    },
+    {
+        "type": "inline",
+        "contents": "eb5dc2f3c6b23e637ecb2f506865e15e24380d65\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz\", \"integrity\": \"sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==\", \"time\": 0, \"size\": 2472, \"metadata\": {\"url\": \"https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2953701ac0c3bbcad9386cb5df0c034fbdfc47242f902c888707f6346f12",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/8f/92"
+    },
+    {
+        "type": "inline",
+        "contents": "eb76f995fa8aef3242acf6b6db5e3e17fb4f80f6\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz\", \"integrity\": \"sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==\", \"time\": 0, \"size\": 876918, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6b187554cca76b5972740d783d352378ae8ffe42d62f67fa8f360284097f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cd/f5"
+    },
+    {
+        "type": "inline",
+        "contents": "ec8f83abc6c326ad5e55e9b636eee4899f690a1b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz\", \"integrity\": \"sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==\", \"time\": 0, \"size\": 430086, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "36aefaea91cb94f411f0976aeeaf8e03672362e7f0b609e67da2e3af95fb",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/33/31"
+    },
+    {
+        "type": "inline",
+        "contents": "ed9f3054915ec708a2efc2e894a99b7d3f1e1cef\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz\", \"integrity\": \"sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==\", \"time\": 0, \"size\": 883748, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7078b07bfb6e2bcd4005265e56a288f1e41089aca14da628ee67848ff451",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/53/9e"
+    },
+    {
+        "type": "inline",
+        "contents": "ee04e38700fe66e8a1b5175bf877f844451062b3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz\", \"integrity\": \"sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==\", \"time\": 0, \"size\": 6185, \"metadata\": {\"url\": \"https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6ad8d5e5d8774e509dd94a10a4531314fa6a50449d0d716566032847d82e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9c/4d"
+    },
+    {
+        "type": "inline",
+        "contents": "ee3082490029ed97e3563b79482acc4ac549fd56\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz\", \"integrity\": \"sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==\", \"time\": 0, \"size\": 48342, \"metadata\": {\"url\": \"https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "ad5a13cb3c117456fa21364942799d30eda1173935fe360398263de81128",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/46/d0"
+    },
+    {
+        "type": "inline",
+        "contents": "ee3f0db4c476ccac15546071989f2aae3ad3a4e2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz\", \"integrity\": \"sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==\", \"time\": 0, \"size\": 2225, \"metadata\": {\"url\": \"https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d7156880ad5c5d031b02bd4e7f7c2a6d0c0655146a4df5647682be15a6ba",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7e/e1"
+    },
+    {
+        "type": "inline",
+        "contents": "eeada8a7de22b1f7c31b4bd193a0d96c34c7a9fd\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz\", \"integrity\": \"sha512-WbzE9sdmQtKy8vrNPa9BRnwZh5UF4s1KTmSK0KUVLo3eff5BlQNNWDnFOouNpKfPKDnms9xynJjsMYjMaT/aFQ==\", \"time\": 0, \"size\": 9505, \"metadata\": {\"url\": \"https://registry.npmjs.org/@keyv/bigmap/-/bigmap-1.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5740da65c6e6f129543678b684c783a09036a3c63728fc53d77dccc77ae5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7a/af"
+    },
+    {
+        "type": "inline",
+        "contents": "eec943f6dd66c8b4c8b18588e53e16de1150f32a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz\", \"integrity\": \"sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==\", \"time\": 0, \"size\": 3828886, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d56a8dccf497cee622a6d8c41e31dbc5b8fb84aeed3bd102a3370cd7ba10",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/f6/0f"
+    },
+    {
+        "type": "inline",
+        "contents": "ef5c66a93fa57bcb3857c82a20a90f21bbaa4349\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz\", \"integrity\": \"sha512-iZyKG96/JwPz1N55vj2Ie2vXbhu440zfUfJvSwEqEbeLluk7NnapfGqa7LH0mOsnDxTF85Mx8/dyR6HfqcbmbQ==\", \"time\": 0, \"size\": 67625, \"metadata\": {\"url\": \"https://registry.npmjs.org/hashery/-/hashery-1.5.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d095b2698e11138433e09e12339a49a5c105f91226262b02f7047ef9fc26",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0e/bd"
+    },
+    {
+        "type": "inline",
+        "contents": "ef9e602146e14145af7918b2d47487b6312921e9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz\", \"integrity\": \"sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==\", \"time\": 0, \"size\": 30023, \"metadata\": {\"url\": \"https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "86e844b90998bc2fde97c185d57a7e407ed9baf8a225280f4941a14fdc80",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/9e/50"
+    },
+    {
+        "type": "inline",
+        "contents": "ef9f74c120ebad0e8042ecaacf7e317c6cbd926f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz\", \"integrity\": \"sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==\", \"time\": 0, \"size\": 23707, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "d70c8557b1454c85f3f01b9b7bc53a8fdeee08f70b646483e56bd7384d1a",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ba/3d"
+    },
+    {
+        "type": "inline",
+        "contents": "f0adc5842f8c0a07be3f927a6df0070c6dc9fe85\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz\", \"integrity\": \"sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==\", \"time\": 0, \"size\": 8052, \"metadata\": {\"url\": \"https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1dc46fbb60fdd4bf8b84dc091030bd86c7d42fd5d9cf9bb6bc7a6d2a8ce0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c1/62"
+    },
+    {
+        "type": "inline",
+        "contents": "f14994d62b6153c334f3eb58465c90a313e54226\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz\", \"integrity\": \"sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==\", \"time\": 0, \"size\": 3699, \"metadata\": {\"url\": \"https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "f18a9a75bf7bd16cdb1b75eaccaa4ced854717a581a33918e15c61fc4ac5",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1c/e6"
+    },
+    {
+        "type": "inline",
+        "contents": "f183c4707b6d42a882673f4d36645b6763ac0624\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz\", \"integrity\": \"sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==\", \"time\": 0, \"size\": 23492, \"metadata\": {\"url\": \"https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c8a8a8262c48e83b6fd62f768ad22af5c71ff9472c30357ba9c124c409c7",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3e/11"
+    },
+    {
+        "type": "inline",
+        "contents": "f1c729b8e289898b059ca98fc2890e20433e0c3b\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz\", \"integrity\": \"sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==\", \"time\": 0, \"size\": 111837, \"metadata\": {\"url\": \"https://registry.npmjs.org/yaml/-/yaml-2.8.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "538860679a92dd91c1f1e8763e7c1fcb0c553ddb2eaa09c41072d71b2d84",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a0/f2"
+    },
+    {
+        "type": "inline",
+        "contents": "f2b408cb05c77c4519252851725023f578f451f7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz\", \"integrity\": \"sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==\", \"time\": 0, \"size\": 2156, \"metadata\": {\"url\": \"https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7a96344f2b139adbb2d367863738188c938fdf38d5ef69f08dbbd9f85e18",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e7/d9"
+    },
+    {
+        "type": "inline",
+        "contents": "f3014f5b0c78d2bdd936ae3e98740fb65f9dbdc7\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz\", \"integrity\": \"sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==\", \"time\": 0, \"size\": 74929, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "867f6ed39e2d8a6f3a6355779990acfe09c0c59d4c43d56bb55d305b879b",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/a3/3b"
+    },
+    {
+        "type": "inline",
+        "contents": "f3f9b6dac9cd0b5078eb61e3281d8429c4ea584c\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz\", \"integrity\": \"sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==\", \"time\": 0, \"size\": 2190551, \"metadata\": {\"url\": \"https://registry.npmjs.org/prettier/-/prettier-3.8.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "0b930027b1222cc15f888f171024d3ff6c24789d1841a47284b43a23e48e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/73/fd"
+    },
+    {
+        "type": "inline",
+        "contents": "f49a35b62fd925f40ce87761b764297787761c3d\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz\", \"integrity\": \"sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==\", \"time\": 0, \"size\": 1816, \"metadata\": {\"url\": \"https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "483e6b07a338fc56daa546a5c7d73c769d72f488be87ff50117370bdf004",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c3/db"
+    },
+    {
+        "type": "inline",
+        "contents": "f4b781104775ae43ee450aabb3627eb3eb8fac69\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz\", \"integrity\": \"sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==\", \"time\": 0, \"size\": 102934, \"metadata\": {\"url\": \"https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c034368dafb2662e1726272881867e5e84f2c97739f3d48b848daa239ae0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/be/65"
+    },
+    {
+        "type": "inline",
+        "contents": "f570bb86e1b44057d8807cbaaa957031131951bf\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz\", \"integrity\": \"sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==\", \"time\": 0, \"size\": 4409, \"metadata\": {\"url\": \"https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "7551d241cb30c6b780bfac91fe638ab4ee94cbbb639305be492e439c37b0",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/72/6f"
+    },
+    {
+        "type": "inline",
+        "contents": "f5e53e3f01fa8a003a388beb9c41d778f37b8f3e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz\", \"integrity\": \"sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==\", \"time\": 0, \"size\": 131798, \"metadata\": {\"url\": \"https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "9936347eaa7b039e8314c7c94e6e3354307210df5e1d5bee43bfefadc175",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/51/fe"
+    },
+    {
+        "type": "inline",
+        "contents": "f602f50d86a013f1ed8937b139084ea43006ad39\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz\", \"integrity\": \"sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==\", \"time\": 0, \"size\": 7442, \"metadata\": {\"url\": \"https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "115303ea18a519131a06a54e40e89d11ac3d6417db6551daad7b909f4d80",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/29/da"
+    },
+    {
+        "type": "inline",
+        "contents": "f65cffb0ae35ff1a898023412cf4abac1bd88091\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz\", \"integrity\": \"sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==\", \"time\": 0, \"size\": 12133, \"metadata\": {\"url\": \"https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a85e675f1cbd4760cee0104b8fc8b6d718def1224eef0a5257884ce51f2c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c1/e5"
+    },
+    {
+        "type": "inline",
+        "contents": "f7bef7cb388fdee8ff784797cda4410cb249cd00\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz\", \"integrity\": \"sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==\", \"time\": 0, \"size\": 167252, \"metadata\": {\"url\": \"https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-3.5.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "434d7a553843e56d17ad8359dcb03145fe4b3d20a4d6b323f7962a04644e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c4/5a"
+    },
+    {
+        "type": "inline",
+        "contents": "f8026ff0506fa3b5f0a3c71bb2ea91bb902a725a\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz\", \"integrity\": \"sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==\", \"time\": 0, \"size\": 5360, \"metadata\": {\"url\": \"https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "fa4fe23b6bc134c60d26da3033c87003fb50204af907f8ec32c9a7c9e48c",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/56/71"
+    },
+    {
+        "type": "inline",
+        "contents": "f88bb8d2870b2315b20709fbe371db42e7eb37a9\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz\", \"integrity\": \"sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==\", \"time\": 0, \"size\": 4895, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.3.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a7c22ba183764c0c27f706d74812444c27c14a97fc43669b7dd7c32a717f",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/94/07"
+    },
+    {
+        "type": "inline",
+        "contents": "f892f504c7f04b0a9f3b49a8c58834360c0aa7fa\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz\", \"integrity\": \"sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==\", \"time\": 0, \"size\": 117062, \"metadata\": {\"url\": \"https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "343915cdb905d78874b0956bd28c5b5e748b3b313e5eb6084604665d9098",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/3b/ce"
+    },
+    {
+        "type": "inline",
+        "contents": "f95fed267aae7b9411f075851b3733805330f1fc\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz\", \"integrity\": \"sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==\", \"time\": 0, \"size\": 22156, \"metadata\": {\"url\": \"https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "6fa24c524d665c135483dda945136b4b1a21ed4b3157c6b683b52df58ed6",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ad/a6"
+    },
+    {
+        "type": "inline",
+        "contents": "f9e8cc4e9266c00877133a3f846e87e94f02e1d1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz\", \"integrity\": \"sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==\", \"time\": 0, \"size\": 12860, \"metadata\": {\"url\": \"https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "8b676d3aa47926784ae93445ccbb67ab3cd5cde01ed2fb99100c51c73d52",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/1a/51"
+    },
+    {
+        "type": "inline",
+        "contents": "fa9190cc53e3c80450b1a72f1cf23e01cd486813\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz\", \"integrity\": \"sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==\", \"time\": 0, \"size\": 11507, \"metadata\": {\"url\": \"https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c7d4ccbee3c5912687c4607a7f53c8ab015e564be259f6358c1bae3c128e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/06/b2"
+    },
+    {
+        "type": "inline",
+        "contents": "fb005df0cb62ac930a7e20a765db159fbf55c3f5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz\", \"integrity\": \"sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==\", \"time\": 0, \"size\": 935990, \"metadata\": {\"url\": \"https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "85a41c659904a9a340d98bbb2a537f97ed91b39341172c344d2cf0934077",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/0d/f1"
+    },
+    {
+        "type": "inline",
+        "contents": "fb1be7f69d4ecf636c0348cbebd02d75a02b5d24\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz\", \"integrity\": \"sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==\", \"time\": 0, \"size\": 2765, \"metadata\": {\"url\": \"https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "2ace9a1dfbea06eafdda3044e21e830e5cbd76a5eb5a794acdc111e0c31e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/cb/f4"
+    },
+    {
+        "type": "inline",
+        "contents": "fb3f711d1eb13cdb45a2e73b2ab71a65a5ebb479\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz\", \"integrity\": \"sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==\", \"time\": 0, \"size\": 3689, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c262607742a3ef38b1772599ae8e3f6d8f48c929a7f9846b251395e96916",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/e6/b9"
+    },
+    {
+        "type": "inline",
+        "contents": "fbf027c4eb21a709245fcc04eee5dd998c1b98f3\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz\", \"integrity\": \"sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==\", \"time\": 0, \"size\": 10388, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "b4b9308433eb3379d175bfa8ae99fa8c0a13ae2919de342b6041ead66f8e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/c3/cb"
+    },
+    {
+        "type": "inline",
+        "contents": "fc1bdef33c1658d5896219662e97c9af32df6ce1\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz\", \"integrity\": \"sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==\", \"time\": 0, \"size\": 9704, \"metadata\": {\"url\": \"https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a45e494ca2e846d401646ceab55186fcfe87c4fa76d70a3850d08faf8949",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/45/74"
+    },
+    {
+        "type": "inline",
+        "contents": "fcd35da05f9c87a2f7725b0457d2f4579eec1bf2\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz\", \"integrity\": \"sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==\", \"time\": 0, \"size\": 11106, \"metadata\": {\"url\": \"https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "c8d4583d3ccd74993cd4f903c6c061c4ce30fbfede60b4bb8856e13cfae9",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/47/f8"
+    },
+    {
+        "type": "inline",
+        "contents": "fcf2b03890b82fbcfcdbb8eb008f8568b14e575f\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz\", \"integrity\": \"sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==\", \"time\": 0, \"size\": 4119035, \"metadata\": {\"url\": \"https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "567fa04456d9d69c442d4a6e7166c56fd84d21cd3e0b73f65746be33d473",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/df/cc"
+    },
+    {
+        "type": "inline",
+        "contents": "fd2177b08997b26245c61e6eb5ac73cca21e5917\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz\", \"integrity\": \"sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==\", \"time\": 0, \"size\": 1619, \"metadata\": {\"url\": \"https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "308df508a58e8a5bcfc3519be49b8b0b08e7c694e63ef68863636690a659",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/59/25"
+    },
+    {
+        "type": "inline",
+        "contents": "fd3e87f2433c4a3fb9f42c218f7f39f8dab04563\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz\", \"integrity\": \"sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==\", \"time\": 0, \"size\": 4869, \"metadata\": {\"url\": \"https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "433161abfe4962ed74605ce8f1664c5bf82d68c8d44c3d810f6548070d15",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/59/45"
+    },
+    {
+        "type": "inline",
+        "contents": "fd54922d7267a4e2a335f4faa666e3a88bf25bae\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz\", \"integrity\": \"sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==\", \"time\": 0, \"size\": 3806, \"metadata\": {\"url\": \"https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a2590d81727a5f907971aec316d449516a7f62bdc4422e85ce5dbe1cc3ce",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/ce/0c"
+    },
+    {
+        "type": "inline",
+        "contents": "fd81d7ed78a018d57d6d1911b059b8726077994e\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/semver/-/semver-6.3.1.tgz\", \"integrity\": \"sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==\", \"time\": 0, \"size\": 19093, \"metadata\": {\"url\": \"https://registry.npmjs.org/semver/-/semver-6.3.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "1e3daaea93f68bf9dcdd7e978b6dd8f43627145028c05ccc5d6187e7a25d",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/bf"
+    },
+    {
+        "type": "inline",
+        "contents": "fe33c0ce2d74cb6b73d331bcfacce4ce8b5e23c8\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz\", \"integrity\": \"sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==\", \"time\": 0, \"size\": 2365, \"metadata\": {\"url\": \"https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.1.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5d145862c809774efedb998cae0b11c4062b94265112f8db93a55edb929e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/d1/3b"
+    },
+    {
+        "type": "inline",
+        "contents": "fe7ec1f17c15f7ecc769bcf7052b9014c34e91e5\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz\", \"integrity\": \"sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==\", \"time\": 0, \"size\": 14624, \"metadata\": {\"url\": \"https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "a2c7cee872051584ce9afbd7cd92701c7fe77cb8be37a304f4703459da8e",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/7c/01"
+    },
+    {
+        "type": "inline",
+        "contents": "feac9a7bca959dd8450536886271a72a23d8d481\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz\", \"integrity\": \"sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==\", \"time\": 0, \"size\": 438316, \"metadata\": {\"url\": \"https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "e245eed96c4bc40ebd7ed43bb906110230b71c75b3734a2fd01b7a60f846",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/b9/16"
+    },
+    {
+        "type": "inline",
+        "contents": "fec2e4d34636dd3a26c0cbb6987e49e522c95d41\t{\"key\": \"make-fetch-happen:request-cache:https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz\", \"integrity\": \"sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==\", \"time\": 0, \"size\": 26688, \"metadata\": {\"url\": \"https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz\", \"reqHeaders\": {}, \"resHeaders\": {}}}",
+        "dest-filename": "5945e2af39a1610ef2f4cfce4bb53a9ee0066845d9f897443739b4375314",
+        "dest": "flatpak-node/npm-cache/_cacache/index-v5/09/50"
+    },
+    {
+        "type": "script",
+        "commands": [
+            "version=$(node --version | sed \"s/^v//\")",
+            "nodedir=$(dirname \"$(dirname \"$(which node)\")\")",
+            "mkdir -p \"flatpak-node/cache/node-gyp/$version\"",
+            "ln -s \"$nodedir/include\" \"flatpak-node/cache/node-gyp/$version/include\"",
+            "echo 11 > \"flatpak-node/cache/node-gyp/$version/installVersion\""
+        ],
+        "dest-filename": "setup_sdk_node_headers.sh",
+        "dest": "flatpak-node"
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "bash flatpak-node/setup_sdk_node_headers.sh"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"bin/@esbuild\"",
+            "cp \".package/@esbuild/linux-arm64@0.21.5/bin/esbuild\" \"bin/@esbuild/linux-arm64@0.21.5\"",
+            "ln -sf \"@esbuild/linux-arm64@0.21.5\" \"bin/esbuild-current\""
+        ],
+        "dest": "flatpak-node/cache/esbuild",
+        "only-arches": [
+            "aarch64"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"bin/@esbuild\"",
+            "cp \".package/@esbuild/linux-arm@0.21.5/bin/esbuild\" \"bin/@esbuild/linux-arm@0.21.5\"",
+            "ln -sf \"@esbuild/linux-arm@0.21.5\" \"bin/esbuild-current\""
+        ],
+        "dest": "flatpak-node/cache/esbuild",
+        "only-arches": [
+            "arm"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"bin/@esbuild\"",
+            "cp \".package/@esbuild/linux-ia32@0.21.5/bin/esbuild\" \"bin/@esbuild/linux-ia32@0.21.5\"",
+            "ln -sf \"@esbuild/linux-ia32@0.21.5\" \"bin/esbuild-current\""
+        ],
+        "dest": "flatpak-node/cache/esbuild",
+        "only-arches": [
+            "i386"
+        ]
+    },
+    {
+        "type": "shell",
+        "commands": [
+            "mkdir -p \"bin/@esbuild\"",
+            "cp \".package/@esbuild/linux-x64@0.21.5/bin/esbuild\" \"bin/@esbuild/linux-x64@0.21.5\"",
+            "ln -sf \"@esbuild/linux-x64@0.21.5\" \"bin/esbuild-current\""
+        ],
+        "dest": "flatpak-node/cache/esbuild",
+        "only-arches": [
+            "x86_64"
+        ]
+    }
+]

--- a/flatpak/python3-requirements.json
+++ b/flatpak/python3-requirements.json
@@ -1,0 +1,916 @@
+{
+    "name": "python3-requirements",
+    "buildsystem": "simple",
+    "build-commands": [],
+    "modules": [
+        {
+            "name": "python3-tidalapi",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"tidalapi>=0.8.11\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl",
+                    "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl",
+                    "sha256": "3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
+                    "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl",
+                    "sha256": "28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/ca/a0/7a2734a7d734d81b6627ac1c470ce388f5a80e5669d9803a5c3c179ca84f/mpegdash-0.4.1-py3-none-any.whl",
+                    "sha256": "788e559b73acbf9175422548c58a4c441486c0ce0633fa10f77097bfffeaad4d"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/44/66/2c17bae31c906613795711fc78045c285048168919ace2220daa372c7d72/pyaes-1.6.1.tar.gz",
+                    "sha256": "02c1b1405c38d3c370b085fb952dd8bea3fadcee6411ad99f312cc129c536d8f"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl",
+                    "sha256": "a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/ab/38/ff60c8fc9e002d50d48822cc5095deb8ebbc5f91a6b8fdd9731c87a147c9/ratelimit-2.2.1.tar.gz",
+                    "sha256": "af8a9b64b821529aca09ebaf6d8d279100d766f19e90b5059ac6a718ca6dee42"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl",
+                    "sha256": "2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl",
+                    "sha256": "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a0/dc/11ae1f4150754e82234a56ed4d94d5c326022502ce3f1e6e214f569c5c3e/tidalapi-0.8.11-py3-none-any.whl",
+                    "sha256": "1ed2485bb4634907afc434163fba22dc8a323d90cc92306973ab68bcdfef5c54"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl",
+                    "sha256": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl",
+                    "sha256": "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
+                }
+            ]
+        },
+        {
+            "name": "python3-mutagen",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"mutagen>=1.47.0\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b0/7a/620f945b96be1f6ee357d211d5bf74ab1b7fe72a9f1525aafbfe3aee6875/mutagen-1.47.0-py3-none-any.whl",
+                    "sha256": "edd96f50c5907a9539d8e5bba7245f62c9f520aef333d13392a79a4f70aca719"
+                }
+            ]
+        },
+        {
+            "name": "python3-requests",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"requests>=2.33.1\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl",
+                    "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl",
+                    "sha256": "3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
+                    "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl",
+                    "sha256": "2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl",
+                    "sha256": "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
+                }
+            ]
+        },
+        {
+            "name": "python3-orjson",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"orjson>=3.10.0\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a1/08/dca0082dd2a194acb93e5457e73455388e2e2ca464a2672449a9ddbb679d/orjson-3.11.9-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                    "sha256": "4e39364e726a8fff737309aff059ff67d8a8c8d5b677be7bb49a8b3e84b7e218",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/21/0f/c9ede0bf052f6b4051e64a7d4fa91b725cccf8321a6a786e86eb03519f00/orjson-3.11.9-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+                    "sha256": "ffe02797b5e9f3a9d8292ddcd289b474ad13e81ad83cd1891a240811f1d2cb81",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "python3-curl-cffi",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"curl-cffi>=0.7.0\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl",
+                    "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+                    "sha256": "c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+                    "sha256": "d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/5c/12/c70b835487ace3b9ba1502631912e3440082b8ae3a162f60b59cb0b6444d/curl_cffi-0.15.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+                    "sha256": "2b6c847d86283b07ae69bb72c82eb8a59242277142aa35b89850f89e792a02fc",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/2a/b3/9d2f1057749a1b07ba1989db3c1503ce8bed998310bae9aea2c43aa64f20/curl_cffi-0.15.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+                    "sha256": "582e570aa2586b96ed47cf4a17586b9a3c462cbe43f780487c3dc245c6ef1527",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl",
+                    "sha256": "9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl",
+                    "sha256": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl",
+                    "sha256": "b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl",
+                    "sha256": "81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl",
+                    "sha256": "33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"
+                }
+            ]
+        },
+        {
+            "name": "python3-pillow",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pillow>=10.0.0\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+                    "sha256": "03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+                    "sha256": "f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "python3-fastapi",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"fastapi>=0.110.0\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/1e/d3/26bf1008eb3d2daa8ef4cacc7f3bfdc11818d111f7e2d0201bc6e3b49d45/annotated_doc-0.0.4-py3-none-any.whl",
+                    "sha256": "571ac1dc6991c450b25a9c2d84a3705e2ae7a53467b5d111c24fa8baabbed320"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl",
+                    "sha256": "1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl",
+                    "sha256": "08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl",
+                    "sha256": "a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
+                    "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl",
+                    "sha256": "45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                    "sha256": "9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+                    "sha256": "f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl",
+                    "sha256": "d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl",
+                    "sha256": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl",
+                    "sha256": "4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7"
+                }
+            ]
+        },
+        {
+            "name": "python3-uvicorn",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"uvicorn[standard]>=0.27.0\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl",
+                    "sha256": "08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl",
+                    "sha256": "40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl",
+                    "sha256": "63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl",
+                    "sha256": "04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
+                    "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl",
+                    "sha256": "1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+                    "sha256": "0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/15/41/ac2dfdbc1f60c7af4f994c7a335cfa7040c01642b605d65f611cecc2a1e4/uvicorn-0.47.0-py3-none-any.whl",
+                    "sha256": "2c5715bc12d1892d84752049f400cd1c3cb018514967fdfeb97640443a6a9432"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+                    "sha256": "0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl",
+                    "sha256": "ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl",
+                    "sha256": "4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl",
+                    "sha256": "1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec"
+                }
+            ]
+        },
+        {
+            "name": "python3-sse-starlette",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"sse-starlette>=3.4.1\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl",
+                    "sha256": "08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
+                    "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl",
+                    "sha256": "3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl",
+                    "sha256": "d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b"
+                }
+            ]
+        },
+        {
+            "name": "python3-pywebview",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pywebview>=6.2.1\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/83/f6/b55ec74cfe68c6584163faa311503c20b0da4c09883a41e8e00d6726c954/bottle-0.13.4-py2.py3-none-any.whl",
+                    "sha256": "045684fbd2764eac9cdeb824861d1551d113e8b683d8d26e296898d3dd99a12e"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/f2/cf/77d3e19b7fabd03895caca7857ef51e4c409e0ca6b37ee6e9f7daa50b642/proxy_tools-0.1.0.tar.gz",
+                    "sha256": "ccb3751f529c047e2d8a58440d86b205303cf0fe8146f784d1cbcd94f0a28010"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/3d/25/9491695c22c4842c5b3903b4dc172e0eecf67a27c0af34a71512c9b76a0a/pywebview-6.2.1-py3-none-any.whl",
+                    "sha256": "9d07275f53894ab4d5e2e0e996227193e7187dec276d9b624dccbce029216b46"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl",
+                    "sha256": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+                }
+            ]
+        },
+        {
+            "name": "python3-av",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"av>=12.0.0\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/02/28/167b291356c2cc315a2d62a95b0ceace72b5b0bf547de30b89313110f032/av-17.0.1-cp311-abi3-manylinux_2_28_x86_64.whl",
+                    "sha256": "c58c71bffd9383908c85695ac61d3184c668accb04a5bd1b262e0fb8d09f60a5",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a8/8b/8de3fd21c4b0b74d44337421abeab0e71462337fb6a28fff888e0c356cbd/av-17.0.1-cp311-abi3-manylinux_2_28_aarch64.whl",
+                    "sha256": "e6eee84afa48d0e9321047cd3e4facd44b401493f6bdc753e2e1d1e7c9e6d13e",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "python3-sounddevice",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"sounddevice>=0.5.5\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+                    "sha256": "c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+                    "sha256": "d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl",
+                    "sha256": "b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/1e/0a/478e441fd049002cf308520c0d62dd8333e7c6cc8d997f0dda07b9fbcc46/sounddevice-0.5.5-py3-none-any.whl",
+                    "sha256": "30ff99f6c107f49d25ad16a45cacd8d91c25a1bcdd3e81a206b921a3a6405b1f"
+                }
+            ]
+        },
+        {
+            "name": "python3-numpy",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"numpy>=1.26.0\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+                    "sha256": "a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "python3-scipy",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"scipy>=1.17.1\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+                    "sha256": "a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+                    "sha256": "581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "python3-rapidfuzz",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"rapidfuzz>=3.0.0\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/90/79/2fc252a63bc91d3c3b234d0a3a6ad4ebc460037a23cdcdaf9285f986e6c9/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+                    "sha256": "17a34330cd2a538c1ce5d400b61ba358c5b72c654b928ff87b362e88f8b864c7",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a3/31/7aa7e62c4c516a7af322ed0c4f0774208b72d457d0cfec808bad0df12f4a/rapidfuzz-3.14.5-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "b002c7994cc9f2bc9d9856f0fbaee6e8072c983873846c92f25cefba5b2a925f",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                }
+            ]
+        },
+        {
+            "name": "python3-pynput",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pynput>=1.8.1\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a5/f5/397b61091120a9ca5001041dd7bf76c385b3bfd67a0e5bcb74b852bd22a4/evdev-1.9.3.tar.gz",
+                    "sha256": "2c140e01ac8437758fa23fe5c871397412461f42d421aa20241dc8fe8cfccbc9"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/6d/98/bbeb760852adb27f166ce1617f0e51aabb15f21b1e60ea703f2aed3c78ac/pynput-1.8.2-py2.py3-none-any.whl",
+                    "sha256": "8cc38cf13a6ab2749cb375678be8a0fd705d7ce49c8001ff5db4007a723bbef1"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/fc/b8/ff33610932e0ee81ae7f1269c890f697d56ff74b9f5b2ee5d9b7fa2c5355/python_xlib-0.33-py2.py3-none-any.whl",
+                    "sha256": "c3534038d42e0df2f1392a1b30a15a4ff5fdc2b86cfa94f072bf11b10a164398"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl",
+                    "sha256": "4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274"
+                }
+            ]
+        },
+        {
+            "name": "python3-spotapi",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"spotapi>=1.2.7\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl",
+                    "sha256": "0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl",
+                    "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl",
+                    "sha256": "3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl",
+                    "sha256": "4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
+                    "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+                    "sha256": "03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+                    "sha256": "f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/c3/c0/c33c8792c3e50193ef55adb95c1c3c2786fe281123291c2dbf0eaab95a6f/pyotp-2.9.0-py3-none-any.whl",
+                    "sha256": "81c2e5865b8ac55e825b0358e496e1d9387c811e85bb40e71a3b29b288963612"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/c2/5a/2f2e7fc026d5e64b5408aa3fbe0296a6407b8481196cae4daacacb3a3ae0/readerwriterlock-1.0.9-py3-none-any.whl",
+                    "sha256": "8c4b704e60d15991462081a27ef46762fea49b478aa4426644f2146754759ca7"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl",
+                    "sha256": "2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl",
+                    "sha256": "ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/f6/e9/758080fa98dd27e872fa9811980f9b2f6563a3c4e55c2b70200314fef047/spotapi-1.2.7-py3-none-any.whl",
+                    "sha256": "9b8b11b1d4fd34473b2124ed1c03bc8ae55b86faba762d892031d3afd159a4f6"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/75/cd/5c735818692927e07980357445569adb6ee204c3332d19c516bae01c6cfa/tls_client-1.0.1-py3-none-any.whl",
+                    "sha256": "2f8915c0642c2226c9e33120072a2af082812f6310d32f4ea4da322db7d3bb1c"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl",
+                    "sha256": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl",
+                    "sha256": "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/fa/6e/3e955517e22cbdd565f2f8b2e73d52528b14b8bcfdb04f62466b071de847/validators-0.35.0-py3-none-any.whl",
+                    "sha256": "e8c947097eae7892cb3d26868d637f79f47b4a0554bc6b80065dfe5aac3705dd"
+                }
+            ]
+        },
+        {
+            "name": "python3-async-upnp-client",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"async-upnp-client>=0.47.0\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl",
+                    "sha256": "f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/f0/d2/e2f77eef1acb7111405433c707dc735e63f67a56e176e72e9e7a2cd3f493/aiohttp-3.13.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+                    "sha256": "3df334e39d4c2f899a914f1dba283c1aadc311790733f705182998c6f7cae665",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/3b/86/b7c870053e36a94e8951b803cb5b909bfbc9b90ca941527f5fcafbf6b0fa/aiohttp-3.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "57653eac22c6a4c13eb22ecf4d673d64a12f266e72785ab1c8b8e5940d0e8090",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl",
+                    "sha256": "053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/88/27/37f09d39fb4a7617a5ded95d1013b3a498c25857ca9445f3d8661f6e0ac6/async_upnp_client-0.47.0-py3-none-any.whl",
+                    "sha256": "a879b1041b03b347dcf009c243e084b9ecb19e9c521c39bd435438229dd99602"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/64/b4/17d4b0b2a2dc85a6df63d1157e028ed19f90d4cd97c36717afef2bc2f395/attrs-26.1.0-py3-none-any.whl",
+                    "sha256": "c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl",
+                    "sha256": "a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/9a/9a/e35b4a917281c0b8419d4207f4334c8e8c5dbf4f3f5f9ada73958d937dcc/frozenlist-1.8.0-py3-none-any.whl",
+                    "sha256": "0c18a16eab41e82c295618a77502e17b195883241c563b00f0aa5106fc4eaa0d"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
+                    "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl",
+                    "sha256": "55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/3a/ed/1cdcab6ba3d6ab7feca11fc14f0eeea80755bb53ef4e892079f31b10a25f/propcache-0.5.2-py3-none-any.whl",
+                    "sha256": "be1ddfcbb376e3de5d2e2db1d58d6d67463e6b4f9f040c000de8e300295465fe"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/13/24/a5f4a5e69cac8eb3be721a2b3271042fc8b785eb696f1c58ef79c5b003f9/python_didl_lite-1.5.0-py3-none-any.whl",
+                    "sha256": "88023b04458019e88cc3c64445a1da4d11bae0fbe1cd96f49888e53862610a97"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d1/00/0e0da784245c93cf346150ab67634177bf277f93b7a162bb56c928c39c04/voluptuous-0.16.0-py3-none-any.whl",
+                    "sha256": "ee342095263e1b5afbd4d418cb5adc92810eebfd07696bb033a261210df33db4"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/fd/4d/4b880086bd0d3e034d25647be1d830afc3e3f610e98c4ab3490af6b1b6d5/yarl-1.24.2-py3-none-any.whl",
+                    "sha256": "2783d9226db8797636cd6896e4de81feed252d1db72265686c9558d97a4d94b9"
+                }
+            ]
+        },
+        {
+            "name": "python3-pychromecast",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pychromecast>=14.0.10\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/0a/d2/0f5006892e07ea342d57dbeda46027e99a097ffb6218bee1e37f9776ed95/casttube-0.2.1-py3-none-any.whl",
+                    "sha256": "36f118007f9eead3959cf30de03c1640b53a263569ff2a3971c0521826c835b2"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl",
+                    "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl",
+                    "sha256": "3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
+                    "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/9c/1f/19ebc343cc71a7ffa78f17018535adc5cbdd87afb31d7c34874680148b32/ifaddr-0.2.0-py3-none-any.whl",
+                    "sha256": "085e0305cfe6f16ab12d72e2024030f5d52674afad6911bb1eee207177b8a748"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl",
+                    "sha256": "bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/1f/61/f0f176622e2b4df06318a3abb2a27cc4c2fee8d40d7a0db8d60034785c09/pychromecast-14.0.10-py2.py3-none-any.whl",
+                    "sha256": "f5ea52b1db0edc3019ec72c9f5354c7e77c2564ecd44f809a6d2f4f518a02e67"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl",
+                    "sha256": "2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl",
+                    "sha256": "9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/51/44/4601cc6f6a3c97344c35abc00a0e9ba2ddc8e1048572c5343de3f06c3715/zeroconf-0.149.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+                    "sha256": "73ad77937f02dafe1722a42ff347af633169be7477828a6d74bbbc519538da82",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d3/f5/6c1da0ed1e22f7e33acf6e9e656ea6423a9b1b3453735f58ca102aaad19c/zeroconf-0.149.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "267ed7fbfd2076971bbdbb485914daaba6e4a2e16a640e29a2fa4f8b4ac02713",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/flatpak/tideway-launcher.sh
+++ b/flatpak/tideway-launcher.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+# Flatpak entry point. Runs Tideway under the GNOME runtime's
+# Python so pywebview imports `gi` and uses the native WebKitGTK
+# backend (no browser fallback). Not a frozen build — desktop.py's
+# frozen-only paths are inert here.
+export PYTHONPATH=/app/share/tideway
+cd /app/share/tideway || exit 1
+exec python3 desktop.py "$@"

--- a/flatpak/tideway.flatpakrepo
+++ b/flatpak/tideway.flatpakrepo
@@ -5,4 +5,7 @@ Homepage=https://github.com/J-M-PUNK/tideway
 Description=Native Tidal/Spotify/Qobuz client with hi-res playback, Last.fm scrobbling, ReplayGain, crossfeed, and offline downloads.
 SuggestedRemoteName=tideway
 DefaultBranch=master
-Comment=Drop this file at flatpak/tideway.flatpakrepo and serve it from GitHub Pages. Users run `flatpak remote-add --user --if-not-exists tideway <Url>tideway.flatpakrepo` to subscribe.
+# release.yml's publish-flatpak-repo job appends `GpgKey=<base64>`
+# below when flatpak/tideway-release.pub.gpg is committed — see
+# docs/flatpak-gpg-signing.md for the setup. Without that file the
+# remote installs in no-gpg-verify mode, with HTTPS-only trust.

--- a/flatpak/tideway.flatpakrepo
+++ b/flatpak/tideway.flatpakrepo
@@ -1,0 +1,8 @@
+[Flatpak Repo]
+Title=Tideway
+Url=https://j-m-punk.github.io/tideway/
+Homepage=https://github.com/J-M-PUNK/tideway
+Description=Native Tidal/Spotify/Qobuz client with hi-res playback, Last.fm scrobbling, ReplayGain, crossfeed, and offline downloads.
+SuggestedRemoteName=tideway
+DefaultBranch=master
+Comment=Drop this file at flatpak/tideway.flatpakrepo and serve it from GitHub Pages. Users run `flatpak remote-add --user --if-not-exists tideway <Url>tideway.flatpakrepo` to subscribe.

--- a/scripts/sign-release.sh
+++ b/scripts/sign-release.sh
@@ -90,10 +90,11 @@ gh release download "$TAG" \
     --repo "$REPO" \
     --pattern 'Tideway-*.dmg' \
     --pattern 'Tideway-setup-*.exe' \
-    --pattern 'Tideway-*-x86_64.AppImage'
+    --pattern 'Tideway-*-x86_64.AppImage' \
+    --pattern 'Tideway-*.flatpak'
 
 shopt -s nullglob
-ARTIFACTS=( Tideway-*.dmg Tideway-setup-*.exe Tideway-*-x86_64.AppImage )
+ARTIFACTS=( Tideway-*.dmg Tideway-setup-*.exe Tideway-*-x86_64.AppImage Tideway-*.flatpak )
 if [ "${#ARTIFACTS[@]}" -eq 0 ]; then
     echo "No installer artifacts found on release $TAG. Did the build job run?" >&2
     exit 1

--- a/server.py
+++ b/server.py
@@ -1509,6 +1509,24 @@ _update_cache_lock = threading.Lock()
 _UPDATE_CACHE_TTL_SEC = 3600.0
 
 
+def _running_in_flatpak() -> bool:
+    """True when this process is running inside a Flatpak sandbox.
+
+    The Flatpak runtime drops `/.flatpak-info` into every sandboxed
+    process's root and sets `$FLATPAK_ID`; either is enough on its
+    own but checking both shields against odd hosts that mount one
+    without the other. Used to redirect the in-app self-updater away
+    from the AppImage download path — Flatpak users get their
+    updates through `flatpak update`, not by re-running an installer.
+    """
+    if os.environ.get("FLATPAK_ID"):
+        return True
+    try:
+        return Path("/.flatpak-info").is_file()
+    except OSError:
+        return False
+
+
 def _parse_semver(v: str) -> tuple[int, ...]:
     """Parse 'v1.2.3' / '1.2.3' / '1.2.3-beta' → (1, 2, 3). Tags that
     don't parse get (0,) so they always compare as older than a real
@@ -1802,12 +1820,19 @@ def update_check() -> dict:
         if cached and now - cached[0] < _UPDATE_CACHE_TTL_SEC:
             return cached[1]
 
+    # `kind` tells the frontend which install affordance to render.
+    # Flatpak users update through `flatpak update`; the in-app
+    # "Install now" button would download an AppImage they can't
+    # execute. The banner reads this and switches to a hint pointing
+    # at the package manager.
+    in_flatpak = _running_in_flatpak()
     payload: dict = {
         "available": False,
         "current": APP_VERSION,
         "latest": None,
         "url": None,
         "notes": None,
+        "kind": "flatpak" if in_flatpak else "installer",
         "error": None,
     }
     asset_url: Optional[str] = None
@@ -1829,9 +1854,17 @@ def update_check() -> dict:
             payload["url"] = latest_url
             payload["notes"] = latest_notes
             if _parse_semver(latest_tag) > _parse_semver(APP_VERSION):
-                asset_url = _match_release_asset(data)
-                if asset_url is not None:
+                if in_flatpak:
+                    # Inside Flatpak we don't need a per-platform
+                    # asset URL to consider the update available —
+                    # the user runs `flatpak update`, the bits come
+                    # from the Flatpak remote, not GitHub. The
+                    # release page link is still useful for notes.
                     payload["available"] = True
+                else:
+                    asset_url = _match_release_asset(data)
+                    if asset_url is not None:
+                        payload["available"] = True
     except Exception as exc:
         # Offline / rate-limited / cert verify failure / repo private.
         # Surface the reason on the response so support can see what's
@@ -1896,6 +1929,21 @@ def update_install() -> dict:
     can tell the user where to look if something goes sideways.
     """
     _require_local_access()
+    if _running_in_flatpak():
+        # The Flatpak path is `flatpak update --user
+        # com.tidaldownloader.Tideway`; downloading the AppImage
+        # here would just confuse the user. Tell them how to get
+        # the update instead of failing silently.
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                "Tideway is installed via Flatpak. Updates come from "
+                "the Flatpak remote — run `flatpak update --user "
+                "com.tidaldownloader.Tideway` (or use your software "
+                "centre / GNOME Software) to install the latest "
+                "release."
+            ),
+        )
     url = _update_asset_url()
     if url is None:
         raise HTTPException(

--- a/tests/test_update_flatpak.py
+++ b/tests/test_update_flatpak.py
@@ -1,0 +1,119 @@
+"""Tests for the Flatpak detection branch of the in-app self-updater.
+
+Inside a Flatpak sandbox the in-app "Install now" button can't reach
+the real installation — updates come through `flatpak update`, not by
+downloading an AppImage and exec'ing it. `_running_in_flatpak()`
+detects the sandbox via `/.flatpak-info` or `$FLATPAK_ID`, and the
+two updater endpoints branch off that:
+
+  - `/api/update-check` flags `kind="flatpak"` so the banner can swap
+    the install action for a `flatpak update ...` hint. The check
+    still considers an update "available" without looking up a
+    per-platform asset URL, since the bits come from the Flatpak
+    remote.
+  - `/api/update/install` refuses with HTTP 409 and a message naming
+    the right command, instead of downloading an AppImage the user
+    can't run.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+import server
+
+
+@pytest.fixture(autouse=True)
+def _reset_update_cache(monkeypatch):
+    monkeypatch.setattr(server, "_update_cache", {})
+    monkeypatch.setattr(server, "_UPDATE_REPO", "test/repo")
+    monkeypatch.setattr(server, "APP_VERSION", "0.4.7")
+
+
+def _fake_release_with_dmg(timeout: float = 8.0) -> dict:  # noqa: ARG001
+    return {
+        "tag_name": "v0.4.8",
+        "html_url": "https://example/r/v0.4.8",
+        "body": "release notes",
+        "assets": [
+            {
+                "name": "Tideway-0.4.8.dmg",
+                "browser_download_url": "https://example/Tideway-0.4.8.dmg",
+            }
+        ],
+    }
+
+
+def test_running_in_flatpak_detects_env_var(monkeypatch):
+    monkeypatch.setenv("FLATPAK_ID", "com.tidaldownloader.Tideway")
+    assert server._running_in_flatpak() is True
+
+
+def test_running_in_flatpak_returns_false_outside_sandbox(monkeypatch):
+    """On macOS/Windows or a non-Flatpak Linux install neither the
+    env var nor the marker file exists, and the helper must say so —
+    a false-positive here would silently disable the in-app updater."""
+    monkeypatch.delenv("FLATPAK_ID", raising=False)
+    # The marker file probe is what matters here; on the dev box
+    # `/.flatpak-info` doesn't exist. Patch the Path check to be
+    # explicit so the test stays meaningful on a build host that
+    # happens to have a stray file there.
+    with patch.object(server.Path, "is_file", return_value=False):
+        assert server._running_in_flatpak() is False
+
+
+def test_update_check_emits_flatpak_kind(monkeypatch):
+    monkeypatch.setenv("FLATPAK_ID", "com.tidaldownloader.Tideway")
+    with patch.object(server, "_fetch_latest_release", _fake_release_with_dmg):
+        result = server.update_check()
+    assert result["kind"] == "flatpak"
+    assert result["available"] is True
+    assert result["latest"] == "v0.4.8"
+
+
+def test_update_check_emits_installer_kind_by_default(monkeypatch):
+    monkeypatch.delenv("FLATPAK_ID", raising=False)
+    with patch.object(server.Path, "is_file", return_value=False):
+        with patch.object(server, "_fetch_latest_release", _fake_release_with_dmg):
+            # The dmg asset matches macOS; on Linux without an AppImage
+            # match this would return available=False, but kind is
+            # independent of platform-match. Test the field directly.
+            result = server.update_check()
+    assert result["kind"] == "installer"
+
+
+def test_update_check_flatpak_available_without_asset_match(monkeypatch):
+    """In Flatpak we don't need a per-platform asset URL — the user
+    runs `flatpak update`, the bits come from the Flatpak remote.
+    The release that's "available" is just the GitHub tag. A
+    release without any matching installer (e.g. Windows-only
+    point release) still reports available for Flatpak users."""
+    monkeypatch.setenv("FLATPAK_ID", "com.tidaldownloader.Tideway")
+    def _release_no_assets(timeout: float = 8.0) -> dict:  # noqa: ARG001
+        return {
+            "tag_name": "v0.4.8",
+            "html_url": "https://example/r/v0.4.8",
+            "body": "windows-only patch",
+            "assets": [],
+        }
+    with patch.object(server, "_fetch_latest_release", _release_no_assets):
+        result = server.update_check()
+    assert result["available"] is True
+    assert result["kind"] == "flatpak"
+
+
+def test_update_install_refuses_in_flatpak(monkeypatch):
+    """The endpoint must return 409 with the `flatpak update` hint,
+    not try to download the AppImage."""
+    monkeypatch.setenv("FLATPAK_ID", "com.tidaldownloader.Tideway")
+    from fastapi import HTTPException
+
+    with pytest.raises(HTTPException) as exc_info:
+        # `_require_local_access` is the first thing the endpoint
+        # checks; patch it out so we exercise the Flatpak branch.
+        with patch.object(server, "_require_local_access", lambda: None):
+            server.update_install()
+    assert exc_info.value.status_code == 409
+    assert "flatpak update" in exc_info.value.detail.lower()
+    assert "com.tidaldownloader.Tideway" in exc_info.value.detail

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -444,6 +444,13 @@ export const api = {
       latest: string | null;
       url: string | null;
       notes: string | null;
+      // "flatpak" when the backend detects /.flatpak-info or
+      // $FLATPAK_ID; "installer" everywhere else (macOS, Windows,
+      // and the Linux AppImage path). The banner uses this to swap
+      // the in-app "Install now" button for a "managed by Flatpak"
+      // hint, since downloading and execing an AppImage from inside
+      // a Flatpak sandbox can't update the installed app.
+      kind?: "flatpak" | "installer";
       // Non-null when the GitHub fetch itself failed (offline, cert
       // verification problem, rate limit, repo private). The banner
       // doesn't display this, but it's useful for `/api/health`-style

--- a/web/src/components/UpdateBanner.test.tsx
+++ b/web/src/components/UpdateBanner.test.tsx
@@ -1,0 +1,100 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { UpdateBanner } from "./UpdateBanner";
+import { api } from "@/api/client";
+import { ToastProvider } from "@/components/toast";
+
+function flush() {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0));
+}
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  try {
+    localStorage.removeItem("tideway:update-dismissed-version");
+  } catch {
+    /* ignore */
+  }
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  document.body.removeChild(container);
+  vi.restoreAllMocks();
+});
+
+async function mountWith(response: {
+  available: boolean;
+  current: string;
+  latest: string | null;
+  url: string | null;
+  notes: string | null;
+  kind?: "flatpak" | "installer";
+}) {
+  vi.spyOn(api, "updateCheck").mockResolvedValue(response);
+  await act(async () => {
+    root.render(
+      <ToastProvider>
+        <UpdateBanner />
+      </ToastProvider>,
+    );
+  });
+  await act(async () => {
+    await flush();
+  });
+}
+
+describe("UpdateBanner", () => {
+  it("shows the 'Install now' button when kind is installer", async () => {
+    await mountWith({
+      available: true,
+      current: "1.9.4",
+      latest: "v1.9.5",
+      url: "https://example/r/v1.9.5",
+      notes: "n",
+      kind: "installer",
+    });
+    expect(container.textContent).toContain("Install now");
+    expect(container.textContent).not.toContain("flatpak update");
+  });
+
+  it("hides 'Install now' and shows the flatpak hint when kind is flatpak", async () => {
+    await mountWith({
+      available: true,
+      current: "1.9.4",
+      latest: "v1.9.5",
+      url: "https://example/r/v1.9.5",
+      notes: "n",
+      kind: "flatpak",
+    });
+    expect(container.textContent).not.toContain("Install now");
+    expect(container.textContent).toContain(
+      "flatpak update --user com.tidaldownloader.Tideway",
+    );
+    // The release notes button still shows so users can read the changelog.
+    expect(container.textContent).toContain("Release notes");
+  });
+
+  it("renders nothing when no update is available", async () => {
+    await mountWith({
+      available: false,
+      current: "1.9.5",
+      latest: "v1.9.5",
+      url: null,
+      notes: null,
+      kind: "installer",
+    });
+    expect(container.textContent).toBe("");
+  });
+});

--- a/web/src/components/UpdateBanner.tsx
+++ b/web/src/components/UpdateBanner.tsx
@@ -28,6 +28,7 @@ export function UpdateBanner() {
     available: boolean;
     latest: string | null;
     url: string | null;
+    kind?: "flatpak" | "installer";
   } | null>(null);
   const [dismissed, setDismissed] = useState(false);
   const [installing, setInstalling] = useState(false);
@@ -111,22 +112,38 @@ export function UpdateBanner() {
     }
   };
 
+  // Flatpak users update through `flatpak update` — the AppImage
+  // download path can't reach into a Flatpak install. Show the
+  // command instead of the "Install now" button.
+  const isFlatpak = update.kind === "flatpak";
+
   return (
     <div className="flex items-center gap-3 border-b border-primary/30 bg-primary/10 px-6 py-2 text-sm">
       <Download className="h-4 w-4 flex-shrink-0 text-primary" />
       <div className="min-w-0 flex-1">
         <span className="font-medium">Update available:</span>{" "}
         <span className="text-muted-foreground">{update.latest}</span>
+        {isFlatpak && (
+          <span className="ml-2 text-muted-foreground">
+            Run{" "}
+            <code className="rounded bg-primary/15 px-1 py-0.5 font-mono text-xs">
+              flatpak update --user com.tidaldownloader.Tideway
+            </code>{" "}
+            to install.
+          </span>
+        )}
       </div>
-      <button
-        type="button"
-        onClick={onInstall}
-        disabled={installing}
-        className="flex items-center gap-1.5 rounded bg-primary px-3 py-1 text-xs font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
-      >
-        {installing && <Loader2 className="h-3 w-3 animate-spin" />}
-        {installing ? "Downloading…" : "Install now"}
-      </button>
+      {!isFlatpak && (
+        <button
+          type="button"
+          onClick={onInstall}
+          disabled={installing}
+          className="flex items-center gap-1.5 rounded bg-primary px-3 py-1 text-xs font-semibold text-primary-foreground hover:bg-primary/90 disabled:opacity-60"
+        >
+          {installing && <Loader2 className="h-3 w-3 animate-spin" />}
+          {installing ? "Downloading…" : "Install now"}
+        </button>
+      )}
       <button
         type="button"
         onClick={onView}


### PR DESCRIPTION
## Summary

The Linux AppImage falls back to opening the app in the system browser because a frozen PyInstaller build can't import the host's PyGObject/WebKit2GTK. This branch replaces it with a Flatpak that runs under the GNOME 49 runtime, where pywebview's GTK backend gives a real native window — same UX as the macOS .app and the Windows installer.

Six commits, each its own stage of the plan in `docs/linux-flatpak.md`:

- **Stage 0** (`7d50f7d`) — branch + scope doc + manifest scaffold.
- **Stage 1** (`1abe369`) — flatpak-builder builds a 526 MB payload on GNOME 49 (Python 3.13, freedesktop 25.08 base). Two non-obvious wires: `--prefer-wheels` against `flatpak-pip-generator` for the Rust/Cython transitives whose PEP-517 backends aren't available in the sandbox (orjson, pydantic-core, watchfiles, numpy, scipy, av, etc.); and `flatpak-node-generator` producing `node-sources.json` so `npm ci --offline` works inside the network-disabled build sandbox.
- **Stage 2** (also `1abe369`) — headless harness in a Multipass VM proves pywebview picks the GTK backend (xvfb + `flatpak run` shows the FastAPI server boots, `/api/health` returns 200, and pywebview emits `Gtk-WARNING: cannot open display` — the failure mode itself is the proof that GTK is what got loaded; on a real display the window would open).
- **Stage 3a** (`1b5d4f4`) — Flatpak-aware self-updater. `_running_in_flatpak()` (server.py) checks `/.flatpak-info` and `$FLATPAK_ID`. `/api/update-check` returns `kind: "flatpak"` and `/api/update/install` refuses with HTTP 409 + the exact `flatpak update --user com.tidaldownloader.Tideway` command. The banner swaps the in-app "Install now" button for that command rendered inline. Pinned by 6 backend tests and 3 frontend tests.
- **Stage 3b** (`64c4622`) — CI. `build-linux-flatpak` in `release.yml` installs flatpak-builder + GNOME 49 on a stock ubuntu-22.04 runner, mirroring the VM verification setup. Produces a `.flatpak` bundle (attached to the GitHub Release alongside DMG/exe/AppImage, signed by `sign-release.sh`) and the OSTree repo directory as a separate artifact.
- **Stage 3c** (`5ae4927`) — Distribution. `publish-flatpak-repo` runs after `publish` lands the GitHub Release, downloads the OSTree artifact, drops `tideway.flatpakrepo` + a minimal `index.html` landing page next to it, and pushes to the `gh-pages` branch. Served at `https://j-m-punk.github.io/tideway/`. Users `flatpak remote-add tideway https://j-m-punk.github.io/tideway/tideway.flatpakrepo` and `flatpak install tideway com.tidaldownloader.Tideway`; `flatpak update` thereafter.

The AppImage stays attached to every release as a fallback. README's Linux section now leads with the Flatpak install (both subscribe-and-auto-update and one-shot bundle) and demotes the AppImage to "still works, but opens a browser instead of a native window."

## One-time setup before the first release tag

GitHub Pages must be enabled on the repo before the first `publish-flatpak-repo` run can succeed:

  Settings → Pages → Source: **Deploy from a branch** → Branch: **gh-pages** / **(root)** → Save.

Subsequent tags then publish automatically.

## Test plan

- [x] `pytest tests/` — 789 passed (6 new tests in `tests/test_update_flatpak.py`).
- [x] `cd web && npx tsc -b --noEmit` — clean.
- [x] `cd web && npm run lint:all` — clean.
- [x] `cd web && npm test` — 50 passed (3 new tests in `web/src/components/UpdateBanner.test.tsx`).
- [x] Manual: `flatpak-builder` in Multipass VM produced a 526 MB GNOME 49 payload that installs to `--user` cleanly.
- [x] Manual: `xvfb-run flatpak run --user com.tidaldownloader.Tideway` — server bound on 47823, `/api/health` returned 200, pywebview reached into GTK (failed window creation only on the xvfb cookie, which won't happen under a real display).
- [x] Manual: dev preview in browser shows the Flatpak hint banner replacing "Install now" when `FLATPAK_ID=...` is set on the backend.
- [ ] First real release tag exercises the CI Flatpak job + Pages publish end-to-end. Cache will be cold on the first run; ~30-40 min build expected the first time, ~5-10 min subsequently.