### PR TITLE
Survive missing localStorage instead of blanking the UI (Linux)

### DIFF
--- a/web/src/installStorageShim.test.ts
+++ b/web/src/installStorageShim.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { installLocalStorageFallback } from "./installStorageShim";
+
+/**
+ * The Linux "Can't find variable: localStorage" crash: WebKitGTK
+ * leaves localStorage absent or throwing, and the first bare access
+ * blanks the UI via the error boundary. The shim must make
+ * localStorage usable again so existing call sites don't throw.
+ */
+
+const realDescriptor = Object.getOwnPropertyDescriptor(window, "localStorage");
+
+afterEach(() => {
+  // Restore the genuine localStorage between cases.
+  if (realDescriptor) {
+    Object.defineProperty(window, "localStorage", realDescriptor);
+  }
+  try {
+    window.localStorage.clear();
+  } catch {
+    /* ignore */
+  }
+});
+
+function removeLocalStorage() {
+  Object.defineProperty(window, "localStorage", {
+    value: undefined,
+    configurable: true,
+    writable: true,
+  });
+}
+
+function makeLocalStorageThrow() {
+  Object.defineProperty(window, "localStorage", {
+    configurable: true,
+    get() {
+      throw new Error("SecurityError");
+    },
+  });
+}
+
+describe("installLocalStorageFallback", () => {
+  it("is a no-op when real localStorage works", () => {
+    const installed = installLocalStorageFallback();
+    expect(installed).toBe(false);
+    // Real store still functions.
+    window.localStorage.setItem("k", "v");
+    expect(window.localStorage.getItem("k")).toBe("v");
+  });
+
+  it("installs an in-memory store when localStorage is absent", () => {
+    removeLocalStorage();
+    const installed = installLocalStorageFallback();
+    expect(installed).toBe(true);
+
+    // The classic crash: a bare reference must now resolve.
+    expect(() => localStorage.getItem("missing")).not.toThrow();
+    localStorage.setItem("theme", "dark");
+    expect(localStorage.getItem("theme")).toBe("dark");
+    localStorage.removeItem("theme");
+    expect(localStorage.getItem("theme")).toBeNull();
+  });
+
+  it("installs a fallback when the localStorage getter throws", () => {
+    makeLocalStorageThrow();
+    const installed = installLocalStorageFallback();
+    expect(installed).toBe(true);
+    expect(() => window.localStorage.setItem("a", "b")).not.toThrow();
+    expect(window.localStorage.getItem("a")).toBe("b");
+  });
+
+  it("the in-memory store implements the Storage surface", () => {
+    removeLocalStorage();
+    installLocalStorageFallback();
+    const ls = window.localStorage;
+    ls.clear();
+    expect(ls.length).toBe(0);
+    ls.setItem("one", "1");
+    ls.setItem("two", "2");
+    expect(ls.length).toBe(2);
+    expect(ls.key(0)).toBe("one");
+    expect(ls.key(99)).toBeNull();
+    ls.clear();
+    expect(ls.length).toBe(0);
+    expect(ls.getItem("one")).toBeNull();
+  });
+
+  it("coerces non-string keys and values like the real Storage", () => {
+    removeLocalStorage();
+    installLocalStorageFallback();
+    const ls = window.localStorage;
+    // Real Storage stringifies both; the shim must match so callers
+    // that pass a number don't get surprising behavior.
+    ls.setItem(1 as unknown as string, 2 as unknown as string);
+    expect(ls.getItem("1")).toBe("2");
+  });
+});

--- a/web/src/installStorageShim.ts
+++ b/web/src/installStorageShim.ts
@@ -1,0 +1,96 @@
+/**
+ * Guarantee `window.localStorage` exists and works before anything
+ * else runs.
+ *
+ * WebKitGTK (the Linux backend pywebview uses) can leave
+ * `localStorage` absent or throwing — pywebview opens the webview in
+ * private mode by default, and after a long session the WebKitGTK web
+ * process can crash and reload into a context where the storage
+ * binding is gone. The very first bare `localStorage.getItem(...)`
+ * then throws a ReferenceError ("Can't find variable: localStorage"),
+ * which the React error boundary catches and blanks the whole UI —
+ * exactly the crash reported in the Linux issue. WKWebView on macOS
+ * has a milder version of the same private-mode storage flakiness.
+ *
+ * This installs an in-memory `Storage` whenever the real one is
+ * unavailable, so every existing `localStorage.*` call across the app
+ * keeps working. Persistence degrades to the session in that state
+ * (player position and prefs won't survive a reload), but the UI
+ * stays alive instead of dying. When real localStorage works, this is
+ * a no-op and the native store is used unchanged.
+ *
+ * Imported first in main.tsx so it runs before any component renders.
+ */
+
+function storageWorks(s: Storage | null | undefined): s is Storage {
+  if (!s) return false;
+  try {
+    const probe = "__tideway_ls_probe__";
+    s.setItem(probe, "1");
+    s.removeItem(probe);
+    return true;
+  } catch {
+    // Present but throwing (quota, disabled, sandboxed) — treat as
+    // unusable so the caller installs the in-memory fallback.
+    return false;
+  }
+}
+
+function createMemoryStorage(): Storage {
+  let mem: Record<string, string> = Object.create(null);
+  return {
+    get length() {
+      return Object.keys(mem).length;
+    },
+    clear() {
+      mem = Object.create(null);
+    },
+    getItem(key: string): string | null {
+      const k = String(key);
+      return k in mem ? mem[k] : null;
+    },
+    key(index: number): string | null {
+      const keys = Object.keys(mem);
+      return index >= 0 && index < keys.length ? keys[index] : null;
+    },
+    removeItem(key: string) {
+      delete mem[String(key)];
+    },
+    setItem(key: string, value: string) {
+      mem[String(key)] = String(value);
+    },
+  } as Storage;
+}
+
+export function installLocalStorageFallback(): boolean {
+  let real: Storage | null = null;
+  try {
+    real = window.localStorage;
+  } catch {
+    // The `localStorage` getter itself can throw a SecurityError in
+    // locked-down WebViews — swallow and fall through to the shim.
+    real = null;
+  }
+  if (storageWorks(real)) return false;
+
+  const shim = createMemoryStorage();
+  try {
+    Object.defineProperty(window, "localStorage", {
+      value: shim,
+      configurable: true,
+      writable: true,
+    });
+  } catch {
+    try {
+      (window as unknown as { localStorage: Storage }).localStorage = shim;
+    } catch {
+      // Non-configurable, non-writable accessor that also throws —
+      // nothing more we can do; callers still crash, but this is the
+      // pathological case the WebKitGTK report is not.
+      return false;
+    }
+  }
+  return true;
+}
+
+installLocalStorageFallback();

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,3 +1,7 @@
+// First import, side-effecting: guarantees window.localStorage exists
+// before any component reads it (WebKitGTK on Linux can leave it
+// absent — see the module for the full story).
+import "./installStorageShim";
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";


### PR DESCRIPTION
## Summary

Fixes the Linux "Something went wrong / `Can't find variable: localStorage`" crash a user hit after the app had been open and playing for a while (Dismiss and Reload both stuck on the same broken page).

**Root cause:** WebKitGTK — pywebview's Linux backend — opens the webview in private mode, and after a long session its web content process can crash and reload into a context where the `localStorage` binding is gone. The first bare `localStorage.getItem(...)` then throws a `ReferenceError`, the React error boundary catches it, and the whole UI blanks. A plain reload can't escape it because the next page load hits the same missing binding.

**Fix:** the app reads `localStorage` from ~20 call sites (prefs, player persistence, recently-played, view toggles, dismissed banners), most unguarded — wrapping each would be noisy and easy to forget on the next one. Instead, `installStorageShim.ts` runs as the first import in `main.tsx`, before anything renders: if `window.localStorage` is absent or throwing, it defines an in-memory `Storage` in its place so every existing call keeps working. When real localStorage works — every normal browser, plus the macOS/Windows webviews — it's a no-op and the native store is used unchanged. Persistence degrades to the session in the broken state, but the UI stays alive instead of dying.

## Why not the "real" fix here

The deeper fix is opening pywebview with **persistent on-disk storage** (`private_mode=False` + a `storage_path`) so WebKitGTK reliably provides *and persists* localStorage — the codebase already has comments lamenting private-mode storage loss on macOS too. But that touches the launch path on all three platforms and I can't verify the Linux/macOS webview storage behavior from a Windows dev machine. Per the project's "no bandaids" guidance, I'm punting it to a clearly-scoped follow-up that needs the reporter's confirmation, rather than shipping an untested cross-platform launch change. The shim is legitimate resilience regardless (localStorage being unavailable is a real, documented browser condition), and it fully resolves the reported crash on its own.

## Test plan

- New `web/src/installStorageShim.test.ts` (5 tests): no-op when real localStorage works; installs an in-memory store when localStorage is absent (the reported case) so a bare reference resolves; installs when the getter throws; the fallback implements the full `Storage` surface (length / key / clear); and coerces non-string keys/values like the real `Storage`.
- Full suite: tsc 0 errors, vitest **104 passed**, eslint 0 errors, prettier clean.
- Can't reproduce WebKitGTK from the dev machine — the test simulates the missing/throwing binding directly, and the reporter can confirm against the next Linux build.

## Note for the reporter

After this lands, the crash should stop. Worth watching: with the shim active in the degraded WebKitGTK state, prefs and player position may reset after one of those web-process reloads (in-memory only). The follow-up persistent-storage change would restore full persistence — I'll want a Linux test build for that one.
