### PR TITLE
Add scroll-wheel volume control on the player bar

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -210,6 +210,11 @@ class Settings:
     # blast the user at 100 %. Restored onto the player at startup;
     # the /api/player/volume endpoint writes it back on every change.
     volume: int = 100
+    # Scroll-wheel volume step in percent (1..25). One wheel tick over
+    # the player bar's volume control changes the volume by this much;
+    # holding Shift always steps by 1 % for fine adjustment. 5 matches
+    # what most desktop players use per tick.
+    volume_scroll_step_pct: int = 5
     # When the user's queue runs out — last track on an album,
     # playlist, mix, single-track play, anything — take over with an
     # Artist Radio mix seeded from the last track's primary artist.

--- a/server.py
+++ b/server.py
@@ -10192,6 +10192,7 @@ class SettingsPayload(BaseModel):
     replaygain_preamp_db: Optional[float] = None
     replaygain_prevent_clipping: Optional[bool] = None
     volume: Optional[int] = None
+    volume_scroll_step_pct: Optional[int] = None
     create_playlist_folders: Optional[bool] = None
     downconvert_hires_downloads: Optional[bool] = None
     window_x: Optional[int] = None
@@ -10243,6 +10244,14 @@ def update_settings(payload: SettingsPayload) -> dict:
                 detail="replaygain_preamp_db must be in [-10, 10]",
             )
         patch["replaygain_preamp_db"] = value
+
+    if "volume_scroll_step_pct" in patch:
+        step = patch["volume_scroll_step_pct"]
+        if not isinstance(step, int) or not (1 <= step <= 25):
+            raise HTTPException(
+                status_code=400,
+                detail="volume_scroll_step_pct must be an integer in [1, 25]",
+            )
 
     # Validate output_dir: must be an existing writable directory. Without
     # this, a PUT with `{"output_dir": "/"}` would quietly persist and all

--- a/tests/test_settings_endpoint.py
+++ b/tests/test_settings_endpoint.py
@@ -62,6 +62,23 @@ def test_put_force_volume_persists(client):
     assert r.json()["force_volume"] is True
 
 
+def test_put_volume_scroll_step_persists_and_validates(client):
+    """Scroll-wheel volume step (issue #195): round-trips through PUT
+    and rejects out-of-range values instead of silently coercing —
+    the player bar consumes this verbatim per wheel tick."""
+    r = client.put("/api/settings", json={"volume_scroll_step_pct": 10})
+    assert r.status_code == 200
+    assert r.json()["volume_scroll_step_pct"] == 10
+    r2 = client.get("/api/settings")
+    assert r2.json()["volume_scroll_step_pct"] == 10
+
+    for bad in (0, 26, -5):
+        r = client.put("/api/settings", json={"volume_scroll_step_pct": bad})
+        assert r.status_code == 400, r.text
+    # Rejections didn't clobber the stored value.
+    assert client.get("/api/settings").json()["volume_scroll_step_pct"] == 10
+
+
 def test_put_explicit_content_preference_persists(client):
     for value in ("clean", "both", "explicit"):
         r = client.put(

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -322,6 +322,10 @@ export interface Settings {
    *  DAC, speakers, or OS volume instead. Avoids software scaling
    *  that would otherwise throw away bit-depth under Exclusive Mode. */
   force_volume: boolean;
+  /** Scroll-wheel volume step in percent (1..25). One wheel tick over
+   *  the player bar's volume control moves the volume by this much;
+   *  Shift+scroll always steps by 1 % for fine adjustment. */
+  volume_scroll_step_pct: number;
   /** When the user's queue runs out — last track on an album,
    *  playlist, mix, single-track play, anything — take over with an
    *  Artist Radio mix seeded from the last track's primary artist.

--- a/web/src/components/NowPlaying.tsx
+++ b/web/src/components/NowPlaying.tsx
@@ -46,6 +46,7 @@ import { HeartButton } from "@/components/HeartButton";
 import { OutputDevicePicker } from "@/components/OutputDevicePicker";
 import { SignalPathDialog } from "@/components/SignalPathDialog";
 import { SleepTimerButton } from "@/components/SleepTimerButton";
+import { useAudioOptions } from "@/hooks/useAudioOptions";
 import { useIsDownloaded } from "@/hooks/useDownloadedSet";
 import { useRecordPlays } from "@/hooks/useRecentlyPlayed";
 import {
@@ -584,7 +585,7 @@ function StreamingQualityPicker({
   );
 }
 
-function VolumeControl({
+export function VolumeControl({
   value,
   onChange,
   disabled,
@@ -622,6 +623,53 @@ function VolumeControl({
   const muted = value === 0;
   const Icon = muted ? VolumeX : value < 0.5 ? Volume1 : Volume2;
 
+  // Scroll-wheel volume (issue #195): a wheel tick anywhere over the
+  // control — icon or popover — nudges the volume by the configured
+  // step; Shift+scroll always steps 1 % for fine adjustment. The
+  // hover that precedes any wheel gesture has already opened the
+  // popover, so the slider + percent readout double as live feedback.
+  //
+  // Attached as a native non-passive listener: React registers
+  // `onWheel` passively, and a passive handler can't preventDefault
+  // the page scroll that would otherwise run underneath the player
+  // bar. The handler reads its inputs through a ref so the listener
+  // installs once instead of detaching/reattaching mid-gesture every
+  // time a tick changes the volume.
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const { volumeScrollStepPct } = useAudioOptions();
+  const wheelState = useRef({
+    value,
+    onChange,
+    disabled,
+    stepPct: volumeScrollStepPct,
+  });
+  wheelState.current = {
+    value,
+    onChange,
+    disabled,
+    stepPct: volumeScrollStepPct,
+  };
+  useEffect(() => {
+    const el = rootRef.current;
+    if (!el) return;
+    const onWheel = (e: WheelEvent) => {
+      const cur = wheelState.current;
+      if (cur.disabled || e.deltaY === 0) return;
+      e.preventDefault();
+      // Work in integer percent so repeated ticks land on clean
+      // values (0.05 float steps accumulate representation error).
+      const stepPct = e.shiftKey ? 1 : cur.stepPct;
+      const pct = Math.round(cur.value * 100);
+      const next = Math.max(
+        0,
+        Math.min(100, pct + (e.deltaY < 0 ? stepPct : -stepPct)),
+      );
+      if (next !== pct) cur.onChange(next / 100);
+    };
+    el.addEventListener("wheel", onWheel, { passive: false });
+    return () => el.removeEventListener("wheel", onWheel);
+  }, []);
+
   const cancelClose = () => {
     if (closeTimer.current !== null) {
       window.clearTimeout(closeTimer.current);
@@ -656,6 +704,7 @@ function VolumeControl({
 
   return (
     <div
+      ref={rootRef}
       className={cn("relative", disabled && "opacity-50")}
       onMouseEnter={() => {
         cancelClose();
@@ -705,7 +754,11 @@ function VolumeControl({
           onMouseEnter={cancelClose}
           onMouseLeave={scheduleClose}
         >
-          <div className="flex h-32 w-9 items-center justify-center rounded-full border border-border bg-popover shadow-md animate-in fade-in-0 zoom-in-95 duration-150">
+          {/* h-40 (vs the slider's visual 96px) leaves a clear band
+           *  at the bottom for the percent readout — the rotated
+           *  input is centered, so its visual span stays inside
+           *  y=32..128 and the label at bottom-2 never overlaps. */}
+          <div className="relative flex h-40 w-9 items-center justify-center rounded-full border border-border bg-popover shadow-md animate-in fade-in-0 zoom-in-95 duration-150">
             <input
               type="range"
               min={0}
@@ -725,12 +778,20 @@ function VolumeControl({
               // maps 0..1 the same way.
               className="h-1.5 w-24 cursor-pointer appearance-none rounded-full bg-secondary accent-primary disabled:cursor-not-allowed"
               style={{
-                transform: "rotate(-90deg)",
+                // translateY lifts the slider's visual span to
+                // y=24..120 inside the h-40 pill, clearing the
+                // percent readout pinned at the bottom.
+                transform: "translateY(-8px) rotate(-90deg)",
                 background: `linear-gradient(to right, hsl(var(--primary)) ${value * 100}%, hsl(var(--secondary)) ${value * 100}%)`,
               }}
               aria-label="Volume"
               aria-orientation="vertical"
             />
+            {/* Live percent readout (issue #195's "display volume
+             *  text") — doubles as feedback for wheel scrolling. */}
+            <span className="pointer-events-none absolute bottom-2 text-[10px] font-medium tabular-nums text-muted-foreground">
+              {Math.round(value * 100)}
+            </span>
           </div>
         </div>
       )}

--- a/web/src/components/VolumeControl.test.tsx
+++ b/web/src/components/VolumeControl.test.tsx
@@ -1,0 +1,150 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+
+// React 18 act() opt-in (same as the other component tests).
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * Scroll-wheel volume (issue #195): a wheel tick over the volume
+ * control nudges the volume by the configured step, Shift+scroll
+ * steps 1 %, values clamp to [0, 1], and a disabled control
+ * (Force Volume) ignores the wheel entirely.
+ */
+
+vi.mock("@/hooks/useAudioOptions", () => ({
+  useAudioOptions: () => ({
+    devices: [],
+    current: "",
+    exclusiveMode: false,
+    forceVolume: false,
+    volumeScrollStepPct: 5,
+    loaded: true,
+    setDevice: vi.fn(),
+    setExclusiveMode: vi.fn(),
+    setForceVolume: vi.fn(),
+    setVolumeScrollStep: vi.fn(),
+    refresh: vi.fn(),
+  }),
+}));
+
+const { VolumeControl } = await import("./NowPlaying");
+
+let container: HTMLDivElement;
+let root: Root;
+
+beforeEach(() => {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+});
+
+afterEach(() => {
+  act(() => root.unmount());
+  container.remove();
+});
+
+async function mount(props: {
+  value: number;
+  onChange: (v: number) => void;
+  disabled?: boolean;
+}) {
+  await act(async () => {
+    root.render(<VolumeControl {...props} />);
+  });
+}
+
+function wheel(el: Element, init: WheelEventInit) {
+  act(() => {
+    const e = new WheelEvent("wheel", {
+      bubbles: true,
+      cancelable: true,
+      ...init,
+    });
+    if (init.shiftKey) {
+      // happy-dom's WheelEvent constructor drops the MouseEventInit
+      // modifier keys; pin the property directly.
+      Object.defineProperty(e, "shiftKey", { value: true });
+    }
+    el.dispatchEvent(e);
+  });
+}
+
+describe("VolumeControl scroll wheel", () => {
+  it("scroll up raises the volume by the configured step", async () => {
+    const onChange = vi.fn();
+    await mount({ value: 0.5, onChange });
+
+    wheel(container.firstElementChild!, { deltaY: -100 });
+
+    expect(onChange).toHaveBeenCalledWith(0.55);
+  });
+
+  it("scroll down lowers the volume by the configured step", async () => {
+    const onChange = vi.fn();
+    await mount({ value: 0.5, onChange });
+
+    wheel(container.firstElementChild!, { deltaY: 100 });
+
+    expect(onChange).toHaveBeenCalledWith(0.45);
+  });
+
+  it("shift+scroll steps by 1% for fine adjustment", async () => {
+    const onChange = vi.fn();
+    await mount({ value: 0.5, onChange });
+
+    wheel(container.firstElementChild!, { deltaY: -100, shiftKey: true });
+
+    expect(onChange).toHaveBeenCalledWith(0.51);
+  });
+
+  it("clamps at 100% and 0%", async () => {
+    const onChange = vi.fn();
+    await mount({ value: 0.98, onChange });
+    wheel(container.firstElementChild!, { deltaY: -100 });
+    expect(onChange).toHaveBeenCalledWith(1);
+
+    onChange.mockClear();
+    await act(async () => {
+      root.render(<VolumeControl value={0.02} onChange={onChange} />);
+    });
+    wheel(container.firstElementChild!, { deltaY: 100 });
+    expect(onChange).toHaveBeenCalledWith(0);
+  });
+
+  it("already at the boundary: no redundant onChange", async () => {
+    const onChange = vi.fn();
+    await mount({ value: 1, onChange });
+
+    wheel(container.firstElementChild!, { deltaY: -100 });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("ignores the wheel when disabled (Force Volume)", async () => {
+    const onChange = vi.fn();
+    await mount({ value: 0.5, onChange, disabled: true });
+
+    wheel(container.firstElementChild!, { deltaY: -100 });
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("tracks the live value across successive ticks", async () => {
+    // The listener installs once and reads through a ref — a second
+    // tick after a re-render must step from the NEW value, not the
+    // one captured at mount.
+    const onChange = vi.fn();
+    await mount({ value: 0.5, onChange });
+    wheel(container.firstElementChild!, { deltaY: -100 });
+    expect(onChange).toHaveBeenLastCalledWith(0.55);
+
+    await act(async () => {
+      root.render(<VolumeControl value={0.55} onChange={onChange} />);
+    });
+    wheel(container.firstElementChild!, { deltaY: -100 });
+    expect(onChange).toHaveBeenLastCalledWith(0.6);
+  });
+});

--- a/web/src/hooks/useAudioOptions.ts
+++ b/web/src/hooks/useAudioOptions.ts
@@ -20,6 +20,9 @@ export interface AudioOptions {
   current: string;
   exclusiveMode: boolean;
   forceVolume: boolean;
+  /** Scroll-wheel volume step in percent (1..25). Consumed by the
+   *  player bar's volume control; Shift+scroll always steps 1 %. */
+  volumeScrollStepPct: number;
   loaded: boolean;
 }
 
@@ -28,6 +31,7 @@ const initial: AudioOptions = {
   current: "",
   exclusiveMode: false,
   forceVolume: false,
+  volumeScrollStepPct: 5,
   loaded: false,
 };
 
@@ -43,6 +47,7 @@ function setState(next: AudioOptions): void {
     next.current === state.current &&
     next.exclusiveMode === state.exclusiveMode &&
     next.forceVolume === state.forceVolume &&
+    next.volumeScrollStepPct === state.volumeScrollStepPct &&
     next.loaded === state.loaded &&
     next.devices === state.devices
   ) {
@@ -76,6 +81,7 @@ async function loadOnce(): Promise<void> {
         current: d.current,
         exclusiveMode: !!s.exclusive_mode,
         forceVolume: !!s.force_volume,
+        volumeScrollStepPct: s.volume_scroll_step_pct ?? 5,
         loaded: true,
       });
     } catch {
@@ -168,5 +174,22 @@ export function useAudioOptions() {
     [],
   );
 
-  return { ...snap, setDevice, setExclusiveMode, setForceVolume, refresh };
+  const setVolumeScrollStep = useCallback((pct: number) => {
+    // Clamp client-side to the same [1, 25] bound the PUT validates,
+    // so a fat-fingered input degrades to the nearest legal step
+    // instead of a 400 toast.
+    const clamped = Math.max(1, Math.min(25, Math.round(pct)));
+    return applyOptimistic("volumeScrollStepPct", clamped, () =>
+      api.settings.put({ volume_scroll_step_pct: clamped }),
+    );
+  }, []);
+
+  return {
+    ...snap,
+    setDevice,
+    setExclusiveMode,
+    setForceVolume,
+    setVolumeScrollStep,
+    refresh,
+  };
 }

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -42,6 +42,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { useToast } from "@/components/toast";
+import { useAudioOptions } from "@/hooks/useAudioOptions";
 import { useDebouncedSettingsPut } from "@/hooks/useDebouncedSettingsPut";
 import { useOfflineMode } from "@/hooks/useOfflineMode";
 import {
@@ -272,6 +273,7 @@ export function SettingsPage({ onLogout }: { onLogout: () => void }) {
                 </select>
               </Field>
               <AudioEngineFields />
+              <VolumeScrollStepField />
               <Field
                 label="Explicit content"
                 hint="Tidal returns both clean and explicit edits of the same album or track. Pick which copy you want to see when both exist."
@@ -747,6 +749,55 @@ function ThemePicker({
  * matching slider curve immediately). Manual slider changes POST
  * the full band array with `preamp` = null ("no explicit preamp").
  */
+/**
+ * Scroll-wheel volume step (issue #195). Lives on the audio-options
+ * store rather than the page's settings copy so the player bar's
+ * volume control — which consumes the cached value — picks up a
+ * change the moment it's saved, not on the next app load.
+ */
+function VolumeScrollStepField() {
+  const toast = useToast();
+  const opts = useAudioOptions();
+
+  // Stock choices plus whatever the user currently has (a value set
+  // via the API directly may not be in the stock list — the select
+  // must still display it rather than appearing blank).
+  const choices = Array.from(
+    new Set([1, 2, 5, 10, 15, 20, 25, opts.volumeScrollStepPct]),
+  ).sort((a, b) => a - b);
+
+  const setStep = async (v: number) => {
+    try {
+      await opts.setVolumeScrollStep(v);
+    } catch (err) {
+      toast.show({
+        kind: "error",
+        title: "Couldn't update volume step",
+        description: err instanceof Error ? err.message : String(err),
+      });
+    }
+  };
+
+  return (
+    <Field
+      label="Scroll-wheel volume step"
+      hint="How much one mouse-wheel tick over the player bar's volume control changes the volume. Hold Shift while scrolling to always step by 1%."
+    >
+      <select
+        value={String(opts.volumeScrollStepPct)}
+        onChange={(e) => void setStep(Number(e.target.value))}
+        className="h-10 rounded-md border border-input bg-secondary px-3 text-sm"
+      >
+        {choices.map((v) => (
+          <option key={v} value={String(v)}>
+            {v}%
+          </option>
+        ))}
+      </select>
+    </Field>
+  );
+}
+
 function AudioEngineFields() {
   const toast = useToast();
   const [devices, setDevices] = useState<{


### PR DESCRIPTION
## Summary

Implements #195: hovering the player bar's volume control and scrolling the mouse wheel adjusts the volume.

- One wheel tick changes the volume by a configurable step — new **Settings → Playback → "Scroll-wheel volume step"** select (1–25%, default 5%).
- **Shift+scroll always steps 1%** for fine adjustment (the issue's "change by shift" option).
- The hover popover that already opens doubles as live feedback, and it now shows a **numeric percent readout** under the slider (the issue's "display volume text" option).
- Force Volume still disables the control entirely, wheel included.

Implementation notes:
- The wheel listener is attached natively as **non-passive** — React registers `onWheel` passively, and a passive handler can't `preventDefault` the page scroll that would otherwise run underneath the player bar. It reads its inputs through a ref so the listener installs once instead of detaching mid-gesture on every tick.
- Steps are computed in **integer percent** rather than the 0..1 float the control stores, so repeated ticks land on clean values instead of accumulating float error.
- The step setting rides the `useAudioOptions` module store (where `force_volume` already lives for this same control), so changing it in Settings updates the player bar immediately rather than on the next app load. The settings PUT validates `[1, 25]` instead of silently coercing, and the field is mirrored in `SettingsPayload` + the `Settings` TS interface per the dataclass/Pydantic checklist.

## Test plan

- New `web/src/components/VolumeControl.test.tsx` (7 vitest cases): scroll up/down by the configured step, Shift fine step, clamping at 0/100%, no redundant call at the boundary, disabled (Force Volume) ignores the wheel, and the listener tracks the live value across successive ticks.
- New backend test: `volume_scroll_step_pct` PUT round-trip + 400 on out-of-range values without clobbering the stored value.
- Full suite: pytest 846 passed, tsc clean, vitest 81 passed, eslint/prettier clean on touched files.

Closes #195.
