### PR TITLE
Force-exit on Linux when pywebview's GTK backend hangs in start()

### DIFF
--- a/desktop.py
+++ b/desktop.py
@@ -668,6 +668,41 @@ def main(argv: Optional[list[str]] = None) -> int:
         except Exception:
             pass
 
+        # Linux-only force-exit. pywebview's WebKitGTK backend has a
+        # long-standing issue where `webview.start()` doesn't always
+        # return after the window is destroyed; the Flatpak sandbox
+        # makes this more reliable to hit, leaving the process alive
+        # with no UI and the user having to kill it from a terminal.
+        # The `closed` event still fires inside the stuck GTK loop, so
+        # we hook it, run the same graceful shutdown the post-start()
+        # path runs, and hard-exit. A guard makes it safe if start()
+        # *does* return naturally — the finally block's call is a no-op.
+        if sys.platform.startswith("linux"):
+            _shutdown_done = threading.Event()
+
+            def _shutdown_once() -> None:
+                if _shutdown_done.is_set():
+                    return
+                _shutdown_done.set()
+                try:
+                    _graceful_shutdown(server)
+                except Exception:
+                    pass
+
+            def _on_closed_linux() -> None:
+                _shutdown_once()
+                # os._exit (not sys.exit) so finalizers / atexit hooks
+                # can't reintroduce the hang they were trying to avoid
+                # — sounddevice's atexit Pa_Terminate has hung on
+                # Linux/Flatpak too, and at this point the window is
+                # already gone so the user has decided to quit.
+                os._exit(0)
+
+            try:
+                window.events.closed += _on_closed_linux
+            except Exception:
+                pass
+
     # Mini-player state. Held here so a second request doesn't spawn a
     # duplicate window — we just focus the existing one. We don't try
     # to share state with the main window beyond URL routing; both


### PR DESCRIPTION
## Summary

User report from the Flatpak ship: *"Tideway runs now... however quitting is a problem. it does not close.. have to kill it from the terminal"*. The native window closes via the X button but the process stays alive with no UI.

pywebview's WebKitGTK backend has a long-standing issue where `webview.start()` doesn't always return after the window is destroyed. The Flatpak sandbox makes this more reliable to hit. Our existing post-start() shutdown path can't run if start() never returns.

This PR adds a `closed` event handler on Linux that runs the same graceful shutdown the post-start() path does, then calls `os._exit(0)` so the process terminates regardless of whether GTK's main loop ever exits. The `closed` event fires inside the stuck GTK loop, so the hook still reaches us.

`os._exit` rather than `sys.exit` because finalizers / atexit hooks have themselves hung on Linux/Flatpak before (sounddevice's `Pa_Terminate` is the documented offender). The graceful shutdown stops the PCM player first so PortAudio is in a clean state before we hard-exit.

Windows and macOS quit paths are unchanged; the new behaviour is gated on `sys.platform.startswith("linux")`.

## Test plan

- [x] `pytest tests/` — 819 passing, no regressions
- [x] Syntax check on desktop.py
- [ ] Linux Flatpak user verifies the X-button quit closes the process (requires the ship)
- [ ] macOS sanity check that the new Linux-only branch doesn't trip — the `else` arm of `sys.platform == "darwin"` is the existing Windows/Linux path, and the new code is wrapped in its own `if sys.platform.startswith("linux")` guard, so Windows is unaffected