### PR TITLE
Exclude FEATURED credits from the ARTIST tag

### DIFF
--- a/app/metadata.py
+++ b/app/metadata.py
@@ -220,10 +220,35 @@ def _tag_m4a(path: Path, track, cover_data: Optional[bytes], album_obj=None):
 
 
 def _artist_names(track) -> str:
+    """The track-level ARTIST tag credit: MAIN-credit artists,
+    comma-joined. FEATURED credits are excluded — Tidal already
+    carries the featuring in the track title ("… (feat. Jack)"), and
+    including them in the artist string makes strict-grouping players
+    (iPods, iTunes, Rockbox) mint a phantom "John, Jack" artist for
+    every featured track instead of filing it under John.
+
+    True collaborations credit every artist as MAIN, so duets still
+    list everyone. Credits without role information (older payloads,
+    objects from other code paths) are kept — dropping a credit is
+    worse than the grouping nit this fixes.
+    """
     try:
-        return ", ".join(a.name for a in track.artists)
+        artists = [a for a in track.artists if getattr(a, "name", None)]
     except Exception:
-        pass
+        artists = []
+    if artists:
+        def _role_value(artist) -> Optional[str]:
+            role = getattr(artist, "role", None)
+            # tidalapi's Role enum (`role.value` is "MAIN"/"FEATURED")
+            # or a raw string, depending on the payload's vintage.
+            value = getattr(role, "value", role)
+            return str(value).upper() if value is not None else None
+
+        mains = [a for a in artists if _role_value(a) != "FEATURED"]
+        # Defensive: a payload crediting ONLY featured artists still
+        # needs an artist tag — better the old joined string than an
+        # empty field.
+        return ", ".join(a.name for a in (mains or artists))
     try:
         return track.artist.name
     except Exception:

--- a/tests/test_metadata_artist_credits.py
+++ b/tests/test_metadata_artist_credits.py
@@ -1,0 +1,99 @@
+"""ARTIST tag credit filtering (the "phantom 'John, Jack' artist" bug).
+
+Joining every credited artist into the ARTIST tag makes
+strict-grouping players (iPods, iTunes, Rockbox) create a separate
+artist entry per featuring combination. The tag must carry only the
+MAIN credits; FEATURED artists already live in the track title's
+"(feat. …)". True collaborations credit everyone as MAIN and keep the
+joined form.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+
+from app.metadata import _artist_names, tag_file
+
+
+def _artist(name: str, role=None):
+    a = SimpleNamespace(name=name)
+    if role is not None:
+        a.role = role
+    return a
+
+
+def _track(artists):
+    return SimpleNamespace(
+        id=1,
+        name="Song",
+        track_num=1,
+        artists=artists,
+        album=SimpleNamespace(name="Album", num_tracks=10),
+    )
+
+
+class _EnumLikeRole:
+    """Mimics tidalapi's Role enum member (has a .value)."""
+
+    def __init__(self, value: str):
+        self.value = value
+
+
+def test_featured_artist_excluded_from_artist_tag():
+    track = _track([_artist("John", "MAIN"), _artist("Jack", "FEATURED")])
+    assert _artist_names(track) == "John"
+
+
+def test_enum_style_roles_are_understood():
+    track = _track(
+        [
+            _artist("John", _EnumLikeRole("MAIN")),
+            _artist("Jack", _EnumLikeRole("FEATURED")),
+        ]
+    )
+    assert _artist_names(track) == "John"
+
+
+def test_true_collaboration_keeps_every_main_artist():
+    track = _track([_artist("John", "MAIN"), _artist("Jack", "MAIN")])
+    assert _artist_names(track) == "John, Jack"
+
+
+def test_credits_without_roles_are_kept():
+    # Older payloads / other code paths don't attach roles — dropping
+    # a credit would be worse than the grouping nit.
+    track = _track([_artist("John"), _artist("Jack")])
+    assert _artist_names(track) == "John, Jack"
+
+
+def test_all_featured_falls_back_to_full_credit():
+    # Defensive: a payload crediting ONLY featured artists still needs
+    # an artist tag.
+    track = _track([_artist("Jack", "FEATURED")])
+    assert _artist_names(track) == "Jack"
+
+
+def test_flac_artist_tag_round_trip(tmp_path: Path):
+    """End-to-end through the production tag path on a real FLAC."""
+    import av
+    from mutagen.flac import FLAC
+
+    f = tmp_path / "01 - Song.flac"
+    with av.open(str(f), "w", format="flac") as container:
+        stream = container.add_stream("flac", rate=44100)
+        frame = av.AudioFrame.from_ndarray(
+            np.zeros((2, 1024), dtype=np.int16), format="s16p", layout="stereo"
+        )
+        frame.sample_rate = 44100
+        for packet in stream.encode(frame):
+            container.mux(packet)
+        for packet in stream.encode(None):
+            container.mux(packet)
+
+    track = _track([_artist("John", "MAIN"), _artist("Jack", "FEATURED")])
+    tag_file(f, track, cover_data=None, album_obj=None)
+
+    audio = FLAC(str(f))
+    assert audio["artist"] == ["John"]


### PR DESCRIPTION
## Summary

Fixes the phantom-artist bug on iPods (and iTunes / Rockbox / any strict-grouping player): a track credited "John featuring Jack" was tagged with `ARTIST = "John, Jack"`, which those players treat as a brand-new artist instead of filing the track under John.

Tidal's track payloads distinguish **MAIN** from **FEATURED** credits, and tidalapi parses the role onto each artist object. The ARTIST tag now carries only the MAIN credits — the featuring already lives in the track title's "(feat. …)", so nothing visible is lost.

Behavior matrix:
- "John feat. Jack" (MAIN + FEATURED) → `ARTIST = "John"` ✅ the fix
- True duet (both MAIN) → `ARTIST = "John, Jack"` — unchanged, correct (that's the actual credit, same as iTunes Store content)
- Credits without role info (older payloads / non-Tidal paths) → all kept; dropping a credit would be worse than the grouping nit
- Degenerate all-FEATURED payload → falls back to the full list rather than an empty artist

Applies to both FLAC (`artist`) and M4A (`©ART`). Already-downloaded files keep their tags; re-downloading refreshes them. The `albumartist` tag (which was already primary-only) is untouched.

## Test plan

- New `tests/test_metadata_artist_credits.py` (6 tests): featured excluded (string and enum-style roles), duets keep everyone, role-less credits kept, all-featured fallback, and an end-to-end round-trip on a real PyAV-generated FLAC through the production `tag_file` path asserting `artist == ["John"]`.
- Full suite: 851 passed, 2 skipped.
