### PR TITLE
Stop Stats page crashing on incomplete Last.fm user info

### DIFF
--- a/app/lastfm.py
+++ b/app/lastfm.py
@@ -392,12 +392,24 @@ class LastFmClient:
         except Exception:
             return None
 
-    def get_user_info(self) -> dict:
-        """User profile header: total playcount, registered date, avatar."""
+    def get_user_info(self) -> Optional[dict]:
+        """User profile header: total playcount, registered date, avatar.
+
+        Returns None when the upstream call fails or Last.fm doesn't
+        recognize the configured username (a stored-but-renamed user
+        was the original failure mode — Last.fm responded 404 and the
+        old `return {}` path silently passed an empty object through
+        to the UI, where the Stats page tried to call .toLocaleString
+        on undefined and crashed). Callers should treat None as "no
+        profile available" and skip the header instead of pretending
+        a zero-filled record arrived.
+        """
         data = self._public_get({"method": "user.getInfo"})
         if not data:
-            return {}
+            return None
         user = data.get("user") or {}
+        if not user.get("name"):
+            return None
         reg_raw = user.get("registered") or {}
         # Last.fm returns `registered` as {"unixtime": "123", "#text": 123}
         reg_ts = None

--- a/server.py
+++ b/server.py
@@ -3332,11 +3332,16 @@ def _invalidate_lastfm_cache() -> None:
 
 
 @app.get("/api/lastfm/user-info")
-def lastfm_user_info() -> dict:
+def lastfm_user_info() -> Optional[dict]:
     """Header profile data for the Stats page — playcount, registered
-    date, avatar. Empty dict if Last.fm isn't connected."""
+    date, avatar. Returns null when Last.fm isn't connected or the
+    configured username doesn't resolve (e.g. user renamed their
+    Last.fm account); the frontend uses null to render a "couldn't
+    load your profile" hint instead of crashing on undefined counts.
+    Don't cache the empty case so a settings fix is reflected without
+    a wait."""
     _require_auth()
-    return _lastfm_cached("user-info", lastfm.get_user_info)
+    return _lastfm_cached("user-info", lastfm.get_user_info, cache_empty=False)
 
 
 @app.get("/api/lastfm/top-artists")

--- a/tests/test_lastfm_user_info.py
+++ b/tests/test_lastfm_user_info.py
@@ -1,0 +1,71 @@
+"""Tests for `get_user_info` returning None on failure.
+
+Background: Last.fm's `user.getInfo` endpoint 404s when the
+configured username doesn't resolve (e.g. the user renamed
+their Last.fm account). The old code path returned `{}` in
+that case, which the frontend treated as a present-but-empty
+user object and crashed when rendering counts. The fix is to
+return None — these tests pin that contract so a refactor
+can't drop us back into the silent-empty-object behavior.
+"""
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from app.lastfm import LastFmClient
+
+
+def test_get_user_info_returns_none_on_no_data():
+    """`_public_get` returns None when the API call fails — get_user_info
+    must surface that as None, not paper over it with `{}`."""
+    client = LastFmClient.__new__(LastFmClient)
+    with patch.object(client, "_public_get", return_value=None):
+        assert client.get_user_info() is None
+
+
+def test_get_user_info_returns_none_when_no_user_in_payload():
+    """Last.fm 404s for unknown users with a JSON body that has no
+    `user` key. `_public_get` will return None for the HTTP 404, but
+    a future change could route through and return the JSON anyway —
+    pin the safety check that we ignore a payload without a username."""
+    client = LastFmClient.__new__(LastFmClient)
+    with patch.object(client, "_public_get", return_value={"foo": "bar"}):
+        assert client.get_user_info() is None
+
+
+def test_get_user_info_returns_none_when_user_has_no_name():
+    """A `user` key with an empty `name` field is the same shape Last.fm
+    returns for malformed/partial responses — also treat as None so
+    the UI never has to render a header without a real username."""
+    client = LastFmClient.__new__(LastFmClient)
+    with patch.object(client, "_public_get", return_value={"user": {"name": ""}}):
+        assert client.get_user_info() is None
+
+
+def test_get_user_info_passes_through_good_payload():
+    """Sanity check: a complete payload should still resolve into the
+    expected dict shape with all counts defaulting to 0."""
+    client = LastFmClient.__new__(LastFmClient)
+    payload = {
+        "user": {
+            "name": "someuser",
+            "realname": "Some User",
+            "playcount": "12345",
+            "track_count": "200",
+            "artist_count": "50",
+            "album_count": "30",
+            "country": "US",
+            "url": "https://www.last.fm/user/someuser",
+            "registered": {"unixtime": "1500000000"},
+            "image": [],
+        }
+    }
+    with patch.object(client, "_public_get", return_value=payload):
+        out = client.get_user_info()
+    assert out is not None
+    assert out["username"] == "someuser"
+    assert out["playcount"] == 12345
+    assert out["track_count"] == 200
+    assert out["artist_count"] == 50
+    assert out["album_count"] == 30
+    assert out["registered_at"] == 1500000000

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -255,7 +255,7 @@ export const api = {
       req<LastFmStatus>("/api/lastfm/disconnect", { method: "POST" }),
     recentTracks: (limit = 100) =>
       req<LastFmRecentTrack[]>(`/api/lastfm/recent-tracks?limit=${limit}`),
-    userInfo: () => req<LastFmUserInfo>("/api/lastfm/user-info"),
+    userInfo: () => req<LastFmUserInfo | null>("/api/lastfm/user-info"),
     topArtists: (period: LastFmPeriod, limit = 50) =>
       req<LastFmTopArtist[]>(
         `/api/lastfm/top-artists?period=${period}&limit=${limit}`,

--- a/web/src/pages/StatsPage.tsx
+++ b/web/src/pages/StatsPage.tsx
@@ -64,6 +64,11 @@ const PERIOD_ORDER: LastFmPeriod[] = [
 export function StatsPage() {
   const [connected, setConnected] = useState<boolean | null>(null);
   const [user, setUser] = useState<LastFmUserInfo | null>(null);
+  // Distinguishes "haven't tried yet" from "tried and got null".
+  // We need both to render the header sensibly when the configured
+  // Last.fm username doesn't resolve (renamed account etc.) — the
+  // status endpoint says connected, but user-info comes back null.
+  const [userFetched, setUserFetched] = useState(false);
   const [period, setPeriod] = useState<LastFmPeriod>("1month");
 
   // Probe status once. If Last.fm isn't connected the whole page
@@ -79,9 +84,13 @@ export function StatsPage() {
         if (s.connected) {
           api.lastfm
             .userInfo()
-            .then((u) => !cancelled && setUser(u))
+            .then((u) => {
+              if (cancelled) return;
+              setUser(u);
+              setUserFetched(true);
+            })
             .catch(() => {
-              /* header falls back to a monogram */
+              if (!cancelled) setUserFetched(true);
             });
         }
       })
@@ -127,7 +136,7 @@ export function StatsPage() {
 
   return (
     <div>
-      <UserHeader user={user} />
+      <UserHeader user={user} userFetched={userFetched} />
       <p className="mb-6 text-xs text-muted-foreground">
         Stats provided by Last.fm. Numbers reflect every scrobble from your
         connected Last.fm account, including plays from this app and from any
@@ -145,7 +154,13 @@ export function StatsPage() {
   );
 }
 
-function UserHeader({ user }: { user: LastFmUserInfo | null }) {
+function UserHeader({
+  user,
+  userFetched,
+}: {
+  user: LastFmUserInfo | null;
+  userFetched: boolean;
+}) {
   const avatar = user?.image ? imageProxy(user.image) : undefined;
   const initial = (user?.username || "?").trim().charAt(0).toUpperCase();
   const memberSince = user?.registered_at
@@ -154,6 +169,16 @@ function UserHeader({ user }: { user: LastFmUserInfo | null }) {
         month: "short",
       })
     : null;
+  // Render the stat row only when Last.fm actually returned a
+  // profile with the four counts. The previous guard (`{user && …}`)
+  // accepted a `{}` payload as truthy and then crashed on
+  // `undefined.toLocaleString()` inside <Stat>.
+  const hasCounts = !!user?.username;
+  // "Tried to fetch, came back empty" — username Tideway has on
+  // record doesn't resolve on Last.fm. Most likely a renamed
+  // account; nudge the user toward Settings instead of silently
+  // serving a half-empty header.
+  const showProfileMissing = userFetched && !user;
 
   return (
     <div className="mb-8">
@@ -192,9 +217,22 @@ function UserHeader({ user }: { user: LastFmUserInfo | null }) {
                 Since {memberSince}
               </>
             )}
+            {showProfileMissing && (
+              <span>
+                Couldn't load your Last.fm profile — the username on file may
+                not exist anymore. Check it in{" "}
+                <Link
+                  to="/settings"
+                  className="underline underline-offset-2 hover:text-foreground"
+                >
+                  Settings
+                </Link>
+                .
+              </span>
+            )}
           </div>
         </div>
-        {user && (
+        {hasCounts && user && (
           <div className="flex flex-wrap gap-6">
             <Stat label="Plays" value={user.playcount} />
             <Stat label="Artists" value={user.artist_count} />


### PR DESCRIPTION
## Summary

- When the configured Last.fm username doesn't resolve on Last.fm (renamed account, typo'd value), `user.getInfo` returns 404 and `get_user_info()` used to swallow that into `{}`.
- The frontend treated the empty object as a present user, tried to render `<Stat>` with undefined counts, and crashed inside `.toLocaleString()` — the whole Stats page bailed into the error boundary with "Something went wrong".
- `get_user_info` now returns `None` on any failure (404, JSON parse, missing `user` payload). The endpoint forwards `None` so the frontend can distinguish "couldn't load" from "user has no plays".
- `StatsPage` renders the header without the counts when the profile didn't load and adds an inline "couldn't load your profile — check it in Settings" hint with a link.

## Test plan

- [x] `pytest tests/test_lastfm_user_info.py` covers the new None-on-failure contract
- [x] Full preflight: 814 backend tests, 63 frontend tests, tsc, lint clean
- [x] Loaded `/stats` against a Last.fm session whose stored username 404s on Last.fm — page now renders cleanly with the explainer instead of crashing
- [x] Verified the username-link helper still works (clicking the Settings link navigates correctly)