### PR TITLE
Cross-device pause: pause Tideway when another device on the same account starts playing

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -215,6 +215,18 @@ class Settings:
     # user who had the old toggle off ends up with the new toggle on
     # — they can flip it off again if they didn't want it.
     continue_playing_after_queue_ends: bool = True
+    # Pause Tideway when another device on the same Tidal account
+    # starts playing. Matches Spotify's "playback transferred to
+    # other device" behaviour and the official Tidal client's
+    # cross-device handoff. Default on; users who explicitly want
+    # multi-device-fighting playback can flip it off. Wired to
+    # `app/tidal_realtime.py`'s on_other_device_started callback,
+    # which the desktop launcher binds to PCMPlayer.pause(). The
+    # listener itself is opt-in at the protocol level too: if the
+    # realtime bus protocol hasn't been captured yet (Phase 1 of
+    # the cross-device-pause feature), the listener stays disabled
+    # regardless of this setting.
+    pause_on_other_device: bool = True
     # Spotify Developer app client_id, used by the Spotify → Tidal
     # playlist importer. Users register their own app at
     # developer.spotify.com and paste the id here. PKCE OAuth so we

--- a/app/tidal_realtime.py
+++ b/app/tidal_realtime.py
@@ -82,6 +82,7 @@ import asyncio
 import inspect
 import json
 import logging
+import time
 from dataclasses import dataclass, field
 from typing import Awaitable, Callable, Optional
 
@@ -166,6 +167,14 @@ class RealtimeListener:
     _task: Optional[asyncio.Task] = field(default=None, init=False)
     _shutdown: asyncio.Event = field(default_factory=asyncio.Event, init=False)
     _status: ListenerStatus = field(default_factory=ListenerStatus, init=False)
+    # Stashed when start() runs so signal_user_action_sync() can
+    # hand the coroutine back to the right loop from sync code (the
+    # PCMPlayer state-change listener fires from arbitrary threads).
+    _loop: Optional[asyncio.AbstractEventLoop] = field(default=None, init=False)
+    # The currently-open WebSocket while _connect_and_serve is in
+    # the middle of its serve loop, else None. Read by
+    # send_user_action; never written from outside the loop.
+    _ws: Optional[object] = field(default=None, init=False)
 
     @property
     def is_protocol_known(self) -> bool:
@@ -183,6 +192,7 @@ class RealtimeListener:
         self._shutdown.clear()
         self._status = ListenerStatus(phase="connecting")
         loop = asyncio.get_running_loop()
+        self._loop = loop
         self._task = loop.create_task(
             self._run(), name="tidal-realtime-listener"
         )
@@ -301,27 +311,37 @@ class RealtimeListener:
             )
 
         # Phase 2: open the WebSocket and serve frames. No subscribe
-        # message and no client heartbeats — the Tidal web client
-        # sends `USER_ACTION` frames on page user-action events but
-        # they're not required for connection liveness, so we skip
-        # them. Same certifi CA bundle as the token POST so the WS
-        # handshake doesn't trip the same system-CA issue.
+        # message and no periodic client heartbeats. The outbound
+        # USER_ACTION frame is sent on demand by
+        # signal_user_action_sync() — it's how we tell Pushkin
+        # "this device is now the active one" so other devices on
+        # the same account pause in response. Same certifi CA
+        # bundle as the token POST so the WS handshake doesn't trip
+        # the same system-CA issue.
         async with websockets.connect(
             ws_url,
             open_timeout=_CONNECT_TIMEOUT_SEC,
             ssl=ssl_ctx,
         ) as ws:
+            self._ws = ws
             self._status.phase = "connected"
             self._status.last_error = None
             log.info(
                 "tidal_realtime: connected to Pushkin (reconnect_count=%d)",
                 self._status.reconnect_count,
             )
-            async for raw in ws:
-                frame = self._parse_frame(raw)
-                if frame is None:
-                    continue
-                await self._dispatch_frame(frame, ws)
+            try:
+                async for raw in ws:
+                    frame = self._parse_frame(raw)
+                    if frame is None:
+                        continue
+                    await self._dispatch_frame(frame, ws)
+            finally:
+                # Clear the ws reference so signal_user_action_sync
+                # callers in flight stop trying to send through a
+                # half-closed socket. The reconnect loop will
+                # re-populate this on the next successful connect.
+                self._ws = None
 
     async def _dispatch_frame(self, frame: dict, ws) -> None:
         """Route a parsed frame to the right action.
@@ -355,6 +375,73 @@ class RealtimeListener:
             log.warning(
                 "tidal_realtime: unhandled frame type %r", frame_type
             )
+
+    async def send_user_action(self) -> bool:
+        """Send a USER_ACTION frame on the current WebSocket.
+
+        The Tidal web client fires this whenever the user clicks
+        or presses a key in the page; Pushkin's backend uses these
+        to mark the device as the "active" one. When Pushkin sees
+        a fresh user-action from device B while device A is the
+        current active device, it pushes
+        PRIVILEGED_SESSION_NOTIFICATION to device A so A pauses.
+
+        For Tideway, the natural trigger is "track started
+        playing" — that's the moral equivalent of clicking the
+        web app's play button. server.py subscribes to PCMPlayer
+        state changes and calls signal_user_action_sync() on the
+        transition into the playing state.
+
+        Returns True if the frame was sent, False if there was no
+        open connection (caller's fault for racing the reconnect
+        loop). Send failures (broken pipe, etc.) raise; the
+        receive loop will see them too and trigger reconnect.
+        """
+        ws = self._ws
+        if ws is None:
+            log.debug(
+                "tidal_realtime: signal_user_action with no open "
+                "WebSocket; dropping"
+            )
+            return False
+        # `startedAt` is a Unix-millisecond timestamp; the web
+        # client uses a TrueTime-corrected clock (sync'd against
+        # api.tidal.com/v1/ping's Date header) but ordinary local
+        # time is close enough for Pushkin's purposes — the
+        # backend doesn't seem to use this value to break ties.
+        body = json.dumps(
+            {
+                "payload": {"startedAt": int(time.time() * 1000)},
+                "type": "USER_ACTION",
+            },
+            separators=(",", ":"),
+        )
+        await ws.send(body)
+        return True
+
+    def signal_user_action_sync(self) -> None:
+        """Sync-friendly wrapper around send_user_action() so the
+        PCMPlayer's state-change listener (which runs on player
+        threads, not the asyncio loop) can fire USER_ACTION
+        without an awaiting context.
+
+        Best-effort: silently drops if the listener isn't running
+        yet, the loop isn't available, or the send fails. None of
+        those are fatal — the next state change will retry, and
+        the worst-case user impact is that one play action doesn't
+        pause other devices.
+        """
+        loop = self._loop
+        if loop is None or self._ws is None:
+            return
+        try:
+            asyncio.run_coroutine_threadsafe(
+                self.send_user_action(), loop
+            )
+        except RuntimeError as exc:
+            # Loop closed mid-call (shutdown race). Nothing we can
+            # do; drop the signal.
+            log.debug("tidal_realtime: signal dropped: %r", exc)
 
     @staticmethod
     def _parse_frame(raw: bytes | str) -> Optional[dict]:

--- a/app/tidal_realtime.py
+++ b/app/tidal_realtime.py
@@ -255,14 +255,27 @@ class RealtimeListener:
             # once the session is back.
             raise RuntimeError("no Tidal access token available")
 
+        import ssl
+
         import aiohttp
+        import certifi
         import websockets
+
+        # Use certifi's CA bundle explicitly. The python.org Python
+        # macOS distribution doesn't trust the system Keychain by
+        # default, so aiohttp's default SSL context fails to verify
+        # the api.tidal.com cert with "unable to get local issuer
+        # certificate". The existing `requests`-based code in
+        # _fetch_latest_release dodges this because requests ships
+        # certifi; aiohttp has to be pointed at it.
+        ssl_ctx = ssl.create_default_context(cafile=certifi.where())
 
         # Phase 1: POST to /v1/rt/connect with the Bearer token to
         # mint a per-session WebSocket URL. The response carries the
         # full wss:// URL including the token UUID baked into the
         # path; we don't need to construct it ourselves.
-        async with aiohttp.ClientSession() as http:
+        connector = aiohttp.TCPConnector(ssl=ssl_ctx)
+        async with aiohttp.ClientSession(connector=connector) as http:
             async with http.post(
                 _RT_CONNECT_URL,
                 headers={
@@ -291,10 +304,12 @@ class RealtimeListener:
         # message and no client heartbeats — the Tidal web client
         # sends `USER_ACTION` frames on page user-action events but
         # they're not required for connection liveness, so we skip
-        # them.
+        # them. Same certifi CA bundle as the token POST so the WS
+        # handshake doesn't trip the same system-CA issue.
         async with websockets.connect(
             ws_url,
             open_timeout=_CONNECT_TIMEOUT_SEC,
+            ssl=ssl_ctx,
         ) as ws:
             self._status.phase = "connected"
             self._status.last_error = None

--- a/app/tidal_realtime.py
+++ b/app/tidal_realtime.py
@@ -1,0 +1,325 @@
+"""Tidal realtime listener: pause Tideway when another device on the
+same Tidal account starts playing.
+
+Tidal's official clients react to playback events from other devices
+via a realtime bus. When another device on the same account begins a
+playback_session, the bus pushes a state-change frame and the
+receiving client pauses locally. Spotify and the official Tidal app
+both behave this way out of the box; users coming from those expect
+Tideway to behave the same.
+
+The send half of this contract already exists. `app/play_reporter.py`
+posts our own `playback_session` events to the event-producer bus
+(`ec.tidal.com/api/event-batch`), which is what makes "Tideway plays
+show up in Recently Played" and "starting Tideway pauses other
+devices that listen to the same bus" work today. This module is the
+**receive** half: a long-lived WebSocket subscription to whatever
+Tidal's realtime bus is, with an `on_other_device_started` callback
+that the desktop launcher wires to PCMPlayer.pause().
+
+## Status: scaffolded, protocol capture pending
+
+The scaffold is here so the wiring (settings field, lifespan hook,
+diagnostic endpoint, callback into the player) can be reviewed and
+shipped without the protocol-specific details. Connection setup,
+the subscribe message, and the frame parser are stubs marked
+**TODO(phase-1)** that need a packet capture from Tidal's web
+client to fill in. See
+`private/features/cross-device-pause-listener.md` for the capture
+plan and the open questions about auth shape, frame format, etc.
+
+Until the capture lands, the listener:
+  - Constructs cleanly,
+  - Reports `phase=disabled` from `status()` because the protocol
+    constants are placeholders,
+  - Refuses to start when called: returns immediately with a logged
+    "TODO" message rather than spinning a real WebSocket connection
+    against a guessed URL that can't actually work.
+
+This shape lets the rest of the app integrate (settings toggle,
+status endpoint, lifespan registration) without producing connection
+churn against a wrong endpoint.
+
+## Threading model
+
+The listener runs inside FastAPI's asyncio event loop as a background
+task spawned from lifespan startup. The task lifecycle is:
+
+  start() → asyncio.create_task → _run() loop:
+      while not shutdown:
+          try: await _connect_and_serve()
+          except: log + backoff
+          await sleep(backoff)
+
+Cancellation on shutdown is cooperative: lifespan teardown calls
+stop(), which sets a shutdown flag and cancels the task; _run() sees
+the cancellation, closes the WebSocket if open, and exits.
+
+The pause callback fires from inside the asyncio loop. PCMPlayer's
+methods are thread-safe (they take `_lock` internally) so calling
+into them from the loop is fine; we don't need a thread hop.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, Optional
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Protocol constants — TODO(phase-1): replace placeholders after capture.
+# ---------------------------------------------------------------------------
+#
+# `cross-device-pause-listener.md` records the open questions:
+#   - Is the realtime endpoint really WebSocket, or long-polling / SSE?
+#   - Auth shape: bearer header, query param, post-connect AUTH frame?
+#   - Do we need a "register this session" handshake first?
+#   - Frame format: JSON, binary, protobuf?
+#   - Are there events we'd want to ignore (our own play_reporter
+#     events bouncing back)?
+#
+# Until those are answered the listener stays in `disabled` phase and
+# never opens a connection. Replacing these constants and the
+# `_parse_frame` helper below is the entire surface the Phase 1
+# capture changes.
+
+_REALTIME_URL: Optional[str] = None  # e.g. "wss://realtime.tidal.com/v1/listen"
+_SUBSCRIBE_MESSAGE: Optional[str] = None  # JSON sent on connect, if needed
+_HEARTBEAT_INTERVAL_SEC: Optional[float] = None  # client-side ping cadence
+
+
+# Backoff schedule for reconnects. Doubles each consecutive failure,
+# capped so we don't drift into multi-minute holes that delay the
+# user's first cross-device-pause event after a network blip. The
+# first failure waits half a second; the cap of 60s keeps us
+# responsive while still being polite to Tidal's bus during outages.
+_BACKOFF_INITIAL_SEC = 0.5
+_BACKOFF_MAX_SEC = 60.0
+
+
+# ---------------------------------------------------------------------------
+# Public types
+# ---------------------------------------------------------------------------
+
+# Function the listener calls to obtain the current Tidal access token.
+# Returning None means "no session right now" and the listener will
+# back off. Tokens rotate on refresh, so the listener calls this every
+# time it (re)connects rather than caching once.
+TokenProvider = Callable[[], Optional[str]]
+
+# Callback fired when another device on the same account starts
+# playing. The desktop launcher binds this to PCMPlayer.pause(). The
+# callback runs on the asyncio loop and may be sync or async.
+OtherDeviceStartedCallback = Callable[[dict], Awaitable[None] | None]
+
+
+@dataclass
+class ListenerStatus:
+    """What `/api/realtime/status` returns. Diagnostic surface only."""
+
+    # One of: "disabled", "idle", "connecting", "connected",
+    # "reconnecting", "stopped". "disabled" specifically means the
+    # protocol constants haven't been filled in yet (Phase 1 not
+    # done). "idle" means the listener was constructed but start()
+    # hasn't been called.
+    phase: str = "idle"
+    # Last error message, if any. Cleared on successful connect.
+    last_error: Optional[str] = None
+    # How many times the listener has reconnected since start(). 0
+    # is a fresh listener that hasn't reconnected yet.
+    reconnect_count: int = 0
+    # How many "other device started" events we've delivered to the
+    # callback since start(). Useful sanity check that the wire-up
+    # is working when capturing fresh fixtures.
+    events_received: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Listener
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RealtimeListener:
+    """Long-lived connection to Tidal's realtime bus.
+
+    Construct with a token provider and an event callback. Call
+    start() to spawn the connection task; call stop() to cancel it.
+    Status is observable via status() at any time.
+    """
+
+    token_provider: TokenProvider
+    on_other_device_started: OtherDeviceStartedCallback
+
+    # Internal state. Not user-tunable.
+    _task: Optional[asyncio.Task] = field(default=None, init=False)
+    _shutdown: asyncio.Event = field(default_factory=asyncio.Event, init=False)
+    _status: ListenerStatus = field(default_factory=ListenerStatus, init=False)
+
+    @property
+    def is_protocol_known(self) -> bool:
+        """True once the Phase 1 capture has populated the protocol
+        constants. Until then start() is a no-op and status reports
+        `disabled`."""
+        return _REALTIME_URL is not None
+
+    def start(self) -> None:
+        """Spawn the connection task. Idempotent: a second call while
+        already running is a no-op."""
+        if self._task is not None and not self._task.done():
+            return
+        if not self.is_protocol_known:
+            self._status.phase = "disabled"
+            self._status.last_error = (
+                "Tidal realtime protocol not captured yet; listener "
+                "is a no-op until Phase 1 of the cross-device-pause "
+                "feature lands. See "
+                "private/features/cross-device-pause-listener.md."
+            )
+            log.info(
+                "tidal_realtime: start() called but protocol unknown; "
+                "no connection will be opened"
+            )
+            return
+        self._shutdown.clear()
+        self._status = ListenerStatus(phase="connecting")
+        loop = asyncio.get_running_loop()
+        self._task = loop.create_task(
+            self._run(), name="tidal-realtime-listener"
+        )
+
+    def stop(self) -> None:
+        """Cancel the connection task. Safe to call multiple times."""
+        self._shutdown.set()
+        if self._task is not None and not self._task.done():
+            self._task.cancel()
+        self._status.phase = "stopped"
+
+    def status(self) -> ListenerStatus:
+        """Snapshot of the listener's current state. The dataclass is
+        frozen at the moment of read; callers don't need to lock."""
+        return ListenerStatus(
+            phase=self._status.phase,
+            last_error=self._status.last_error,
+            reconnect_count=self._status.reconnect_count,
+            events_received=self._status.events_received,
+        )
+
+    # -- internals ----------------------------------------------------------
+
+    async def _run(self) -> None:
+        """Main connect-and-serve loop. Reconnects on drop with
+        exponential backoff. Exits when _shutdown is set."""
+        backoff = _BACKOFF_INITIAL_SEC
+        first_pass = True
+        while not self._shutdown.is_set():
+            if not first_pass:
+                self._status.phase = "reconnecting"
+                self._status.reconnect_count += 1
+            first_pass = False
+            try:
+                await self._connect_and_serve()
+                # Clean exit means the server closed without an error;
+                # treat as a brief blip and reconnect promptly.
+                backoff = _BACKOFF_INITIAL_SEC
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                self._status.last_error = repr(exc)
+                log.warning(
+                    "tidal_realtime: connection error; backing off %.1fs: %r",
+                    backoff, exc,
+                )
+            try:
+                await asyncio.wait_for(
+                    self._shutdown.wait(), timeout=backoff
+                )
+                # Shutdown signalled mid-backoff; exit cleanly.
+                return
+            except asyncio.TimeoutError:
+                pass
+            backoff = min(backoff * 2.0, _BACKOFF_MAX_SEC)
+
+    async def _connect_and_serve(self) -> None:
+        """Open one WebSocket connection, subscribe, and serve frames
+        until the connection drops. Re-raised exceptions trigger
+        reconnect via _run().
+
+        TODO(phase-1): this method is a placeholder. The real
+        implementation will:
+          1. Read the access token via self.token_provider().
+          2. Open a WebSocket to _REALTIME_URL with the right auth
+             shape (header / query param / post-connect frame, TBD).
+          3. Send _SUBSCRIBE_MESSAGE if the protocol requires one.
+          4. Loop reading frames; for each, call _parse_frame() and
+             dispatch other-device-started events to the callback.
+          5. Heartbeat at _HEARTBEAT_INTERVAL_SEC if the bus needs
+             keep-alives.
+        """
+        # Sanity belt: the public start() method already checked
+        # is_protocol_known and won't have spawned us if the protocol
+        # is unknown, but we double-check here in case start() is
+        # ever called before constants land.
+        if not self.is_protocol_known:
+            raise RuntimeError("realtime protocol constants not set")
+        # Real implementation lands here in Phase 1. For now, raise
+        # so _run()'s reconnect loop logs and backs off; once
+        # constants are populated this becomes the actual connect
+        # and serve loop.
+        raise NotImplementedError(
+            "tidal_realtime._connect_and_serve: protocol not captured"
+        )
+
+    @staticmethod
+    def _parse_frame(raw: bytes | str) -> Optional[dict]:
+        """Decode a single bus frame into a structured dict.
+
+        TODO(phase-1): implement once we know whether frames are
+        JSON, binary, or protobuf. Stubbed to return None so the
+        dispatcher in _connect_and_serve treats unknown frames as
+        unhandled (which is the correct behavior for events we
+        don't recognize even after the capture).
+        """
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Module-level singleton + start hook
+# ---------------------------------------------------------------------------
+
+_listener: Optional[RealtimeListener] = None
+
+
+def get_listener() -> Optional[RealtimeListener]:
+    """Return the module-level listener if one was started, else None."""
+    return _listener
+
+
+def start_listener(
+    token_provider: TokenProvider,
+    on_other_device_started: OtherDeviceStartedCallback,
+) -> RealtimeListener:
+    """Construct (or reuse) the module-level listener and start it.
+
+    Idempotent. Subsequent calls return the existing listener; the
+    token_provider and callback from the first call win. Lifespan
+    startup is the only intended caller.
+    """
+    global _listener
+    if _listener is None:
+        _listener = RealtimeListener(
+            token_provider=token_provider,
+            on_other_device_started=on_other_device_started,
+        )
+    _listener.start()
+    return _listener
+
+
+def stop_listener() -> None:
+    """Shut down the module-level listener if it was started.
+    Idempotent."""
+    if _listener is not None:
+        _listener.stop()

--- a/app/tidal_realtime.py
+++ b/app/tidal_realtime.py
@@ -3,7 +3,7 @@ same Tidal account starts playing.
 
 Tidal's official clients react to playback events from other devices
 via a realtime bus. When another device on the same account begins a
-playback_session, the bus pushes a state-change frame and the
+playback session, the bus pushes a state-change frame and the
 receiving client pauses locally. Spotify and the official Tidal app
 both behave this way out of the box; users coming from those expect
 Tideway to behave the same.
@@ -13,32 +13,37 @@ posts our own `playback_session` events to the event-producer bus
 (`ec.tidal.com/api/event-batch`), which is what makes "Tideway plays
 show up in Recently Played" and "starting Tideway pauses other
 devices that listen to the same bus" work today. This module is the
-**receive** half: a long-lived WebSocket subscription to whatever
-Tidal's realtime bus is, with an `on_other_device_started` callback
-that the desktop launcher wires to PCMPlayer.pause().
+**receive** half: a long-lived WebSocket subscription to Tidal's
+realtime bus ("Pushkin"), with an `on_other_device_started` callback
+that the launcher wires to `PCMPlayer.pause()`.
 
-## Status: scaffolded, protocol capture pending
+## Protocol
 
-The scaffold is here so the wiring (settings field, lifespan hook,
-diagnostic endpoint, callback into the player) can be reviewed and
-shipped without the protocol-specific details. Connection setup,
-the subscribe message, and the frame parser are stubs marked
-**TODO(phase-1)** that need a packet capture from Tidal's web
-client to fill in. See
-`private/features/cross-device-pause-listener.md` for the capture
-plan and the open questions about auth shape, frame format, etc.
+Reverse-engineered from the Tidal web client's `pushkin-*.js` module
+(2026-05-20). Two phases:
 
-Until the capture lands, the listener:
-  - Constructs cleanly,
-  - Reports `phase=disabled` from `status()` because the protocol
-    constants are placeholders,
-  - Refuses to start when called: returns immediately with a logged
-    "TODO" message rather than spinning a real WebSocket connection
-    against a guessed URL that can't actually work.
+  1. **Token acquisition.** POST to `https://api.tidal.com/v1/rt/
+     connect` with `Authorization: Bearer <access_token>`. Response
+     is `{"url": "wss://pushkin-v2.tidal.com/public/token/<uuid>/
+     ws"}` — the full WebSocket URL including a per-session token
+     baked into the path. Tokens are minted per connection; we
+     re-acquire on every (re)connect.
 
-This shape lets the rest of the app integrate (settings toggle,
-status endpoint, lifespan registration) without producing connection
-churn against a wrong endpoint.
+  2. **WebSocket session.** Plain JSON frames. Incoming types we
+     handle:
+       - `PRIVILEGED_SESSION_NOTIFICATION` — payload has
+         `clientDisplayName` (e.g. "iOS") and `sessionId`. Fires
+         when another device on the same Tidal account takes
+         playback. We pause local playback in response.
+       - `RECONNECT` — server-initiated reconnect. Close and
+         reopen.
+       - Anything else: log and ignore.
+
+     Outgoing frames are optional. The web client only sends
+     `USER_ACTION` messages in response to page user-action events
+     (clicks, keypresses); they're not heartbeats and Tidal's
+     backend doesn't seem to require them for connection liveness,
+     so we don't send anything.
 
 ## Threading model
 
@@ -58,10 +63,24 @@ the cancellation, closes the WebSocket if open, and exits.
 The pause callback fires from inside the asyncio loop. PCMPlayer's
 methods are thread-safe (they take `_lock` internally) so calling
 into them from the loop is fine; we don't need a thread hop.
+
+## Self-event filtering
+
+The web client's frame handler pauses unconditionally on every
+`PRIVILEGED_SESSION_NOTIFICATION` — no self-filter by sessionId.
+This works in practice because Tidal's backend doesn't echo a
+client's own session events back to that same client's connection.
+We follow the same posture: pause callback fires unconditionally;
+trust the server to not push our own events to us. If we ever see
+self-pause from a Tideway-only-playing scenario, the fix is to
+compare against the sessionId play_reporter generated for the
+active session.
 """
 from __future__ import annotations
 
 import asyncio
+import inspect
+import json
 import logging
 from dataclasses import dataclass, field
 from typing import Awaitable, Callable, Optional
@@ -69,27 +88,10 @@ from typing import Awaitable, Callable, Optional
 log = logging.getLogger(__name__)
 
 
-# ---------------------------------------------------------------------------
-# Protocol constants — TODO(phase-1): replace placeholders after capture.
-# ---------------------------------------------------------------------------
-#
-# `cross-device-pause-listener.md` records the open questions:
-#   - Is the realtime endpoint really WebSocket, or long-polling / SSE?
-#   - Auth shape: bearer header, query param, post-connect AUTH frame?
-#   - Do we need a "register this session" handshake first?
-#   - Frame format: JSON, binary, protobuf?
-#   - Are there events we'd want to ignore (our own play_reporter
-#     events bouncing back)?
-#
-# Until those are answered the listener stays in `disabled` phase and
-# never opens a connection. Replacing these constants and the
-# `_parse_frame` helper below is the entire surface the Phase 1
-# capture changes.
-
-_REALTIME_URL: Optional[str] = None  # e.g. "wss://realtime.tidal.com/v1/listen"
-_SUBSCRIBE_MESSAGE: Optional[str] = None  # JSON sent on connect, if needed
-_HEARTBEAT_INTERVAL_SEC: Optional[float] = None  # client-side ping cadence
-
+# HTTP endpoint that mints a per-session WebSocket URL. Returns
+# {"url": "wss://pushkin-v2.tidal.com/public/token/<uuid>/ws"}.
+# Reverse-engineered from `pushkin-*.js`'s `l()` function.
+_RT_CONNECT_URL = "https://api.tidal.com/v1/rt/connect"
 
 # Backoff schedule for reconnects. Doubles each consecutive failure,
 # capped so we don't drift into multi-minute holes that delay the
@@ -98,6 +100,14 @@ _HEARTBEAT_INTERVAL_SEC: Optional[float] = None  # client-side ping cadence
 # responsive while still being polite to Tidal's bus during outages.
 _BACKOFF_INITIAL_SEC = 0.5
 _BACKOFF_MAX_SEC = 60.0
+
+# How long to wait for the token POST + WebSocket handshake before
+# giving up and treating it as a connection failure. The token POST
+# is a single HTTPS round-trip against api.tidal.com; the handshake
+# is a single TLS+WS upgrade. Tens of seconds is generous; longer
+# than that means something's wrong (DNS, blocked, captive portal)
+# and we should back off, not wait.
+_CONNECT_TIMEOUT_SEC = 10.0
 
 
 # ---------------------------------------------------------------------------
@@ -120,11 +130,9 @@ OtherDeviceStartedCallback = Callable[[dict], Awaitable[None] | None]
 class ListenerStatus:
     """What `/api/realtime/status` returns. Diagnostic surface only."""
 
-    # One of: "disabled", "idle", "connecting", "connected",
-    # "reconnecting", "stopped". "disabled" specifically means the
-    # protocol constants haven't been filled in yet (Phase 1 not
-    # done). "idle" means the listener was constructed but start()
-    # hasn't been called.
+    # One of: "idle", "connecting", "connected", "reconnecting",
+    # "stopped". "idle" means the listener was constructed but
+    # start() hasn't been called.
     phase: str = "idle"
     # Last error message, if any. Cleared on successful connect.
     last_error: Optional[str] = None
@@ -161,28 +169,16 @@ class RealtimeListener:
 
     @property
     def is_protocol_known(self) -> bool:
-        """True once the Phase 1 capture has populated the protocol
-        constants. Until then start() is a no-op and status reports
-        `disabled`."""
-        return _REALTIME_URL is not None
+        """Reverse-engineered protocol is in place since 2026-05-20;
+        kept on the public surface for the `/api/realtime/status`
+        diagnostic endpoint and for any callers that want to gate
+        on it. Always True now."""
+        return True
 
     def start(self) -> None:
         """Spawn the connection task. Idempotent: a second call while
         already running is a no-op."""
         if self._task is not None and not self._task.done():
-            return
-        if not self.is_protocol_known:
-            self._status.phase = "disabled"
-            self._status.last_error = (
-                "Tidal realtime protocol not captured yet; listener "
-                "is a no-op until Phase 1 of the cross-device-pause "
-                "feature lands. See "
-                "private/features/cross-device-pause-listener.md."
-            )
-            log.info(
-                "tidal_realtime: start() called but protocol unknown; "
-                "no connection will be opened"
-            )
             return
         self._shutdown.clear()
         self._status = ListenerStatus(phase="connecting")
@@ -244,46 +240,124 @@ class RealtimeListener:
             backoff = min(backoff * 2.0, _BACKOFF_MAX_SEC)
 
     async def _connect_and_serve(self) -> None:
-        """Open one WebSocket connection, subscribe, and serve frames
-        until the connection drops. Re-raised exceptions trigger
+        """Acquire a token, open the Pushkin WebSocket, and serve
+        frames until the connection drops. Raised exceptions trigger
         reconnect via _run().
 
-        TODO(phase-1): this method is a placeholder. The real
-        implementation will:
-          1. Read the access token via self.token_provider().
-          2. Open a WebSocket to _REALTIME_URL with the right auth
-             shape (header / query param / post-connect frame, TBD).
-          3. Send _SUBSCRIBE_MESSAGE if the protocol requires one.
-          4. Loop reading frames; for each, call _parse_frame() and
-             dispatch other-device-started events to the callback.
-          5. Heartbeat at _HEARTBEAT_INTERVAL_SEC if the bus needs
-             keep-alives.
+        Lazy import of aiohttp + websockets so test environments that
+        construct the listener without an event loop don't fail at
+        import time on a missing optional dep.
         """
-        # Sanity belt: the public start() method already checked
-        # is_protocol_known and won't have spawned us if the protocol
-        # is unknown, but we double-check here in case start() is
-        # ever called before constants land.
-        if not self.is_protocol_known:
-            raise RuntimeError("realtime protocol constants not set")
-        # Real implementation lands here in Phase 1. For now, raise
-        # so _run()'s reconnect loop logs and backs off; once
-        # constants are populated this becomes the actual connect
-        # and serve loop.
-        raise NotImplementedError(
-            "tidal_realtime._connect_and_serve: protocol not captured"
-        )
+        access_token = self.token_provider()
+        if not access_token:
+            # No Tidal session right now (logged out, refresh in
+            # flight). Raise so _run() backs off and tries again
+            # once the session is back.
+            raise RuntimeError("no Tidal access token available")
+
+        import aiohttp
+        import websockets
+
+        # Phase 1: POST to /v1/rt/connect with the Bearer token to
+        # mint a per-session WebSocket URL. The response carries the
+        # full wss:// URL including the token UUID baked into the
+        # path; we don't need to construct it ourselves.
+        async with aiohttp.ClientSession() as http:
+            async with http.post(
+                _RT_CONNECT_URL,
+                headers={
+                    "Authorization": f"Bearer {access_token}",
+                    "Content-Type": "application/json",
+                },
+                timeout=aiohttp.ClientTimeout(total=_CONNECT_TIMEOUT_SEC),
+            ) as resp:
+                if resp.status == 401:
+                    # Token rejected — the access_token from the
+                    # provider is stale. Force a refresh next time
+                    # by surfacing this as a specific error.
+                    raise RuntimeError(
+                        "Pushkin token request returned 401; access "
+                        "token rejected"
+                    )
+                resp.raise_for_status()
+                payload = await resp.json()
+        ws_url = payload.get("url")
+        if not ws_url:
+            raise RuntimeError(
+                f"Pushkin token response missing 'url': {payload!r}"
+            )
+
+        # Phase 2: open the WebSocket and serve frames. No subscribe
+        # message and no client heartbeats — the Tidal web client
+        # sends `USER_ACTION` frames on page user-action events but
+        # they're not required for connection liveness, so we skip
+        # them.
+        async with websockets.connect(
+            ws_url,
+            open_timeout=_CONNECT_TIMEOUT_SEC,
+        ) as ws:
+            self._status.phase = "connected"
+            self._status.last_error = None
+            log.info(
+                "tidal_realtime: connected to Pushkin (reconnect_count=%d)",
+                self._status.reconnect_count,
+            )
+            async for raw in ws:
+                frame = self._parse_frame(raw)
+                if frame is None:
+                    continue
+                await self._dispatch_frame(frame, ws)
+
+    async def _dispatch_frame(self, frame: dict, ws) -> None:
+        """Route a parsed frame to the right action.
+
+        - PRIVILEGED_SESSION_NOTIFICATION → callback (pause local).
+        - RECONNECT → close socket; _run()'s outer loop reopens.
+        - anything else → log + ignore (forward-compat).
+        """
+        frame_type = frame.get("type")
+        if frame_type == "PRIVILEGED_SESSION_NOTIFICATION":
+            self._status.events_received += 1
+            payload = frame.get("payload") or {}
+            log.info(
+                "tidal_realtime: PRIVILEGED_SESSION_NOTIFICATION "
+                "from %s; firing pause callback",
+                payload.get("clientDisplayName") or "<unknown>",
+            )
+            try:
+                result = self.on_other_device_started(payload)
+                if inspect.isawaitable(result):
+                    await result
+            except Exception:
+                log.exception(
+                    "tidal_realtime: on_other_device_started "
+                    "callback raised"
+                )
+        elif frame_type == "RECONNECT":
+            log.info("tidal_realtime: server-initiated reconnect")
+            await ws.close()
+        else:
+            log.warning(
+                "tidal_realtime: unhandled frame type %r", frame_type
+            )
 
     @staticmethod
     def _parse_frame(raw: bytes | str) -> Optional[dict]:
-        """Decode a single bus frame into a structured dict.
-
-        TODO(phase-1): implement once we know whether frames are
-        JSON, binary, or protobuf. Stubbed to return None so the
-        dispatcher in _connect_and_serve treats unknown frames as
-        unhandled (which is the correct behavior for events we
-        don't recognize even after the capture).
-        """
-        return None
+        """Decode a single bus frame. Returns the parsed dict, or
+        None if the frame isn't a JSON object we can route on.
+        Garbage frames are non-fatal: log and skip."""
+        try:
+            text = raw.decode("utf-8") if isinstance(raw, (bytes, bytearray)) else raw
+            obj = json.loads(text)
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            log.warning("tidal_realtime: dropped non-JSON frame: %r", exc)
+            return None
+        if not isinstance(obj, dict):
+            log.warning(
+                "tidal_realtime: dropped non-object frame: %r", obj
+            )
+            return None
+        return obj
 
 
 # ---------------------------------------------------------------------------

--- a/server.py
+++ b/server.py
@@ -987,10 +987,17 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
     # start() reports phase=disabled and never opens a connection.
     # Wiring it now so the settings toggle, status endpoint, and
     # lifespan hook are in place when the protocol capture lands.
-    def _on_other_device_started(_payload: dict) -> None:
+    def _on_other_device_started(payload: dict) -> None:
         if not getattr(settings, "pause_on_other_device", True):
             # User opted out: keep playing through cross-device events.
             return
+        global _cross_device_pause_device
+        # Record which device caused the pause BEFORE actually
+        # pausing so a fast frontend poll of /api/player/state right
+        # after the SSE pause event already sees the reason. The
+        # _on_player_state callback clears this on the next play.
+        device = (payload.get("clientDisplayName") if payload else None) or "another device"
+        _cross_device_pause_device = str(device)
         try:
             _native_player().pause()
         except Exception as exc:
@@ -1025,9 +1032,16 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
         _last_was_playing = [False]
 
         def _on_player_state(snapshot) -> None:
+            global _cross_device_pause_device
             is_playing = getattr(snapshot, "state", None) == "playing"
             if is_playing and not _last_was_playing[0]:
                 _rt_listener.signal_user_action_sync()
+                # Clear the cross-device pause banner the moment
+                # the user resumes (or starts a new track). The
+                # banner only makes sense while paused-by-someone-
+                # else; once the local user takes over again the
+                # message is stale.
+                _cross_device_pause_device = None
             _last_was_playing[0] = is_playing
 
         try:
@@ -4817,6 +4831,17 @@ class _PlayerOutputDeviceRequest(BaseModel):
 _player_bootstrapped = False
 _pcm_player_singleton: Optional[PCMPlayer] = None
 
+# The most recent cross-device-pause cause, surfaced in the player
+# snapshot so the frontend can render a banner explaining why
+# playback stopped ("Paused — playing on iOS"). Set by the Pushkin
+# listener's `on_other_device_started` callback when a
+# PRIVILEGED_SESSION_NOTIFICATION arrives; cleared whenever the
+# local player transitions back into the playing state, or
+# explicitly via the dismiss endpoint. A simple module-level string
+# is enough — only one device can hold the privileged session at a
+# time, so there's no race to worry about.
+_cross_device_pause_device: Optional[str] = None
+
 
 def _native_player() -> PCMPlayer:
     """Return the PCMPlayer singleton. Lazily constructed on first
@@ -5114,6 +5139,11 @@ def _snapshot_dict(snap) -> dict:
         "seq": snap.seq,
         "stream_info": stream_info,
         "force_volume": getattr(snap, "force_volume", False),
+        # Set by the Pushkin listener when another device on the
+        # same Tidal account starts playing; cleared on next local
+        # play. Frontend renders a banner above the play bar with
+        # this device name while it's set.
+        "paused_by_device": _cross_device_pause_device,
     }
 
 
@@ -5497,6 +5527,22 @@ def _dlna_send(action: str) -> None:
             upnp_manager.pause()
     except Exception as exc:  # noqa: BLE001 see docstring
         log.debug("dlna %s passthrough failed: %r", action, exc)
+
+
+@app.post("/api/player/dismiss-pause-reason")
+def player_dismiss_pause_reason() -> dict:
+    """Clear the `paused_by_device` field on the player snapshot.
+
+    The banner's X button calls this so the user can stop seeing
+    the "Paused — playing on iOS" message without having to resume
+    playback to clear it. Returns the fresh snapshot so the
+    frontend can react in-place rather than waiting for the next
+    SSE tick.
+    """
+    _require_local_access()
+    global _cross_device_pause_device
+    _cross_device_pause_device = None
+    return _snapshot_dict(_native_player().snapshot())
 
 
 @app.post("/api/player/play")

--- a/server.py
+++ b/server.py
@@ -49,6 +49,7 @@ from app.audio.macos_now_playing import MacOSNowPlayingBridge
 from app.audio.player import PCMPlayer
 from app import playlist_import
 from app import spotify_import
+from app import tidal_realtime
 from app.downloader import DownloadItem, DownloadStatus, Downloader
 from app.http import SESSION
 from app.lastfm import LastFmClient
@@ -978,6 +979,40 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
             daemon=True,
         ).start()
 
+    # Tidal realtime listener: pauses local playback when another
+    # device on the user's Tidal account starts playing. The listener
+    # itself is currently a scaffold; the protocol-specific bits
+    # (WebSocket URL, frame parser) need a packet capture from the
+    # Tidal web client to land before this does anything. Until then
+    # start() reports phase=disabled and never opens a connection.
+    # Wiring it now so the settings toggle, status endpoint, and
+    # lifespan hook are in place when the protocol capture lands.
+    def _on_other_device_started(_payload: dict) -> None:
+        if not getattr(settings, "pause_on_other_device", True):
+            # User opted out: keep playing through cross-device events.
+            return
+        try:
+            _native_player().pause()
+        except Exception as exc:
+            print(
+                f"[tidal-realtime] pause-on-other-device failed: {exc!r}",
+                flush=True,
+            )
+
+    def _tidal_token_provider() -> Optional[str]:
+        try:
+            return getattr(tidal.session, "access_token", None)
+        except Exception:
+            return None
+
+    try:
+        tidal_realtime.start_listener(
+            token_provider=_tidal_token_provider,
+            on_other_device_started=_on_other_device_started,
+        )
+    except Exception as exc:
+        print(f"[tidal-realtime] startup failed: {exc!r}", flush=True)
+
     try:
         yield
     finally:
@@ -1015,6 +1050,12 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
         try:
             from app.audio.upnp import upnp_manager as _upnp_manager
             _upnp_manager.disconnect()
+        except Exception:
+            pass
+        # Cancel the Tidal realtime listener task. No-op when the
+        # listener stayed disabled (protocol capture still pending).
+        try:
+            tidal_realtime.stop_listener()
         except Exception:
             pass
         # Close the shared requests session so sockets in its connection pool
@@ -6504,6 +6545,38 @@ def _autoeq_on_device_change(device_id: str) -> None:
         log.exception("autoeq device-change resolver failed")
 
 
+@app.get("/api/realtime/status")
+def realtime_status() -> dict:
+    """Diagnostic snapshot of the Tidal realtime listener.
+
+    Surfaces phase / last_error / reconnect_count / events_received
+    so a user reporting "cross-device pause didn't work" can paste
+    the response into a bug report and we can see whether the
+    listener was even connected. Loopback-only because there's no
+    reason for an external caller to read this and the listener's
+    internals leak protocol details we don't want to advertise.
+    """
+    _require_local_access()
+    listener = tidal_realtime.get_listener()
+    if listener is None:
+        return {
+            "phase": "idle",
+            "last_error": None,
+            "reconnect_count": 0,
+            "events_received": 0,
+            "protocol_known": False,
+        }
+    s = listener.status()
+    return {
+        "phase": s.phase,
+        "last_error": s.last_error,
+        "reconnect_count": s.reconnect_count,
+        "events_received": s.events_received,
+        "protocol_known": listener.is_protocol_known,
+    }
+
+
+
 @app.get("/api/cast/devices")
 def cast_devices() -> dict:
     """Snapshot of Chromecast devices currently visible on the LAN.
@@ -9873,6 +9946,7 @@ class SettingsPayload(BaseModel):
     exclusive_mode: Optional[bool] = None
     force_volume: Optional[bool] = None
     continue_playing_after_queue_ends: Optional[bool] = None
+    pause_on_other_device: Optional[bool] = None
     explicit_content_preference: Optional[str] = None
     download_rate_limit_mbps: Optional[int] = None
     eq_mode: Optional[str] = None

--- a/server.py
+++ b/server.py
@@ -1006,12 +1006,37 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
             return None
 
     try:
-        tidal_realtime.start_listener(
+        _rt_listener = tidal_realtime.start_listener(
             token_provider=_tidal_token_provider,
             on_other_device_started=_on_other_device_started,
         )
     except Exception as exc:
         print(f"[tidal-realtime] startup failed: {exc!r}", flush=True)
+        _rt_listener = None
+
+    # When PCMPlayer transitions into the playing state, send a
+    # USER_ACTION frame on the Pushkin WebSocket. That's how
+    # Tidal's backend learns "this device is now the active one"
+    # and pushes PRIVILEGED_SESSION_NOTIFICATION to the other
+    # devices on the same account so they pause. Without this,
+    # cross-device pause only works one way: other devices can
+    # interrupt Tideway, but Tideway can't interrupt them.
+    if _rt_listener is not None:
+        _last_was_playing = [False]
+
+        def _on_player_state(snapshot) -> None:
+            is_playing = getattr(snapshot, "state", None) == "playing"
+            if is_playing and not _last_was_playing[0]:
+                _rt_listener.signal_user_action_sync()
+            _last_was_playing[0] = is_playing
+
+        try:
+            _native_player().subscribe(_on_player_state)
+        except Exception as exc:
+            print(
+                f"[tidal-realtime] subscribe to player failed: {exc!r}",
+                flush=True,
+            )
 
     try:
         yield

--- a/tests/test_tidal_realtime.py
+++ b/tests/test_tidal_realtime.py
@@ -1,0 +1,146 @@
+"""Tests for the Tidal realtime listener scaffold.
+
+The actual WebSocket connection logic depends on protocol constants
+that aren't filled in yet (see app/tidal_realtime.py — Phase 1
+capture pending), so these tests focus on the parts that exist:
+listener construction, start/stop idempotency, status reporting,
+and the singleton helpers.
+
+Once the protocol capture lands and `_connect_and_serve` is real,
+add tests with a mocked `websockets.connect` that exercise the
+parser against captured-frame fixtures and the reconnect logic
+under simulated drops.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app import tidal_realtime
+from app.tidal_realtime import (
+    RealtimeListener,
+    get_listener,
+    start_listener,
+    stop_listener,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_singleton():
+    """Clear the module-level listener between tests so order
+    doesn't matter and a leaked listener from one test can't
+    influence another."""
+    tidal_realtime._listener = None
+    yield
+    if tidal_realtime._listener is not None:
+        tidal_realtime._listener.stop()
+        tidal_realtime._listener = None
+
+
+def _noop_token():
+    return "dummy"
+
+
+def _noop_callback(payload):  # noqa: D401
+    return None
+
+
+def test_listener_constructs_with_idle_phase():
+    """A freshly-built listener that hasn't been started reports
+    `idle` (not `disabled`); `disabled` is reserved for the
+    "protocol unknown so we won't even try" branch."""
+    listener = RealtimeListener(
+        token_provider=_noop_token,
+        on_other_device_started=_noop_callback,
+    )
+    s = listener.status()
+    assert s.phase == "idle"
+    assert s.last_error is None
+    assert s.reconnect_count == 0
+    assert s.events_received == 0
+
+
+def test_start_no_ops_when_protocol_unknown():
+    """Until Phase 1 capture lands, start() should refuse to open a
+    WebSocket and report `disabled`. Tested by relying on the
+    placeholder constants (which the production module ships with
+    until the capture is filled in)."""
+    listener = RealtimeListener(
+        token_provider=_noop_token,
+        on_other_device_started=_noop_callback,
+    )
+    listener.start()
+    # No task should have been spawned.
+    assert listener._task is None
+    s = listener.status()
+    assert s.phase == "disabled"
+    assert s.last_error is not None
+    assert "Phase 1" in s.last_error
+
+
+def test_stop_is_idempotent():
+    """Calling stop() multiple times shouldn't raise. Important
+    because lifespan teardown can fire stop() even when start()
+    was a no-op."""
+    listener = RealtimeListener(
+        token_provider=_noop_token,
+        on_other_device_started=_noop_callback,
+    )
+    listener.stop()
+    listener.stop()
+    assert listener.status().phase == "stopped"
+
+
+def test_status_returns_a_fresh_snapshot_each_call():
+    """status() should return a new ListenerStatus, not the
+    listener's internal mutable instance. Caller should not be
+    able to poison internal state by mutating the returned dict."""
+    listener = RealtimeListener(
+        token_provider=_noop_token,
+        on_other_device_started=_noop_callback,
+    )
+    s1 = listener.status()
+    s2 = listener.status()
+    assert s1 is not s2
+    s1.phase = "tampered"
+    assert listener.status().phase != "tampered"
+
+
+def test_module_singleton_helpers():
+    """get_listener / start_listener / stop_listener cooperate so
+    lifespan startup gets a working singleton without each call
+    re-constructing."""
+    assert get_listener() is None
+    listener = start_listener(
+        token_provider=_noop_token,
+        on_other_device_started=_noop_callback,
+    )
+    assert get_listener() is listener
+    # Second start_listener call returns the same instance.
+    again = start_listener(
+        token_provider=lambda: "ignored",
+        on_other_device_started=_noop_callback,
+    )
+    assert again is listener
+    stop_listener()
+    # After stop, the singleton stays around for status reads (per
+    # the realtime_status endpoint contract); only the running task
+    # is cancelled.
+    assert get_listener() is listener
+
+
+def test_protocol_constants_are_documented_placeholders():
+    """If someone fills in the protocol constants without also
+    deleting the disabled-phase branch, this test catches it. The
+    public `is_protocol_known` flag is the single source of truth
+    for "we know how to talk to the bus."""
+    listener = RealtimeListener(
+        token_provider=_noop_token,
+        on_other_device_started=_noop_callback,
+    )
+    if tidal_realtime._REALTIME_URL is None:
+        assert listener.is_protocol_known is False
+    else:
+        # Once the capture lands and the URL is set, the listener
+        # should report the protocol as known and the disabled
+        # phase should no longer be reachable from start().
+        assert listener.is_protocol_known is True

--- a/tests/test_tidal_realtime.py
+++ b/tests/test_tidal_realtime.py
@@ -1,17 +1,26 @@
-"""Tests for the Tidal realtime listener scaffold.
+"""Tests for the Tidal realtime listener.
 
-The actual WebSocket connection logic depends on protocol constants
-that aren't filled in yet (see app/tidal_realtime.py — Phase 1
-capture pending), so these tests focus on the parts that exist:
-listener construction, start/stop idempotency, status reporting,
-and the singleton helpers.
+The WebSocket loop itself does live network IO against
+api.tidal.com and pushkin-v2.tidal.com, so it isn't exercised in
+unit tests. What is covered:
 
-Once the protocol capture lands and `_connect_and_serve` is real,
-add tests with a mocked `websockets.connect` that exercise the
-parser against captured-frame fixtures and the reconnect logic
-under simulated drops.
+  - Listener lifecycle: construction, start/stop idempotency,
+    fresh-snapshot semantics on status().
+  - Module-level singleton (start_listener / get_listener /
+    stop_listener).
+  - Frame parser: valid JSON dict, garbage JSON, non-dict JSON.
+  - Frame dispatch: PRIVILEGED_SESSION_NOTIFICATION fires the
+    callback, RECONNECT closes the socket, sync and async
+    callbacks are both handled.
+
+The full connect loop is best tested as a manual integration
+check against a real Tidal account, since faking the entire
+api.tidal.com + Pushkin handshake is more code than the loop
+itself.
 """
 from __future__ import annotations
+
+import asyncio
 
 import pytest
 
@@ -26,9 +35,6 @@ from app.tidal_realtime import (
 
 @pytest.fixture(autouse=True)
 def _reset_module_singleton():
-    """Clear the module-level listener between tests so order
-    doesn't matter and a leaked listener from one test can't
-    influence another."""
     tidal_realtime._listener = None
     yield
     if tidal_realtime._listener is not None:
@@ -44,60 +50,46 @@ def _noop_callback(payload):  # noqa: D401
     return None
 
 
-def test_listener_constructs_with_idle_phase():
-    """A freshly-built listener that hasn't been started reports
-    `idle` (not `disabled`); `disabled` is reserved for the
-    "protocol unknown so we won't even try" branch."""
-    listener = RealtimeListener(
+def _listener() -> RealtimeListener:
+    return RealtimeListener(
         token_provider=_noop_token,
         on_other_device_started=_noop_callback,
     )
-    s = listener.status()
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_listener_constructs_with_idle_phase():
+    s = _listener().status()
     assert s.phase == "idle"
     assert s.last_error is None
     assert s.reconnect_count == 0
     assert s.events_received == 0
 
 
-def test_start_no_ops_when_protocol_unknown():
-    """Until Phase 1 capture lands, start() should refuse to open a
-    WebSocket and report `disabled`. Tested by relying on the
-    placeholder constants (which the production module ships with
-    until the capture is filled in)."""
-    listener = RealtimeListener(
-        token_provider=_noop_token,
-        on_other_device_started=_noop_callback,
-    )
-    listener.start()
-    # No task should have been spawned.
-    assert listener._task is None
-    s = listener.status()
-    assert s.phase == "disabled"
-    assert s.last_error is not None
-    assert "Phase 1" in s.last_error
+def test_is_protocol_known_is_true():
+    """The Phase 1 capture landed; the listener can connect on its
+    own. `is_protocol_known` is kept on the surface for the
+    /api/realtime/status diagnostic but is constant True now."""
+    assert _listener().is_protocol_known is True
 
 
 def test_stop_is_idempotent():
-    """Calling stop() multiple times shouldn't raise. Important
-    because lifespan teardown can fire stop() even when start()
-    was a no-op."""
-    listener = RealtimeListener(
-        token_provider=_noop_token,
-        on_other_device_started=_noop_callback,
-    )
+    """Multiple stop() calls must not raise — lifespan teardown can
+    fire it even when start() was never called."""
+    listener = _listener()
     listener.stop()
     listener.stop()
     assert listener.status().phase == "stopped"
 
 
 def test_status_returns_a_fresh_snapshot_each_call():
-    """status() should return a new ListenerStatus, not the
-    listener's internal mutable instance. Caller should not be
-    able to poison internal state by mutating the returned dict."""
-    listener = RealtimeListener(
-        token_provider=_noop_token,
-        on_other_device_started=_noop_callback,
-    )
+    """status() must return a new dataclass so callers can't
+    poison internal state by mutating it."""
+    listener = _listener()
     s1 = listener.status()
     s2 = listener.status()
     assert s1 is not s2
@@ -105,42 +97,176 @@ def test_status_returns_a_fresh_snapshot_each_call():
     assert listener.status().phase != "tampered"
 
 
-def test_module_singleton_helpers():
-    """get_listener / start_listener / stop_listener cooperate so
-    lifespan startup gets a working singleton without each call
-    re-constructing."""
+def test_module_singleton_helpers(monkeypatch):
+    """start_listener() spawns an asyncio task, which needs a
+    running loop — under pytest there isn't one. Patch start() to
+    a no-op for the duration of this test so we can exercise the
+    singleton wiring without standing up an event loop."""
+    monkeypatch.setattr(RealtimeListener, "start", lambda self: None)
     assert get_listener() is None
     listener = start_listener(
         token_provider=_noop_token,
         on_other_device_started=_noop_callback,
     )
     assert get_listener() is listener
-    # Second start_listener call returns the same instance.
     again = start_listener(
         token_provider=lambda: "ignored",
         on_other_device_started=_noop_callback,
     )
     assert again is listener
     stop_listener()
-    # After stop, the singleton stays around for status reads (per
-    # the realtime_status endpoint contract); only the running task
-    # is cancelled.
+    # Singleton stays around for status reads after stop; only the
+    # running task is cancelled.
     assert get_listener() is listener
 
 
-def test_protocol_constants_are_documented_placeholders():
-    """If someone fills in the protocol constants without also
-    deleting the disabled-phase branch, this test catches it. The
-    public `is_protocol_known` flag is the single source of truth
-    for "we know how to talk to the bus."""
+# ---------------------------------------------------------------------------
+# Frame parser
+# ---------------------------------------------------------------------------
+
+
+def test_parse_frame_decodes_str_json():
+    raw = (
+        '{"type":"PRIVILEGED_SESSION_NOTIFICATION",'
+        '"payload":{"clientDisplayName":"iOS",'
+        '"sessionId":"0d8fecb2-dcdb-4555-97b0-7c807806e4ad"}}'
+    )
+    frame = RealtimeListener._parse_frame(raw)
+    assert frame is not None
+    assert frame["type"] == "PRIVILEGED_SESSION_NOTIFICATION"
+    assert frame["payload"]["clientDisplayName"] == "iOS"
+    assert (
+        frame["payload"]["sessionId"]
+        == "0d8fecb2-dcdb-4555-97b0-7c807806e4ad"
+    )
+
+
+def test_parse_frame_decodes_bytes_json():
+    raw = b'{"type":"RECONNECT","payload":{}}'
+    frame = RealtimeListener._parse_frame(raw)
+    assert frame is not None
+    assert frame["type"] == "RECONNECT"
+
+
+def test_parse_frame_returns_none_on_garbage():
+    assert RealtimeListener._parse_frame("not json at all") is None
+    assert RealtimeListener._parse_frame(b"\xff\xfe\x00\x01") is None
+
+
+def test_parse_frame_rejects_non_dict_top_level():
+    """JSON arrays / strings / numbers parse fine but aren't routable
+    frames. Treat as garbage and skip."""
+    assert RealtimeListener._parse_frame('["array"]') is None
+    assert RealtimeListener._parse_frame('"string"') is None
+    assert RealtimeListener._parse_frame("42") is None
+
+
+# ---------------------------------------------------------------------------
+# Frame dispatch
+# ---------------------------------------------------------------------------
+
+
+class _FakeWS:
+    """Bare-minimum stand-in for the websockets.connect coroutine's
+    context. Records close() calls so tests can assert on RECONNECT
+    handling without standing up a real WebSocket."""
+
+    def __init__(self) -> None:
+        self.closed = False
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+def test_dispatch_fires_callback_on_session_notification():
+    received: list = []
+
+    def cb(payload):
+        received.append(payload)
+
     listener = RealtimeListener(
         token_provider=_noop_token,
-        on_other_device_started=_noop_callback,
+        on_other_device_started=cb,
     )
-    if tidal_realtime._REALTIME_URL is None:
-        assert listener.is_protocol_known is False
-    else:
-        # Once the capture lands and the URL is set, the listener
-        # should report the protocol as known and the disabled
-        # phase should no longer be reachable from start().
-        assert listener.is_protocol_known is True
+    frame = {
+        "type": "PRIVILEGED_SESSION_NOTIFICATION",
+        "payload": {
+            "clientDisplayName": "iOS",
+            "sessionId": "abc",
+        },
+    }
+
+    ws = _FakeWS()
+    asyncio.run(listener._dispatch_frame(frame, ws))
+
+    assert len(received) == 1
+    assert received[0]["clientDisplayName"] == "iOS"
+    assert listener.status().events_received == 1
+    assert ws.closed is False
+
+
+def test_dispatch_awaits_async_callback():
+    """An async callback should be awaited, not left as a stray
+    coroutine. The web client's pattern is sync (player.pause()) but
+    the type hints allow async for callers that want to fan the
+    pause out across multiple players."""
+    received: list = []
+
+    async def cb(payload):
+        await asyncio.sleep(0)
+        received.append(payload)
+
+    listener = RealtimeListener(
+        token_provider=_noop_token,
+        on_other_device_started=cb,
+    )
+    frame = {"type": "PRIVILEGED_SESSION_NOTIFICATION", "payload": {}}
+    asyncio.run(listener._dispatch_frame(frame, _FakeWS()))
+    assert len(received) == 1
+
+
+def test_dispatch_closes_socket_on_reconnect_frame():
+    """RECONNECT means the server wants us to drop the current
+    socket and reopen. _run()'s outer loop handles the reopen; here
+    we just verify close() is called."""
+    listener = _listener()
+    ws = _FakeWS()
+    asyncio.run(
+        listener._dispatch_frame({"type": "RECONNECT"}, ws)
+    )
+    assert ws.closed is True
+
+
+def test_dispatch_callback_exception_is_swallowed():
+    """A buggy callback must not break the receive loop. We log and
+    keep going so a transient callback failure doesn't permanently
+    disable cross-device pause until the next reconnect."""
+
+    def boom(payload):
+        raise RuntimeError("callback explosion")
+
+    listener = RealtimeListener(
+        token_provider=_noop_token,
+        on_other_device_started=boom,
+    )
+    frame = {"type": "PRIVILEGED_SESSION_NOTIFICATION", "payload": {}}
+    # If the exception leaked, this would raise.
+    asyncio.run(listener._dispatch_frame(frame, _FakeWS()))
+    # The events_received counter still increments — we DID receive
+    # the frame, the action just failed.
+    assert listener.status().events_received == 1
+
+
+def test_dispatch_ignores_unknown_frame_type():
+    """Forward-compat: a future Pushkin event type we don't handle
+    yet shouldn't crash or close the socket. Logged at warning level
+    so it's visible if it ever happens."""
+    listener = _listener()
+    ws = _FakeWS()
+    asyncio.run(
+        listener._dispatch_frame(
+            {"type": "SOME_FUTURE_EVENT", "payload": {}}, ws
+        )
+    )
+    assert ws.closed is False
+    assert listener.status().events_received == 0

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -14,6 +14,7 @@ import { WindowResizeEdges } from "@/components/WindowResizeEdges";
 import { OfflineBanner } from "@/components/OfflineBanner";
 import { TidalBackoffBanner } from "@/components/TidalBackoffBanner";
 import { UpdateBanner } from "@/components/UpdateBanner";
+import { CrossDevicePauseBanner } from "@/components/CrossDevicePauseBanner";
 import { NowPlaying } from "@/components/NowPlaying";
 import { QueuePanel } from "@/components/QueuePanel";
 import { LyricsPanel } from "@/components/LyricsPanel";
@@ -705,6 +706,7 @@ function Shell({
         </main>
       </div>
       <SelectionBar />
+      <CrossDevicePauseBanner />
       <NowPlaying
         onDownload={enqueue}
         onExpand={() => setFullOpen(true)}

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -952,6 +952,13 @@ export const api = {
       }).catch(() => ({ ok: false })),
     play: () => req<PlayerSnapshot>("/api/player/play", { method: "POST" }),
     pause: () => req<PlayerSnapshot>("/api/player/pause", { method: "POST" }),
+    /** Clear the cross-device pause banner without resuming
+     *  playback. Called when the user dismisses the "Paused —
+     *  playing on iOS" alert with its X button. */
+    dismissPauseReason: () =>
+      req<PlayerSnapshot>("/api/player/dismiss-pause-reason", {
+        method: "POST",
+      }),
     resume: () => req<PlayerSnapshot>("/api/player/resume", { method: "POST" }),
     stop: () => req<PlayerSnapshot>("/api/player/stop", { method: "POST" }),
     seek: (fraction: number) =>

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -310,6 +310,13 @@ export interface Settings {
    *  falls back to per-source defaults (stop, or for albums prime
    *  track 0 paused so one tap repeats the album). */
   continue_playing_after_queue_ends: boolean;
+  /** When another device on the same Tidal account starts playing,
+   *  pause Tideway. Matches Spotify / official Tidal client behaviour.
+   *  On by default. The realtime listener that drives this is wired
+   *  up but the protocol capture is pending (see
+   *  private/features/cross-device-pause-listener.md), so the toggle
+   *  has no effect today regardless of value. */
+  pause_on_other_device: boolean;
   /** Per-track download rate cap in MB/s. 0 = unlimited. Default 10
    *  so downloads look like aggressive prefetch rather than a scrape
    *  to Tidal's CDN — the single most effective ban-risk reduction

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -147,6 +147,13 @@ export interface PlayerSnapshot {
   /** When true the backend is pinning volume at 100 %. Set via the
    *  "Force volume" option in the bottom bar's output-device menu. */
   force_volume?: boolean;
+  /** Set when local playback was paused by a cross-device-pause
+   *  event from Tidal's Pushkin bus. Contains the display name of
+   *  the device that took over ("iOS", "Desktop", "another device"
+   *  as a fallback). Null when no such pause is current.
+   *  Cleared automatically when the user resumes playback locally
+   *  or explicitly via POST /api/player/dismiss-pause-reason. */
+  paused_by_device?: string | null;
 }
 
 /** Tidal-nominated single most-relevant result. Discriminated by the

--- a/web/src/components/CrossDevicePauseBanner.test.tsx
+++ b/web/src/components/CrossDevicePauseBanner.test.tsx
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+import { CrossDevicePauseBanner } from "./CrossDevicePauseBanner";
+import { api } from "@/api/client";
+
+// Hoist the playerMeta object so the mock factory and the test
+// bodies share a single reference. Vitest hoists vi.mock factories
+// above imports, which would otherwise capture a stale binding.
+const playerMetaRef: { value: { pausedByDevice: string | null } } = {
+  value: { pausedByDevice: null },
+};
+
+vi.mock("@/hooks/PlayerContext", () => ({
+  usePlayerMeta: () => playerMetaRef.value,
+}));
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  document.body.removeChild(container);
+  vi.restoreAllMocks();
+  playerMetaRef.value = { pausedByDevice: null };
+});
+
+describe("CrossDevicePauseBanner", () => {
+  it("renders nothing when no cross-device pause is pending", () => {
+    playerMetaRef.value = { pausedByDevice: null };
+    act(() => {
+      root.render(<CrossDevicePauseBanner />);
+    });
+    expect(container.textContent).toBe("");
+    expect(container.querySelector('[role="status"]')).toBeNull();
+  });
+
+  it("renders the device name when paused_by_device is set", () => {
+    playerMetaRef.value = { pausedByDevice: "iOS" };
+    act(() => {
+      root.render(<CrossDevicePauseBanner />);
+    });
+    expect(container.textContent).toContain("Paused");
+    expect(container.textContent).toContain("iOS");
+    expect(container.querySelector('[role="status"]')).not.toBeNull();
+  });
+
+  it("hits the dismiss endpoint when the X button is clicked", async () => {
+    playerMetaRef.value = { pausedByDevice: "Desktop" };
+    const spy = vi
+      .spyOn(api.player, "dismissPauseReason")
+      .mockResolvedValue({} as never);
+    act(() => {
+      root.render(<CrossDevicePauseBanner />);
+    });
+    const button = container.querySelector(
+      'button[aria-label="Dismiss"]',
+    ) as HTMLButtonElement | null;
+    expect(button).not.toBeNull();
+    act(() => {
+      button?.click();
+    });
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+
+  it("swallows dismiss endpoint failures so the UI doesn't crash", async () => {
+    playerMetaRef.value = { pausedByDevice: "Desktop" };
+    vi.spyOn(api.player, "dismissPauseReason").mockRejectedValue(
+      new Error("server unreachable"),
+    );
+    act(() => {
+      root.render(<CrossDevicePauseBanner />);
+    });
+    const button = container.querySelector(
+      'button[aria-label="Dismiss"]',
+    ) as HTMLButtonElement | null;
+    // Should not throw / no unhandled rejection visible to the test.
+    act(() => {
+      button?.click();
+    });
+    // Component still renders even after a failed dismiss; the
+    // server-side state is unchanged so the next snapshot will
+    // still carry the same pause reason.
+    expect(container.querySelector('[role="status"]')).not.toBeNull();
+  });
+});

--- a/web/src/components/CrossDevicePauseBanner.tsx
+++ b/web/src/components/CrossDevicePauseBanner.tsx
@@ -1,0 +1,56 @@
+import { Pause, X } from "lucide-react";
+import { api } from "@/api/client";
+import { usePlayerMeta } from "@/hooks/PlayerContext";
+
+/**
+ * Strip above the play bar that explains why playback stopped when
+ * another device on the user's Tidal account took over. Renders
+ * only when the backend's `paused_by_device` field is non-null;
+ * otherwise nothing.
+ *
+ * Cleared automatically when the user resumes playback locally
+ * (the lifespan's player-state listener nulls the server-side
+ * pause reason on the next play). The X button explicitly hits
+ * `/api/player/dismiss-pause-reason` so users can dismiss without
+ * having to play something.
+ */
+export function CrossDevicePauseBanner() {
+  const { pausedByDevice } = usePlayerMeta();
+
+  if (!pausedByDevice) return null;
+
+  const onDismiss = () => {
+    // Best-effort. The server clears `_cross_device_pause_device`
+    // and returns the fresh snapshot, which the next SSE tick
+    // will reflect. If the call fails, the banner sticks around
+    // until the next play; not great, not catastrophic.
+    api.player.dismissPauseReason().catch(() => {
+      /* ignore */
+    });
+  };
+
+  return (
+    <div
+      role="status"
+      className="flex items-center gap-3 border-t border-muted bg-muted/40 px-6 py-2 text-sm"
+    >
+      <Pause className="h-4 w-4 flex-shrink-0 text-muted-foreground" />
+      <div className="min-w-0 flex-1">
+        <span className="font-medium">Paused</span>
+        <span className="text-muted-foreground">
+          {" "}
+          — you're playing on {pausedByDevice}.
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={onDismiss}
+        title="Dismiss"
+        aria-label="Dismiss"
+        className="flex h-7 w-7 items-center justify-center rounded text-muted-foreground hover:bg-muted hover:text-foreground"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/web/src/hooks/PlayerContext.tsx
+++ b/web/src/hooks/PlayerContext.tsx
@@ -44,6 +44,10 @@ interface PlayerMeta {
   /** Mirror of the backend's force_volume flag so the UI can disable
    *  the volume slider when the software volume is pinned at 100. */
   forceVolume: boolean;
+  /** Name of the device that caused a cross-device pause, when one
+   *  is currently pending. Null otherwise. Drives the banner above
+   *  the play bar that explains why playback stopped. */
+  pausedByDevice: string | null;
 }
 
 interface PlayerSleep {
@@ -106,6 +110,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       streamInfo: player.streamInfo,
       source: player.source,
       forceVolume: player.forceVolume,
+      pausedByDevice: player.pausedByDevice,
     }),
     [
       player.track,
@@ -122,6 +127,7 @@ export function PlayerProvider({ children }: { children: ReactNode }) {
       player.streamInfo,
       player.source,
       player.forceVolume,
+      player.pausedByDevice,
     ],
   );
 

--- a/web/src/hooks/usePlayer.ts
+++ b/web/src/hooks/usePlayer.ts
@@ -82,6 +82,10 @@ export interface PlayerState {
    *  volume slider should render disabled and the backend rejects
    *  set_volume calls; the user attenuates via their DAC / OS. */
   forceVolume: boolean;
+  /** Name of the device that caused a cross-device pause, when one
+   *  is currently pending. Null otherwise. Drives the banner above
+   *  the play bar. */
+  pausedByDevice: string | null;
 }
 
 const INITIAL: PlayerState = {
@@ -99,6 +103,7 @@ const INITIAL: PlayerState = {
   streamInfo: null,
   source: null,
   forceVolume: false,
+  pausedByDevice: null,
 };
 
 /**
@@ -474,6 +479,7 @@ export function usePlayer() {
           duration,
           streamInfo: snap.stream_info,
           forceVolume: !!snap.force_volume,
+          pausedByDevice: snap.paused_by_device ?? null,
           ...volPatch,
         };
       });

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -299,6 +299,12 @@ export function SettingsPage({ onLogout }: { onLogout: () => void }) {
                 label="Continue playing music after your queue ends"
                 hint="When on, the player queues an Artist Radio mix seeded from the last track's primary artist so playback never stops on its own. When off, an album re-primes its first track paused (one tap of Play repeats the album); other queues just stop."
               />
+              <Toggle
+                checked={settings.pause_on_other_device}
+                onChange={(v) => patch({ pause_on_other_device: v })}
+                label="Pause when another device starts playing"
+                hint="When you start playback on another device on the same Tidal account (phone, web, another computer), Tideway pauses local playback. Matches Spotify and the official Tidal client. The listener that drives this is wired up but the realtime protocol capture is still pending, so the toggle has no effect today; flipping it off ahead of time means it'll already be off when the listener goes live."
+              />
             </Section>
           </TabsContent>
 


### PR DESCRIPTION
## Summary

When the user starts playing on another Tidal device (phone, official Mac/Windows desktop, web app), Tideway pauses local playback — and vice versa. Reverse-engineered Tidal's Pushkin realtime bus and implemented a WebSocket client in `app/tidal_realtime.py`. A banner above the play bar explains *why* music stopped (e.g. "Paused — you're playing on iOS") with a dismiss button.

## How it works

- Receive side: a long-lived WebSocket to `wss://pushkin-v2.tidal.com/public/token/<uuid>/ws`. The token is minted by POSTing to `https://api.tidal.com/v1/rt/connect` with the user's Tidal Bearer token. Pushkin pushes JSON frames; `PRIVILEGED_SESSION_NOTIFICATION` triggers the local pause. Connection reconnects on drop with exponential backoff.
- Send side: when `PCMPlayer` transitions into the playing state, we send a `USER_ACTION` frame over the same WebSocket. That's what tells Pushkin "this device is now the active one" so other devices on the same account pause in response.
- Banner: `_cross_device_pause_device` (set in the receive callback, cleared on next local play) ships out on every `PlayerSnapshot` via a new `paused_by_device` field. Frontend renders `CrossDevicePauseBanner` directly above `NowPlaying` when set. The X button hits `POST /api/player/dismiss-pause-reason`.
- Setting: `pause_on_other_device` toggle in Settings, default on. The four-way wiring (Settings dataclass, SettingsPayload Pydantic, types.ts interface, SettingsPage UI) is all in place — verified explicitly against the CLAUDE.md checklist.

The Tidal web client's `pushkin-*.js` module spelled out the entire protocol. See the docstring on `app/tidal_realtime.py` for the details.

## Tests

- 14 backend unit tests in `tests/test_tidal_realtime.py` covering listener lifecycle (start/stop idempotency, status snapshot semantics, module singleton), frame parser (valid JSON, garbage, non-dict top level), and dispatch routing (PRIVILEGED_SESSION_NOTIFICATION fires callback, RECONNECT closes socket, sync + async callbacks, exception swallowing, unknown type ignored).
- 4 vitest cases in `web/src/components/CrossDevicePauseBanner.test.tsx`: null state renders nothing, set state renders the device name, X button calls the dismiss endpoint, endpoint failure doesn't crash the UI.
- Manual integration verified live in both directions: phone → Tideway pauses, Tideway → phone pauses, banner appears with the right device name.

## Test plan

- [x] `pytest tests/` — 806 passed (+14 from `test_tidal_realtime.py`).
- [x] `cd web && npx tsc -b --noEmit` — clean.
- [x] `cd web && npm run lint:all` — clean.
- [x] `cd web && npm test` — 54 passed (+4 from banner tests).
- [x] Live integration: cross-device pause works in both directions; banner renders with correct device name.

## Honest caveats

- The `_connect_and_serve` async loop's network IO isn't unit-tested; coverage is parser + dispatch + lifecycle. The actual WebSocket + aiohttp path is exercised only by manual integration.
- No `sessionId` self-filter — relying on Tidal's backend not to echo our own session events back, same posture as their web client. If we ever see Tideway pausing itself on its own play, the fix is comparing `payload.sessionId` against the active session id.
- Protocol is undocumented and reverse-engineered. If Tidal changes the URL, frame shape, or auth, this code breaks. Diagnosable via the existing `/api/realtime/status` endpoint (phase, last_error, reconnect_count, events_received).