### PR TITLE
Popular tracks: stop pinning transient empty results for an hour

### DIFF
--- a/server.py
+++ b/server.py
@@ -3259,6 +3259,7 @@ _LASTFM_CACHE_TTL_SEC = 300.0
 def _lastfm_cached(
     key: str, fetch, ttl_sec: float = _LASTFM_CACHE_TTL_SEC,
     persistent: bool = False,
+    cache_empty: bool = True,
 ):
     """Scope the cache to (username, endpoint, args). Username is part
     of the key so reconnecting to a different account doesn't serve
@@ -3279,6 +3280,14 @@ def _lastfm_cached(
     the full 18 seconds again. With persistence, the cold load
     happens once per real cache miss instead of once per process
     lifetime.
+
+    `cache_empty=False` skips both cache writes when the fetch
+    returned a falsy value (empty list/dict/None). The Popular
+    page's resolved chart was previously locking in transient
+    "no Tidal resolved" failures for the full 1-hour TTL — every
+    subsequent visit in that window served `[]` even though Tidal
+    had recovered immediately. Caller opts in per endpoint;
+    other endpoints keep the default behavior.
     """
     from app import lastfm_disk_cache
 
@@ -3300,6 +3309,10 @@ def _lastfm_cached(
             return disk_value
     # 3. Real fetch.
     data = fetch()
+    # Skip the cache write for empty results when the caller asked
+    # us to. Otherwise treat the freshly-fetched value as canonical.
+    if not cache_empty and not data:
+        return data
     with _lastfm_cache_lock:
         _lastfm_cache[full_key] = (now, data)
     if persistent:
@@ -4004,6 +4017,12 @@ def lastfm_chart_top_tracks_resolved(limit: int = 50) -> list[dict]:
             title = (entry.get("name") or "").strip()
             artist = (entry.get("artist") or "").strip()
             if not title or not artist:
+                print(
+                    f"[lastfm] chart entry missing title/artist: "
+                    f"{entry!r}",
+                    file=sys.stderr,
+                    flush=True,
+                )
                 return None
 
             cache_key = (
@@ -4017,12 +4036,27 @@ def lastfm_chart_top_tracks_resolved(limit: int = 50) -> list[dict]:
             tidal_jitter_sleep()
             try:
                 results = tidal.search(f"{artist} {title}", limit=5)
-            except Exception:
+            except Exception as exc:  # noqa: BLE001
+                # Don't bury exceptions silently — when every entry
+                # fails this way, the user just sees a blank Popular
+                # tab with no idea Tidal was the culprit.
+                print(
+                    f"[lastfm] chart resolve exception "
+                    f"({artist} / {title}): {exc!r}",
+                    file=sys.stderr,
+                    flush=True,
+                )
                 return None
             tracks = filter_explicit_dupes(
                 results.get("tracks", []), pref, kind="track"
             )
             if not tracks:
+                print(
+                    f"[lastfm] chart resolve: no Tidal match for "
+                    f"{artist} / {title}",
+                    file=sys.stderr,
+                    flush=True,
+                )
                 return None
             # Exact title + artist first; fall back to Tidal's top hit.
             wt = title.lower()
@@ -4059,7 +4093,21 @@ def lastfm_chart_top_tracks_resolved(limit: int = 50) -> list[dict]:
         with ThreadPoolExecutor(max_workers=3) as pool:
             results = list(pool.map(_one, entries))
 
-        return [r for r in results if r is not None]
+        resolved = [r for r in results if r is not None]
+        # When Last.fm returned chart entries but we couldn't
+        # resolve a single one to Tidal, something's wrong upstream
+        # (rate limit, expired session, etc.). Log the chart-level
+        # outcome; the cache_empty=False below ensures we don't
+        # pin this empty result for an hour like we used to.
+        if entries and not resolved:
+            print(
+                f"[lastfm] chart resolve fully failed: {len(entries)} "
+                f"Last.fm entries, zero Tidal matches. Empty result "
+                f"will NOT be cached; next visit retries.",
+                file=sys.stderr,
+                flush=True,
+            )
+        return resolved
 
     # 1-hour TTL with disk persistence. The Last.fm global chart
     # turns over slowly, and the cold-load cost (~18 s for 50 rows
@@ -4068,11 +4116,19 @@ def lastfm_chart_top_tracks_resolved(limit: int = 50) -> list[dict]:
     # layer alone died with the process; the SQLite-backed layer
     # rides through restarts so the user only pays the resolve
     # once per hour even across launches.
+    #
+    # `cache_empty=False` so a transient Tidal failure that empties
+    # the result doesn't lock the user out of Popular for the full
+    # hour. Previous symptom was a recurring "Last.fm didn't return
+    # any results" message that stuck until the cache expired even
+    # after Tidal had recovered. Now an empty result re-fetches on
+    # the next visit, costing ~18 s of resolve once Tidal is back.
     return _lastfm_cached(
         f"chart-top-tracks-resolved:{limit}",
         _resolve_all,
         ttl_sec=3600.0,
         persistent=True,
+        cache_empty=False,
     )
 
 

--- a/tests/test_lastfm_cache_ttl.py
+++ b/tests/test_lastfm_cache_ttl.py
@@ -217,3 +217,87 @@ def test_invalidate_clears_disk_layer_too(tmp_path, monkeypatch):
         # Both layers gone: refetch happens.
         server._lastfm_cached("k", fetch, ttl_sec=3600.0, persistent=True)
         assert fetch_count[0] == 2
+
+
+# ---------------------------------------------------------------------------
+# cache_empty=False — Popular tracks regression guard.
+# ---------------------------------------------------------------------------
+#
+# The Popular page's resolved chart endpoint used to cache empty
+# results from `_resolve_all` for the full 1-hour TTL. Symptom: one
+# transient Tidal failure left the user looking at "Last.fm didn't
+# return any results" for an hour even after Tidal recovered.
+# `cache_empty=False` makes the empty case bypass both cache layers.
+
+
+def test_cache_empty_false_skips_memory_write_when_fetch_returns_empty():
+    fetch_count = [0]
+
+    def fetch():
+        fetch_count[0] += 1
+        return []  # transient upstream failure
+
+    with patch.object(server.lastfm, "status", return_value={"username": "u"}):
+        server._lastfm_cached("k", fetch, cache_empty=False)
+        # No entry should have been written.
+        assert (
+            server._lastfm_cache.get("u|k") is None
+        ), "empty result must not be cached when cache_empty=False"
+        # Second call refetches — exactly the desired retry.
+        server._lastfm_cached("k", fetch, cache_empty=False)
+        assert fetch_count[0] == 2
+
+
+def test_cache_empty_false_skips_disk_write_when_fetch_returns_empty(
+    tmp_path, monkeypatch
+):
+    """The persistent layer must also skip the write — otherwise the
+    empty list survives app restarts, which was the original bug."""
+    from app import lastfm_disk_cache
+
+    monkeypatch.setattr(
+        lastfm_disk_cache, "_db_path", tmp_path / "lastfm_disk_cache.db"
+    )
+
+    def fetch():
+        return []
+
+    with patch.object(server.lastfm, "status", return_value={"username": "u"}):
+        server._lastfm_cached(
+            "k", fetch, ttl_sec=3600.0, persistent=True, cache_empty=False
+        )
+        # Disk row should be absent.
+        assert lastfm_disk_cache.get("u|k", 3600.0) is None
+
+
+def test_cache_empty_false_still_caches_truthy_results():
+    """The opt-out should only affect empty results — a normal,
+    populated list still gets cached as usual."""
+    fetch_count = [0]
+
+    def fetch():
+        fetch_count[0] += 1
+        return [{"track": "Bohemian Rhapsody"}]
+
+    with patch.object(server.lastfm, "status", return_value={"username": "u"}):
+        server._lastfm_cached("k", fetch, cache_empty=False)
+        server._lastfm_cached("k", fetch, cache_empty=False)
+        assert fetch_count[0] == 1, (
+            "second call should hit the in-memory cache"
+        )
+
+
+def test_default_cache_empty_true_preserves_existing_behavior():
+    """Other endpoints don't opt in; their caching shape must not
+    change. An empty list cached as today's default."""
+    fetch_count = [0]
+
+    def fetch():
+        fetch_count[0] += 1
+        return []
+
+    with patch.object(server.lastfm, "status", return_value={"username": "u"}):
+        server._lastfm_cached("k", fetch)
+        server._lastfm_cached("k", fetch)
+        # Empty result is cached → only one fetch.
+        assert fetch_count[0] == 1

--- a/web/src/pages/PopularPage.tsx
+++ b/web/src/pages/PopularPage.tsx
@@ -248,7 +248,7 @@ function ArtistChartCard({
 // ---------------------------------------------------------------------------
 
 function ChartTracks({ onDownload }: { onDownload: OnDownload }) {
-  const { data, loading } = useApi(
+  const { data, loading, error } = useApi(
     () => api.lastfm.chartTopTracksResolved(50),
     [],
     { cacheKey: queryKeys.popularTracks },
@@ -291,11 +291,23 @@ function ChartTracks({ onDownload }: { onDownload: OnDownload }) {
 
   if (loading && !data) return <TrackListSkeleton />;
   if (!data || data.length === 0) {
+    // Distinguish "the backend failed" from "the backend returned
+    // genuinely no results". The previous copy ("Last.fm didn't
+    // return any results") was misleading: most of the time the
+    // empty list came from Tidal failing to resolve any of the
+    // chart entries, not from Last.fm having no data. When useApi
+    // surfaces an error (network drop, 500 from /api/lastfm/...),
+    // show it. Otherwise blame Tidal — Last.fm's chart endpoint is
+    // pure JSON, basically never empty in practice; an empty
+    // resolved list means Tidal couldn't find a single match.
+    const description = error
+      ? `Couldn't load chart tracks: ${error.message}`
+      : "Last.fm had chart entries but none of them resolved to Tidal — likely a temporary Tidal hiccup. Try again in a few seconds.";
     return (
       <EmptyState
         icon={Music}
-        title="No data"
-        description="Last.fm didn't return any results."
+        title={error ? "Couldn't load" : "No matches"}
+        description={description}
       />
     );
   }


### PR DESCRIPTION
## Summary

Chronic complaint, prior attempts to fix didn't stick: the Popular tab's Tracks list shows "Last.fm didn't return any results" even when Last.fm itself is returning data fine.

Root cause traced. When the chart resolver (`_resolve_all` inside `lastfm_chart_top_tracks_resolved`) loops through Last.fm's 50 chart entries and every Tidal search transiently fails (rate limit, session refresh window, etc.), each `_one()` call returns `None`, the comprehension produces `[]`, and that empty list gets written to both the in-memory cache AND the SQLite-backed disk cache **with a 1-hour TTL**. Every subsequent visit for the next hour serves the cached empty list, even though Tidal usually recovers within seconds. To make it worse the diagnostic was zero: 50 of 50 failing left no log trace.

Three fixes:

**1. `_lastfm_cached` gains an opt-in `cache_empty=False` flag.** When the fetch returns a falsy value, both cache layers skip the write. The chart endpoint opts in. Existing callers keep current behavior (default `True`), so this is non-breaking everywhere else.

**2. Per-track and chart-level failure logging.** `_one()` now prints to stderr on missing fields, exceptions from `tidal.search`, and the "Tidal returned no search results" case. The chart-level "all 50 failed" case logs its own line so we can spot the pattern in users' logs.

**3. The Popular tracks empty-state message is now honest.** Previously read "Last.fm didn't return any results" regardless of why the list was empty — but most of the time Last.fm is fine and Tidal is the culprit. New copy:
- If `useApi` surfaced an error: "Couldn't load chart tracks: \<message\>"
- If genuinely empty: "Last.fm had chart entries but none of them resolved to Tidal — likely a temporary Tidal hiccup. Try again in a few seconds."

## Test plan

- [x] `pytest tests/` — 810 passed (+4 from new `cache_empty=False` cases in `test_lastfm_cache_ttl.py`).
- [x] `cd web && npx tsc -b --noEmit` — clean.
- [x] `cd web && npm run lint:all` — clean.
- [x] `cd web && npm test` — 54 passed (no frontend tests changed, regression sanity).
- [ ] Manual: trigger an empty resolve (e.g., temporarily make `tidal.search` raise inside `_one`), confirm:
  - The "No matches" empty state shows the new copy (not "Last.fm didn't return any results").
  - The next visit retries instead of serving cached empty list.
  - stderr logs name which tracks failed and why.