### PR TITLE
Guard against concurrent Artist Radio takeovers at album end

### DIFF
--- a/web/src/hooks/usePlayer.ts
+++ b/web/src/hooks/usePlayer.ts
@@ -317,6 +317,19 @@ export function usePlayer() {
   const lastSeqRef = useRef(-1);
   const expectedTrackIdRef = useRef<string | null>(null);
   const endOfTrackPendingRef = useRef(false);
+  // Set to true while an `endOfQueueAdvance` is awaiting the
+  // Artist Radio fetch. Stops a second "ended" SSE event from
+  // re-entering the takeover concurrently — the network call to
+  // `api.artistRadio` takes 50-300ms during which the SSE can fire
+  // another "ended" snapshot (or the user can hit Next manually).
+  // Without the guard the player has been observed to play exactly
+  // one radio track after the album finishes and then hang at its
+  // end, which is consistent with two parallel takeovers each
+  // appending the same radio list and racing on the resulting
+  // setState — the second commit lands AFTER the first
+  // pickNextIndex read it, leaving advanceRef stranded with a
+  // stale queue snapshot.
+  const takeoverInProgressRef = useRef(false);
   // advanceRef is set by a later effect so the SSE "ended" handler can
   // call pickNextIndex against the freshest state without reinstalling
   // the subscription every queue change.
@@ -854,33 +867,44 @@ export function usePlayer() {
   // control which "last track" seeds the takeover.
   const endOfQueueAdvance = useCallback(
     async (cur: PlayerState) => {
-      const stopAndClear = () => {
-        api.player.stop().catch(() => {});
-        setState((s) => ({
-          ...s,
-          playing: false,
-          loading: false,
-          currentTime: 0,
-          queueIndex: -1,
-          track: null,
-        }));
-      };
-      const fallbackOff = () => {
-        if (cur.source?.type === "ALBUM" && cur.queue.length > 0) {
-          loadAtIndexPaused(0);
-        } else {
-          stopAndClear();
-        }
-      };
+      // Re-entry guard. See `takeoverInProgressRef` for the long
+      // version; the short version is a second concurrent takeover
+      // races with the first one's setState commit and the result is
+      // a queue the auto-advance reads as "I'm at the end" even
+      // though radio tracks were appended.
+      if (takeoverInProgressRef.current) return;
+      takeoverInProgressRef.current = true;
+      try {
+        const stopAndClear = () => {
+          api.player.stop().catch(() => {});
+          setState((s) => ({
+            ...s,
+            playing: false,
+            loading: false,
+            currentTime: 0,
+            queueIndex: -1,
+            track: null,
+          }));
+        };
+        const fallbackOff = () => {
+          if (cur.source?.type === "ALBUM" && cur.queue.length > 0) {
+            loadAtIndexPaused(0);
+          } else {
+            stopAndClear();
+          }
+        };
 
-      if (continuePlayingRef.current) {
-        const takeover = await fetchRadioTakeover(cur);
-        if (takeover) {
-          playAtIndex(takeover.index, takeover.newQueue, takeover.source);
-          return;
+        if (continuePlayingRef.current) {
+          const takeover = await fetchRadioTakeover(cur);
+          if (takeover) {
+            playAtIndex(takeover.index, takeover.newQueue, takeover.source);
+            return;
+          }
         }
+        fallbackOff();
+      } finally {
+        takeoverInProgressRef.current = false;
       }
-      fallbackOff();
     },
     [playAtIndex, loadAtIndexPaused, continuePlayingRef],
   );


### PR DESCRIPTION
## Summary

User report: *"after finishing an album one song will play afterwards. after that song ends no more songs play. it just hangs up on the end of the track."*

`endOfQueueAdvance` is async — it awaits the artist-radio network call (~50-300 ms). During that await, the SSE keeps delivering "ended" snapshots for the just-finished album track (the backend stays in ended state until the next play_track lands), so a second "ended" event fires `advanceRef` again, `pickNextIndex` returns null again, and a second `endOfQueueAdvance` enters concurrently.

Both takeovers fetch radio, both call `playAtIndex` with the same args. Their `setState` commits race: the second commit lands with queue/queueIndex values resolved at takeover-1's input snapshot, which can stomp takeover-1's queue extension. The symptom matches the report — one radio track plays (the one common to both), but the next advance hangs because the racing setState left the player in a partially-stitched state.

`takeoverInProgressRef` short-circuits a second concurrent entry. The first run finishes, releases the guard, and any further "ended" snapshots after the new track has started playing are filtered by the existing late-echo guard (different `track_id`).

## Test plan
- [x] tsc + frontend tests clean
- [ ] Live: play an album to the end, confirm Artist Radio takes over AND auto-advances past the first radio track, not just the first one
- [ ] Sanity: Continue Playing toggle still respected (off → loadAtIndexPaused for albums, stop+clear otherwise)