### PR TITLE
Rename sidebar Charts entry to Discover

### DIFF
--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -48,7 +48,7 @@ const primary: Array<{
   { to: "/feed", label: "Feed", icon: Rss, prefetch: prefetch.feed },
   {
     to: "/popular",
-    label: "Charts",
+    label: "Discover",
     icon: TrendingUp,
     prefetch: prefetch.popularArtists,
   },


### PR DESCRIPTION
## Summary

User feedback: "Charts" reads like a single endpoint (Billboard, etc.) but the page it lands on is actually a multi-tab surface mixing Last.fm popularity, Tidal's editorial charts, and AOTY drill-downs. "Discover" describes that destination better and matches the language Spotify and Apple Music use for the same shape of page.

One-character UX change. Route, icon, prefetch behavior all unchanged — the link still points at /popular. The destination page itself still uses "Charts", "Popular", "Top", "Rising" internally where they refer to specific data sources; renaming those would mislead about the underlying APIs.

## Test plan

- [x] Verified live in browser preview: sidebar entry now reads "Discover", same `href="/popular"`, same icon, same styling.
- [ ] Click "Discover" in the sidebar and confirm it routes to the same destination as the prior "Charts" entry.