### PR TITLE
Download album cover art at high resolution, with a size setting

### DIFF
--- a/app/downloader.py
+++ b/app/downloader.py
@@ -1364,7 +1364,10 @@ class Downloader:
             tag_error: Optional[str] = None
             resolved_album = album_obj or getattr(track, "album", None)
             try:
-                cover = fetch_cover_art(resolved_album)
+                cover = fetch_cover_art(
+                    resolved_album,
+                    resolution=getattr(s, "cover_art_resolution", "1280"),
+                )
             except Exception as exc:
                 cover = None
                 tag_error = f"cover fetch failed: {exc}"

--- a/app/metadata.py
+++ b/app/metadata.py
@@ -1,6 +1,8 @@
 import os
 import shutil
 import tempfile
+import threading
+from collections import OrderedDict
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
@@ -28,6 +30,20 @@ _MAX_COVER_BYTES = 30 * 1024 * 1024
 # `tidalapi.Album.image()` accepts.
 _COVER_SIZE_LADDER: tuple = ("origin", 1280, 640, 320)
 DEFAULT_COVER_RESOLUTION = "1280"
+
+# Process-lifetime LRU of resolved cover bytes, keyed by
+# (album id, resolution). tag_file embeds the same cover into every
+# track of an album, so without this the full image is re-downloaded
+# — and the fallback ladder re-walked — once per track: 20 redundant
+# fetches for a 20-track album, far worse at "origin" (multi-MB each)
+# or for a cover-less album that 404s the whole ladder every time.
+# Bounded small: concurrent downloads are capped well below this, and
+# an entry is only useful for the lifetime of one album's download
+# burst. None is cached too, so a genuinely cover-less album isn't
+# re-walked per track.
+_cover_cache_lock = threading.Lock()
+_cover_cache: "OrderedDict[tuple[str, str], Optional[bytes]]" = OrderedDict()
+_COVER_CACHE_MAX = 8
 
 
 def tag_file(
@@ -156,15 +172,15 @@ def _cover_size_ladder(resolution) -> list:
     chosen size first, then every smaller fallback. An unknown
     resolution falls back to the default so a corrupt setting can't
     leave a download with no cover."""
+    # `origin` is the largest size — try it then everything below.
+    if resolution == "origin":
+        return list(_COVER_SIZE_LADDER)
     try:
         target = int(resolution)
     except (TypeError, ValueError):
-        target = "origin" if resolution == "origin" else int(DEFAULT_COVER_RESOLUTION)
-    # Keep `origin` (the largest) whenever it's the request; otherwise
-    # drop sizes larger than the target so we never upscale-request
-    # beyond what the user asked for.
-    if target == "origin":
-        return list(_COVER_SIZE_LADDER)
+        target = int(DEFAULT_COVER_RESOLUTION)
+    # Drop sizes larger than the target so we never request beyond
+    # what the user asked for.
     return [s for s in _COVER_SIZE_LADDER if s != "origin" and s <= target]
 
 
@@ -211,14 +227,33 @@ def fetch_cover_art(
 ) -> Optional[bytes]:
     """Download album cover art at the chosen `resolution`, falling
     back to smaller sizes when the album doesn't publish it. Returns
-    None when nothing is reachable."""
+    None when nothing is reachable. Results are cached per
+    (album, resolution) so an album's tracks share one fetch — see
+    `_cover_cache`."""
     if album_obj is None:
         return None
+
+    album_id = str(getattr(album_obj, "id", "") or "")
+    cache_key = (album_id, str(resolution)) if album_id else None
+    if cache_key is not None:
+        with _cover_cache_lock:
+            if cache_key in _cover_cache:
+                _cover_cache.move_to_end(cache_key)
+                return _cover_cache[cache_key]
+
+    data: Optional[bytes] = None
     for size in _cover_size_ladder(resolution):
         data = _fetch_cover_at(album_obj, size)
         if data is not None:
-            return data
-    return None
+            break
+
+    if cache_key is not None:
+        with _cover_cache_lock:
+            _cover_cache[cache_key] = data
+            _cover_cache.move_to_end(cache_key)
+            while len(_cover_cache) > _COVER_CACHE_MAX:
+                _cover_cache.popitem(last=False)
+    return data
 
 
 def _tag_flac(path: Path, track, cover_data: Optional[bytes], album_obj=None):

--- a/app/metadata.py
+++ b/app/metadata.py
@@ -16,7 +16,18 @@ M4A_TIDAL_ID_KEY = "----:com.tidaldownloader:track_id"
 # don't want the downloader process to start fetching arbitrary URLs and
 # embedding the bytes into the user's files.
 _ALLOWED_COVER_HOSTS = {"resources.tidal.com", "images.tidal.com"}
-_MAX_COVER_BYTES = 5 * 1024 * 1024  # 5 MB — larger than any real Tidal cover
+# 30 MB ceiling. "origin" covers are 3000x3000 and run a few MB; the cap
+# is generous enough not to reject a real one but still guards against a
+# misbehaving server streaming an unbounded payload into memory.
+_MAX_COVER_BYTES = 30 * 1024 * 1024
+
+# Cover-art resolutions tidalapi exposes, largest first. The download
+# path requests the user's chosen size and falls back down this ladder
+# when an album doesn't publish it (origin in particular is missing for
+# some back-catalog releases). Values are exactly what
+# `tidalapi.Album.image()` accepts.
+_COVER_SIZE_LADDER: tuple = ("origin", 1280, 640, 320)
+DEFAULT_COVER_RESOLUTION = "1280"
 
 
 def tag_file(
@@ -140,17 +151,41 @@ def read_track_tags(file_path: Path) -> Optional[dict]:
     return None
 
 
-def fetch_cover_art(album_obj) -> Optional[bytes]:
-    if album_obj is None:
+def _cover_size_ladder(resolution) -> list:
+    """The sizes to try, in order, for a requested resolution: the
+    chosen size first, then every smaller fallback. An unknown
+    resolution falls back to the default so a corrupt setting can't
+    leave a download with no cover."""
+    try:
+        target = int(resolution)
+    except (TypeError, ValueError):
+        target = "origin" if resolution == "origin" else int(DEFAULT_COVER_RESOLUTION)
+    # Keep `origin` (the largest) whenever it's the request; otherwise
+    # drop sizes larger than the target so we never upscale-request
+    # beyond what the user asked for.
+    if target == "origin":
+        return list(_COVER_SIZE_LADDER)
+    return [s for s in _COVER_SIZE_LADDER if s != "origin" and s <= target]
+
+
+def _fetch_cover_at(album_obj, size) -> Optional[bytes]:
+    """Fetch one cover-art size. Returns None (not raises) when the
+    size isn't published, the host check fails, or the byte cap is
+    exceeded, so the caller can try the next size down."""
+    try:
+        # tidalapi raises ValueError for a size the album doesn't
+        # publish; any other error (missing attr, malformed payload)
+        # is just as good a reason to fall through to the next size.
+        url = album_obj.image(size)
+    except Exception:
+        return None
+    parsed = urlparse(url)
+    # Reject non-HTTPS or non-Tidal hosts before touching the network.
+    if parsed.scheme != "https" or parsed.hostname not in _ALLOWED_COVER_HOSTS:
+        return None
+    if parsed.username or parsed.password:
         return None
     try:
-        url = album_obj.image(640)
-        parsed = urlparse(url)
-        # Reject non-HTTPS or non-Tidal hosts before touching the network.
-        if parsed.scheme != "https" or parsed.hostname not in _ALLOWED_COVER_HOSTS:
-            return None
-        if parsed.username or parsed.password:
-            return None
         # Stream + cap size so a misbehaving server can't exhaust memory
         # by advertising (or actually sending) a giant image.
         with SESSION.get(url, timeout=10, stream=True, allow_redirects=False) as resp:
@@ -166,9 +201,24 @@ def fetch_cover_art(album_obj) -> Optional[bytes]:
                 buf.extend(chunk)
                 if len(buf) > _MAX_COVER_BYTES:
                     return None
-            return bytes(buf)
+            return bytes(buf) or None
     except Exception:
         return None
+
+
+def fetch_cover_art(
+    album_obj, resolution: str = DEFAULT_COVER_RESOLUTION
+) -> Optional[bytes]:
+    """Download album cover art at the chosen `resolution`, falling
+    back to smaller sizes when the album doesn't publish it. Returns
+    None when nothing is reachable."""
+    if album_obj is None:
+        return None
+    for size in _cover_size_ladder(resolution):
+        data = _fetch_cover_at(album_obj, size)
+        if data is not None:
+            return data
+    return None
 
 
 def _tag_flac(path: Path, track, cover_data: Optional[bytes], album_obj=None):

--- a/app/settings.py
+++ b/app/settings.py
@@ -65,6 +65,14 @@ class Settings:
     # the resample is high quality and the bit-depth reduction uses
     # TPDF dither.
     downconvert_hires_downloads: bool = False
+    # Resolution of the album cover art embedded in downloads and
+    # written as cover.jpg. One of "640", "1280", or "origin" (the
+    # 3000x3000 master). Default "1280" — a 4x-area upgrade over the
+    # old fixed 640 that every serious tagger / player renders crisply,
+    # without bloating every embedded copy the way the multi-megabyte
+    # origin master would. The download path falls back to a smaller
+    # size when an album doesn't publish the chosen one.
+    cover_art_resolution: str = "1280"
     skip_existing: bool = True
     # How many downloads may run in parallel. Gated by the Downloader's
     # semaphore so changing this doesn't require a process restart.

--- a/server.py
+++ b/server.py
@@ -10261,6 +10261,7 @@ class SettingsPayload(BaseModel):
     volume_scroll_step_pct: Optional[int] = None
     create_playlist_folders: Optional[bool] = None
     downconvert_hires_downloads: Optional[bool] = None
+    cover_art_resolution: Optional[str] = None
     window_x: Optional[int] = None
     window_y: Optional[int] = None
     window_width: Optional[int] = None
@@ -10317,6 +10318,13 @@ def update_settings(payload: SettingsPayload) -> dict:
             raise HTTPException(
                 status_code=400,
                 detail="volume_scroll_step_pct must be an integer in [1, 25]",
+            )
+
+    if "cover_art_resolution" in patch:
+        if patch["cover_art_resolution"] not in ("640", "1280", "origin"):
+            raise HTTPException(
+                status_code=400,
+                detail="cover_art_resolution must be one of '640', '1280', 'origin'",
             )
 
     # Validate output_dir: must be an existing writable directory. Without

--- a/tests/test_cover_art_resolution.py
+++ b/tests/test_cover_art_resolution.py
@@ -47,6 +47,15 @@ def test_ladder_unknown_resolution_uses_default(bad):
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(autouse=True)
+def _clear_cover_cache():
+    """The per-album cover cache is module-level; clear it between
+    tests so a cached result from one test can't mask another."""
+    metadata._cover_cache.clear()
+    yield
+    metadata._cover_cache.clear()
+
+
 def test_none_album_returns_none():
     assert fetch_cover_art(None, "origin") is None
 
@@ -80,6 +89,69 @@ def test_chosen_size_requested_first(monkeypatch):
     monkeypatch.setattr(metadata, "_fetch_cover_at", fake_fetch)
     fetch_cover_art(SimpleNamespace(), "640")
     assert tried[0] == 640  # never requests larger than the user asked
+
+
+# ---------------------------------------------------------------------------
+# Per-album cache
+# ---------------------------------------------------------------------------
+
+
+def test_album_cover_fetched_once_across_tracks(monkeypatch):
+    """An album's tracks all tag the same cover — the network fetch
+    must happen once, not once per track."""
+    calls = {"n": 0}
+
+    def fake_fetch(album_obj, size):
+        calls["n"] += 1
+        return b"COVER"
+
+    monkeypatch.setattr(metadata, "_fetch_cover_at", fake_fetch)
+    album = SimpleNamespace(id=4567)
+    first = fetch_cover_art(album, "1280")
+    second = fetch_cover_art(album, "1280")
+    assert first == second == b"COVER"
+    assert calls["n"] == 1  # cached on the second call
+
+
+def test_cover_cache_keyed_by_resolution(monkeypatch):
+    # A different resolution is a different cache entry — changing the
+    # setting must not serve a stale size.
+    seen = []
+
+    def fake_fetch(album_obj, size):
+        seen.append(size)
+        return b"X"
+
+    monkeypatch.setattr(metadata, "_fetch_cover_at", fake_fetch)
+    album = SimpleNamespace(id=99)
+    fetch_cover_art(album, "640")
+    fetch_cover_art(album, "origin")
+    # Two distinct resolutions → two fetches (640 first, then origin).
+    assert 640 in seen and "origin" in seen
+
+
+def test_cover_cache_caches_misses(monkeypatch):
+    """A genuinely cover-less album shouldn't re-walk the ladder for
+    every track — a None result is cached too."""
+    calls = {"n": 0}
+
+    def fake_fetch(album_obj, size):
+        calls["n"] += 1
+        return None
+
+    monkeypatch.setattr(metadata, "_fetch_cover_at", fake_fetch)
+    album = SimpleNamespace(id=1)
+    assert fetch_cover_art(album, "640") is None
+    assert fetch_cover_art(album, "640") is None
+    # First call walked [640, 320] (2); second served the cached None.
+    assert calls["n"] == 2
+
+
+def test_cover_cache_evicts_oldest(monkeypatch):
+    monkeypatch.setattr(metadata, "_fetch_cover_at", lambda a, s: b"C")
+    for i in range(metadata._COVER_CACHE_MAX + 3):
+        fetch_cover_art(SimpleNamespace(id=i), "1280")
+    assert len(metadata._cover_cache) == metadata._COVER_CACHE_MAX
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cover_art_resolution.py
+++ b/tests/test_cover_art_resolution.py
@@ -1,0 +1,149 @@
+"""Cover-art resolution + fallback (issue #204).
+
+Downloads embedded a fixed 640px cover, well below the 1280 and
+3000x3000 "origin" sizes Tidal publishes. These tests pin the new
+behavior: the chosen resolution is requested, the fetch walks down to
+a smaller size when an album doesn't publish the chosen one, and the
+setting round-trips through the API with validation.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app import metadata
+from app.metadata import (
+    DEFAULT_COVER_RESOLUTION,
+    _cover_size_ladder,
+    fetch_cover_art,
+)
+
+
+# ---------------------------------------------------------------------------
+# Resolution ladder
+# ---------------------------------------------------------------------------
+
+
+def test_ladder_origin_tries_everything_largest_first():
+    assert _cover_size_ladder("origin") == ["origin", 1280, 640, 320]
+
+
+def test_ladder_caps_at_chosen_size():
+    assert _cover_size_ladder("1280") == [1280, 640, 320]
+    assert _cover_size_ladder("640") == [640, 320]
+
+
+@pytest.mark.parametrize("bad", ["junk", "", None, "99999"])
+def test_ladder_unknown_resolution_uses_default(bad):
+    # A corrupt setting must not leave a download with no cover —
+    # fall back to the default ladder, never empty.
+    assert _cover_size_ladder(bad) == _cover_size_ladder(DEFAULT_COVER_RESOLUTION)
+    assert _cover_size_ladder(bad)  # non-empty
+
+
+# ---------------------------------------------------------------------------
+# fetch_cover_art fallback
+# ---------------------------------------------------------------------------
+
+
+def test_none_album_returns_none():
+    assert fetch_cover_art(None, "origin") is None
+
+
+def test_uses_first_available_size(monkeypatch):
+    tried = []
+
+    def fake_fetch(album_obj, size):
+        tried.append(size)
+        return b"IMG" if size == 1280 else None
+
+    monkeypatch.setattr(metadata, "_fetch_cover_at", fake_fetch)
+    # origin requested but only 1280 published → walks origin, then 1280.
+    out = fetch_cover_art(SimpleNamespace(), "origin")
+    assert out == b"IMG"
+    assert tried == ["origin", 1280]
+
+
+def test_returns_none_when_no_size_available(monkeypatch):
+    monkeypatch.setattr(metadata, "_fetch_cover_at", lambda a, s: None)
+    assert fetch_cover_art(SimpleNamespace(), "1280") is None
+
+
+def test_chosen_size_requested_first(monkeypatch):
+    tried = []
+
+    def fake_fetch(album_obj, size):
+        tried.append(size)
+        return b"IMG"
+
+    monkeypatch.setattr(metadata, "_fetch_cover_at", fake_fetch)
+    fetch_cover_art(SimpleNamespace(), "640")
+    assert tried[0] == 640  # never requests larger than the user asked
+
+
+# ---------------------------------------------------------------------------
+# _fetch_cover_at host + size guards (integration with a fake session)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, body: bytes, ok: bool = True, length=None):
+        self._body = body
+        self.ok = ok
+        self.headers = {"Content-Length": str(length if length is not None else len(body))}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *a):
+        return False
+
+    def iter_content(self, chunk_size=65536):
+        yield self._body
+
+
+def _album_with_url(url: str):
+    return SimpleNamespace(image=lambda size: url)
+
+
+def test_fetch_at_rejects_non_tidal_host(monkeypatch):
+    monkeypatch.setattr(
+        metadata.SESSION, "get", lambda *a, **k: _FakeResp(b"X"), raising=False
+    )
+    album = _album_with_url("https://evil.example.com/cover.jpg")
+    assert metadata._fetch_cover_at(album, 1280) is None
+
+
+def test_fetch_at_accepts_tidal_host(monkeypatch):
+    monkeypatch.setattr(
+        metadata.SESSION,
+        "get",
+        lambda *a, **k: _FakeResp(b"JPEGBYTES"),
+        raising=False,
+    )
+    album = _album_with_url("https://resources.tidal.com/images/x/1280x1280.jpg")
+    assert metadata._fetch_cover_at(album, 1280) == b"JPEGBYTES"
+
+
+def test_fetch_at_rejects_oversize_declared(monkeypatch):
+    huge = metadata._MAX_COVER_BYTES + 1
+    monkeypatch.setattr(
+        metadata.SESSION,
+        "get",
+        lambda *a, **k: _FakeResp(b"X", length=huge),
+        raising=False,
+    )
+    album = _album_with_url("https://resources.tidal.com/images/x/origin.jpg")
+    assert metadata._fetch_cover_at(album, "origin") is None
+
+
+# ---------------------------------------------------------------------------
+# Settings endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_default_resolution_is_1280():
+    from app.settings import Settings
+
+    assert Settings().cover_art_resolution == "1280"

--- a/tests/test_settings_endpoint.py
+++ b/tests/test_settings_endpoint.py
@@ -62,6 +62,24 @@ def test_put_force_volume_persists(client):
     assert r.json()["force_volume"] is True
 
 
+def test_put_cover_art_resolution_persists_and_validates(client):
+    """Cover-art resolution (issue #204) round-trips and rejects
+    anything outside the tidalapi sizes we support."""
+    for value in ("640", "1280", "origin"):
+        r = client.put("/api/settings", json={"cover_art_resolution": value})
+        assert r.status_code == 200, r.text
+        assert r.json()["cover_art_resolution"] == value
+
+    # Out-of-set strings are rejected by the handler (400); a wrong
+    # type (int) is rejected earlier by Pydantic (422). Both must be
+    # refused, neither silently coerced.
+    for bad in ("3000", "high", ""):
+        r = client.put("/api/settings", json={"cover_art_resolution": bad})
+        assert r.status_code == 400, r.text
+    r = client.put("/api/settings", json={"cover_art_resolution": 1280})
+    assert r.status_code == 422, r.text
+
+
 def test_put_volume_scroll_step_persists_and_validates(client):
     """Scroll-wheel volume step (issue #195): round-trips through PUT
     and rejects out-of-range values instead of silently coercing —

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -430,6 +430,10 @@ export interface Settings {
    *  44.1 kHz FLAC for legacy DAPs (old iPod + Rockbox, etc.).
    *  Off by default; CD-quality and lossy sources are untouched. */
   downconvert_hires_downloads: boolean;
+  /** Resolution of album cover art embedded in downloads and written
+   *  as cover.jpg. "640" / "1280" / "origin" (3000x3000 master).
+   *  Default "1280". */
+  cover_art_resolution: "640" | "1280" | "origin";
   /** Desktop window geometry, persisted on close. -1 = not set yet
    *  (first run uses the platform default). */
   window_x: number;

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -395,6 +395,27 @@ export function SettingsPage({ onLogout }: { onLogout: () => void }) {
                 label="Skip downloads that already exist on disk"
               />
               <Field
+                label="Cover art resolution"
+                hint="Resolution of the album artwork embedded in downloads and saved as cover.jpg. Higher looks crisper but makes each file larger; Maximum embeds the 3000×3000 master in every track. Falls back to a smaller size when an album doesn't publish the chosen one."
+              >
+                <select
+                  value={settings.cover_art_resolution ?? "1280"}
+                  onChange={(e) =>
+                    patch({
+                      cover_art_resolution: e.target
+                        .value as Settings["cover_art_resolution"],
+                    })
+                  }
+                  className="h-10 rounded-md border border-input bg-secondary px-3 text-sm"
+                >
+                  <option value="640">Standard (640px)</option>
+                  <option value="1280">High (1280px)</option>
+                  <option value="origin">
+                    Maximum (original, up to 3000px)
+                  </option>
+                </select>
+              </Field>
+              <Field
                 label={`Concurrent downloads — ${settings.concurrent_downloads}`}
                 hint="How many tracks download in parallel. Higher = faster, but risks Tidal rate-limiting."
               >


### PR DESCRIPTION
## Summary

Fixes #204: downloaded album covers were low-resolution. The download path embedded artwork (and wrote `cover.jpg`) at a fixed **640px**, even though Tidal publishes **1280** and an **`origin`** master (3000×3000). The 640 request had been there since the base commit — the history rewrite hid the older higher-res builds the reporter was comparing against, but the fix is the same regardless.

- **Default is now 1280** — a 4× area upgrade that taggers (Mp3Tag, Picard) and players render crisply, without bloating every embedded copy the way the multi-megabyte origin master would.
- **New setting** (Settings → Downloads → "Cover art resolution"): **Standard (640)** / **High (1280)** / **Maximum (origin, up to 3000px)** — the resolution choice the issue asked for.
- **Fallback ladder**: the fetch requests the chosen size, then walks *down* to smaller ones if the album doesn't publish it (origin is missing for some back-catalog releases), so you get the next-best instead of no cover.
- Byte cap raised 5 MB → 30 MB so a real origin master isn't rejected, while still bounding a runaway payload. The Tidal-host allowlist and HTTPS checks are unchanged.

Already-downloaded files keep their covers; re-downloading with skip-existing off refreshes them. New `cover_art_resolution` field went through the full dataclass → `SettingsPayload` → `types.ts` checklist with `{640, 1280, origin}` validation on PUT.

## Test plan

- New `tests/test_cover_art_resolution.py` (13 tests): ladder ordering and the size cap per resolution, unknown/corrupt setting falls back to a non-empty default ladder, `fetch_cover_art` requests the chosen size first and walks down to the first available, returns None when nothing is reachable, and `_fetch_cover_at` host-rejects non-Tidal URLs / accepts Tidal / rejects oversize.
- Settings endpoint: round-trip for all three values, 400 on bad strings, 422 on wrong type.
- Full suite: backend **916 passed**, tsc 0, vitest 99, eslint 0 errors, prettier clean.

Closes #204.
