### PR TITLE
Fix Linux quit deadlock in the closing-event geometry save

### DIFF
--- a/desktop.py
+++ b/desktop.py
@@ -269,22 +269,38 @@ def _run_uvicorn_in_thread() -> "uvicorn.Server":  # type: ignore[name-defined]
     return server
 
 
+# Flipped by the first _graceful_shutdown call. Makes it idempotent —
+# the post-start() path, the Linux closed-event path, and the exit
+# watchdog can all call it without double-flushing state — and lets
+# the watchdog's diagnostics say whether the clean path ever ran.
+_graceful_ran = threading.Event()
+
+
 def _graceful_shutdown(server: "uvicorn.Server") -> None:  # type: ignore[name-defined]
-    """Signal uvicorn to stop and give in-flight requests a brief grace
-    period to drain. Runs on the main thread after the pywebview window
-    closes."""
+    """Signal uvicorn to stop and flush state to disk. Runs on the main
+    thread after the pywebview window closes (or from the Linux closed
+    handler / exit watchdog).
+
+    Every step prints a trace line. Quit-hang reports arrive as
+    "terminal prints nothing", which is only diagnosable if the
+    shutdown path narrates how far it got."""
+    if _graceful_ran.is_set():
+        return
+    _graceful_ran.set()
+    print("[desktop] shutdown: signaling uvicorn", file=sys.stderr, flush=True)
     try:
         server.should_exit = True
-    except Exception:
-        pass
+    except Exception as exc:
+        print(f"[desktop] shutdown: uvicorn signal failed: {exc!r}", file=sys.stderr, flush=True)
     # Flush the downloader's pending-queue snapshot so a reopen picks up
     # where we left off. The worker threads are daemons and will be
     # killed on process exit; the state on disk is what matters.
+    print("[desktop] shutdown: persisting download queue", file=sys.stderr, flush=True)
     try:
         import server as _server
         _server.downloader._persist_pending()  # type: ignore[attr-defined]
-    except Exception:
-        pass
+    except Exception as exc:
+        print(f"[desktop] shutdown: download-queue persist failed: {exc!r}", file=sys.stderr, flush=True)
 
     # Tear down the macOS Now Playing integration before the
     # interpreter finalizes. MediaRemote retains our nowPlayingInfo
@@ -294,13 +310,14 @@ def _graceful_shutdown(server: "uvicorn.Server") -> None:  # type: ignore[name-d
     # ("Tideway quit unexpectedly", crash thread on
     # com.apple.MediaRemote...serialQueue). stop() removes every Python
     # object from Apple's side so a late callback has nothing to call.
+    print("[desktop] shutdown: stopping Now Playing bridge", file=sys.stderr, flush=True)
     try:
         import server as _server
         bridge = getattr(_server, "macos_now_playing_bridge", None)
         if bridge is not None:
             bridge.stop()
-    except Exception:
-        pass
+    except Exception as exc:
+        print(f"[desktop] shutdown: Now Playing stop failed: {exc!r}", file=sys.stderr, flush=True)
 
     # Close the audio OutputStream before the interpreter exits.
     # sounddevice registers an atexit Pa_Terminate(); if a stream is
@@ -311,13 +328,66 @@ def _graceful_shutdown(server: "uvicorn.Server") -> None:  # type: ignore[name-d
     # terminated the process. stop() does the ordered teardown
     # (abort + close the stream, stop the decoder thread) so
     # Pa_Terminate has nothing left to free.
+    print("[desktop] shutdown: stopping audio engine", file=sys.stderr, flush=True)
     try:
         import server as _server
         player = getattr(_server, "_pcm_player_singleton", None)
         if player is not None:
             player.stop()
-    except Exception:
-        pass
+    except Exception as exc:
+        print(f"[desktop] shutdown: audio stop failed: {exc!r}", file=sys.stderr, flush=True)
+    print("[desktop] shutdown: state flushed", file=sys.stderr, flush=True)
+
+
+# Ensures only one watchdog thread starts no matter how many close
+# paths try to arm it.
+_watchdog_armed = threading.Event()
+
+
+def _arm_exit_watchdog(
+    server: "uvicorn.Server",  # type: ignore[name-defined]
+    deadline_s: float = 10.0,
+) -> None:
+    """Guarantee the process dies once a window close has begun.
+
+    The geometry-cache fix removes the known close-path deadlock, but
+    pywebview's GTK backend has a wider history of the loop wedging
+    during teardown (r0x0r/pywebview #95, #690, #793) — and any wedge
+    between the `closing` event and the `closed` event leaves the
+    Linux closed-handler's os._exit unreachable. Armed from `closing`
+    (the first thing pywebview fires when a close starts). If the
+    process is still alive `deadline_s` later, log a diagnostic naming
+    which threads are alive and whether the clean shutdown ever ran,
+    flush state, and force-exit. State is safe: `_graceful_shutdown`
+    is idempotent and every worker thread is a daemon designed to die
+    with the process.
+
+    On the normal path the process exits within moments of the close
+    and the (daemon) watchdog dies with it, having done nothing.
+    """
+    if _watchdog_armed.is_set():
+        return
+    _watchdog_armed.set()
+
+    def _watch() -> None:
+        time.sleep(deadline_s)
+        clean = _graceful_ran.is_set()
+        print(
+            f"[desktop] exit watchdog: still alive {deadline_s:.0f}s after the "
+            f"window close began (clean shutdown ran: {clean}) — forcing exit. "
+            "If you are reporting a quit hang, include the lines above.",
+            file=sys.stderr,
+            flush=True,
+        )
+        alive = ", ".join(
+            f"{t.name}{'' if t.daemon else ' (non-daemon)'}"
+            for t in threading.enumerate()
+        )
+        print(f"[desktop] exit watchdog: threads alive: {alive}", file=sys.stderr, flush=True)
+        _graceful_shutdown(server)
+        os._exit(0)
+
+    threading.Thread(target=_watch, daemon=True, name="exit-watchdog").start()
 
 
 def _enable_webview_media_prefs() -> None:
@@ -514,31 +584,71 @@ def main(argv: Optional[list[str]] = None) -> int:
         easy_drag=False,
     )
 
+    # Live geometry cache, fed by pywebview's resized / moved events.
+    # _save_window_geometry used to read window.width/.height/.x/.y at
+    # close time, but on the GTK backend those getters marshal to the
+    # main loop via glib.idle_add and then BLOCK on a semaphore until
+    # the idle callback runs. The `closing` event's handlers execute
+    # synchronously ON that same main loop (it's a should_lock Event,
+    # fired from close_window), so the geometry read deadlocked the
+    # loop against itself: it sat in semaphore.acquire() waiting for
+    # an idle callback that only the blocked loop could run. Nothing
+    # after the deadlock ever happened — no destroy, no `closed`
+    # event, no shutdown logs, webview.start() never returned — which
+    # is exactly the Linux "window closes but the process survives
+    # until killed" report. Caching the values as the events deliver
+    # them costs an int store per resize/move and makes the close
+    # path entirely backend-free.
+    _geom = {"w": _win_w, "h": _win_h, "x": _win_x, "y": _win_y}
+
+    def _on_window_resized(width: int, height: int) -> None:
+        _geom["w"], _geom["h"] = int(width), int(height)
+
+    def _on_window_moved(x: int, y: int) -> None:
+        _geom["x"], _geom["y"] = int(x), int(y)
+
+    try:
+        window.events.resized += _on_window_resized
+        window.events.moved += _on_window_moved
+    except Exception as exc:
+        # Geometry restore degrades to the last persisted values —
+        # visible but not load-bearing. Log it: a backend that stops
+        # delivering these events is worth knowing about.
+        print(
+            f"[desktop] geometry event hooks failed: {exc!r}",
+            file=sys.stderr,
+            flush=True,
+        )
+
     def _save_window_geometry() -> None:
-        """Capture the window's current size + position into settings
-        so the next launch restores it. Best-effort: reading geometry
-        off a window that's already torn down (or a backend that
-        doesn't report it) must not break the close path. Called
-        while the window is still alive — the macOS hide path and the
-        Win/Linux closing event, before destroy."""
+        """Persist the cached size + position so the next launch
+        restores it. Reads ONLY the event-fed cache — never the
+        window object — so it is safe to call from any thread,
+        including inside the `closing` event on the GUI loop (see the
+        deadlock note above the cache)."""
         try:
             from app.settings import save_settings as _save_settings
 
-            w = int(window.width)
-            h = int(window.height)
-            x = int(window.x)
-            y = int(window.y)
+            w, h = int(_geom["w"]), int(_geom["h"])
             # A minimized/zero-size read is junk; keep the last good
             # geometry rather than persisting a collapsed window.
             if w < 800 or h < 600:
                 return
             _server.settings.window_width = w
             _server.settings.window_height = h
-            _server.settings.window_x = x
-            _server.settings.window_y = y
+            # x/y stay None until the first moved event (fresh install
+            # that was never dragged) — keep the persisted values
+            # untouched rather than writing a fake origin.
+            if _geom["x"] is not None and _geom["y"] is not None:
+                _server.settings.window_x = int(_geom["x"])
+                _server.settings.window_y = int(_geom["y"])
             _save_settings(_server.settings)
-        except Exception:
-            pass
+        except Exception as exc:
+            print(
+                f"[desktop] window geometry save failed: {exc!r}",
+                file=sys.stderr,
+                flush=True,
+            )
 
     # Close behavior. On Windows / Linux the X destroys the window and
     # the process exits. On macOS we follow the platform convention:
@@ -569,11 +679,19 @@ def main(argv: Optional[list[str]] = None) -> int:
         # Used by the in-app Quit menu's /api/_internal/quit
         # endpoint. Bypasses the closing-to-hide path on macOS by
         # calling destroy directly, so capture geometry first.
+        print("[desktop] quit requested from app menu", file=sys.stderr, flush=True)
         _save_window_geometry()
         try:
             window.destroy()
-        except Exception:
-            pass
+        except Exception as exc:
+            # A destroy that fails means the Quit click "did nothing"
+            # from the user's perspective — log the actual error so a
+            # report contains it instead of silence.
+            print(
+                f"[desktop] quit: window destroy failed: {exc!r}",
+                file=sys.stderr,
+                flush=True,
+            )
 
     if sys.platform == "darwin":
         def _on_closing_macos() -> bool:
@@ -657,10 +775,22 @@ def main(argv: Optional[list[str]] = None) -> int:
     else:
         # Windows / Linux: the X destroys the window and the process
         # exits, so geometry has to be captured here, in the closing
-        # event, while the window is still alive. Returning True lets
-        # the close proceed unchanged.
+        # event, while the window is still alive. The save reads only
+        # the event-fed cache — it must NOT touch the window object,
+        # because this handler runs synchronously on the GUI loop (see
+        # the deadlock note above the cache). Returning True lets the
+        # close proceed unchanged.
         def _on_closing_win_linux() -> bool:
+            print(
+                "[desktop] window close requested",
+                file=sys.stderr,
+                flush=True,
+            )
             _save_window_geometry()
+            # Arm the watchdog at the earliest moment of the close —
+            # any wedge between here and the `closed` event would
+            # otherwise leave the process alive with no recourse.
+            _arm_exit_watchdog(server)
             return True
 
         try:
@@ -675,22 +805,20 @@ def main(argv: Optional[list[str]] = None) -> int:
         # with no UI and the user having to kill it from a terminal.
         # The `closed` event still fires inside the stuck GTK loop, so
         # we hook it, run the same graceful shutdown the post-start()
-        # path runs, and hard-exit. A guard makes it safe if start()
-        # *does* return naturally — the finally block's call is a no-op.
+        # path runs, and hard-exit. _graceful_shutdown is idempotent,
+        # so this is safe when start() *does* return naturally — the
+        # finally block's call becomes a no-op.
         if sys.platform.startswith("linux"):
-            _shutdown_done = threading.Event()
-
-            def _shutdown_once() -> None:
-                if _shutdown_done.is_set():
-                    return
-                _shutdown_done.set()
+            def _on_closed_linux() -> None:
+                print(
+                    "[desktop] window closed; exiting",
+                    file=sys.stderr,
+                    flush=True,
+                )
                 try:
                     _graceful_shutdown(server)
                 except Exception:
                     pass
-
-            def _on_closed_linux() -> None:
-                _shutdown_once()
                 # os._exit (not sys.exit) so finalizers / atexit hooks
                 # can't reintroduce the hang they were trying to avoid
                 # — sounddevice's atexit Pa_Terminate has hung on
@@ -1455,7 +1583,9 @@ def main(argv: Optional[list[str]] = None) -> int:
             except KeyboardInterrupt:
                 pass
     finally:
+        print("[desktop] GUI loop ended; shutting down", file=sys.stderr, flush=True)
         _graceful_shutdown(server)
+        print("[desktop] shutdown complete; exiting", file=sys.stderr, flush=True)
 
     return 0
 

--- a/tests/test_desktop_shutdown.py
+++ b/tests/test_desktop_shutdown.py
@@ -1,0 +1,166 @@
+"""Tests for the desktop shell's shutdown path.
+
+Covers the Linux quit-hang fix: `_graceful_shutdown` must be
+idempotent (the post-start() path, the Linux closed handler, and the
+exit watchdog all call it) and keep going past failing steps, and the
+exit watchdog must force a logged exit when the close sequence wedges
+before the `closed` event (the GTK geometry-read deadlock class).
+
+The watchdog's force-exit is `os._exit`, monkeypatched to a recorder
+here. Every test that arms a watchdog waits for the recorder to fire
+before returning — a watchdog thread outliving the monkeypatch would
+call the REAL os._exit and kill the pytest process.
+"""
+from __future__ import annotations
+
+import sys
+import threading
+
+import pytest
+
+import desktop
+
+
+class _StubUvicorn:
+    def __init__(self):
+        self.should_exit = False
+
+
+class _StubPlayer:
+    def __init__(self, raise_on_stop: bool = False):
+        self.stopped = 0
+        self.raise_on_stop = raise_on_stop
+
+    def stop(self):
+        self.stopped += 1
+        if self.raise_on_stop:
+            raise RuntimeError("portaudio teardown boom")
+
+
+class _StubDownloader:
+    def __init__(self):
+        self.persisted = 0
+
+    def _persist_pending(self):
+        self.persisted += 1
+
+
+class _StubServerModule:
+    """Stands in for the real `server` module inside
+    `_graceful_shutdown`'s lazy imports."""
+
+    def __init__(self, player=None):
+        self._pcm_player_singleton = player
+        self.macos_now_playing_bridge = None
+        self.downloader = _StubDownloader()
+
+
+@pytest.fixture(autouse=True)
+def reset_shutdown_state():
+    """The shutdown latches are module-level Events; clear them so
+    each test starts from a fresh process-lifetime state."""
+    desktop._graceful_ran.clear()
+    desktop._watchdog_armed.clear()
+    yield
+    desktop._graceful_ran.clear()
+    desktop._watchdog_armed.clear()
+
+
+@pytest.fixture
+def stub_server_module(monkeypatch):
+    stub = _StubServerModule(player=_StubPlayer())
+    monkeypatch.setitem(sys.modules, "server", stub)
+    return stub
+
+
+@pytest.fixture
+def exit_recorder(monkeypatch):
+    """Replace os._exit with a recorder. Returns (event, codes):
+    `event` fires on the first call, `codes` collects exit codes."""
+    fired = threading.Event()
+    codes: list[int] = []
+
+    def _record(code):
+        codes.append(code)
+        fired.set()
+
+    monkeypatch.setattr(desktop.os, "_exit", _record)
+    return fired, codes
+
+
+def test_graceful_shutdown_runs_once_and_flushes_everything(stub_server_module):
+    uv = _StubUvicorn()
+    desktop._graceful_shutdown(uv)
+    desktop._graceful_shutdown(uv)  # second call is a no-op
+
+    assert uv.should_exit is True
+    assert stub_server_module.downloader.persisted == 1
+    assert stub_server_module._pcm_player_singleton.stopped == 1
+
+
+def test_graceful_shutdown_continues_past_failing_steps(monkeypatch):
+    """A wedged audio teardown must not stop the download-queue
+    persist — each step is independent."""
+    stub = _StubServerModule(player=_StubPlayer(raise_on_stop=True))
+    monkeypatch.setitem(sys.modules, "server", stub)
+    uv = _StubUvicorn()
+
+    desktop._graceful_shutdown(uv)  # must not raise
+
+    assert stub._pcm_player_singleton.stopped == 1
+    assert uv.should_exit is True
+    assert stub.downloader.persisted == 1
+
+
+def test_watchdog_forces_exit_when_close_wedges(stub_server_module, exit_recorder):
+    """The deadlock class: close began (closing fired) but `closed`
+    never arrived. The watchdog must finish the shutdown work itself
+    and force-exit."""
+    fired, codes = exit_recorder
+    uv = _StubUvicorn()
+
+    desktop._arm_exit_watchdog(uv, deadline_s=0.05)
+
+    assert fired.wait(5.0), "watchdog never forced an exit"
+    assert codes == [0]
+    # The watchdog ran the graceful shutdown before exiting.
+    assert uv.should_exit is True
+    assert stub_server_module.downloader.persisted == 1
+
+
+def test_watchdog_does_not_rerun_completed_shutdown(
+    stub_server_module, exit_recorder
+):
+    """If the clean path already flushed state, the watchdog's own
+    call is a no-op — no double persist."""
+    fired, codes = exit_recorder
+    uv = _StubUvicorn()
+
+    desktop._graceful_shutdown(uv)
+    assert stub_server_module.downloader.persisted == 1
+
+    desktop._arm_exit_watchdog(uv, deadline_s=0.05)
+
+    assert fired.wait(5.0), "watchdog never forced an exit"
+    assert codes == [0]
+    assert stub_server_module.downloader.persisted == 1
+
+
+def test_watchdog_arms_only_once(stub_server_module, exit_recorder, monkeypatch):
+    fired, codes = exit_recorder
+    uv = _StubUvicorn()
+
+    started: list[str] = []
+    real_thread = threading.Thread
+
+    class _CountingThread(real_thread):
+        def __init__(self, *args, **kwargs):
+            started.append(kwargs.get("name", ""))
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(desktop.threading, "Thread", _CountingThread)
+    desktop._arm_exit_watchdog(uv, deadline_s=0.05)
+    desktop._arm_exit_watchdog(uv, deadline_s=0.05)
+
+    assert fired.wait(5.0)
+    assert started.count("exit-watchdog") == 1

--- a/tests/test_graceful_shutdown.py
+++ b/tests/test_graceful_shutdown.py
@@ -13,8 +13,20 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
+import pytest
+
 import desktop
 import server
+
+
+@pytest.fixture(autouse=True)
+def reset_graceful_latch():
+    """_graceful_shutdown is idempotent via a module-level latch (the
+    post-start() path, the Linux closed handler, and the exit watchdog
+    all call it). Clear it so each test exercises a fresh shutdown."""
+    desktop._graceful_ran.clear()
+    yield
+    desktop._graceful_ran.clear()
 
 
 def test_graceful_shutdown_stops_audio_player(monkeypatch):


### PR DESCRIPTION
## Summary

Fixes the Linux quit hang (window closes, process stays alive, terminal prints nothing — reported on Omarchy/Hyprland under Wayland via Flatpak).

**Root cause — a self-deadlock on the GTK main loop, in our `closing` handler:**

```
close_window (GTK main loop)
  → closing event (handlers run synchronously on the loop)
    → _save_window_geometry()
      → window.width
        → pywebview GTK get_size(): glib.idle_add + semaphore.acquire()
```

The `acquire()` blocks the main loop waiting for an idle callback that only the blocked loop could run. Nothing downstream ever happens: no destroy, no `closed` event (so the existing Linux `closed → os._exit` force-quit never fires), no shutdown logs, and `webview.start()` never returns. The same chain exists on X11 — Wayland users just reported it first. macOS/Windows never hit it because their pywebview backends read geometry without the idle/semaphore marshaling. Introduced with the window-geometry-restore feature.

**Fix:** cache geometry from pywebview's `resized`/`moved` events into plain variables; persist the cache on close. The close path no longer touches the window object at all, from any thread.

**Defense in layers behind the root fix:**
- **Exit watchdog** armed from the `closing` event (the first thing pywebview fires when a close starts). pywebview's GTK backend has a wider history of teardown wedges (r0x0r/pywebview #95, #690, #793); any future wedge between `closing` and `closed` would again strand the process. If still alive 10 s after a close began, it logs which threads are alive and whether clean shutdown ran, flushes state, and `os._exit(0)`s.
- **Shutdown narration** — every shutdown step now prints a `[desktop]` trace line. Hang reports arrived as "terminal prints nothing" with no way to tell which step wedged; the next report pinpoints it.
- `_graceful_shutdown` is idempotent via a latch (replacing the closed-handler's local guard), logs step failures instead of swallowing them, and a failed `window.destroy()` in the quit-menu path is logged too.

## Test plan

- New `tests/test_desktop_shutdown.py` (5 tests): shutdown idempotency + flush, continues past failing steps, watchdog force-exits and flushes on the wedge path, watchdog doesn't re-run completed shutdown, watchdog arms once.
- `tests/test_graceful_shutdown.py` updated with a latch-reset fixture (the new idempotency latch is module state).
- Full suite: 850 passed, 2 skipped. tsc clean, vitest 74 passed (no frontend changes).
- Wayland isn't reproducible from the dev machine; the diagnosis is from reading the exact code path against pywebview 6.2.1's GTK backend, and the trace lines confirm it in the field. A `py-spy dump` from the reporter while hung (MainThread in `gtk.py get_size → semaphore.acquire`) would be conclusive confirmation.
