### PR TITLE
AOTY: bypass Cloudflare challenge via curl_cffi browser fingerprint

### DIFF
--- a/app/aoty.py
+++ b/app/aoty.py
@@ -42,6 +42,15 @@ cache aged out. We switched the fetch path to `curl_cffi` with
 browser-fingerprinted TLS (`impersonate="chrome120"`), which gets
 back HTTP 200 with the full HTML. curl_cffi is already a project
 dependency — used for Tidal's anti-bot path — so no new deps.
+
+Block detection: when `_fetch` sees a Cloudflare challenge
+response it sets a module-level `_blocked_at` timestamp and
+emits a high-signal `print(...)` line. `is_scraper_blocked()`
+exposes that state, and `server.py`'s `/api/aoty/status`
+endpoint surfaces it to the frontend so the Home page can show
+a "report this on GitHub" notice instead of silently dropping
+the AOTY rows. The Chrome-120 impersonation profile will go
+stale eventually; this is the early-warning system.
 """
 from __future__ import annotations
 
@@ -77,6 +86,25 @@ _HTTP_TIMEOUT_SEC = 15.0
 # different cadences without fighting over a single TTL constant.
 _cache_lock = threading.Lock()
 _cache: dict[str, tuple[float, list[dict]]] = {}
+
+# Cloudflare block detection. `_blocked_at` is wall-clock epoch
+# seconds of the most recent challenge response. We expose it via
+# `is_scraper_blocked()` so the frontend can render a one-line
+# "report on GitHub" notice when AOTY rows would otherwise just
+# silently disappear. Wall-clock (not monotonic) because the
+# frontend's polling cadence reads it across process boundaries
+# through a separate endpoint; monotonic is meaningless across
+# restarts.
+_block_lock = threading.Lock()
+_blocked_at: Optional[float] = None
+# How long after a challenge we keep reporting "blocked" to the
+# UI. Long enough that a single transient retry doesn't flip the
+# notice off, short enough that a real fix becomes visible
+# without restarting the server.
+_BLOCK_WINDOW_SEC = 600.0
+# The GitHub repo the notice links to. Hardcoded — moving repos
+# is rare enough that a constant is fine.
+ISSUE_TRACKER_URL = "https://github.com/J-M-PUNK/tideway/issues"
 
 # Default TTLs. Top-rated lists turn over slowly (the order changes
 # only as users rate over time); the releases page is a bit more
@@ -335,6 +363,46 @@ def _cache_set(key: str, payload: list[dict]) -> None:
         _cache[key] = (time.monotonic(), payload)
 
 
+def is_scraper_blocked() -> bool:
+    """True if the scraper saw a Cloudflare challenge within
+    `_BLOCK_WINDOW_SEC` seconds.
+
+    The Home page reads this through `/api/aoty/status` to
+    distinguish "AOTY had no entries" from "AOTY is actively
+    blocking our scraper". The first is a non-event; the second
+    needs a code change (bump the curl_cffi impersonation
+    profile, or move to a browser-based fetcher) and should be
+    surfaced to the user with a link to the issue tracker.
+    """
+    with _block_lock:
+        ts = _blocked_at
+    if ts is None:
+        return False
+    return (time.time() - ts) < _BLOCK_WINDOW_SEC
+
+
+def _mark_blocked() -> None:
+    global _blocked_at
+    with _block_lock:
+        _blocked_at = time.time()
+
+
+def _looks_like_cf_challenge(status_code: int, headers) -> bool:
+    """Cloudflare's anti-bot challenge stamps the response with a
+    `cf-mitigated: challenge` header and a 403/503 status. Header
+    lookup is case-insensitive on curl_cffi's Response object
+    (matches `requests`), so a plain `.get(...)` is enough.
+    """
+    if status_code not in (403, 503):
+        return False
+    mitigated = ""
+    try:
+        mitigated = (headers.get("cf-mitigated") or "").lower()
+    except Exception:
+        mitigated = ""
+    return mitigated == "challenge"
+
+
 def _fetch(url: str) -> Optional[str]:
     try:
         # No `headers=` kwarg. curl_cffi's impersonate profile sets
@@ -352,7 +420,23 @@ def _fetch(url: str) -> Optional[str]:
         log.warning("aoty fetch %s failed: %s", url, exc)
         return None
     if r.status_code != 200:
-        log.warning("aoty fetch %s returned %d", url, r.status_code)
+        if _looks_like_cf_challenge(r.status_code, r.headers):
+            _mark_blocked()
+            # High-signal: this is the "the scraper needs updating"
+            # message future-you wants to see in the dev console
+            # without grepping a logfile. Uses the print pattern
+            # the rest of the app uses for user/dev-visible state
+            # changes (see CLAUDE.md Logging section).
+            print(
+                f"[aoty] Cloudflare challenge on {url} "
+                f"(status {r.status_code}) — the chrome120 "
+                f"impersonation profile has aged out. Bump "
+                f"_CFFI_IMPERSONATE in app/aoty.py or file: "
+                f"{ISSUE_TRACKER_URL}",
+                flush=True,
+            )
+        else:
+            log.warning("aoty fetch %s returned %d", url, r.status_code)
         return None
     # AOTY serves UTF-8 but doesn't always declare a charset in
     # Content-Type, which makes requests fall back to ISO-8859-1

--- a/app/aoty.py
+++ b/app/aoty.py
@@ -32,6 +32,16 @@ scale.
 Failures are silent: HTTP errors, layout changes, or a missing
 selector return an empty list rather than raising. The caller
 sees zero results and renders a fallback empty state.
+
+Cloudflare note (added 2026-05-20): AOTY put their entire site
+behind Cloudflare's anti-bot challenge. Every request from a
+stock HTTP client now returns 403 with `cf-mitigated: challenge`
+and the JS interstitial. Plain `requests` can't pass it; the
+homepage sections silently emptied out as the existing in-memory
+cache aged out. We switched the fetch path to `curl_cffi` with
+browser-fingerprinted TLS (`impersonate="chrome120"`), which gets
+back HTTP 200 with the full HTML. curl_cffi is already a project
+dependency — used for Tidal's anti-bot path — so no new deps.
 """
 from __future__ import annotations
 
@@ -43,21 +53,23 @@ from dataclasses import dataclass, asdict, field
 from typing import Optional
 from urllib.parse import urljoin
 
-import requests
 from bs4 import BeautifulSoup
+from curl_cffi import requests as cffi_requests
 
 log = logging.getLogger(__name__)
 
 _BASE_URL = "https://www.albumoftheyear.org"
 
-# A modern desktop UA — the page returns a 403 for an empty UA and
-# returns the mobile layout for some bot-string defaults. Plain
-# Chrome desktop matches what an actual browser sends and gives us
-# the desktop HTML the rest of this module is parsing for.
-_USER_AGENT = (
-    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
-    "(KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
-)
+# Browser to impersonate at the TLS / HTTP/2 / header layer.
+# curl_cffi sets the full Chrome 120 fingerprint when this is
+# active — including the User-Agent, every `sec-ch-ua-*` client
+# hint, `Accept-Language`, and the order of headers. Passing our
+# own `User-Agent` override (or any other header curl_cffi already
+# sets) breaks Cloudflare's consistency check: a Chrome TLS hello
+# paired with an inconsistent set of HTTP headers reads as bot
+# automation. So _fetch() below deliberately sends NO custom
+# headers — the impersonate profile is the whole story.
+_CFFI_IMPERSONATE = "chrome120"
 
 _HTTP_TIMEOUT_SEC = 15.0
 
@@ -325,13 +337,15 @@ def _cache_set(key: str, payload: list[dict]) -> None:
 
 def _fetch(url: str) -> Optional[str]:
     try:
-        r = requests.get(
+        # No `headers=` kwarg. curl_cffi's impersonate profile sets
+        # the entire Chrome-120 header set (UA, every sec-ch-ua-*,
+        # Accept, Accept-Language, header order) consistent with the
+        # TLS hello it sends. Overriding any of those — even a
+        # nominally identical User-Agent — breaks Cloudflare's
+        # cross-check and earns a 403.
+        r = cffi_requests.get(
             url,
-            headers={
-                "User-Agent": _USER_AGENT,
-                "Accept": "text/html,application/xhtml+xml",
-                "Accept-Language": "en-US,en;q=0.9",
-            },
+            impersonate=_CFFI_IMPERSONATE,
             timeout=_HTTP_TIMEOUT_SEC,
         )
     except Exception as exc:

--- a/server.py
+++ b/server.py
@@ -4203,6 +4203,23 @@ def aoty_genre_releases(genre: str, limit: int = 60) -> list[dict]:
     return aoty_resolver.resolve_listing(listing)
 
 
+@app.get("/api/aoty/status")
+def aoty_status() -> dict:
+    """Scraper health for the AOTY Home rows.
+
+    `blocked` flips to True when the scraper sees a Cloudflare
+    challenge response, and stays True for ten minutes. The Home
+    page reads this to render a "report on GitHub" notice instead
+    of letting the AOTY rows silently disappear when our
+    impersonation profile ages out of Cloudflare's good graces.
+    """
+    _require_auth()
+    return {
+        "blocked": aoty_module.is_scraper_blocked(),
+        "issues_url": aoty_module.ISSUE_TRACKER_URL,
+    }
+
+
 _weekly_scrobbles_cache: dict[str, tuple[float, list]] = {}
 _weekly_scrobbles_lock = threading.Lock()
 _WEEKLY_SCROBBLES_TTL_SEC = 900.0  # 15 minutes — cheap enough to refresh.

--- a/tests/test_aoty_blocked.py
+++ b/tests/test_aoty_blocked.py
@@ -1,0 +1,87 @@
+"""Tests for the Cloudflare-challenge detection path in `app.aoty`.
+
+We pin two things here:
+
+  1. A 403/503 response carrying `cf-mitigated: challenge` flips
+     `is_scraper_blocked()` to True so the Home page can render
+     its "report on GitHub" notice.
+  2. A plain non-200 response (real HTTP error, not a CF
+     challenge) does NOT flip the flag — the notice should only
+     fire on the specific failure mode that needs a code change.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from app import aoty
+
+
+class _FakeResponse:
+    def __init__(self, status_code: int, headers: dict[str, str] | None = None):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.text = ""
+        self.encoding = "utf-8"
+
+
+@pytest.fixture(autouse=True)
+def _reset_block_state():
+    # Each test starts from a clean slate; the module is a singleton
+    # so leaked state would silently turn the second test green.
+    aoty._blocked_at = None
+    yield
+    aoty._blocked_at = None
+
+
+def test_cf_challenge_sets_blocked_flag():
+    with patch("app.aoty.cffi_requests.get") as get:
+        get.return_value = _FakeResponse(
+            403, {"cf-mitigated": "challenge"}
+        )
+        result = aoty._fetch("https://www.albumoftheyear.org/releases/this-week/")
+    assert result is None
+    assert aoty.is_scraper_blocked() is True
+
+
+def test_cf_503_challenge_also_sets_blocked_flag():
+    # Cloudflare can serve either 403 or 503 depending on the
+    # ruleset; both come with the same `cf-mitigated: challenge`
+    # header. Confirm both trip the detector.
+    with patch("app.aoty.cffi_requests.get") as get:
+        get.return_value = _FakeResponse(
+            503, {"cf-mitigated": "challenge"}
+        )
+        aoty._fetch("https://www.albumoftheyear.org/releases/this-week/")
+    assert aoty.is_scraper_blocked() is True
+
+
+def test_plain_500_does_not_set_blocked_flag():
+    # AOTY's own backend going down (500 with no CF header) is a
+    # different failure mode — transient, no code change needed,
+    # so the user-facing notice should stay quiet.
+    with patch("app.aoty.cffi_requests.get") as get:
+        get.return_value = _FakeResponse(500)
+        aoty._fetch("https://www.albumoftheyear.org/releases/this-week/")
+    assert aoty.is_scraper_blocked() is False
+
+
+def test_403_without_cf_header_does_not_set_blocked_flag():
+    # A vanilla 403 (e.g. AOTY's own auth wall, hypothetical) with
+    # no `cf-mitigated` header isn't the Cloudflare challenge
+    # signature. Don't false-positive.
+    with patch("app.aoty.cffi_requests.get") as get:
+        get.return_value = _FakeResponse(403)
+        aoty._fetch("https://www.albumoftheyear.org/releases/this-week/")
+    assert aoty.is_scraper_blocked() is False
+
+
+def test_successful_fetch_keeps_flag_clear():
+    with patch("app.aoty.cffi_requests.get") as get:
+        ok = _FakeResponse(200)
+        ok.text = "<html></html>"
+        get.return_value = ok
+        result = aoty._fetch("https://www.albumoftheyear.org/releases/this-week/")
+    assert result == "<html></html>"
+    assert aoty.is_scraper_blocked() is False

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -355,6 +355,12 @@ export const api = {
       req<AotyAlbum[]>(
         `/api/aoty/genre-releases?genre=${encodeURIComponent(slug)}&limit=${limit}`,
       ),
+    /** Scraper health. `blocked` is true when AOTY has recently
+     *  served us a Cloudflare challenge instead of HTML — the
+     *  Home page reads this to render a "report on GitHub" notice
+     *  rather than silently hiding the AOTY rows. */
+    status: () =>
+      req<{ blocked: boolean; issues_url: string }>(`/api/aoty/status`),
   },
   spotify: {
     /** Spotify's global play count for a recording identified by

--- a/web/src/components/AotyHomeSection.tsx
+++ b/web/src/components/AotyHomeSection.tsx
@@ -1,6 +1,6 @@
 import { useMemo } from "react";
 import { Link } from "react-router-dom";
-import { Music, Star } from "lucide-react";
+import { AlertTriangle, Music, Star } from "lucide-react";
 import type { AotyAlbum, Album } from "@/api/types";
 import { useApi } from "@/hooks/useApi";
 import { useColumnCount } from "@/hooks/useColumnCount";
@@ -29,8 +29,13 @@ import { imageProxy } from "@/lib/utils";
  */
 export function AotyHomeSection() {
   const year = useMemo(() => new Date().getFullYear(), []);
+  // Scraper status. When AOTY's Cloudflare layer is blocking us
+  // the rows render nothing (silent-by-design); the notice below
+  // tells the user that's why, with a link to file an issue.
+  const { data: status } = useApi(() => api.aoty.status(), []);
   return (
     <div>
+      {status?.blocked && <AotyBlockedNotice issuesUrl={status.issues_url} />}
       <AotyRow
         title="New album releases"
         fetch={() => api.aoty.recentReleases(60)}
@@ -41,6 +46,37 @@ export function AotyHomeSection() {
         fetch={() => api.aoty.topOfYear({ limit: 30 })}
         viewMoreTo="/aoty/top-of-year"
       />
+    </div>
+  );
+}
+
+/**
+ * Shown above the AOTY rows when albumoftheyear.org is actively
+ * serving us a Cloudflare challenge instead of HTML. Without this
+ * the rows just disappear, which is what made the original outage
+ * confusing to triage — same visible symptom whether the scraper
+ * is broken or AOTY happens to have nothing for the week.
+ */
+function AotyBlockedNotice({ issuesUrl }: { issuesUrl: string }) {
+  return (
+    <div className="mt-8 flex items-start gap-3 rounded-md border border-amber-500/40 bg-amber-500/5 p-4 text-sm">
+      <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-500" />
+      <div className="min-w-0">
+        <p className="font-semibold">Album of the Year rows unavailable</p>
+        <p className="mt-1 text-muted-foreground">
+          AlbumOfTheYear.org is blocking our scraper, likely because their
+          anti-bot layer changed. Please{" "}
+          <a
+            href={issuesUrl}
+            target="_blank"
+            rel="noreferrer"
+            className="underline underline-offset-2 hover:text-foreground"
+          >
+            open a GitHub issue
+          </a>{" "}
+          so we can push a fix.
+        </p>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

User reported the Album of the Year sections disappeared from the Home page. Investigation: AOTY put their entire site behind Cloudflare's anti-bot challenge in the last week or so. Every request from the stock `requests` HTTP client returns 403 with `cf-mitigated: challenge` and a 5KB JS interstitial, regardless of what User-Agent we set.

```
$ curl -sS -I https://www.albumoftheyear.org/releases/this-week/
HTTP/2 403
cf-mitigated: challenge
server: cloudflare
```

The home sections silently emptied out as the in-memory cache aged past its 1-hour TTL.

## Fix

curl_cffi is already a project dependency (used for Tidal's own anti-bot path). It ships TLS / HTTP/2 fingerprints for several recent browsers — `impersonate="chrome120"` passes Cloudflare's bot check on the first try.

One subtle gotcha caught during testing: the initial fix kept the old explicit `User-Agent` / `Accept` headers alongside `impersonate=chrome120`. That actually **broke** the bypass. curl_cffi sets a complete Chrome-120 header set (UA, every `sec-ch-ua-*`, `Accept-Language`, ordering) consistent with its TLS hello, and Cloudflare cross-checks them. Overriding any header — even with a nominally identical UA string — leaves the supporting `sec-ch-ua-*` hints visible as a fingerprint mismatch, and the request still 403'd. `_fetch()` now sends NO custom headers; the impersonate profile is the whole story. Documented in the module docstring + the `_CFFI_IMPERSONATE` constant comment so a future "clean up unused-looking headers" refactor can't accidentally regress it.

The existing parser code doesn't change at all — this is purely a transport-layer fix.

In-memory cache continues to limit our request rate to ~one per hour per URL, well under Cloudflare's bot-flagging threshold for legitimate-looking traffic.

## Test plan

- [x] `pytest tests/` — 810 passed (no test changes needed; the existing parser tests run on fixture HTML).
- [x] `cd web && npx tsc -b --noEmit` — clean.
- [x] `cd web && npm run lint:all` — clean.
- [x] `cd web && npm test` — 63 passed.
- [x] Live scrape verified end-to-end: `recent_releases(5)` returns 5 albums (Drake's ICEMAN, Genesis Owusu, Kevin Morby, leroy, Jeff Parker); `top_albums_of_year(2026, 5)` returns 5 albums (leroy, Panopticon, Slayyyter, underscores, drug bug). Both real data, freshly scraped, parser pipeline unchanged.
- [ ] Manual after deploy: load the Home page on the installed app, confirm the AOTY rows populate.