### PR TITLE
Drop a cover.jpg in the album folder on each track download

### DIFF
--- a/app/downloader.py
+++ b/app/downloader.py
@@ -1294,6 +1294,27 @@ class Downloader:
                 if not tag_error:
                     tag_error = f"tagging failed: {exc}"
 
+            # Drop a cover.jpg next to the track when the track lives
+            # in a per-album (or per-playlist) subfolder. Most music
+            # managers (Plex, foobar2000, mpd, Roon, etc.) will use a
+            # cover.jpg in the album dir as a fallback when an entry
+            # has no embedded art, and it's the convention the user
+            # asked for in the feature request. Skip when the track
+            # lands directly in the output_dir (no subfolder = lone-
+            # track download, leaving stray cover.jpg files there
+            # would be noise). Write-once to avoid clobbering covers
+            # the user dropped in by hand and to skip the rewrite per
+            # additional track in the same album.
+            try:
+                _maybe_write_album_cover(out_path, Path(s.output_dir), cover)
+            except Exception as exc:
+                print(
+                    f"[downloader] cover.jpg write failed id={item.item_id[:8]}: "
+                    f"{exc}",
+                    file=_sys.stderr,
+                    flush=True,
+                )
+
             item.file_path = str(out_path)
             item.status = DownloadStatus.COMPLETE
             if tag_error:
@@ -1972,6 +1993,51 @@ def _build_path(item: DownloadItem, settings, ext: str) -> Path:
         # fall through — the parent mkdir will surface real issues.
         pass
     return final
+
+
+def _maybe_write_album_cover(
+    out_path: Path, output_dir: Path, cover_bytes: Optional[bytes]
+) -> None:
+    """Drop a cover.jpg in the album/playlist subfolder so external
+    music managers (Plex, Roon, mpd, foobar2000, etc.) can find the
+    artwork without parsing every track's embedded picture frame. We
+    only write when:
+
+      - the track has cover bytes that the fetcher returned (no point
+        writing a zero-byte placeholder),
+      - the track lives in a SUBFOLDER of `output_dir` (a lone-track
+        download with no per-album/playlist nesting would scatter
+        cover.jpg files across the root and pollute it),
+      - the cover.jpg doesn't already exist (skip-clobber: respects
+        anything the user dropped in by hand and avoids one rewrite
+        per track in the same album).
+
+    `cover.jpg` is the de-facto filename convention (every major music
+    manager picks it up by default). Tidal serves JPEG. We don't
+    re-encode the bytes; even if Tidal switches to a different format
+    on some track, the bytes already work for embedding so they'll
+    work in a file too.
+    """
+    if not cover_bytes:
+        return
+    try:
+        out_resolved = out_path.resolve(strict=False)
+        root_resolved = output_dir.resolve(strict=False)
+    except Exception:
+        return
+    parent = out_resolved.parent
+    if parent == root_resolved:
+        return
+    # Defensive: only write into a directory that's actually under the
+    # configured output root, never outside it.
+    try:
+        parent.relative_to(root_resolved)
+    except ValueError:
+        return
+    cover_path = parent / "cover.jpg"
+    if cover_path.exists():
+        return
+    cover_path.write_bytes(cover_bytes)
 
 
 def _find_existing(item: DownloadItem, settings) -> Optional[Path]:

--- a/tests/test_download_cover_art.py
+++ b/tests/test_download_cover_art.py
@@ -1,0 +1,121 @@
+"""Tests for the ``_maybe_write_album_cover`` helper.
+
+The helper drops a ``cover.jpg`` next to a freshly tagged track when
+the track lives in an album / playlist subfolder of the configured
+output directory. Plex, Roon, mpd, foobar2000 and every other music
+manager I've checked all pick up ``cover.jpg`` automatically, so
+this is the right shape for the feature request.
+
+Invariants pinned here:
+
+1. A track inside a subfolder gets a ``cover.jpg`` written.
+2. A track at the output_dir root gets nothing (lone-track downloads
+   shouldn't pollute the root).
+3. An existing ``cover.jpg`` is never clobbered — covers users dropped
+   in by hand stay, and the per-track rewrite cost stays zero.
+4. Empty / None cover bytes are a no-op (no zero-byte placeholder
+   file).
+5. Paths that resolve outside the output_dir are refused (defensive;
+   guards against a malicious template or symlink trick).
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from app.downloader import _maybe_write_album_cover
+
+
+def test_subfolder_track_writes_cover_jpg(tmp_path: Path) -> None:
+    album = tmp_path / "AlbumX"
+    album.mkdir()
+    track = album / "01.flac"
+    track.touch()
+    _maybe_write_album_cover(track, tmp_path, b"JPEG-BYTES")
+    cover = album / "cover.jpg"
+    assert cover.exists()
+    assert cover.read_bytes() == b"JPEG-BYTES"
+
+
+def test_lone_track_at_output_root_does_not_write(tmp_path: Path) -> None:
+    track = tmp_path / "OnlyTrack.flac"
+    track.touch()
+    _maybe_write_album_cover(track, tmp_path, b"JPEG")
+    assert not (tmp_path / "cover.jpg").exists()
+
+
+def test_existing_cover_is_preserved(tmp_path: Path) -> None:
+    album = tmp_path / "AlbumY"
+    album.mkdir()
+    (album / "cover.jpg").write_bytes(b"USER-DROPPED-COVER")
+    track = album / "01.flac"
+    track.touch()
+    _maybe_write_album_cover(track, tmp_path, b"TIDAL-COVER")
+    # The user's hand-placed cover takes priority and the helper
+    # silently no-ops the second-track-of-the-album rewrite too.
+    assert (album / "cover.jpg").read_bytes() == b"USER-DROPPED-COVER"
+
+
+def test_no_cover_bytes_is_a_noop(tmp_path: Path) -> None:
+    album = tmp_path / "AlbumZ"
+    album.mkdir()
+    track = album / "01.flac"
+    track.touch()
+    _maybe_write_album_cover(track, tmp_path, None)
+    _maybe_write_album_cover(track, tmp_path, b"")
+    assert not (album / "cover.jpg").exists()
+
+
+def test_nested_subfolder_writes_cover_too(tmp_path: Path) -> None:
+    # Custom template like {artist}/{album}/{title} produces two
+    # levels of nesting. Cover should still land next to the track.
+    nested = tmp_path / "Artist" / "Album"
+    nested.mkdir(parents=True)
+    track = nested / "01.flac"
+    track.touch()
+    _maybe_write_album_cover(track, tmp_path, b"JPEG-BYTES")
+    assert (nested / "cover.jpg").exists()
+
+
+def test_path_outside_output_dir_is_refused(tmp_path: Path) -> None:
+    # Constructing the scenario: an album folder that's a sibling of
+    # tmp_path (so not under it). The helper should refuse to write
+    # cover.jpg into a directory that isn't under the configured
+    # output root.
+    sibling = tmp_path.parent / f"{tmp_path.name}-sibling"
+    sibling.mkdir(exist_ok=True)
+    try:
+        track = sibling / "01.flac"
+        track.touch()
+        _maybe_write_album_cover(track, tmp_path, b"JPEG")
+        assert not (sibling / "cover.jpg").exists()
+    finally:
+        # Clean up the sibling we just made; tmp_path fixture only
+        # cleans up tmp_path itself.
+        for child in sibling.iterdir():
+            try:
+                child.unlink()
+            except OSError:
+                pass
+        try:
+            sibling.rmdir()
+        except OSError:
+            pass
+
+
+def test_helper_runs_idempotently_across_tracks(tmp_path: Path) -> None:
+    # Simulate the real flow: 12 tracks finish tagging one after the
+    # other. cover.jpg should be written by the first one and the rest
+    # are no-ops. No exception, no file mtime churn.
+    album = tmp_path / "AlbumW"
+    album.mkdir()
+    for i in range(1, 13):
+        (album / f"{i:02d}.flac").touch()
+    _maybe_write_album_cover(album / "01.flac", tmp_path, b"JPEG-V1")
+    first_mtime = (album / "cover.jpg").stat().st_mtime_ns
+    # Tracks 2..12 — cover.jpg already exists, helper should skip.
+    for i in range(2, 13):
+        _maybe_write_album_cover(album / f"{i:02d}.flac", tmp_path, b"JPEG-V2")
+    # Same bytes, same mtime as the first write.
+    assert (album / "cover.jpg").read_bytes() == b"JPEG-V1"
+    assert (album / "cover.jpg").stat().st_mtime_ns == first_mtime


### PR DESCRIPTION
## Summary

User feature request: *"is it a big deal to also extract the album cover and simple download into the dedicated album folder e.g. cover.png?"*

Plex, Roon, mpd, foobar2000, and every other music manager I've checked uses `cover.jpg` in the album dir as a fallback when an entry has no embedded art. After tagging finishes, we now write the same JPEG bytes we already pass to mutagen out to `<album-folder>/cover.jpg`.

Three guard rails in the helper:
- Skip when the track lives directly in `output_dir` (lone-track downloads shouldn't scatter `cover.jpg` at the root)
- Skip when `cover.jpg` already exists (don't clobber user-placed art; idempotent across the 12 tracks of an album)
- Refuse a destination outside `output_dir` (defensive — guards against a future template change letting a track land elsewhere)

Filename is `cover.jpg` since Tidal serves JPEG (the user's "cover.png" example was just illustrative). No re-encode — the bytes that worked for embedding work as a file too.

## Test plan

- [x] 7 new unit tests pin the invariants (subfolder write, root skip, no-clobber, no-cover-bytes, nested template, outside-root refusal, idempotent across all tracks of an album)
- [x] Full backend: 826 passing
- [ ] Real download in the app: queue an album at any quality, confirm the album folder contains both the tagged audio files and `cover.jpg`
- [ ] Re-download the same album: confirm `cover.jpg` is preserved (mtime unchanged)