### PR TITLE
Artist section: list view + sort menu for album discography

### DIFF
--- a/web/src/components/ViewToggle.tsx
+++ b/web/src/components/ViewToggle.tsx
@@ -1,0 +1,57 @@
+import { LayoutGrid, Menu } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+export type ViewMode = "grid" | "list";
+
+/**
+ * Two-segment toggle between tile/grid and list rendering. Shared
+ * between the Library page (liked albums / artists / playlists) and
+ * the Artist view-all page so the affordance and styling stay
+ * consistent across surfaces that walk through a list of items.
+ *
+ * Stays a controlled component — caller owns the `ViewMode` state
+ * and any persistence (localStorage etc.). The toggle just emits
+ * the selected mode on click.
+ */
+export function ViewToggle({
+  view,
+  onChange,
+}: {
+  view: ViewMode;
+  onChange: (v: ViewMode) => void;
+}) {
+  return (
+    <div className="inline-flex rounded-md border border-border bg-secondary p-0.5">
+      <button
+        type="button"
+        onClick={() => onChange("grid")}
+        title="Grid view"
+        aria-label="Grid view"
+        aria-pressed={view === "grid"}
+        className={cn(
+          "flex h-8 w-8 items-center justify-center rounded-sm transition-colors",
+          view === "grid"
+            ? "bg-background text-foreground"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+      >
+        <LayoutGrid className="h-4 w-4" />
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange("list")}
+        title="List view"
+        aria-label="List view"
+        aria-pressed={view === "list"}
+        className={cn(
+          "flex h-8 w-8 items-center justify-center rounded-sm transition-colors",
+          view === "list"
+            ? "bg-background text-foreground"
+            : "text-muted-foreground hover:text-foreground",
+        )}
+      >
+        <Menu className="h-4 w-4" />
+      </button>
+    </div>
+  );
+}

--- a/web/src/pages/ArtistSection.test.ts
+++ b/web/src/pages/ArtistSection.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import type { Album } from "@/api/types";
+import { sortAlbums } from "./ArtistSection";
+
+function album(partial: Partial<Album>): Album {
+  return {
+    kind: "album",
+    id: partial.id ?? "0",
+    name: partial.name ?? "untitled",
+    num_tracks: partial.num_tracks ?? 1,
+    duration: partial.duration ?? 0,
+    year: partial.year ?? null,
+    cover: null,
+    artists: [],
+    explicit: false,
+    release_date: partial.release_date ?? null,
+    ...partial,
+  };
+}
+
+const fixtures: Album[] = [
+  album({ id: "a", name: "Bee", release_date: "2020-03-15", year: 2020 }),
+  album({ id: "b", name: "Apple", release_date: "2018-07-01", year: 2018 }),
+  album({ id: "c", name: "Cherry", release_date: "2024-11-22", year: 2024 }),
+];
+
+describe("sortAlbums", () => {
+  it("orders newest first by default semantics (release_date desc)", () => {
+    const out = sortAlbums(fixtures, "newest");
+    expect(out.map((a) => a.id)).toEqual(["c", "a", "b"]);
+  });
+
+  it("orders oldest first when asked", () => {
+    const out = sortAlbums(fixtures, "oldest");
+    expect(out.map((a) => a.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("orders alphabetically when asked", () => {
+    const out = sortAlbums(fixtures, "alpha");
+    expect(out.map((a) => a.id)).toEqual(["b", "a", "c"]);
+  });
+
+  it("does not mutate the input array", () => {
+    const original = [...fixtures];
+    sortAlbums(fixtures, "newest");
+    expect(fixtures.map((a) => a.id)).toEqual(original.map((a) => a.id));
+  });
+
+  it("falls back to the `year` field when release_date is missing", () => {
+    const items = [
+      album({ id: "x", name: "X", release_date: null, year: 1999 }),
+      album({ id: "y", name: "Y", release_date: null, year: 2010 }),
+    ];
+    expect(sortAlbums(items, "newest").map((a) => a.id)).toEqual(["y", "x"]);
+    expect(sortAlbums(items, "oldest").map((a) => a.id)).toEqual(["x", "y"]);
+  });
+
+  it("buries albums with no date at the back of newest-first", () => {
+    const items = [
+      album({ id: "n", name: "N", release_date: null, year: null }),
+      album({ id: "d", name: "D", release_date: "2020-01-01", year: 2020 }),
+    ];
+    expect(sortAlbums(items, "newest").map((a) => a.id)).toEqual(["d", "n"]);
+  });
+
+  it("alphabetical sort is case-insensitive", () => {
+    const items = [
+      album({ id: "1", name: "banana" }),
+      album({ id: "2", name: "Apple" }),
+      album({ id: "3", name: "cherry" }),
+    ];
+    expect(sortAlbums(items, "alpha").map((a) => a.id)).toEqual([
+      "2",
+      "1",
+      "3",
+    ]);
+  });
+
+  it("preserves input order on ties (stable sort)", () => {
+    const items = [
+      album({ id: "first", name: "Same", release_date: "2020-01-01" }),
+      album({ id: "second", name: "Same", release_date: "2020-01-01" }),
+      album({ id: "third", name: "Same", release_date: "2020-01-01" }),
+    ];
+    expect(sortAlbums(items, "alpha").map((a) => a.id)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+    expect(sortAlbums(items, "newest").map((a) => a.id)).toEqual([
+      "first",
+      "second",
+      "third",
+    ]);
+  });
+
+  it("handles empty input", () => {
+    expect(sortAlbums([], "newest")).toEqual([]);
+    expect(sortAlbums([], "oldest")).toEqual([]);
+    expect(sortAlbums([], "alpha")).toEqual([]);
+  });
+});

--- a/web/src/pages/ArtistSection.tsx
+++ b/web/src/pages/ArtistSection.tsx
@@ -1,5 +1,6 @@
+import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
-import { Video as VideoIcon } from "lucide-react";
+import { List, Video as VideoIcon } from "lucide-react";
 import { api } from "@/api/client";
 import type { Album, Artist, Track, Video } from "@/api/types";
 import type { OnDownload } from "@/api/download";
@@ -8,10 +9,92 @@ import { useLikedByArtist } from "@/hooks/useLikedByArtist";
 import { useVideoPlayer } from "@/hooks/useVideoPlayer";
 import { Grid } from "@/components/Grid";
 import { MediaCard } from "@/components/MediaCard";
+import { MediaListRow } from "@/components/MediaListRow";
 import { TrackList } from "@/components/TrackList";
 import { ErrorView } from "@/components/ErrorView";
 import { GridSkeleton, TrackListSkeleton } from "@/components/Skeletons";
 import { VideoCard } from "@/components/VideoCard";
+import { ViewToggle, type ViewMode } from "@/components/ViewToggle";
+import { Button } from "@/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { cn } from "@/lib/utils";
+
+/**
+ * Sort orders the album-list view exposes. Album discography is
+ * unusual versus the rest of the app: items don't have a
+ * "recently added" notion (they're not user actions), they have
+ * release dates. So the menu offers newest/oldest/alpha instead
+ * of Library's recent/alpha pair.
+ */
+type AlbumSort = "newest" | "oldest" | "alpha";
+
+const ALBUM_VIEW_KEY = "tideway:artist-section-view";
+const ALBUM_SORT_KEY = "tideway:artist-section-sort";
+
+function loadAlbumView(): ViewMode {
+  try {
+    const v = localStorage.getItem(ALBUM_VIEW_KEY);
+    return v === "list" ? "list" : "grid";
+  } catch {
+    return "grid";
+  }
+}
+
+function loadAlbumSort(): AlbumSort {
+  try {
+    const v = localStorage.getItem(ALBUM_SORT_KEY);
+    if (v === "oldest" || v === "alpha") return v;
+    return "newest";
+  } catch {
+    return "newest";
+  }
+}
+
+/**
+ * Sort an album list by the chosen order. Stable for ties (e.g.
+ * two albums released the same day) and tolerant of missing
+ * release_date / name. Pure so it can be unit-tested without
+ * standing up the page.
+ */
+export function sortAlbums(albums: Album[], sort: AlbumSort): Album[] {
+  // Build sortable keys once so the comparator doesn't repeatedly
+  // parse the same release_date string. .slice() so we don't
+  // mutate the array the parent has cached.
+  const decorated = albums.map((a, i) => ({
+    album: a,
+    // release_date arrives as ISO yyyy-MM-dd from Tidal. Fall
+    // back to the year column when the day-level date is null
+    // so older catalog entries still sort reasonably.
+    when: a.release_date
+      ? Date.parse(a.release_date)
+      : a.year != null
+        ? Date.parse(`${a.year}-01-01`)
+        : Number.NEGATIVE_INFINITY,
+    name: (a.name ?? "").toLocaleLowerCase(),
+    originalIndex: i,
+  }));
+  decorated.sort((x, y) => {
+    if (sort === "alpha") {
+      const cmp = x.name.localeCompare(y.name);
+      if (cmp !== 0) return cmp;
+    } else {
+      // Numeric subtract works for both orders.
+      const cmp = sort === "newest" ? y.when - x.when : x.when - y.when;
+      if (cmp !== 0) return cmp;
+    }
+    // Stable tiebreak on the input order so re-sorting between two
+    // equally-valued items doesn't reshuffle them.
+    return x.originalIndex - y.originalIndex;
+  });
+  return decorated.map((d) => d.album);
+}
 
 export type ArtistSectionKey =
   | "top-tracks"
@@ -226,12 +309,122 @@ function SectionBody({
   if (kind === "videos") {
     return <VideosGrid videos={items as Video[]} />;
   }
+  // The "media" kind covers both album lists (albums, EPs,
+  // compilations, appears-on) and artist lists ("similar"). Only
+  // the album lists get the view toggle + sort — sorting artists
+  // by release date is nonsense, and they're rare enough on this
+  // page (only one section, "Fans also like") that the simpler
+  // tile-only render is fine.
+  const firstItemKind = (items as (Album | Artist)[])[0]?.kind ?? "album";
+  if (firstItemKind === "album") {
+    return (
+      <AlbumSectionBody albums={items as Album[]} onDownload={onDownload} />
+    );
+  }
   return (
     <Grid>
-      {(items as (Album | Artist)[]).map((item) => (
+      {(items as Artist[]).map((item) => (
         <MediaCard key={item.id} item={item} onDownload={onDownload} />
       ))}
     </Grid>
+  );
+}
+
+/**
+ * Album-shaped section with a view toggle (tiles ↔ list) and a
+ * sort dropdown (newest / oldest / A–Z). Preferences are
+ * persisted in localStorage so a user who picks list+alpha on
+ * one artist sees the same setup on the next artist they open.
+ */
+function AlbumSectionBody({
+  albums,
+  onDownload,
+}: {
+  albums: Album[];
+  onDownload: OnDownload;
+}) {
+  const [view, setView] = useState<ViewMode>(() => loadAlbumView());
+  const [sort, setSort] = useState<AlbumSort>(() => loadAlbumSort());
+  // Persist immediately on change so the next mount picks up the
+  // same value. Cheap (localStorage writes are sync but tiny) and
+  // avoids the user wondering why their preference reset.
+  useEffect(() => {
+    try {
+      localStorage.setItem(ALBUM_VIEW_KEY, view);
+    } catch {
+      /* ignore quota / disabled storage */
+    }
+  }, [view]);
+  useEffect(() => {
+    try {
+      localStorage.setItem(ALBUM_SORT_KEY, sort);
+    } catch {
+      /* ignore */
+    }
+  }, [sort]);
+
+  const sorted = useMemo(() => sortAlbums(albums, sort), [albums, sort]);
+
+  return (
+    <div>
+      <div className="mb-4 flex items-center justify-end gap-2">
+        <AlbumSortMenu sort={sort} onSort={setSort} />
+        <ViewToggle view={view} onChange={setView} />
+      </div>
+      {view === "grid" ? (
+        <Grid>
+          {sorted.map((album) => (
+            <MediaCard key={album.id} item={album} onDownload={onDownload} />
+          ))}
+        </Grid>
+      ) : (
+        <div className="flex flex-col gap-0.5">
+          {sorted.map((album) => (
+            <MediaListRow key={album.id} item={album} onDownload={onDownload} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AlbumSortMenu({
+  sort,
+  onSort,
+}: {
+  sort: AlbumSort;
+  onSort: (s: AlbumSort) => void;
+}) {
+  const label =
+    sort === "newest" ? "Newest" : sort === "oldest" ? "Oldest" : "A–Z";
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm">
+          <List className="h-4 w-4" />
+          {label}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => onSort("newest")}>
+          <span className={cn(sort === "newest" ? "text-primary" : "")}>
+            Newest first
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onSort("oldest")}>
+          <span className={cn(sort === "oldest" ? "text-primary" : "")}>
+            Oldest first
+          </span>
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => onSort("alpha")}>
+          <span className={cn(sort === "alpha" ? "text-primary" : "")}>
+            Alphabetical
+          </span>
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -7,12 +7,10 @@ import {
   Folder,
   Heart,
   Home,
-  LayoutGrid,
   Library as LibraryIcon,
   List,
   ListMusic,
   Loader2,
-  Menu,
   Plus,
   User,
 } from "lucide-react";
@@ -33,6 +31,7 @@ import { CreateFolderDialog } from "@/components/CreateFolderDialog";
 import { CreatePlaylistDialog } from "@/components/CreatePlaylistDialog";
 import { MediaCard } from "@/components/MediaCard";
 import { MediaListRow } from "@/components/MediaListRow";
+import { ViewToggle, type ViewMode } from "@/components/ViewToggle";
 import {
   FormatFilter,
   type AudioFormat,
@@ -55,7 +54,7 @@ import { cn } from "@/lib/utils";
 
 type Section = "albums" | "artists" | "playlists" | "tracks";
 type Sort = "recent" | "alpha";
-type View = "grid" | "list";
+type View = ViewMode;
 
 const VIEW_KEY_PREFIX = "tideway:library-view:";
 
@@ -436,49 +435,6 @@ function DownloadAllTracks({ tracks }: { tracks: Track[] }) {
       )}
       Download all
     </Button>
-  );
-}
-
-function ViewToggle({
-  view,
-  onChange,
-}: {
-  view: View;
-  onChange: (v: View) => void;
-}) {
-  return (
-    <div className="inline-flex rounded-md border border-border bg-secondary p-0.5">
-      <button
-        type="button"
-        onClick={() => onChange("grid")}
-        title="Grid view"
-        aria-label="Grid view"
-        aria-pressed={view === "grid"}
-        className={cn(
-          "flex h-8 w-8 items-center justify-center rounded-sm transition-colors",
-          view === "grid"
-            ? "bg-background text-foreground"
-            : "text-muted-foreground hover:text-foreground",
-        )}
-      >
-        <LayoutGrid className="h-4 w-4" />
-      </button>
-      <button
-        type="button"
-        onClick={() => onChange("list")}
-        title="List view"
-        aria-label="List view"
-        aria-pressed={view === "list"}
-        className={cn(
-          "flex h-8 w-8 items-center justify-center rounded-sm transition-colors",
-          view === "list"
-            ? "bg-background text-foreground"
-            : "text-muted-foreground hover:text-foreground",
-        )}
-      >
-        <Menu className="h-4 w-4" />
-      </button>
-    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Per the user issue: browsing an artist with a large discography (Frank Zappa, Bowie, etc.) through the full-screen tile grid is rough — you can see a handful of releases per viewport, with no way to scan a long list or order it by date.

The Library page already has the moving parts (`MediaListRow` is a standalone reusable component; `ViewToggle` was private to `Library.tsx` but generic). This PR extracts `ViewToggle` to its own file so both pages share one implementation, and wires it + a sort menu into the artist view-all sections.

On `/artist/:id/albums` (and the EPs / compilations / appears-on siblings):

- Two-segment toggle in the top-right swaps the `MediaCard` grid for a list of `MediaListRow`s.
- Sort dropdown next to it offers **Newest first** (release_date desc, default), **Oldest first**, and **Alphabetical**. The Library's "recent/alpha" pair doesn't fit here — artist albums aren't "added", they have release dates.
- Both preferences are persisted in localStorage so picking "list + alpha" on one artist sticks when browsing the next.

`sortAlbums()` is pure-functional, exported, and unit-tested: 9 cases cover the three orderings, missing `release_date` falling back to `year`, missing year sinking to the back of newest-first, case-insensitive alpha, stable tiebreak on input order, no input mutation, and the empty case.

The "Fans also like" section (`kind="media"`, items are `Artist[]`) keeps its tile-only render — sorting artists by release date is nonsense, and it's the lone artist-shaped section. Detection is `items[0].kind === "album"`; falls through to a plain `MediaCard` grid otherwise. Users who never touch the toggle see exactly the same page as before.

## Test plan

- [x] `pytest tests/` — 806 passed (no backend changes; sanity).
- [x] `cd web && npx tsc -b --noEmit` — clean.
- [x] `cd web && npm run lint:all` — clean.
- [x] `cd web && npm test` — 63 passed (+9 from `ArtistSection.test.ts`).
- [ ] Manual: navigate to an artist with a large discography (Frank Zappa works well), toggle list view, sort by Newest / Oldest / A-Z, confirm the order looks right. Switch artists; the preference persists. Then visit a "Fans also like" section and verify it still renders as a tile grid (no toggle).