### PR TITLE
Hide Max from list-row download menu when album-level tags lie

### DIFF
--- a/web/src/components/DownloadButton.tsx
+++ b/web/src/components/DownloadButton.tsx
@@ -1,4 +1,6 @@
+import { useCallback, useState } from "react";
 import { ChevronDown, Download } from "lucide-react";
+import { api } from "@/api/client";
 import type { ContentKind } from "@/api/types";
 import { Button, type ButtonProps } from "@/components/ui/button";
 import {
@@ -14,7 +16,11 @@ import {
   DOWNLOAD_GATE_TOOLTIP,
   useSubscription,
 } from "@/hooks/useSubscription";
-import { effectiveFormatLabel, filterAvailableQualities } from "@/lib/quality";
+import {
+  effectiveFormatLabel,
+  filterAvailableQualities,
+  unionTrackMediaTags,
+} from "@/lib/quality";
 import { cn } from "@/lib/utils";
 
 interface Props {
@@ -50,8 +56,60 @@ export function DownloadButton({
   mediaTags,
 }: Props) {
   const allQualities = useQualities() ?? [];
-  const qualities = filterAvailableQualities(allQualities, mediaTags);
+  // Effective tags: start with what the caller passed; lazy-fetch the
+  // album detail on dropdown open to surface per-track tags when the
+  // album-level tags don't conclusively answer "is Max real here". The
+  // canonical bad case is Tidal returning an empty media_tags array at
+  // the album level on a CD-quality release — without the per-track
+  // union, filterAvailableQualities fails open and offers Max even
+  // though picking it would just deliver the same FLAC as Lossless.
+  const [resolvedTags, setResolvedTags] = useState<string[] | undefined>(
+    mediaTags,
+  );
+  const [fetched, setFetched] = useState(false);
+  const tagsAreConclusive = useCallback((tags: string[] | undefined) => {
+    // The filter only acts on LOSSLESS / HIRES_LOSSLESS. Any tag set
+    // that contains either of those is enough for the filter to make
+    // the right call. Empty / immersive-only / undefined isn't.
+    if (!tags || tags.length === 0) return false;
+    const upper = tags.map((t) => t.toUpperCase());
+    return upper.includes("HIRES_LOSSLESS") || upper.includes("LOSSLESS");
+  }, []);
   const sub = useSubscription();
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      onOpenChange?.(open);
+      if (
+        !open ||
+        kind !== "album" ||
+        fetched ||
+        tagsAreConclusive(resolvedTags)
+      ) {
+        return;
+      }
+      setFetched(true);
+      // Lazy-resolve via the album detail endpoint. SWR-cached
+      // server-side and re-uses prefetch.album results, so this is a
+      // one-shot cost per album per session. On failure we leave the
+      // existing (probably empty) tags alone — the menu still works,
+      // it just offers Max when it shouldn't, exactly the pre-fix
+      // behaviour.
+      api
+        .album(id)
+        .then((detail) => {
+          setResolvedTags(
+            unionTrackMediaTags(detail.media_tags, detail.tracks),
+          );
+        })
+        .catch(() => {
+          /* leave resolvedTags as-is; menu degrades to album-only filter */
+        });
+    },
+    [onOpenChange, kind, id, fetched, resolvedTags, tagsAreConclusive],
+  );
+
+  const qualities = filterAvailableQualities(allQualities, resolvedTags);
 
   const stop = (e: React.SyntheticEvent) => {
     e.preventDefault();
@@ -74,7 +132,7 @@ export function DownloadButton({
   }
 
   return (
-    <DropdownMenu onOpenChange={onOpenChange}>
+    <DropdownMenu onOpenChange={handleOpenChange}>
       <DropdownMenuTrigger asChild onClick={stop}>
         <Button
           variant={variant}
@@ -99,7 +157,7 @@ export function DownloadButton({
         <DropdownMenuLabel>Download quality</DropdownMenuLabel>
         <DropdownMenuSeparator />
         {qualities.map((q) => {
-          const effective = effectiveFormatLabel(q.value, mediaTags);
+          const effective = effectiveFormatLabel(q.value, resolvedTags);
           return (
             <DropdownMenuItem
               key={q.value}

--- a/web/src/components/MediaListRow.tsx
+++ b/web/src/components/MediaListRow.tsx
@@ -83,6 +83,13 @@ export function MediaListRow({
             kind={item.kind}
             id={item.id}
             onPick={onDownload}
+            // Forward the album-level media_tags so the quality menu
+            // hides Max on releases Tidal flags as Lossless-only. Without
+            // this prop, filterAvailableQualities fails open and offered
+            // Max on every row in list view, including albums where Max
+            // would just deliver the same FLAC as High. Playlists carry
+            // no album-level tags, so this is a no-op for them.
+            mediaTags={item.kind === "album" ? item.media_tags : undefined}
             iconOnly
             variant="ghost"
             size="sm"


### PR DESCRIPTION
## Summary

User report: from the Liked Albums list view, the Max option still shows on albums uploaded as Lossless. The v1.13.3 fix updated `DownloadAlbumButton` on the album detail page but the per-row `DownloadButton` in the library list view had two compounding bugs.

### Bug 1: `mediaTags` wasn't being passed at all
`MediaListRow` rendered `DownloadButton` without `mediaTags`, so the filter saw `undefined` and fell open to every quality on every row.

### Bug 2: Album-level tags aren't reliable
Even after passing `media_tags` through, Tidal sometimes returns an empty `media_tags` array at the album level for CD-quality releases. The existing fail-open behaviour for empty tags still showed Max.

### Fix
- `MediaListRow` now passes `item.media_tags` to `DownloadButton`
- `DownloadButton` lazy-fetches the album detail on dropdown open when the album-level tags can't conclusively answer the filter question (empty, undefined, or only immersive tags). The per-track media_tags get unioned in via the helper from #184, the menu re-renders with the correct quality list, and Max disappears on Lossless-only releases.

One-shot per album per session via React state, so the menu only pays for the fetch once. On fetch failure the menu degrades to the previous behaviour (album-only filter), no worse than pre-fix.

## Test plan
- [x] tsc + frontend tests pass
- [ ] Live: open Liked Albums in list view, find a Lossless-only album, open its download menu — confirm Max disappears within a fraction of a second (after the lazy fetch resolves)
- [ ] Live: find a hi-res album, confirm Max stays
- [ ] Live: pre-cached album (visited the album detail page recently), confirm Max state is correct without any visible flicker