### PR TITLE
Hide Max on the album download menu when no track is hi-res

### DIFF
--- a/web/src/components/DownloadAlbumButton.tsx
+++ b/web/src/components/DownloadAlbumButton.tsx
@@ -17,7 +17,11 @@ import {
   DOWNLOAD_GATE_TOOLTIP,
   useSubscription,
 } from "@/hooks/useSubscription";
-import { effectiveFormatLabel, filterAvailableQualities } from "@/lib/quality";
+import {
+  effectiveFormatLabel,
+  filterAvailableQualities,
+  unionTrackMediaTags,
+} from "@/lib/quality";
 import { cn } from "@/lib/utils";
 
 /**
@@ -46,7 +50,20 @@ export function DownloadAlbumButton({
   // album. Picking Max on a non-hi-res album just downloads the
   // same FLAC the Lossless tier would; better to not offer the
   // illusion of a choice in the first place.
-  const qualities = filterAvailableQualities(allQualities, mediaTags);
+  //
+  // We aggregate the per-track media_tags here in addition to the
+  // album-level field because Tidal's album.media_tags is unreliable:
+  // it sometimes comes back empty even when individual tracks carry
+  // HIRES_LOSSLESS / LOSSLESS, and the fail-open behaviour of
+  // filterAvailableQualities then shows Max on releases where Max
+  // wouldn't give a different file. The union across tracks is the
+  // truth — if ANY track is HIRES_LOSSLESS, Max is real (the rest
+  // fall back to Lossless); if every track has only LOSSLESS, Max
+  // is the same FLAC. Truly lossy-only releases still carry no tags
+  // at any level, which preserves the existing fail-open path for
+  // them.
+  const effectiveTags = unionTrackMediaTags(mediaTags, tracks);
+  const qualities = filterAvailableQualities(allQualities, effectiveTags);
   const sub = useSubscription();
   const [open, setOpen] = useState(false);
 
@@ -115,7 +132,7 @@ export function DownloadAlbumButton({
         <DropdownMenuLabel>Download quality</DropdownMenuLabel>
         <DropdownMenuSeparator />
         {qualities.map((q) => {
-          const effective = effectiveFormatLabel(q.value, mediaTags);
+          const effective = effectiveFormatLabel(q.value, effectiveTags);
           return (
             <DropdownMenuItem
               key={q.value}

--- a/web/src/lib/quality.test.ts
+++ b/web/src/lib/quality.test.ts
@@ -152,9 +152,9 @@ describe("unionTrackMediaTags", () => {
     // existing behaviour for those.
     expect(unionTrackMediaTags(undefined, undefined)).toEqual([]);
     expect(unionTrackMediaTags([], [])).toEqual([]);
-    expect(
-      unionTrackMediaTags([], [_track(undefined), _track([])]),
-    ).toEqual([]);
+    expect(unionTrackMediaTags([], [_track(undefined), _track([])])).toEqual(
+      [],
+    );
   });
 
   it("normalises every tag to upper case", () => {
@@ -181,10 +181,7 @@ describe("unionTrackMediaTags", () => {
     // filter fail-open, showing Max. Now the per-track LOSSLESS
     // shows up in the union and filterAvailableQualities hides Max.
     expect(
-      unionTrackMediaTags(
-        [],
-        [_track(["LOSSLESS"]), _track(["LOSSLESS"])],
-      ),
+      unionTrackMediaTags([], [_track(["LOSSLESS"]), _track(["LOSSLESS"])]),
     ).toEqual(["LOSSLESS"]);
   });
 

--- a/web/src/lib/quality.test.ts
+++ b/web/src/lib/quality.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, it } from "vitest";
 
-import type { QualityOption } from "@/api/types";
-import { effectiveFormatLabel, filterAvailableQualities } from "./quality";
+import type { QualityOption, Track } from "@/api/types";
+import {
+  effectiveFormatLabel,
+  filterAvailableQualities,
+  unionTrackMediaTags,
+} from "./quality";
 
 const ALL_QUALITIES: QualityOption[] = [
   {
@@ -131,5 +135,74 @@ describe("filterAvailableQualities", () => {
     expect(
       values(filterAvailableQualities(ALL_QUALITIES, ["lossless"])),
     ).toEqual(["low_96k", "low_320k", "high_lossless"]);
+  });
+});
+
+// Helper: build a stub Track with only the field unionTrackMediaTags
+// reads. Casting through unknown so we don't have to spell out every
+// required Track field for a unit test that touches one.
+function _track(tags: string[] | undefined): Pick<Track, "media_tags"> {
+  return { media_tags: tags } as Pick<Track, "media_tags">;
+}
+
+describe("unionTrackMediaTags", () => {
+  it("returns an empty array when nothing has any tags", () => {
+    // Truly lossy-only release: filterAvailableQualities will then
+    // fall through its empty-tags fail-open path, preserving the
+    // existing behaviour for those.
+    expect(unionTrackMediaTags(undefined, undefined)).toEqual([]);
+    expect(unionTrackMediaTags([], [])).toEqual([]);
+    expect(
+      unionTrackMediaTags([], [_track(undefined), _track([])]),
+    ).toEqual([]);
+  });
+
+  it("normalises every tag to upper case", () => {
+    expect(
+      unionTrackMediaTags(["lossless"], [_track(["hires_lossless"])]).sort(),
+    ).toEqual(["HIRES_LOSSLESS", "LOSSLESS"]);
+  });
+
+  it("includes a HIRES_LOSSLESS tag from any track in the album union", () => {
+    // The motivating case for the union path: album.media_tags is
+    // empty (Tidal didn't surface anything at the album level) but
+    // one track is hi-res, so Max IS meaningful and shouldn't be
+    // hidden.
+    expect(
+      unionTrackMediaTags(
+        [],
+        [_track(["LOSSLESS"]), _track(["HIRES_LOSSLESS"])],
+      ).sort(),
+    ).toEqual(["HIRES_LOSSLESS", "LOSSLESS"]);
+  });
+
+  it("returns only LOSSLESS when every track and the album are CD-only", () => {
+    // This is the bug fix: previously album.media_tags=[] left the
+    // filter fail-open, showing Max. Now the per-track LOSSLESS
+    // shows up in the union and filterAvailableQualities hides Max.
+    expect(
+      unionTrackMediaTags(
+        [],
+        [_track(["LOSSLESS"]), _track(["LOSSLESS"])],
+      ),
+    ).toEqual(["LOSSLESS"]);
+  });
+
+  it("de-duplicates tags across album and per-track sources", () => {
+    expect(
+      unionTrackMediaTags(
+        ["LOSSLESS"],
+        [_track(["LOSSLESS"]), _track(["LOSSLESS"])],
+      ),
+    ).toEqual(["LOSSLESS"]);
+  });
+
+  it("filters falsy tag entries out (defensive against bad upstream data)", () => {
+    expect(
+      unionTrackMediaTags(
+        ["", "LOSSLESS"],
+        [_track(["", "HIRES_LOSSLESS"])],
+      ).sort(),
+    ).toEqual(["HIRES_LOSSLESS", "LOSSLESS"]);
   });
 });

--- a/web/src/lib/quality.ts
+++ b/web/src/lib/quality.ts
@@ -1,4 +1,4 @@
-import type { QualityOption } from "@/api/types";
+import type { QualityOption, Track } from "@/api/types";
 
 /**
  * Does this track/album benefit from the Max tier? Returns a short
@@ -57,4 +57,45 @@ export function filterAvailableQualities(
   return qualities.filter((q) =>
     q.value === "hi_res_lossless" ? !cdOnly : true,
   );
+}
+
+
+/**
+ * Union the album's media_tags with the per-track media_tags so the
+ * download menu's quality filter sees the truth. Tidal's
+ * album.media_tags is unreliable — it sometimes comes back empty even
+ * when individual tracks carry HIRES_LOSSLESS / LOSSLESS — and using
+ * just the album-level field caused the album-page download menu to
+ * offer Max on releases where Max doesn't deliver a different file.
+ *
+ * The union semantics are right for the "should we offer Max?"
+ * question:
+ *   - If ANY track is HIRES_LOSSLESS, Max is meaningful (you get a
+ *     real hi-res FLAC for that track; the rest fall back to
+ *     Lossless's CD-res FLAC).
+ *   - If every track has only LOSSLESS, Max is the same file as
+ *     Lossless and should be hidden.
+ *   - If nothing has any tags (truly lossy-only release), we return
+ *     an empty array so filterAvailableQualities falls through to its
+ *     existing fail-open behaviour — which preserves the surface area
+ *     of older fixes (e.g. Thriller's Atmos-only tagging where the
+ *     stereo lossless downmix is still real).
+ *
+ * Tags are normalised to upper-case in the output so callers don't
+ * have to.
+ */
+export function unionTrackMediaTags(
+  albumTags: string[] | undefined,
+  tracks: Pick<Track, "media_tags">[] | undefined,
+): string[] {
+  const out = new Set<string>();
+  for (const tag of albumTags ?? []) {
+    if (tag) out.add(tag.toUpperCase());
+  }
+  for (const t of tracks ?? []) {
+    for (const tag of t.media_tags ?? []) {
+      if (tag) out.add(tag.toUpperCase());
+    }
+  }
+  return Array.from(out);
 }

--- a/web/src/lib/quality.ts
+++ b/web/src/lib/quality.ts
@@ -59,7 +59,6 @@ export function filterAvailableQualities(
   );
 }
 
-
 /**
  * Union the album's media_tags with the per-track media_tags so the
  * download menu's quality filter sees the truth. Tidal's


### PR DESCRIPTION
## Summary

User report: *"When downloading from albums page it shows max option when it isn't available"*.

The album-level download menu was filtering quality tiers using `album.media_tags` only, and Tidal sometimes returns that array empty even when individual tracks carry `HIRES_LOSSLESS` / `LOSSLESS`. The empty-tags fail-open in `filterAvailableQualities` then left Max visible for releases where Max wouldn't deliver a different file from Lossless.

New helper `unionTrackMediaTags(albumTags, tracks)` walks both the album-level tags and every track's tags. `DownloadAlbumButton` uses the union as the filter input.

- Any track `HIRES_LOSSLESS` → Max stays visible (it's real on that track; the rest fall back to Lossless's CD-res FLAC)
- Every track `LOSSLESS` only → Max is hidden (same FLAC as Lossless)
- Nothing tagged anywhere → empty union, filter fail-opens as before — preserves the Thriller-Atmos fix surface area

Per-track context-menu downloads (`DownloadButton`) keep using the track's own `media_tags` directly. The union is only needed for the album-level button.

## Test plan
- [x] 6 new unit tests for `unionTrackMediaTags` (empty / normalised / de-duped / per-track-fallback paths)
- [x] vitest, tsc clean
- [ ] Live: open a CD-only album page (`Lossless` only), confirm Max isn't in the dropdown
- [ ] Live: open a hi-res album, confirm Max is still there