### PR TITLE
Sort playlist tracks by date added / title / artist

### DIFF
--- a/server.py
+++ b/server.py
@@ -9102,6 +9102,78 @@ def mix_detail(mix_id: str) -> dict:
     return result
 
 
+def _fetch_playlist_items_with_added_at(
+    playlist_id: str, playlist
+) -> list[dict]:
+    """Walk Tidal's playlist /items endpoint and merge each track's
+    `created` timestamp (when the user added it to the playlist) into
+    the track dict.
+
+    tidalapi's `Playlist.tracks()` parses the raw response into Track
+    objects and drops the per-item wrapper, so `dateAdded` is
+    inaccessible through the regular path. We make the same request
+    by hand here so the playlist-detail page can offer "Recently
+    added" as a sort option (matching what we already have for liked
+    albums / tracks). Pages 100 items at a time — same limit
+    tidalapi uses internally.
+
+    `playlist` is the already-fetched tidalapi Playlist object. We
+    take it as a parameter (instead of looking it up) so the caller's
+    one `tidal.session.playlist(id)` call stays the only one — the
+    detail endpoint's cache + tests expect a single lookup per call.
+
+    Returns a list of `track_to_dict` shapes with an extra `added_at`
+    field (ISO timestamp string, null when Tidal didn't return one).
+    Falls back to `playlist.tracks()` when the raw fetch fails so the
+    page still renders.
+    """
+    out: list[dict] = []
+    page_size = 100
+    offset = 0
+    while True:
+        try:
+            resp = tidal.session.request.request(
+                "GET",
+                f"playlists/{playlist_id}/items",
+                params={"limit": page_size, "offset": offset},
+            )
+            payload = resp.json()
+        except Exception:
+            # Raw endpoint failed (auth expired / rate limit /
+            # network drop). Fall back to the plain tracks() path so
+            # the page still loads without added_at.
+            try:
+                tracks = list(playlist.tracks())
+            except Exception:
+                tracks = []
+            return [
+                {**track_to_dict(t), "added_at": None} for t in tracks
+            ]
+
+        items = payload.get("items") or []
+        if not items:
+            break
+        for entry in items:
+            raw = (entry or {}).get("item")
+            if not raw:
+                continue
+            try:
+                # tidalapi's parser converts a raw track dict into a
+                # Track. We reuse it here so track_to_dict stays the
+                # single source of truth for the response shape.
+                track_obj = tidal.session.parse_track(raw)
+            except Exception:
+                continue
+            track_dict = track_to_dict(track_obj)
+            created = (entry or {}).get("created")
+            track_dict["added_at"] = str(created) if created else None
+            out.append(track_dict)
+        if len(items) < page_size:
+            break
+        offset += page_size
+    return out
+
+
 @app.get("/api/playlist/{playlist_id}")
 def playlist_detail(playlist_id: str) -> dict:
     _require_auth()
@@ -9114,12 +9186,15 @@ def playlist_detail(playlist_id: str) -> dict:
     except Exception as exc:
         raise HTTPException(status_code=404, detail=str(exc))
     try:
-        tracks = list(playlist.tracks())
+        tracks = _fetch_playlist_items_with_added_at(playlist_id, playlist)
     except Exception:
+        # Top-level safety net: any unexpected failure in the
+        # raw-items path falls back to an empty list so the page
+        # still renders the header and the user can retry.
         tracks = []
     result = {
         **playlist_to_dict(playlist),
-        "tracks": [track_to_dict(t) for t in tracks],
+        "tracks": tracks,
     }
     _store_detail_cache(cache_key, result)
     return result

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -36,6 +36,14 @@ export interface Track {
    *  monthly listeners). Null/missing for obscure catalog entries
    *  that lack an ISRC registration. */
   isrc?: string | null;
+  /** ISO timestamp the track was added to the containing playlist.
+   *  Only populated when the Track came through a playlist detail
+   *  fetch and Tidal returned a `created` value (user-curated
+   *  playlists). Null on editorial / collaborative playlists where
+   *  Tidal doesn't expose per-entry timestamps, and on any Track
+   *  fetched outside of a playlist context. Drives PlaylistDetail's
+   *  "Recently added" sort option. */
+  added_at?: string | null;
 }
 
 export interface Album {

--- a/web/src/pages/PlaylistDetail.tsx
+++ b/web/src/pages/PlaylistDetail.tsx
@@ -2,9 +2,14 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import {
   AlertTriangle,
+  ArrowDownAZ,
+  ArrowUpDown,
+  Check,
+  Clock,
   Folder,
   FolderMinus,
   Loader2,
+  ListOrdered,
   Pencil,
   Trash2,
 } from "lucide-react";
@@ -60,9 +65,31 @@ export function PlaylistDetail({ onDownload }: { onDownload: OnDownload }) {
   } = useApi(() => api.playlist(id), [id, refreshTick]);
   // Local optimistic copy of tracks so removing a track feels instant.
   const [localTracks, setLocalTracks] = useState<Track[] | null>(null);
+  // Per-playlist sort, persisted to localStorage so a return visit
+  // keeps whichever ordering the user picked. `playlist` = the
+  // original Tidal order (what the user / curator authored, which
+  // is meaningful for hand-crafted playlists where sequencing
+  // matters); `recent` = newest-added first, only useful on
+  // user-curated playlists where Tidal hands us the `created`
+  // timestamps; `alpha` / `artist` are conveniences for finding
+  // a song fast on bigger playlists.
+  const [sort, setSort] = useState<PlaylistSort>(() => loadSort(id));
+  useEffect(() => {
+    // Re-read the per-playlist preference when the user navigates
+    // between playlists. Without this, the initial-state value would
+    // stick across navigations and override whichever sort the user
+    // previously picked on the new playlist.
+    setSort(loadSort(id));
+  }, [id]);
+  useEffect(() => {
+    saveSort(id, sort);
+  }, [id, sort]);
   const toast = useToast();
 
-  const tracks = localTracks ?? playlist?.tracks ?? [];
+  const tracks = useMemo(() => {
+    const base = localTracks ?? playlist?.tracks ?? [];
+    return sortTracks(base, sort);
+  }, [localTracks, playlist?.tracks, sort]);
 
   // Warm the stream-manifest cache for every track on the playlist so
   // a click on any row skips the Tidal playbackinfo round-trip. Only
@@ -223,6 +250,7 @@ export function PlaylistDetail({ onDownload }: { onDownload: OnDownload }) {
               />
             )}
             <div className="ml-auto flex items-center gap-6">
+              <PlaylistSortMenu sort={sort} onSort={setSort} />
               {!playlist.owned && (
                 <AddToLibraryButton kind="playlist" id={playlist.id} />
               )}
@@ -276,7 +304,15 @@ export function PlaylistDetail({ onDownload }: { onDownload: OnDownload }) {
           tracks={tracks}
           onDownload={onDownload}
           onRemove={playlist.owned ? onRemove : undefined}
-          onReorder={playlist.owned ? onReorder : undefined}
+          // Reorder only makes sense in the original playlist order
+          // — dragging a row when the list is sorted alphabetically
+          // (or by date added) doesn't have a sensible mapping to an
+          // insert position in the underlying Tidal playlist.
+          // Switching the sort menu back to "Playlist order" re-
+          // enables it.
+          onReorder={
+            playlist.owned && sort === "playlist" ? onReorder : undefined
+          }
           source={{ type: "PLAYLIST", id: playlist.id }}
         />
       </div>
@@ -538,5 +574,140 @@ function DeletePlaylistButton({
         </DialogContent>
       </Dialog>
     </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sort
+// ---------------------------------------------------------------------------
+
+type PlaylistSort = "playlist" | "recent" | "alpha" | "artist";
+
+const SORT_OPTIONS: Array<{
+  value: PlaylistSort;
+  label: string;
+  icon: typeof ListOrdered;
+}> = [
+  { value: "playlist", label: "Playlist order", icon: ListOrdered },
+  { value: "recent", label: "Recently added", icon: Clock },
+  { value: "alpha", label: "Title (A–Z)", icon: ArrowDownAZ },
+  { value: "artist", label: "Artist (A–Z)", icon: ArrowDownAZ },
+];
+
+// Per-playlist persistence so a return visit keeps whichever sort the
+// user picked. Stored as `tideway:playlist-sort:<id>` so the value
+// can't bleed across playlists if the user has different preferences
+// for different collections.
+const SORT_STORAGE_PREFIX = "tideway:playlist-sort:";
+
+function loadSort(id: string): PlaylistSort {
+  if (!id || typeof window === "undefined") return "playlist";
+  try {
+    const raw = window.localStorage.getItem(SORT_STORAGE_PREFIX + id);
+    if (raw && SORT_OPTIONS.some((o) => o.value === raw)) {
+      return raw as PlaylistSort;
+    }
+  } catch {
+    // localStorage can throw in some sandboxes (Safari private). Treat
+    // as "no stored value" and fall through to the default.
+  }
+  return "playlist";
+}
+
+function saveSort(id: string, sort: PlaylistSort): void {
+  if (!id || typeof window === "undefined") return;
+  try {
+    if (sort === "playlist") {
+      window.localStorage.removeItem(SORT_STORAGE_PREFIX + id);
+    } else {
+      window.localStorage.setItem(SORT_STORAGE_PREFIX + id, sort);
+    }
+  } catch {
+    // Same Safari-private rationale — never fail the UI for storage.
+  }
+}
+
+function sortTracks(tracks: Track[], sort: PlaylistSort): Track[] {
+  if (sort === "playlist") return tracks;
+  // Stable sort by spreading first — Array.prototype.sort is stable
+  // on all engines we target, but the spread avoids mutating the
+  // upstream array (which would clobber the playlist owner's
+  // "original order" reference if they reorder later).
+  const copy = [...tracks];
+  if (sort === "recent") {
+    // Newest-added first. Tracks without an `added_at` (editorial
+    // playlists where Tidal doesn't expose per-entry timestamps)
+    // sink to the bottom in their original relative order.
+    copy.sort((a, b) => {
+      const ta = a.added_at ? Date.parse(a.added_at) : NaN;
+      const tb = b.added_at ? Date.parse(b.added_at) : NaN;
+      const aMissing = Number.isNaN(ta);
+      const bMissing = Number.isNaN(tb);
+      if (aMissing && bMissing) return 0;
+      if (aMissing) return 1;
+      if (bMissing) return -1;
+      return tb - ta;
+    });
+    return copy;
+  }
+  if (sort === "alpha") {
+    copy.sort((a, b) => a.name.localeCompare(b.name));
+    return copy;
+  }
+  if (sort === "artist") {
+    copy.sort((a, b) => {
+      const aArt = a.artists[0]?.name ?? "";
+      const bArt = b.artists[0]?.name ?? "";
+      const byArtist = aArt.localeCompare(bArt);
+      if (byArtist !== 0) return byArtist;
+      // Same artist → break ties by title so the per-artist clump
+      // stays human-readable instead of jumping around.
+      return a.name.localeCompare(b.name);
+    });
+    return copy;
+  }
+  return copy;
+}
+
+function PlaylistSortMenu({
+  sort,
+  onSort,
+}: {
+  sort: PlaylistSort;
+  onSort: (s: PlaylistSort) => void;
+}) {
+  const active = SORT_OPTIONS.find((o) => o.value === sort) ?? SORT_OPTIONS[0];
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          className="flex flex-col items-center gap-1 text-muted-foreground transition-colors hover:text-foreground data-[state=open]:text-primary"
+          title="Sort tracks"
+          aria-label="Sort tracks"
+        >
+          <ArrowUpDown className="h-5 w-5" />
+          <div className="text-xs font-semibold">{active.label}</div>
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {SORT_OPTIONS.map((opt) => {
+          const Icon = opt.icon;
+          const selected = opt.value === sort;
+          return (
+            <DropdownMenuItem
+              key={opt.value}
+              onSelect={() => onSort(opt.value)}
+              className="flex items-center gap-2"
+            >
+              <Icon className="h-4 w-4" />
+              <span className="flex-1">{opt.label}</span>
+              {selected && <Check className="h-4 w-4 text-primary" />}
+            </DropdownMenuItem>
+          );
+        })}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }


### PR DESCRIPTION
## Summary

User request: add a *sort by date added* option to playlist detail pages, matching what the liked songs / liked albums library pages already do.

**Backend:** `playlist_detail` now walks Tidal's raw `/playlists/{id}/items` endpoint via `tidal.session.request` and merges each entry's `created` timestamp into the track dict as `added_at`. tidalapi's `Playlist.tracks()` parses items into Track objects and drops the per-item wrapper, which is why the timestamp was unreachable through the regular path. Editorial Tidal playlists don't include `created` per item; those tracks render with `added_at: null` and sink to the bottom of the "Recently added" sort, matching the library page's existing `_sort_by_date_added`. Falls back to plain `playlist.tracks()` if the raw fetch fails.

**Frontend:** `PlaylistDetail` gains a `PlaylistSortMenu` in the actions row with four options — *Playlist order* (default), *Recently added*, *Title A–Z*, *Artist A–Z*. Selection persists per-playlist in `localStorage` under `tideway:playlist-sort:<id>` so each playlist remembers its own choice. Drag-reorder is gated to the default *Playlist order* sort, because dragging a row in an alphabetically-sorted view doesn't have a sensible mapping to an insert position in the underlying Tidal playlist.

## Test plan
- [x] `pytest tests/` — 826 passing (cache test caught a redundant `tidal.session.playlist(id)` call which is now gone)
- [x] tsc + frontend tests clean
- [ ] Live: open a user-owned playlist, switch to "Recently added", confirm newest-added tracks are first
- [ ] Live: open an editorial Tidal playlist, switch to "Recently added", confirm tracks stay in playlist order (no `created` from Tidal → all `added_at` are null)
- [ ] Live: switch to "Title A–Z" or "Artist A–Z" on an owned playlist, confirm the drag-reorder handle disappears (gated to playlist-order sort)