### PR TITLE
Flatpak: serve React UI from /share/tideway/web/dist + smoke-test it in CI

### DIFF
--- a/.github/workflows/flatpak-build-check.yml
+++ b/.github/workflows/flatpak-build-check.yml
@@ -82,12 +82,70 @@ jobs:
       - name: Verify payload structure
         # Quick sanity check that the build actually produced what
         # we expect — catches manifest typos that build "cleanly"
-        # into nothing useful.
+        # into nothing useful. The web/dist path is the load-bearing
+        # one: server.py's static mount looks for
+        # bundled_resource_dir() / "web" / "dist" / "index.html",
+        # and v1.10.0 + v1.11.0 shipped with the contents flattened
+        # to /share/tideway/dist/ so the React UI never rendered
+        # (window loaded "{"detail":"Not Found"}"). This step's
+        # previous assertion checked the broken path and silently
+        # passed. Now anchored on the real served file.
         run: |
           test -f .build-flatpak/files/bin/tideway || { echo "FAIL: launcher missing"; exit 1; }
           test -f .build-flatpak/files/share/tideway/desktop.py || { echo "FAIL: desktop.py missing"; exit 1; }
           test -f .build-flatpak/files/share/tideway/server.py || { echo "FAIL: server.py missing"; exit 1; }
-          test -d .build-flatpak/files/share/tideway/dist || { echo "FAIL: web/dist missing"; exit 1; }
+          test -f .build-flatpak/files/share/tideway/VERSION || { echo "FAIL: VERSION missing"; exit 1; }
+          test -f .build-flatpak/files/share/tideway/web/dist/index.html || { echo "FAIL: React index.html missing from /share/tideway/web/dist/"; exit 1; }
+          test -d .build-flatpak/files/share/tideway/web/dist/assets || { echo "FAIL: hashed Vite assets missing"; exit 1; }
           test -f .build-flatpak/files/lib/libportaudio.so.2 || { echo "FAIL: PortAudio missing"; exit 1; }
           echo "OK: build payload looks correct"
           du -sh .build-flatpak/files
+
+      - name: Smoke-test the running app serves the React UI
+        # Install the freshly built bits, launch under --browser
+        # (no pywebview window, just the FastAPI server), and assert
+        # the root URL returns HTML — not the JSON 404 that v1.10
+        # and v1.11 shipped. This is the test that would have caught
+        # the original bug. --browser short-circuits the GTK window
+        # creation, so no xvfb is needed.
+        run: |
+          set -uo pipefail
+          flatpak-builder --user --install --force-clean \
+            .build-flatpak flatpak/com.tidaldownloader.Tideway.yaml
+          flatpak run --user com.tidaldownloader.Tideway --browser \
+            > flatpak_smoke.log 2>&1 &
+          APP_PID=$!
+          ok=0
+          for _ in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:47823/api/health 2>/dev/null \
+                 | grep -q tidal-downloader; then
+              ok=1
+              break
+            fi
+            kill -0 "$APP_PID" 2>/dev/null || break
+            sleep 1
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "FAIL: server never bound on :47823"
+            cat flatpak_smoke.log
+            exit 1
+          fi
+          # Probe the root URL — the path pywebview loads. Bug class
+          # is "static SPA mount didn't register, fallback 404s with
+          # JSON". Catch that here: response must be HTML and must
+          # contain the app title.
+          body=$(curl -fsS http://127.0.0.1:47823/)
+          if ! echo "$body" | grep -qi "<title>Tideway</title>"; then
+            echo "FAIL: root URL did not serve the React index.html"
+            echo "----- response body -----"
+            echo "$body" | head -c 500
+            echo
+            echo "----- /api/health (for comparison, should be JSON) -----"
+            curl -sS http://127.0.0.1:47823/api/health
+            echo
+            kill "$APP_PID" 2>/dev/null || true
+            exit 1
+          fi
+          echo "PASS: root URL serves the React index.html"
+          kill "$APP_PID" 2>/dev/null || true
+          wait "$APP_PID" 2>/dev/null || true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -466,6 +466,51 @@ jobs:
             flatpak/com.tidaldownloader.Tideway.yaml
           flatpak build-update-repo "${UPDATE_ARGS[@]}" repo
 
+      - name: Smoke-test the running app serves the React UI
+        # Verifies the user-facing URL works before we package the
+        # bundle and ship it. v1.10.0 + v1.11.0 shipped with the
+        # static SPA mount looking at the wrong path; the window
+        # loaded "{"detail":"Not Found"}" instead of the React app
+        # and nobody caught it until a user reported it. This step
+        # installs to --user, launches under --browser (skips the
+        # GTK window, so no xvfb needed), and asserts that the
+        # root URL returns HTML with the app title in it. Fails the
+        # release if not.
+        run: |
+          set -uo pipefail
+          flatpak-builder --user --install --force-clean \
+            .build-flatpak flatpak/com.tidaldownloader.Tideway.yaml
+          flatpak run --user com.tidaldownloader.Tideway --browser \
+            > flatpak_smoke.log 2>&1 &
+          APP_PID=$!
+          ok=0
+          for _ in $(seq 1 60); do
+            if curl -fsS http://127.0.0.1:47823/api/health 2>/dev/null \
+                 | grep -q tidal-downloader; then
+              ok=1
+              break
+            fi
+            kill -0 "$APP_PID" 2>/dev/null || break
+            sleep 1
+          done
+          if [ "$ok" -ne 1 ]; then
+            echo "FAIL: server never bound on :47823"
+            cat flatpak_smoke.log
+            exit 1
+          fi
+          body=$(curl -fsS http://127.0.0.1:47823/)
+          if ! echo "$body" | grep -qi "<title>Tideway</title>"; then
+            echo "FAIL: root URL did not serve the React index.html"
+            echo "----- response body -----"
+            echo "$body" | head -c 500
+            echo
+            kill "$APP_PID" 2>/dev/null || true
+            exit 1
+          fi
+          echo "PASS: root URL serves the React index.html"
+          kill "$APP_PID" 2>/dev/null || true
+          wait "$APP_PID" 2>/dev/null || true
+
       - name: Build single-file .flatpak bundle from repo
         # `flatpak build-bundle` extracts a single .flatpak file
         # from the OSTree repo for users who want to install

--- a/flatpak/com.tidaldownloader.Tideway.yaml
+++ b/flatpak/com.tidaldownloader.Tideway.yaml
@@ -76,8 +76,20 @@ modules:
       - npm --prefix web run build
       # App payload. The runtime Python imports `gi`, so pywebview
       # uses the GTK/WebKit backend — no browser fallback.
-      - install -d /app/share/tideway
-      - cp -r app server.py desktop.py VERSION web/dist /app/share/tideway/
+      #
+      # `web/dist` MUST land at `/app/share/tideway/web/dist/`, not
+      # `/app/share/tideway/dist/`. server.py's static mount resolves
+      # the Vite build via `bundled_resource_dir() / "web" / "dist"`,
+      # and `bundled_resource_dir()` returns the package root
+      # (`/app/share/tideway` inside the sandbox). Earlier releases
+      # used a single `cp -r ... web/dist /app/share/tideway/` which
+      # flattens the destination to `/app/share/tideway/dist/`; the
+      # static mount then skipped registration, the SPA fallback
+      # route was never wired up, and the pywebview window loaded
+      # `{"detail":"Not Found"}` instead of the React app.
+      - install -d /app/share/tideway/web
+      - cp -r app server.py desktop.py VERSION /app/share/tideway/
+      - cp -r web/dist /app/share/tideway/web/
       - install -Dm755 flatpak/tideway-launcher.sh /app/bin/tideway
       - install -Dm644 flatpak/com.tidaldownloader.Tideway.desktop
         /app/share/applications/com.tidaldownloader.Tideway.desktop


### PR DESCRIPTION
## Summary

A user on v1.11.0 reported the Flatpak window loading `{"detail":"Not Found"}` instead of the app. Same regression on v1.10.0. **Every Flatpak install of v1.10.0 and v1.11.0 is broken** — the React UI never loads, users see raw JSON.

Root cause: the manifest's

```yaml
cp -r app server.py desktop.py VERSION web/dist /app/share/tideway/
```

flattens the `web/dist` source directory's contents into `/app/share/tideway/dist/`. server.py's static SPA mount resolves the Vite build via `bundled_resource_dir() / "web" / "dist"`, which inside the sandbox is `/app/share/tideway/web/dist` — never populated, so the mount silently no-ops, the SPA fallback route is never registered, and every `GET /` falls through to FastAPI's default 404 handler returning JSON.

The fix is mechanical:

```yaml
install -d /app/share/tideway/web
cp -r app server.py desktop.py VERSION /app/share/tideway/
cp -r web/dist /app/share/tideway/web/
```

Verified manually in the Multipass VM: rebuilt Flatpak now responds to `GET /` with HTTP 200, `text/html`, body containing `<title>Tideway</title>`.

## CI changes so this can't ship silently again

The Stage 2 verification harness from PR #165 only curled `/api/health` and called that good. That covered "did the backend bind?" — not "does the user-facing URL render the app?" Closing the gap with two CI changes:

1. **Pin the payload assertion to the load-bearing file.** `flatpak-build-check.yml`'s payload check was asserting the broken path (`share/tideway/dist`) and silently passing on every build. Now anchored on `share/tideway/web/dist/index.html` + the hashed Vite assets dir.
2. **Add a real run + curl root URL smoke step** to both `flatpak-build-check.yml` (PR-time) and `release.yml`'s `build-linux-flatpak` (tag-time). The step installs the just-built bits to `--user`, launches under `--browser` (no GTK window, no xvfb), polls `/api/health` until the server binds, then curls `GET /` and fails the build if the response isn't HTML containing `<title>Tideway</title>`. The original regression would have failed this step instantly.

## Test plan

- [x] `pytest tests/` — 792 passed (no Python changes; sanity only).
- [x] Manual: rebuilt Flatpak in VM, installed, curl `http://127.0.0.1:47823/` returns HTTP 200 + HTML body with `<title>Tideway</title>`.
- [ ] CI's new smoke step exercises the same probe on a fresh x86_64 GitHub-Actions runner. Cold-cache run expected ~5 min.