### PR TITLE
Probe duration for local files so seek works

### DIFF
--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -1869,8 +1869,13 @@ class PCMPlayer:
         if self._local_lookup is not None:
             local_path = self._local_lookup(track_id)
             if local_path and os.path.exists(local_path):
-                info = _probe_local_stream_info(local_path)
-                return (local_path, None, info or StreamInfo(source="local"), {})
+                info, duration_s = _probe_local_stream_info(local_path)
+                return (
+                    local_path,
+                    duration_s,
+                    info or StreamInfo(source="local"),
+                    {},
+                )
 
         session = self._session_getter()
         if quality and self._quality_clamp is not None:
@@ -3512,17 +3517,29 @@ def _build_source(
     return SegmentReader(spec, prefetched=prefetched)
 
 
-def _probe_local_stream_info(path: str) -> Optional[StreamInfo]:
+def _probe_local_stream_info(
+    path: str,
+) -> tuple[Optional[StreamInfo], Optional[float]]:
+    """Read codec/duration metadata for a local file. Returns
+    `(info, duration_seconds)`; either or both can be None when
+    mutagen can't read the file.
+
+    The duration is what makes seek work on local files. Before
+    this returned just the StreamInfo, `_resolve_source` passed
+    `None` for duration to the player, which left
+    `_current_duration_ms = 0` and made `PCMPlayer.seek` bail at
+    its `duration_ms <= 0` guard — the user dragged the scrubber
+    and the audio kept playing wherever it was."""
     try:
         from mutagen import File as MutagenFile  # type: ignore
     except Exception:
-        return None
+        return None, None
     try:
         m = MutagenFile(path)
     except Exception:
-        return None
+        return None, None
     if m is None or getattr(m, "info", None) is None:
-        return None
+        return None, None
     info = m.info
     codec: Optional[str] = None
     mime_list = getattr(info, "mime", None) or []
@@ -3532,7 +3549,12 @@ def _probe_local_stream_info(path: str) -> Optional[StreamInfo]:
         ext = os.path.splitext(path)[1].lstrip(".").lower()
         codec = _normalize_codec(ext)
     rg = _read_local_replaygain(m)
-    return StreamInfo(
+    raw_length = getattr(info, "length", None)
+    try:
+        duration_s = float(raw_length) if raw_length else None
+    except (TypeError, ValueError):
+        duration_s = None
+    stream_info = StreamInfo(
         source="local",
         codec=codec,
         bit_depth=_safe_int(getattr(info, "bits_per_sample", None)),
@@ -3542,6 +3564,7 @@ def _probe_local_stream_info(path: str) -> Optional[StreamInfo]:
         album_replay_gain_db=rg.album_gain_db,
         album_peak=rg.album_peak,
     )
+    return stream_info, duration_s
 
 
 def _read_local_replaygain(m) -> ReplayGainTags:

--- a/tests/test_local_duration_probe.py
+++ b/tests/test_local_duration_probe.py
@@ -1,0 +1,103 @@
+"""Tests for the local-file duration probe + StreamInfo extraction.
+
+User report: clicking the progress bar to scrub through a locally-
+downloaded track did nothing. Root cause: ``_resolve_source`` was
+passing ``duration_s=None`` to the player for local files, which left
+``_current_duration_ms=0``, which made ``PCMPlayer.seek`` bail at its
+``duration_ms <= 0`` guard. The fix is to read ``info.length`` (from
+mutagen) inside ``_probe_local_stream_info`` and hand it back to the
+resolver. These tests pin that contract so the seek path can't go
+silent on local files again.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from app.audio.player import _probe_local_stream_info
+
+
+class _Info:
+    """Stand-in for mutagen.flac.StreamInfo / mp3.StreamInfo / etc."""
+
+    def __init__(
+        self,
+        *,
+        length: Optional[float] = None,
+        bits_per_sample: Optional[int] = None,
+        sample_rate: Optional[int] = None,
+        mime: Optional[list[str]] = None,
+    ) -> None:
+        self.length = length
+        self.bits_per_sample = bits_per_sample
+        self.sample_rate = sample_rate
+        self.mime = mime or []
+
+
+class _Mut:
+    def __init__(self, info: Optional[_Info]):
+        self.info = info
+        self.tags = None  # ReplayGain path returns all None — fine.
+
+    def get(self, _key: str):
+        return None
+
+
+def _patch(monkeypatch, mut: Optional[_Mut]) -> None:
+    """Replace ``mutagen.File`` so the probe doesn't need a real file."""
+
+    def fake_File(_path):  # noqa: N802 - mirrors mutagen.File name
+        return mut
+
+    import mutagen
+
+    monkeypatch.setattr(mutagen, "File", fake_File)
+
+
+def test_flac_length_returned_for_seek(monkeypatch):
+    """The motivating case: a 3-minute FLAC carries info.length=180.0,
+    the probe returns it, the resolver passes 180000 ms to the player,
+    PCMPlayer.seek runs through its math instead of bailing."""
+    _patch(
+        monkeypatch,
+        _Mut(_Info(length=180.0, bits_per_sample=16, sample_rate=44100, mime=["audio/flac"])),
+    )
+    info, duration_s = _probe_local_stream_info("/tmp/whatever.flac")
+    assert info is not None
+    assert info.source == "local"
+    assert info.codec == "flac"
+    assert info.bit_depth == 16
+    assert info.sample_rate_hz == 44100
+    assert duration_s == 180.0
+
+
+def test_missing_length_returns_none_without_crashing(monkeypatch):
+    """Some legacy / corrupt files have no info.length. The probe must
+    degrade to ``duration_s=None`` (rather than raise), so the resolver
+    can still play the file even though seek won't work on it."""
+    _patch(
+        monkeypatch,
+        _Mut(_Info(length=None, bits_per_sample=16, sample_rate=44100)),
+    )
+    info, duration_s = _probe_local_stream_info("/tmp/odd.flac")
+    assert info is not None
+    assert duration_s is None
+
+
+def test_garbage_length_returns_none(monkeypatch):
+    """A non-numeric length (mutagen normally won't produce this, but
+    cheap defence) gets coerced to None, not propagated as a string
+    that the player's int(duration_s * 1000) would explode on."""
+    _patch(monkeypatch, _Mut(_Info(length="banana", sample_rate=44100)))  # type: ignore[arg-type]
+    info, duration_s = _probe_local_stream_info("/tmp/garbage.flac")
+    assert info is not None
+    assert duration_s is None
+
+
+def test_unreadable_file_returns_double_none(monkeypatch):
+    """mutagen.File can return None for unreadable inputs. The probe
+    forwards that as (None, None) so the resolver falls back to the
+    default StreamInfo and the player still tries to play."""
+    _patch(monkeypatch, None)
+    info, duration_s = _probe_local_stream_info("/tmp/missing.flac")
+    assert info is None
+    assert duration_s is None


### PR DESCRIPTION
## Summary

User report: scrubbing the progress bar on a downloaded track did nothing — the bar moved visually, but playback kept going wherever it was. Root cause: `_resolve_source` passed `duration_s=None` on the local-file path, leaving `_current_duration_ms=0`, and `PCMPlayer.seek` bails at its `if duration_ms <= 0: return self.snapshot()` guard. The scrubber's value reached the backend, the seek call returned a snapshot, but the position never actually changed.

`_probe_local_stream_info` now returns `(info, duration_s)` where `duration_s` is `info.length` from mutagen (mp3, flac, m4a, ogg, etc. all populate this via their StreamInfo subclasses). `_resolve_source` forwards the duration to the player, `_current_duration_ms` ends up non-zero, seek's math runs, and the audio actually jumps to the requested position.

Streaming tracks are unaffected — Tidal's playbackinfo response always carried duration_s, so they were already seeking correctly.

## Test plan
- [x] 4 new unit tests in `tests/test_local_duration_probe.py` pin the contract (happy path, missing length, garbage length, unreadable file)
- [x] Full backend: 837 passing
- [ ] Live: play a downloaded track, drag the scrubber — playback jumps to the new position. Duration shows correctly in the progress bar.