### PR TITLE
Add toggle for "Artist - Album" album folder names

### DIFF
--- a/app/downloader.py
+++ b/app/downloader.py
@@ -1969,7 +1969,24 @@ def _build_path(item: DownloadItem, settings, ext: str) -> Path:
         ):
             base = base / _sanitize_segment(item.playlist_name)
         elif settings.create_album_folders and item.album:
-            base = base / _sanitize_segment(item.album)
+            # Optional "<Artist> - <Album>" layout for users who
+            # sideload the downloaded library into Plex / Roon /
+            # foobar and want the artist visible at the folder
+            # level. Album-artist is preferred so a compilation
+            # entry doesn't pick up a featured name from track 1;
+            # we fall back to the per-track artist (which is the
+            # only name we have for older catalog entries that lack
+            # the album_artist field).
+            if getattr(settings, "album_folder_includes_artist", False):
+                folder_artist = item.album_artist or item.artist
+                folder_name = (
+                    f"{folder_artist} - {item.album}"
+                    if folder_artist
+                    else item.album
+                )
+            else:
+                folder_name = item.album
+            base = base / _sanitize_segment(folder_name)
 
     *dirs, last = safe_segments
     final = base

--- a/app/settings.py
+++ b/app/settings.py
@@ -42,6 +42,16 @@ class Settings:
     videos_dir: str = field(default_factory=_default_videos_dir)
     filename_template: str = "{artist} - {title}"
     create_album_folders: bool = True
+    # When `create_album_folders` is on, prefix the folder name with
+    # the album artist: "<Artist> - <Album>/" instead of just
+    # "<Album>/". Matches the "Artist - Album" convention Plex / Roon /
+    # foobar use for sideloaded libraries. Off by default so existing
+    # users' libraries don't fragment on upgrade — flipping it on only
+    # affects subsequent downloads. Album artist is preferred over the
+    # per-track artist so compilation entries don't pick up a featured
+    # name from track 1; falls back to the per-track artist when no
+    # album artist is set.
+    album_folder_includes_artist: bool = False
     # When downloading a playlist, group its tracks under a folder
     # named after the playlist (parallel to create_album_folders for
     # albums). The {playlist_num} template token then numbers them in

--- a/server.py
+++ b/server.py
@@ -10087,6 +10087,7 @@ class SettingsPayload(BaseModel):
     videos_dir: Optional[str] = None
     filename_template: Optional[str] = None
     create_album_folders: Optional[bool] = None
+    album_folder_includes_artist: Optional[bool] = None
     skip_existing: Optional[bool] = None
     concurrent_downloads: Optional[int] = None
     offline_mode: Optional[bool] = None

--- a/tests/test_filename_template.py
+++ b/tests/test_filename_template.py
@@ -49,12 +49,14 @@ def _settings(
     output_dir,
     create_album_folders=True,
     create_playlist_folders=True,
+    album_folder_includes_artist=False,
 ):
     return SimpleNamespace(
         filename_template=template,
         output_dir=str(output_dir),
         create_album_folders=create_album_folders,
         create_playlist_folders=create_playlist_folders,
+        album_folder_includes_artist=album_folder_includes_artist,
     )
 
 
@@ -214,6 +216,81 @@ def test_build_path_single_segment_with_album_folder_toggle(tmp_path):
     item = _item(album="Astroworld", artist="Travis Scott", title="Sicko Mode")
     settings = _settings(
         "{artist} - {title}", output_dir=tmp_path, create_album_folders=True
+    )
+
+    out = _build_path(item, settings, ".flac")
+
+    assert out == tmp_path / "Astroworld" / "Travis Scott - Sicko Mode.flac"
+
+
+def test_build_path_album_folder_with_artist_prefix(tmp_path):
+    """`album_folder_includes_artist=True` changes the album folder from
+    "<Album>" to "<Artist> - <Album>". The filename is unchanged."""
+    item = _item(
+        album="Astroworld",
+        album_artist="Travis Scott",
+        artist="Travis Scott, Drake",
+        title="Sicko Mode",
+    )
+    settings = _settings(
+        "{artist} - {title}",
+        output_dir=tmp_path,
+        create_album_folders=True,
+        album_folder_includes_artist=True,
+    )
+
+    out = _build_path(item, settings, ".flac")
+
+    assert out == (
+        tmp_path
+        / "Travis Scott - Astroworld"
+        / "Travis Scott, Drake - Sicko Mode.flac"
+    )
+
+
+def test_build_path_album_folder_with_artist_prefix_falls_back_to_track_artist(
+    tmp_path,
+):
+    """When album_artist is empty (older catalog entries), the folder
+    prefix uses the per-track artist so the toggle still produces a
+    sensible folder rather than degrading to "- Album"."""
+    item = _item(
+        album="Astroworld",
+        album_artist="",
+        artist="Travis Scott",
+        title="Sicko Mode",
+    )
+    settings = _settings(
+        "{artist} - {title}",
+        output_dir=tmp_path,
+        create_album_folders=True,
+        album_folder_includes_artist=True,
+    )
+
+    out = _build_path(item, settings, ".flac")
+
+    assert out == (
+        tmp_path
+        / "Travis Scott - Astroworld"
+        / "Travis Scott - Sicko Mode.flac"
+    )
+
+
+def test_build_path_album_folder_artist_prefix_off_by_default(tmp_path):
+    """Existing users: omitting the new toggle keeps the layout exactly
+    where it was before this feature shipped (no library fragmentation
+    on upgrade)."""
+    item = _item(
+        album="Astroworld",
+        album_artist="Travis Scott",
+        artist="Travis Scott",
+        title="Sicko Mode",
+    )
+    settings = _settings(
+        "{artist} - {title}",
+        output_dir=tmp_path,
+        create_album_folders=True,
+        # album_folder_includes_artist defaults to False in _settings
     )
 
     out = _build_path(item, settings, ".flac")

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -291,6 +291,10 @@ export interface Settings {
   videos_dir: string;
   filename_template: string;
   create_album_folders: boolean;
+  /** When `create_album_folders` is on, prefix the album folder with
+   *  the artist name so the layout is `<Artist> - <Album>/` instead of
+   *  `<Album>/`. Off by default. */
+  album_folder_includes_artist: boolean;
   skip_existing: boolean;
   concurrent_downloads: number;
   offline_mode: boolean;

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -354,6 +354,12 @@ export function SettingsPage({ onLogout }: { onLogout: () => void }) {
                 hint="Only takes effect when the filename template doesn't already contain a folder separator (/). With a multi-segment template the template itself defines the folder structure."
               />
               <Toggle
+                checked={settings.album_folder_includes_artist}
+                onChange={(v) => patch({ album_folder_includes_artist: v })}
+                label="Include the artist name in the album folder"
+                hint='Folder becomes "Artist - Album" instead of just "Album". Matches the convention Plex, Roon, and foobar expect for sideloaded libraries. Only applies to new downloads; existing folders stay where they are.'
+              />
+              <Toggle
                 checked={settings.create_playlist_folders}
                 onChange={(v) => patch({ create_playlist_folders: v })}
                 label="Create a subfolder per playlist"


### PR DESCRIPTION
## Summary

User request: *"i would like the folder to be be (artist name) - (album name)"*.

Today, `create_album_folders=True` produces `<Album>/`. The artist is only visible in the per-track filename. The new **"Include the artist name in the album folder"** toggle in Settings switches the layout to `<Artist> - <Album>/`, matching what Plex, Roon, and foobar2000 expect for sideloaded libraries.

- Off by default so existing libraries don't fragment on upgrade — old downloads stay where they are, only new downloads land in the new shape.
- Album artist is preferred over per-track artist so a compilation doesn't pick up a featured name from track 1; falls back to per-track artist when the album_artist field is empty.
- Plumbing mirrors `create_album_folders`: dataclass field, Pydantic mirror, frontend type, UI Toggle row directly under the related option.

## Test plan

- [x] 3 new unit tests in `tests/test_filename_template.py`:
  - toggle on → `Artist - Album/Track.flac`
  - toggle on, no album_artist → falls back to per-track artist
  - toggle off (default) → identical to today's behaviour
- [x] Full backend: 829 tests passing
- [x] tsc, lint, vitest clean
- [ ] Live download with the toggle on: confirm the folder name is `<Artist> - <Album>` and the cover.jpg from #177 still lands in it