### PR TITLE
Make short Home rows fill the grid width

### DIFF
--- a/web/src/components/PageView.tsx
+++ b/web/src/components/PageView.tsx
@@ -183,6 +183,21 @@ function Section({
             ? "grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 min-[1920px]:grid-cols-7 min-[2400px]:grid-cols-8"
             : "grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 2xl:grid-cols-6 min-[1920px]:grid-cols-7 min-[2400px]:grid-cols-8",
         )}
+        // When a single-row section has fewer items than the
+        // breakpoint's column count (Custom mixes typically returns
+        // 5-6 items but the breakpoint goes up to 8), the trailing
+        // grid columns sit empty and the row looks like it's only
+        // half-filling the container. Override to a tight N-column
+        // grid so the cards expand to fill the available width.
+        // Capped at columnCount so wider breakpoints still respect
+        // the responsive sizing chain.
+        style={
+          singleRow && visible.length > 0 && visible.length < columnCount
+            ? {
+                gridTemplateColumns: `repeat(${visible.length}, minmax(0, 1fr))`,
+              }
+            : undefined
+        }
       >
         {visible.map((it, idx) => (
           <PageItemCard


### PR DESCRIPTION
## Summary

User report: *"The custom mixed and personal radio stations categories don't fill up the entire component"*.

On wide screens those rows typically return 5-6 items, but the responsive grid classes go up to 8 columns at ≥2400px — so the row rendered as 6 cards on the left with 2 empty columns padding the right side.

Override `grid-template-columns` to a tight `repeat(N, 1fr)` when a single-row section has fewer items than the breakpoint's column count. Tailwind classes stay the default; the inline style only kicks in for the `items.length < columnCount` case, so multi-row sections and full rows keep their existing responsive layout unchanged.

## Test plan
- [x] tsc clean
- [ ] Visual: open Home on a wide screen, confirm Custom mixes and Personal radio fill the full row width
- [ ] Visual: open Home on a narrow screen, confirm cards aren't unreasonably stretched (mobile / tablet breakpoints stay the same since columnCount drops to 2-3 there anyway)