### PR TITLE
Give Popular Tracks the 60s timeout it actually needs

### DIFF
--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -50,14 +50,29 @@ import type {
 // the OS's TCP timeout (~30s–2min on Windows), which makes the UI look
 // frozen after a drop. 15s is generous enough that slow-but-alive
 // Tidal endpoints still succeed while dropped connections fail fast.
+// Known-slow endpoints (server-side fan-outs that take ~18s+ cold)
+// pass an opts.timeoutMs override; see `chartTopTracksResolved`.
 const DEFAULT_TIMEOUT_MS = 15_000;
 
-async function req<T>(path: string, init?: RequestInit): Promise<T> {
+/** Optional per-call overrides for `req()`. */
+interface ReqOptions {
+  /** Override the default 15-second request timeout. Use for
+   *  endpoints documented to take longer than 15s on a cold call
+   *  (currently `chart-top-tracks-resolved` at ~18s). */
+  timeoutMs?: number;
+}
+
+async function req<T>(
+  path: string,
+  init?: RequestInit,
+  opts?: ReqOptions,
+): Promise<T> {
   // Compose the caller's AbortSignal (if any) with our timeout so we
   // respect both. AbortSignal.any is available in every modern browser
   // we target; falling back to the timeout alone keeps behavior sane
   // on the rare UA where it isn't.
-  const timeoutSignal = AbortSignal.timeout(DEFAULT_TIMEOUT_MS);
+  const timeoutMs = opts?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const timeoutSignal = AbortSignal.timeout(timeoutMs);
   const signal =
     init?.signal && typeof AbortSignal.any === "function"
       ? AbortSignal.any([init.signal, timeoutSignal])
@@ -293,7 +308,17 @@ export const api = {
     /** Last.fm top tracks pre-resolved to Tidal Track objects. One
      *  round-trip instead of the N+1 resolve-on-client pattern. */
     chartTopTracksResolved: (limit = 50) =>
-      req<Track[]>(`/api/lastfm/chart/top-tracks-resolved?limit=${limit}`),
+      // Cold-load takes ~18s server-side (Last.fm chart fetch + N
+      // parallel Tidal search resolves for each entry). The default
+      // 15s timeout aborts before the server finishes, so the
+      // Popular Tracks tab always errored on first load. The
+      // resolved list is cached for an hour after that first
+      // resolve, so the 60s budget is paid at most once per hour.
+      req<Track[]>(
+        `/api/lastfm/chart/top-tracks-resolved?limit=${limit}`,
+        undefined,
+        { timeoutMs: 60_000 },
+      ),
     chartTopTags: (limit = 50) =>
       req<LastFmChartTag[]>(`/api/lastfm/chart/top-tags?limit=${limit}`),
     nowPlaying: (track: {


### PR DESCRIPTION
## Summary

User report: *"Loading tracks under popular literally doesn't even load. Lastfm returns no results"*. The "no results" copy is a paraphrase — the real error is `"Couldn't load chart tracks: Request timed out"`.

Root cause: the client's `req()` helper hardcodes a 15-second timeout on every JSON call. The `chart-top-tracks-resolved` endpoint is documented (server.py:4125-4131) to take ~18s cold because it fans 50 Last.fm chart entries through Tidal search and remuxes the results. The frontend gave up before the server finished — every cold load.

The v1.13.0 fix (`cache_empty=False`) prevented an empty result from sticking for an hour. But there was nothing to cache: the frontend was aborting before the server could write anything.

This PR adds an optional `opts.timeoutMs` override to `req()` and bumps `chartTopTracksResolved` to 60s. The 1-hour result cache means that 60s budget is paid at most once per hour.

## Test plan
- [x] tsc + frontend tests clean
- [ ] Open Popular Tracks on a cold cache, confirm the resolved list populates (takes 10-20s on first load, instant afterwards)
- [ ] Confirm no other endpoint is affected (default 15s still applies everywhere else)