### PR TITLE
Enable the back/prev button on the first track of an album

### DIFF
--- a/web/src/hooks/usePlayer.test.ts
+++ b/web/src/hooks/usePlayer.test.ts
@@ -1,0 +1,91 @@
+/**
+ * Tests for the pure pickPrevIndex helper used by the prev (back-skip)
+ * button. The actual button-disabled wiring (`hasPrev`) and the
+ * "restart this track when there's no previous" branch in the `prev`
+ * callback both depend on this function returning `null` cleanly on
+ * the first track of a queue.
+ */
+import { describe, expect, it } from "vitest";
+import { pickPrevIndex } from "./usePlayer";
+import type { PlayerState } from "./usePlayer";
+
+function _state(overrides: Partial<PlayerState>): PlayerState {
+  return {
+    track: null,
+    playing: false,
+    currentTime: 0,
+    duration: 0,
+    loading: false,
+    error: null,
+    volume: 1,
+    queue: [],
+    queueIndex: -1,
+    shuffle: false,
+    repeat: "off",
+    streamInfo: null,
+    source: null,
+    forceVolume: false,
+    pausedByDevice: null,
+    ...overrides,
+  };
+}
+
+describe("pickPrevIndex", () => {
+  it("returns null on an empty queue", () => {
+    expect(pickPrevIndex(_state({ queue: [], queueIndex: -1 }))).toBeNull();
+  });
+
+  it("returns null on the first track with shuffle off", () => {
+    // This is the case that drove the back-button fix: previously the
+    // button was disabled (`hasPrev: queueIndex > 0`), so pressing it
+    // never reached the `prev` callback's restart-the-track branch.
+    // The function STILL returns null here; the callback now treats a
+    // null return as "restart current track" rather than "no-op".
+    const s = _state({
+      queue: [
+        { id: "1" } as unknown as PlayerState["queue"][number],
+        { id: "2" } as unknown as PlayerState["queue"][number],
+      ],
+      queueIndex: 0,
+      shuffle: false,
+    });
+    expect(pickPrevIndex(s)).toBeNull();
+  });
+
+  it("returns the previous index in the queue with shuffle off", () => {
+    const s = _state({
+      queue: [
+        { id: "1" } as unknown as PlayerState["queue"][number],
+        { id: "2" } as unknown as PlayerState["queue"][number],
+        { id: "3" } as unknown as PlayerState["queue"][number],
+      ],
+      queueIndex: 2,
+      shuffle: false,
+    });
+    expect(pickPrevIndex(s)).toBe(1);
+  });
+
+  it("returns a non-current index when shuffle is on and queue has multiple tracks", () => {
+    const s = _state({
+      queue: [
+        { id: "1" } as unknown as PlayerState["queue"][number],
+        { id: "2" } as unknown as PlayerState["queue"][number],
+        { id: "3" } as unknown as PlayerState["queue"][number],
+      ],
+      queueIndex: 1,
+      shuffle: true,
+    });
+    const result = pickPrevIndex(s);
+    expect(result).not.toBeNull();
+    expect(result).not.toBe(1);
+  });
+
+  it("returns 0 when shuffle is on but the queue has only one track", () => {
+    const s = _state({
+      queue: [{ id: "1" } as unknown as PlayerState["queue"][number]],
+      queueIndex: 0,
+      shuffle: true,
+    });
+    expect(pickPrevIndex(s)).toBe(0);
+  });
+});

--- a/web/src/hooks/usePlayer.ts
+++ b/web/src/hooks/usePlayer.ts
@@ -960,11 +960,6 @@ export function usePlayer() {
   }, [playAtIndex, endOfQueueAdvance]);
 
   const prev = useCallback(() => {
-    // >3s in: restart the current track, matching Spotify/Apple Music.
-    if (stateRef.current.currentTime > 3) {
-      void api.player.seek(0).catch(() => {});
-      return;
-    }
     // Same stale-stateRef guard as `next`; see comment there.
     const s = stateRef.current;
     const intendedId = expectedTrackIdRef.current;
@@ -973,7 +968,20 @@ export function usePlayer() {
       : -1;
     const fromIdx = intendedIdx >= 0 ? intendedIdx : s.queueIndex;
     const p = pickPrevIndex({ ...s, queueIndex: fromIdx });
-    if (p !== null) playAtIndex(p);
+    // Restart-and-return when:
+    //   - >3s into the current track (Spotify / Apple Music convention),
+    //     so a casual press rewinds without flying back to the prior
+    //     track most users didn't mean to revisit, OR
+    //   - there's no previous track to skip to. The button is still
+    //     enabled in this case (see hasPrev below) because a "restart
+    //     this song" affordance is what users expect from the back
+    //     button on the first track of an album — a no-op press would
+    //     read as a bug.
+    if (s.currentTime > 3 || p === null) {
+      void api.player.seek(0).catch(() => {});
+      return;
+    }
+    playAtIndex(p);
   }, [playAtIndex]);
 
   const seek = useCallback((t: number) => {
@@ -1140,7 +1148,12 @@ export function usePlayer() {
   return {
     ...state,
     hasNext: state.queueIndex >= 0 && state.queueIndex < state.queue.length - 1,
-    hasPrev: state.queueIndex > 0,
+    // True whenever ANY track is loaded — pressing prev on the first
+    // track restarts it (see the `prev` callback above), so the button
+    // shouldn't be disabled in that state. Matches Spotify, Apple Music,
+    // and Tidal's own player behaviour. The pre-existing `queueIndex > 0`
+    // gate broke that affordance for the first track of every album.
+    hasPrev: state.queueIndex >= 0,
     sleepRemaining,
     play,
     toggle,


### PR DESCRIPTION
## Summary

User report: *"Can't press back skip button on first song of album"*.

The button was greyed out because `hasPrev` was gated on `queueIndex > 0`. Standard music-player UX (Spotify, Apple Music, Tidal itself) keeps the back button enabled whenever a track is playing — pressing it on the first track restarts the track. The existing `prev` callback already had a `>3s → seek(0)` branch; the button was just never reachable on track 1.

- `hasPrev: queueIndex > 0` → `queueIndex >= 0`. Button enabled whenever a track is loaded.
- `prev` callback: when `pickPrevIndex` returns null (no previous in queue), treat it the same as ">3s into the track" — seek to 0 and return. So a press on the first track rewinds it instead of doing nothing.

## Test plan

- [x] 5 new unit tests in `web/src/hooks/usePlayer.test.ts` pinning `pickPrevIndex` return-null contract
- [x] vitest, tsc clean
- [ ] Live: queue an album, press prev on track 1 — track restarts (Tidal/Spotify behaviour)
- [ ] Live: queue an album, on track 2, press prev within 1s of start — goes to track 1