### PR TITLE
Write the release date into downloaded file tags

### DIFF
--- a/app/metadata.py
+++ b/app/metadata.py
@@ -183,6 +183,11 @@ def _tag_flac(path: Path, track, cover_data: Optional[bytes], album_obj=None):
     num_tracks = _safe(getattr(track, "album", None), "num_tracks")
     if num_tracks:
         audio["totaltracks"] = str(num_tracks)
+    release_date = _release_date_str(track, album_obj)
+    if release_date:
+        # Vorbis `DATE` is the field Mp3Tag / foobar2000 / Picard
+        # derive their "Year" column from (issue #196).
+        audio["date"] = release_date
 
     track_id = getattr(track, "id", None)
     if track_id is not None:
@@ -208,6 +213,11 @@ def _tag_m4a(path: Path, track, cover_data: Optional[bytes], album_obj=None):
     audio["aART"] = _album_artist_name(track, album_obj)
     num_tracks = _safe(getattr(track, "album", None), "num_tracks") or 0
     audio["trkn"] = [(getattr(track, "track_num", 0), num_tracks)]
+    release_date = _release_date_str(track, album_obj)
+    if release_date:
+        # ©day is MP4's release-date atom — same "Year" column
+        # source as FLAC's DATE (issue #196).
+        audio["\xa9day"] = release_date
 
     track_id = getattr(track, "id", None)
     if track_id is not None:
@@ -267,6 +277,44 @@ def _album_artist_name(track, album_obj=None) -> str:
         return track.artist.name
     except Exception:
         return ""
+
+
+def _release_date_str(track, album_obj=None) -> str:
+    """The release date for the FLAC `DATE` / MP4 `©day` tag —
+    `YYYY-MM-DD` when the full date is known, a bare `YYYY` when only
+    the year is. Taggers (Mp3Tag, foobar2000, Picard) derive their
+    "Year" column from these fields, which is what issue #196 asks
+    for.
+
+    Source preference mirrors the downloader's `_album_year` (used
+    for the `{year}` filename token): the editorial `release_date`
+    over `tidal_release_date` — back-catalog reissues should carry
+    the year users expect, not the date Tidal first hosted the
+    stream. And like `_album_artist_name`, the resolved `album_obj`
+    is preferred over the per-track `track.album` blob, which isn't
+    consistent across an album.
+    """
+    for source in (album_obj, getattr(track, "album", None)):
+        if source is None:
+            continue
+        for attr in ("release_date", "tidal_release_date"):
+            dt = _safe(source, attr)
+            if dt is None:
+                continue
+            try:
+                if getattr(dt, "year", None):
+                    return f"{int(dt.year):04d}-{int(dt.month):02d}-{int(dt.day):02d}"
+            except Exception:
+                continue
+        # tidalapi also exposes a plain `year` int on some album
+        # payloads when the full date is missing.
+        year = _safe(source, "year")
+        try:
+            if year:
+                return str(int(year))
+        except Exception:
+            pass
+    return ""
 
 
 def _safe(obj, attr: str):

--- a/tests/test_metadata_year_tag.py
+++ b/tests/test_metadata_year_tag.py
@@ -1,0 +1,146 @@
+"""Release-date tagging (issue #196).
+
+Downloaded files carried title/artist/album/track tags but no
+DATE / ©day, so taggers like Mp3Tag showed an empty "Year" column.
+These tests pin the new behavior: a real FLAC tagged through the
+production `tag_file` path round-trips a `date` Vorbis comment, and
+`_release_date_str` prefers the editorial date with sensible
+fallbacks.
+"""
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from app.metadata import _release_date_str, tag_file
+
+
+def _make_flac(path: Path) -> None:
+    """Write a tiny real FLAC (a few ms of silence) so mutagen has an
+    actual STREAMINFO block to work with. PyAV is already a hard
+    dependency of the audio engine."""
+    import av
+
+    with av.open(str(path), "w", format="flac") as container:
+        stream = container.add_stream("flac", rate=44100)
+        frame = av.AudioFrame.from_ndarray(
+            np.zeros((2, 1024), dtype=np.int16), format="s16p", layout="stereo"
+        )
+        frame.sample_rate = 44100
+        for packet in stream.encode(frame):
+            container.mux(packet)
+        for packet in stream.encode(None):
+            container.mux(packet)
+
+
+def _track(album=None):
+    return SimpleNamespace(
+        id=12345,
+        name="Billie Jean",
+        track_num=6,
+        artists=[SimpleNamespace(name="Michael Jackson")],
+        album=album
+        if album is not None
+        else SimpleNamespace(
+            name="Thriller",
+            num_tracks=9,
+            artist=SimpleNamespace(name="Michael Jackson"),
+        ),
+    )
+
+
+def _album(**over):
+    base = {
+        "name": "Thriller",
+        "num_tracks": 9,
+        "artist": SimpleNamespace(name="Michael Jackson"),
+        "release_date": datetime.datetime(1982, 11, 30),
+    }
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: real FLAC through the production tag path
+# ---------------------------------------------------------------------------
+
+
+def test_flac_gets_date_tag(tmp_path: Path) -> None:
+    from mutagen.flac import FLAC
+
+    f = tmp_path / "06 - Billie Jean.flac"
+    _make_flac(f)
+
+    tag_file(f, _track(), cover_data=None, album_obj=_album())
+
+    audio = FLAC(str(f))
+    assert audio["date"] == ["1982-11-30"]
+    # The pre-existing tags still land — date is additive.
+    assert audio["title"] == ["Billie Jean"]
+    assert audio["tracknumber"] == ["6"]
+
+
+def test_flac_without_any_date_writes_no_date_tag(tmp_path: Path) -> None:
+    from mutagen.flac import FLAC
+
+    f = tmp_path / "no-date.flac"
+    _make_flac(f)
+
+    bare_album = _album(release_date=None)
+    tag_file(f, _track(album=bare_album), cover_data=None, album_obj=bare_album)
+
+    audio = FLAC(str(f))
+    # No fabricated date — an absent field beats a wrong one.
+    assert "date" not in audio
+
+
+# ---------------------------------------------------------------------------
+# Source preference
+# ---------------------------------------------------------------------------
+
+
+def test_editorial_release_date_beats_tidal_hosting_date() -> None:
+    album = _album(
+        release_date=datetime.datetime(1982, 11, 30),
+        tidal_release_date=datetime.datetime(2012, 1, 15),
+    )
+    assert _release_date_str(_track(), album) == "1982-11-30"
+
+
+def test_tidal_release_date_is_the_fallback() -> None:
+    album = _album(release_date=None)
+    album.tidal_release_date = datetime.datetime(2012, 1, 15)
+    assert _release_date_str(_track(), album) == "2012-01-15"
+
+
+def test_bare_year_used_when_no_full_date() -> None:
+    album = _album(release_date=None)
+    album.year = 1982
+    assert _release_date_str(_track(), album) == "1982"
+
+
+def test_track_album_blob_used_when_no_resolved_album() -> None:
+    # Lone-track downloads may not resolve a full album object; the
+    # per-track album blob's date is better than nothing.
+    blob = SimpleNamespace(
+        name="Thriller",
+        num_tracks=9,
+        release_date=datetime.datetime(1982, 11, 30),
+    )
+    assert _release_date_str(_track(album=blob), None) == "1982-11-30"
+
+
+def test_no_date_anywhere_is_empty() -> None:
+    blob = SimpleNamespace(name="Thriller", num_tracks=9)
+    assert _release_date_str(_track(album=blob), None) == ""
+
+
+@pytest.mark.parametrize("junk", ["not-a-date", 0, ""])
+def test_junk_year_values_are_skipped(junk) -> None:
+    album = _album(release_date=None)
+    album.year = junk
+    assert _release_date_str(_track(), album) == ""


### PR DESCRIPTION
## Summary

Implements #196: downloaded files now carry the album release date, so Mp3Tag (and foobar2000, Picard, Plex, …) show a populated "Year" field.

- **FLAC**: writes the `DATE` Vorbis comment; **M4A/MP4**: writes the `©day` atom — the fields taggers derive "Year" from.
- Full `YYYY-MM-DD` when the date is known, bare `YYYY` when only the year is.
- Source preference mirrors the `{year}` filename token's `_album_year`: editorial `release_date` over `tidal_release_date` (back-catalog reissues tag with the year users expect, not the date Tidal first hosted the stream), and the resolved album object over the per-track album blob (same consistency rationale as the `albumartist` tag).
- No date available → no tag written; an absent field beats a fabricated one.

Already-downloaded files keep their existing tags — re-downloading with "skip existing" off refreshes them.

## Test plan

- New `tests/test_metadata_year_tag.py` (10 tests), including an **end-to-end round-trip on a real FLAC** (generated via PyAV, tagged through the production `tag_file` path, read back with mutagen): `date` lands as `1982-11-30` alongside the existing tags; no fabricated tag when no date exists; editorial-over-hosting-date preference; `tidal_release_date` and bare-`year` fallbacks; per-track blob fallback for lone-track downloads; junk year values skipped.
- Full suite: 855 passed, 2 skipped.

Closes #196.
