### PR TITLE
Fix multi-second scrubber jumps from a callback-count seq bump

### DIFF
--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -418,11 +418,18 @@ class PCMPlayer:
         # 1-per-callback log every 100 ticks confirms the callback
         # is actually running + advancing.
         self._callback_counter = 0
-        # Seq-bump counter for the audio callback's position-tick
-        # nudges. Bumped every callback; emits a fresh seq every
-        # 20 callbacks (~4-5 Hz at typical 86 Hz callback rate) so
-        # the SSE position-update path lets the snapshot through.
-        self._seq_bump_counter = 0
+        # Last-bump timestamp for the audio callback's position-tick
+        # nudges. The callback bumps `_seq` from here on a wall-clock
+        # cadence (~5 Hz) so the SSE polling rate (4 Hz) always sees
+        # a fresh seq, regardless of how often the callback itself
+        # fires. The earlier "every 20 callbacks" scheme assumed an
+        # 86 Hz callback rate (44.1k / 512 frames); at lower callback
+        # rates — large buffers, hi-res-output configurations,
+        # exclusive-mode WASAPI on devices that prefer 2048-frame
+        # buffers — seq fell behind 4 Hz, the frontend's seq-dedup
+        # in usePlayer kicked in, and the scrubber updated only
+        # every couple of seconds instead of every 250 ms.
+        self._seq_last_bump_t: float = 0.0
 
         # Stall watchdog. The realtime callback updates _cb_last_t
         # on every invocation (even paused/seeking — it still fires
@@ -2645,10 +2652,15 @@ class PCMPlayer:
                     # advance samples_emitted below so the scrubber
                     # keeps moving through the underrun window —
                     # otherwise position would freeze on every
-                    # hiccup.
+                    # hiccup. Bump seq on the same wall-clock cadence
+                    # as the main path so the frontend's seq-dedup
+                    # actually lets the position update through.
                     self._log_callback_starvation()
                     outdata[written:] = 0
                     self._samples_emitted += frames
+                    if now - self._seq_last_bump_t >= 0.2:
+                        self._seq += 1
+                        self._seq_last_bump_t = now
                     return
                 self._callback_carry = chunk
 
@@ -2742,10 +2754,9 @@ class PCMPlayer:
             # Bump seq so the frontend's position scrubber still
             # advances even though local is silent — playback is
             # still happening, just on the remote.
-            self._seq_bump_counter += 1
-            if self._seq_bump_counter >= 20:
+            if now - self._seq_last_bump_t >= 0.2:
                 self._seq += 1
-                self._seq_bump_counter = 0
+                self._seq_last_bump_t = now
             return
 
         # DSP stages: ReplayGain (scalar gain) → EQ (10-band biquad
@@ -2825,13 +2836,19 @@ class PCMPlayer:
         # measurement (see the jitter check at the top).
         self._cb_prev_audio = True
         # Bump seq so the frontend's SSE dedupe lets through the
-        # position update. The callback fires ~90Hz at 44.1k /512
-        # frames, so ~every 20th call keeps us close to 4-5Hz —
-        # smooth for a scrubber, cheap on CPU.
-        self._seq_bump_counter += 1
-        if self._seq_bump_counter >= 20:
+        # position update. Wall-clock cadence (5 Hz) — independent of
+        # the callback's own rate. PortAudio's frames-per-callback
+        # depends on the device + buffer configuration: ~512 on a
+        # 44.1k Mac (~86 Hz callback), but as low as ~10 Hz callback
+        # for hi-res-output configs that prefer larger buffers.
+        # The earlier "/20" scheme tracked the 86 Hz case and
+        # silently regressed everywhere else — the frontend's
+        # seq-dedup would drop multiple 4 Hz SSE pollings between
+        # consecutive seq bumps, so the scrubber jumped multiple
+        # seconds at a time instead of sliding smoothly.
+        if now - self._seq_last_bump_t >= 0.2:
             self._seq += 1
-            self._seq_bump_counter = 0
+            self._seq_last_bump_t = now
 
     def _adopt_preload_locked(self, pre: _Preload) -> PlayerSnapshot:
         """Synchronous version of the callback's gapless swap,

--- a/tests/test_player_seq_bump_cadence.py
+++ b/tests/test_player_seq_bump_cadence.py
@@ -1,0 +1,136 @@
+"""The audio callback bumps `_seq` on a wall-clock cadence (~5 Hz),
+not a callback-count cadence.
+
+Why this matters: the SSE player-events stream sends a snapshot
+every 250 ms (4 Hz) while playing, and the frontend's `usePlayer`
+hook drops snapshots whose `seq` hasn't advanced past the last
+one it saw. If the callback's seq-bump rate falls below the SSE
+poll rate, the frontend silently drops most of those polls and
+the scrubber jumps several seconds at a time instead of sliding
+smoothly.
+
+The pre-fix scheme bumped `_seq` every 20 callbacks. At a typical
+44.1k / 512-frame configuration that's ~4.3 Hz, fine. But on
+configurations with larger callback buffers — exclusive-mode
+WASAPI on devices that prefer 2048-frame buffers, hi-res output
+that opens with a multi-thousand-frame block — the callback
+fires at 2-10 Hz, which translated to 0.1-0.5 Hz seq bumps. The
+frontend saw the same seq across multiple SSE polls, dropped
+them all, and the user got multi-second scrubber jumps.
+
+Tests below verify the wall-clock cadence with the player's
+internal monotonic clock mocked out — the callback path must
+bump seq when 200 ms have elapsed, regardless of how many
+callbacks fired in that window.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from app.audio import player as player_mod
+from app.audio.player import PCMPlayer
+
+
+def _player() -> PCMPlayer:
+    """A no-network player. `session_getter` is never invoked at
+    construction; a no-op keeps the test offline."""
+    return PCMPlayer(lambda: None)
+
+
+def _drive_callback(p: PCMPlayer, *, frames: int = 256) -> None:
+    """One audio-callback invocation. The pipeline isn't really
+    running so the queue is empty — the callback hits the underrun
+    path, which is exactly the branch we want to exercise for the
+    seq-bump (steady-state-playback codepath uses the same logic)."""
+    out = np.zeros((frames, 2), dtype=np.int16)
+    p._audio_callback(out, frames, None, None)
+
+
+def test_seq_bumps_around_5hz_for_fast_callbacks(monkeypatch):
+    """Fast-callback case: simulate 100 Hz callbacks (10 ms apart).
+    Over 1.0 simulated second the callback fires 100 times, but
+    seq should bump roughly 5 times — once per 200 ms window. Allow
+    ±1 slack to absorb floating-point precision at the 0.2-second
+    boundary (`0.6 - 0.4 == 0.19999…` in IEEE-754 doubles)."""
+    p = _player()
+    p._stream_sample_rate = 44100
+
+    now = [0.0]
+    monkeypatch.setattr(player_mod.time, "monotonic", lambda: now[0])
+
+    p._seq = 0
+    p._seq_last_bump_t = 0.0
+
+    # 100 callbacks * 10 ms = 1.0 s.
+    for _ in range(100):
+        _drive_callback(p)
+        now[0] += 0.010
+
+    # Expect ~5 bumps; tolerate one missed due to float ordering at
+    # exactly 200 ms.
+    assert 4 <= p._seq <= 5, (
+        f"expected ~5 seq bumps in 1s @ 100Hz, got {p._seq}"
+    )
+
+
+def test_seq_still_bumps_at_slow_callback_rate(monkeypatch):
+    """Slow-callback case: simulate ~5 Hz callbacks (~200 ms apart).
+    This is the WASAPI-exclusive / large-buffer regime the old
+    `>= 20 callbacks` scheme regressed on — it would have taken
+    20 callbacks (4 seconds) to bump seq once. The wall-clock check
+    bumps roughly per callback here. Stagger the deltas slightly to
+    avoid hitting the float-precision boundary at the threshold."""
+    p = _player()
+    p._stream_sample_rate = 44100
+
+    now = [0.0]
+    monkeypatch.setattr(player_mod.time, "monotonic", lambda: now[0])
+
+    p._seq = 0
+    p._seq_last_bump_t = 0.0
+
+    # 5 callbacks each spaced ~205 ms apart — keeps every delta
+    # safely above 0.2 even after float rounding.
+    for _ in range(5):
+        now[0] += 0.205
+        _drive_callback(p)
+
+    assert p._seq == 5, (
+        f"expected 5 seq bumps for 5 well-spaced slow callbacks, "
+        f"got {p._seq}"
+    )
+
+
+def test_seq_does_not_bump_between_callbacks_under_200ms(monkeypatch):
+    """Rapid-fire callbacks (three calls within 100 ms) only bump seq
+    on the first. The explicit cadence keeps the bump rate
+    predictable and decoupled from the callback rate."""
+    p = _player()
+    p._stream_sample_rate = 44100
+
+    now = [0.0]
+    monkeypatch.setattr(player_mod.time, "monotonic", lambda: now[0])
+
+    p._seq = 0
+    p._seq_last_bump_t = 0.0
+
+    # Establish the baseline bump at t=0.3 — well past the 200 ms
+    # threshold from the t=0 init.
+    now[0] = 0.3
+    _drive_callback(p)
+    assert p._seq == 1, "first callback past 200ms should bump"
+
+    # Three more callbacks within the next 100 ms — no bump.
+    for delta in (0.020, 0.040, 0.060):
+        now[0] = 0.3 + delta
+        _drive_callback(p)
+
+    assert p._seq == 1, (
+        f"three sub-200ms callbacks must not bump seq again, got {p._seq}"
+    )
+
+    # The next callback past the 200 ms window does bump again. Use
+    # 0.55 to give the threshold check some slack.
+    now[0] = 0.55
+    _drive_callback(p)
+    assert p._seq == 2, "callback past the 200ms window must bump again"


### PR DESCRIPTION
## Summary

User report: time displayed on the bottom bar doesn't progress correctly — it jumps multiple seconds at a time instead of sliding smoothly while the song plays.

Root cause is in the audio callback's seq-bump cadence. `_seq` was incremented every 20 callbacks, tuned for a ~86 Hz callback rate (44.1 kHz / 512-frame buffers on a typical Mac). That gives ~4.3 Hz seq updates, comfortably above the SSE `/api/player/events` poll rate of 4 Hz, so the frontend's `lastSeqRef`-driven dedup in `usePlayer` lets snapshots through.

But the callback frequency depends on the device + buffer configuration. Large-buffer WASAPI configs (2048 frames is common in exclusive mode on USB DACs) and hi-res output paths fire the callback at 5-15 Hz, which translated to 0.25-0.75 Hz seq bumps. The SSE still polls at 4 Hz, so multiple consecutive polls all carry the same seq, the frontend dedups them, and the scrubber updates only every couple of seconds.

## Fix

Replace the count-based bump with a wall-clock check: bump seq if 200 ms have elapsed since the last bump. Now seq always advances at ~5 Hz regardless of how often the callback fires. Applied to all three paths through the callback (main, underrun, external-output) so the scrubber stays smooth through decoder hiccups and Cast / DLNA-tap-only playback.

## Test plan

- [x] Three new unit tests in `tests/test_player_seq_bump_cadence.py` pin the cadence with a mocked monotonic clock — fast-callback case, slow-callback regression case, and the rate-limit between bursts.
- [x] Full backend: 836 passing.
- [x] Live: played a local file on dev, scrubber slides at 4 Hz steps instead of multi-second jumps.