### PR TITLE
Keep all tracks of one album in the same folder under the artist-prefix toggle

### DIFF
--- a/app/downloader.py
+++ b/app/downloader.py
@@ -262,6 +262,17 @@ class DownloadItem:
     # per-playlist folder. 0 / "" means "not from a playlist".
     playlist_index: int = 0
     playlist_name: str = ""
+    # Frozen at enqueue time: the canonical album artist used to build
+    # the `<Artist> - <Album>` folder when `album_folder_includes_artist`
+    # is on. When non-empty, _build_path uses this verbatim instead of
+    # recomputing from `album_artist or artist` — guarantees every track
+    # of one album lands in the same folder even when individual tracks
+    # were resolved via different paths (e.g. restored from disk after
+    # a crash, where tidalapi's `track.album.artist` falls back to the
+    # track's primary artist rather than the canonical album artist).
+    # Empty for single-track and playlist enqueues where the album
+    # folder isn't the organizing unit.
+    album_folder_artist: str = ""
 
 
 class Downloader:
@@ -323,6 +334,16 @@ class Downloader:
         # remembering it wouldn't help. Keyed by item_id for O(1) update.
         self._pending_meta: Dict[str, dict] = {}
         self._pending_lock = threading.Lock()
+        # Side-channel for restore(): when a pending item carries an
+        # `album_folder_artist` value persisted from its original album
+        # enqueue, restore() stages it here keyed by tidal track id. The
+        # enqueue path consumes it after _populate_item_from_track runs,
+        # so the resumed item lands in the SAME folder as its album-
+        # mates rather than a per-track-artist folder (which is what
+        # tidalapi's `track.album.artist` would give us for a track
+        # re-fetched on its own — see _album_artist_name).
+        self._restore_overrides: Dict[str, str] = {}
+        self._restore_overrides_lock = threading.Lock()
         # Sweep any stale `.part` files left behind by a previous crash
         # before workers start — otherwise the user's output folder
         # slowly fills with orphans a skip-existing scan won't touch.
@@ -349,6 +370,42 @@ class Downloader:
     def _track_map_has(self, item_id: str) -> bool:
         with self._track_map_lock:
             return item_id in self._track_map
+
+    def _stamp_album_folder_artist(
+        self,
+        item: DownloadItem,
+        track,
+        album_obj,
+        is_album_enqueue: bool,
+    ) -> None:
+        """Freeze the folder-naming album artist onto the item.
+
+        Two sources, in order:
+          1. A restore override staged by restore() under the track's
+             tidal id — wins because it carries the canonical name from
+             the ORIGINAL album enqueue, before the crash that put us
+             here. Without this, a track re-fetched on its own would
+             use tidalapi's `track.album.artist` (which is set to the
+             track's primary artist, not the album's), so a feature on
+             track 5 would split into "Feature - AlbumName" while the
+             rest of the album sat in "MainArtist - AlbumName".
+          2. The parent album object's artist, only when we KNOW we're
+             enqueuing as part of an album (kind=album). For single-
+             track and playlist enqueues, leave it empty so _build_path
+             keeps its per-track fallback behaviour.
+        """
+        tid = getattr(track, "id", None)
+        if tid is not None:
+            key = str(tid)
+            with self._restore_overrides_lock:
+                override = self._restore_overrides.pop(key, None)
+            if override:
+                item.album_folder_artist = override
+                return
+        if is_album_enqueue and album_obj is not None:
+            name = getattr(getattr(album_obj, "artist", None), "name", None)
+            if name:
+                item.album_folder_artist = name
 
     def submit(self, url: str, quality: Optional[str] = None):
         threading.Thread(target=self._expand_and_enqueue, args=(url, quality), daemon=True).start()
@@ -441,6 +498,7 @@ class Downloader:
             file=_sys.stderr,
             flush=True,
         )
+        is_album_enqueue = content_type == "album"
         for track, album_obj, pl_idx in pairs:
             item = DownloadItem(item_id=str(uuid.uuid4()), url="")
             _populate_item_from_track(
@@ -450,6 +508,9 @@ class Downloader:
                 quality,
                 playlist_index=pl_idx,
                 playlist_name=playlist_name,
+            )
+            self._stamp_album_folder_artist(
+                item, track, album_obj, is_album_enqueue
             )
             self._track_map_put(item.item_id, (track, album_obj))
             self.on_add(item)
@@ -469,6 +530,7 @@ class Downloader:
                         "title": item.title,
                         "artist": item.artist,
                         "album": item.album,
+                        "album_folder_artist": item.album_folder_artist,
                     },
                 )
             self._work_queue.put(item)
@@ -600,6 +662,7 @@ class Downloader:
             self.on_update(placeholder)
             return
 
+        is_album_enqueue = content_type == "album"
         if len(pairs) == 1:
             track, album_obj, pl_idx = pairs[0]
             _populate_item_from_track(
@@ -609,6 +672,9 @@ class Downloader:
                 quality,
                 playlist_index=pl_idx,
                 playlist_name=playlist_name,
+            )
+            self._stamp_album_folder_artist(
+                placeholder, track, album_obj, is_album_enqueue
             )
             self._track_map_put(placeholder.item_id, (track, album_obj))
             self.on_update(placeholder)
@@ -623,6 +689,7 @@ class Downloader:
                         "title": placeholder.title,
                         "artist": placeholder.artist,
                         "album": placeholder.album,
+                        "album_folder_artist": placeholder.album_folder_artist,
                     },
                 )
             self._work_queue.put(placeholder)
@@ -640,6 +707,9 @@ class Downloader:
                     playlist_index=pl_idx,
                     playlist_name=playlist_name,
                 )
+                self._stamp_album_folder_artist(
+                    item, track, album_obj, is_album_enqueue
+                )
                 self._track_map_put(item.item_id, (track, album_obj))
                 self.on_add(item)
                 tid = getattr(track, "id", None)
@@ -653,6 +723,7 @@ class Downloader:
                             "title": item.title,
                             "artist": item.artist,
                             "album": item.album,
+                            "album_folder_artist": item.album_folder_artist,
                         },
                     )
                 self._work_queue.put(item)
@@ -846,6 +917,15 @@ class Downloader:
                 url = f"https://tidal.com/browse/playlist/{obj_id}"
             else:
                 url = f"https://tidal.com/browse/{kind}/{obj_id}"
+            # Stage the folder-naming album artist BEFORE the resubmit:
+            # the expand thread will hit _stamp_album_folder_artist
+            # before populating the item, which is where the override
+            # is consumed. If we set it after submit() returns the work
+            # has already started in another thread.
+            album_folder_artist = entry.get("album_folder_artist") or ""
+            if kind == "track" and album_folder_artist:
+                with self._restore_overrides_lock:
+                    self._restore_overrides[str(obj_id)] = album_folder_artist
             try:
                 self.submit(url, quality=quality)
                 count += 1
@@ -1978,7 +2058,16 @@ def _build_path(item: DownloadItem, settings, ext: str) -> Path:
             # only name we have for older catalog entries that lack
             # the album_artist field).
             if getattr(settings, "album_folder_includes_artist", False):
-                folder_artist = item.album_artist or item.artist
+                # Prefer the value frozen at album-enqueue time so every
+                # track of one album lands in the same folder, even when
+                # a particular track was resolved via a path that lost
+                # the canonical album artist (single-track fetch,
+                # restore-after-crash). See DownloadItem.album_folder_artist.
+                folder_artist = (
+                    item.album_folder_artist
+                    or item.album_artist
+                    or item.artist
+                )
                 folder_name = (
                     f"{folder_artist} - {item.album}"
                     if folder_artist

--- a/tests/test_album_folder_artist_stamp.py
+++ b/tests/test_album_folder_artist_stamp.py
@@ -1,0 +1,143 @@
+"""Tests for the album-folder-artist freeze step.
+
+User report: with `album_folder_includes_artist` on, some tracks of
+one album landed in a folder named after the track's primary artist
+instead of the canonical album artist. The root cause was the seam
+between two ways the same track can arrive at `_populate_item_from_track`:
+
+  * As part of an album enqueue (`kind=album` → `album_obj` is the
+    full parent Album with `.artist` set to the canonical credit).
+  * As a standalone track (single-track download, OR a track restored
+    from a pending snapshot after a crash). Here `album_obj` is
+    `track.album`, which tidalapi populates from the track's primary
+    artist rather than the album's — see `tidalapi.media.Media.parse`.
+
+`_stamp_album_folder_artist` freezes the canonical value onto the
+item at album-enqueue time, and a side-channel dict carries it across
+the restore() re-fetch so a resumed item lands in the same folder as
+its album-mates.
+"""
+from __future__ import annotations
+
+import threading
+from typing import Optional
+
+from app.downloader import DownloadItem, Downloader
+
+
+class _Stub:
+    """Just enough of a Downloader to exercise the stamp helper.
+
+    Avoids the worker-thread spin-up of the real constructor — only
+    the locks + overrides dict matter for this code path.
+    """
+
+    def __init__(self) -> None:
+        self._restore_overrides: dict[str, str] = {}
+        self._restore_overrides_lock = threading.Lock()
+
+
+# Bind the method off the real class so we test the production code,
+# not a copy. `Downloader._stamp_album_folder_artist` only reads
+# `self._restore_overrides` + lock — the rest of Downloader's state
+# isn't touched, so the stub is enough.
+_stamp = Downloader._stamp_album_folder_artist
+
+
+class _Track:
+    def __init__(self, *, tid: Optional[int], artist_name: str = "") -> None:
+        self.id = tid
+        self.artist = type("_A", (), {"name": artist_name})()
+
+
+class _Album:
+    def __init__(self, *, artist_name: Optional[str]) -> None:
+        if artist_name is None:
+            self.artist = None
+        else:
+            self.artist = type("_A", (), {"name": artist_name})()
+
+
+def test_album_enqueue_freezes_canonical_artist_on_item():
+    """Album-enqueue path: the parent album's artist name is frozen
+    onto the item, regardless of what the track's own primary artist
+    is. That's the value `_build_path` reaches for when the folder
+    toggle is on."""
+    stub = _Stub()
+    item = DownloadItem(item_id="i", url="")
+    track = _Track(tid=1, artist_name="Drake")  # featured contributor
+    album = _Album(artist_name="DJ Khaled")  # canonical credit
+
+    _stamp(stub, item, track, album, is_album_enqueue=True)
+
+    assert item.album_folder_artist == "DJ Khaled"
+
+
+def test_single_track_enqueue_does_not_freeze():
+    """Single-track and playlist enqueues leave the field empty so
+    `_build_path` falls back to the per-track logic. The canonical
+    album artist isn't reliable here — tidalapi gives us the track's
+    primary artist as `track.album.artist`, which is exactly the
+    value we'd otherwise be "freezing", defeating the point."""
+    stub = _Stub()
+    item = DownloadItem(item_id="i", url="")
+    track = _Track(tid=1, artist_name="Drake")
+    # Simulate tidalapi's quirk where track.album.artist == track.artist.
+    album = _Album(artist_name="Drake")
+
+    _stamp(stub, item, track, album, is_album_enqueue=False)
+
+    assert item.album_folder_artist == ""
+
+
+def test_restore_override_wins_over_album_obj():
+    """The motivating case: a track restored from pending state after
+    a crash. submit() goes through the kind=track URL path so the
+    `album_obj` it builds is `track.album` (where tidalapi already
+    smuggled the track's primary artist in as the "album" artist).
+    The restore override carries the CANONICAL value from the original
+    album enqueue, so it must win."""
+    stub = _Stub()
+    stub._restore_overrides["42"] = "DJ Khaled"
+    item = DownloadItem(item_id="i", url="")
+    track = _Track(tid=42, artist_name="Drake")
+    # tidalapi-style track.album where artist mirrors track.artist:
+    album = _Album(artist_name="Drake")
+
+    # is_album_enqueue=False mirrors the kind=track restore path.
+    _stamp(stub, item, track, album, is_album_enqueue=False)
+
+    assert item.album_folder_artist == "DJ Khaled"
+    # Override consumed — a second call for a different item with the
+    # same track id (shouldn't happen in practice, but the dict-pop
+    # semantics matter) gets no override.
+    assert "42" not in stub._restore_overrides
+
+
+def test_missing_track_id_does_not_crash():
+    """Defence: tidalapi has surprised us with `None`-id placeholders
+    in the past (404s during retry). The stamp helper should silently
+    skip the override lookup rather than throw."""
+    stub = _Stub()
+    item = DownloadItem(item_id="i", url="")
+    track = _Track(tid=None)
+    album = _Album(artist_name="DJ Khaled")
+
+    _stamp(stub, item, track, album, is_album_enqueue=True)
+
+    # Album-enqueue path still freezes from album_obj.
+    assert item.album_folder_artist == "DJ Khaled"
+
+
+def test_album_obj_without_artist_leaves_field_empty():
+    """If the parent album's `.artist` is None (rare — corrupted or
+    pre-released entries), we shouldn't crash. The field stays empty
+    and `_build_path` falls back to `album_artist or artist`."""
+    stub = _Stub()
+    item = DownloadItem(item_id="i", url="")
+    track = _Track(tid=1, artist_name="Drake")
+    album = _Album(artist_name=None)
+
+    _stamp(stub, item, track, album, is_album_enqueue=True)
+
+    assert item.album_folder_artist == ""

--- a/tests/test_filename_template.py
+++ b/tests/test_filename_template.py
@@ -276,6 +276,80 @@ def test_build_path_album_folder_with_artist_prefix_falls_back_to_track_artist(
     )
 
 
+def test_build_path_album_folder_artist_uses_frozen_value_over_track_artist(
+    tmp_path,
+):
+    """User report: with `album_folder_includes_artist` on, some tracks
+    of one album landed in a separate folder named after the track's
+    primary artist instead of the album's canonical artist. Root cause:
+    a track restored from disk after a crash (or fetched as a single)
+    has `album_artist` set to its own primary artist, because tidalapi
+    sets `track.album.artist` from the track's first listed artist
+    rather than the parent album's. The fix freezes the canonical
+    album artist onto the item at album-enqueue time as
+    `album_folder_artist`, and _build_path prefers that value over the
+    per-track field for folder naming. Pin that here so a future
+    refactor can't silently re-introduce the per-track split."""
+    item = _item(
+        album="We the Best Forever",
+        # album_artist is the per-track album_artist field — for a
+        # track-only fetch tidalapi populates this from the track's
+        # own primary artist (one of the featured contributors), not
+        # the canonical album credit.
+        album_artist="Drake",
+        artist="DJ Khaled, Drake",
+        title="I'm On One",
+        # The frozen value, set at album-enqueue time from the parent
+        # Album's `.artist.name`. This is the value that should win.
+        album_folder_artist="DJ Khaled",
+    )
+    settings = _settings(
+        "{artist} - {title}",
+        output_dir=tmp_path,
+        create_album_folders=True,
+        album_folder_includes_artist=True,
+    )
+
+    out = _build_path(item, settings, ".flac")
+
+    # Folder must use "DJ Khaled" (frozen canonical), NOT "Drake"
+    # (per-track album_artist) — so this track lands in the same
+    # folder as the rest of the album.
+    assert out == (
+        tmp_path
+        / "DJ Khaled - We the Best Forever"
+        / "DJ Khaled, Drake - I'm On One.flac"
+    )
+
+
+def test_build_path_album_folder_artist_empty_falls_back_to_album_artist(tmp_path):
+    """Backward compat: items predating this fix (or single-track
+    submits we deliberately don't stamp) have an empty
+    `album_folder_artist`. The folder name then falls back to
+    `album_artist or artist`, preserving the existing behaviour."""
+    item = _item(
+        album="Astroworld",
+        album_artist="Travis Scott",
+        artist="Travis Scott, Drake",
+        title="Sicko Mode",
+        album_folder_artist="",  # explicitly empty — the fallback path
+    )
+    settings = _settings(
+        "{artist} - {title}",
+        output_dir=tmp_path,
+        create_album_folders=True,
+        album_folder_includes_artist=True,
+    )
+
+    out = _build_path(item, settings, ".flac")
+
+    assert out == (
+        tmp_path
+        / "Travis Scott - Astroworld"
+        / "Travis Scott, Drake - Sicko Mode.flac"
+    )
+
+
 def test_build_path_album_folder_artist_prefix_off_by_default(tmp_path):
     """Existing users: omitting the new toggle keeps the layout exactly
     where it was before this feature shipped (no library fragmentation


### PR DESCRIPTION
## Summary

User report: with the v1.13.3 \`album_folder_includes_artist\` toggle on, downloading an album lands most tracks in \`<AlbumArtist> - <Album>/\` but splits some off into their own \`<Feature> - <Album>/\` folder.

Root cause is a seam between two ways a track can arrive at \`_populate_item_from_track\`:

- **Album enqueue** (\`kind=album\`): the \`album_obj\` is the canonical parent Album with \`.artist\` set to the editorial credit. Every track of the album sees the same \`album_obj\`, so \`item.album_artist\` is consistent.
- **Standalone track** (single-track download, or a track restored from the pending-queue snapshot after a crash): \`album_obj\` is \`track.album\`. tidalapi populates \`track.album.artist\` from the track's primary artist rather than the canonical album credit — see \`tidalapi.media.Media.parse\` line 247. So a track resumed across a restart, or a track downloaded on its own from an album, gets the contributor's name where its siblings have the album-artist's.

\`_build_path\` was using \`item.album_artist or item.artist\` per-track for the folder name, so the split followed straight into the filesystem.

## Fix

- New \`DownloadItem.album_folder_artist\` field, frozen at album-enqueue time to the parent album's \`.artist.name\`.
- \`_build_path\` prefers \`item.album_folder_artist\` when the toggle is on; falls back to \`album_artist or artist\` otherwise (so single-track and playlist enqueues, where we deliberately don't stamp, keep their old behaviour).
- New \`_stamp_album_folder_artist\` helper handles both sources: (a) freeze from the parent album, (b) restore-override via a side-channel \`_restore_overrides\` dict keyed by tidal track id.
- \`album_folder_artist\` persists in pending meta, and \`restore()\` stages it into the override dict before resubmitting the URL. The resumed item picks it up in the enqueue path, after \`_populate_item_from_track\` overwrites the per-track field with whatever tidalapi handed back this time.

## Test plan

- [x] 5 new tests in \`tests/test_album_folder_artist_stamp.py\` cover the stamp helper's two sources, the missing-track-id and empty-album defences, and the override-wins case.
- [x] 2 new tests in \`test_filename_template.py\` pin \`_build_path\`'s frozen-value preference and the backward-compat fallback when the field is empty.
- [x] Full backend: 840 passing.
- [ ] Live: with the toggle on, download a multi-artist album, confirm every track lands in the same folder.
- [ ] Live: restart the app mid-album-download (so some tracks resume), confirm the resumed tracks land in the same folder as the others.