### PR TITLE
Track curl_cffi's newest Chrome profile for the AOTY scraper

### DIFF
--- a/app/aoty.py
+++ b/app/aoty.py
@@ -39,9 +39,15 @@ stock HTTP client now returns 403 with `cf-mitigated: challenge`
 and the JS interstitial. Plain `requests` can't pass it; the
 homepage sections silently emptied out as the existing in-memory
 cache aged out. We switched the fetch path to `curl_cffi` with
-browser-fingerprinted TLS (`impersonate="chrome120"`), which gets
-back HTTP 200 with the full HTML. curl_cffi is already a project
-dependency — used for Tidal's anti-bot path — so no new deps.
+browser-fingerprinted TLS, which gets back HTTP 200 with the full
+HTML. curl_cffi is already a project dependency — used for Tidal's
+anti-bot path — so no new deps.
+
+Profile-staleness note: Cloudflare later started 403'ing the pinned
+`chrome120` profile (the Home rows emptied again). A live probe
+confirmed every newer curl_cffi profile passes, so the impersonate
+target is now the version-tracking `"chrome"` alias — see the
+comment on `_CFFI_IMPERSONATE`.
 
 Block detection: when `_fetch` sees a Cloudflare challenge
 response it sets a module-level `_blocked_at` timestamp and
@@ -70,15 +76,26 @@ log = logging.getLogger(__name__)
 _BASE_URL = "https://www.albumoftheyear.org"
 
 # Browser to impersonate at the TLS / HTTP/2 / header layer.
-# curl_cffi sets the full Chrome 120 fingerprint when this is
-# active — including the User-Agent, every `sec-ch-ua-*` client
-# hint, `Accept-Language`, and the order of headers. Passing our
-# own `User-Agent` override (or any other header curl_cffi already
-# sets) breaks Cloudflare's consistency check: a Chrome TLS hello
-# paired with an inconsistent set of HTTP headers reads as bot
-# automation. So _fetch() below deliberately sends NO custom
-# headers — the impersonate profile is the whole story.
-_CFFI_IMPERSONATE = "chrome120"
+# curl_cffi sets the full Chrome fingerprint when this is active —
+# including the User-Agent, every `sec-ch-ua-*` client hint,
+# `Accept-Language`, and the order of headers. Passing our own
+# `User-Agent` override (or any other header curl_cffi already sets)
+# breaks Cloudflare's consistency check: a Chrome TLS hello paired
+# with an inconsistent set of HTTP headers reads as bot automation.
+# So _fetch() below deliberately sends NO custom headers — the
+# impersonate profile is the whole story.
+#
+# Use the `"chrome"` alias (curl_cffi resolves it to its newest
+# Chrome profile — chrome146 as of curl_cffi 0.15.0) rather than a
+# pinned version. A pinned profile inevitably ages out: Cloudflare
+# tightens its fingerprint allowlist as old Chrome releases fall out
+# of support, and a frozen "chrome120" silently starts getting 403'd
+# (which is exactly what emptied the Home rows, twice — 2026-05-20
+# and again later). The alias means a routine `curl_cffi` dependency
+# bump refreshes the fingerprint for free. The block-detection
+# early-warning below still fires if even the newest profile gets
+# challenged, signalling it's time to upgrade curl_cffi itself.
+_CFFI_IMPERSONATE = "chrome"
 
 _HTTP_TIMEOUT_SEC = 15.0
 
@@ -429,9 +446,10 @@ def _fetch(url: str) -> Optional[str]:
             # changes (see CLAUDE.md Logging section).
             print(
                 f"[aoty] Cloudflare challenge on {url} "
-                f"(status {r.status_code}) — the chrome120 "
-                f"impersonation profile has aged out. Bump "
-                f"_CFFI_IMPERSONATE in app/aoty.py or file: "
+                f"(status {r.status_code}) — the "
+                f"{_CFFI_IMPERSONATE!r} impersonation profile is "
+                f"being blocked. Upgrade curl_cffi (the 'chrome' "
+                f"alias tracks its newest profile) or file: "
                 f"{ISSUE_TRACKER_URL}",
                 flush=True,
             )

--- a/tests/test_aoty_blocked.py
+++ b/tests/test_aoty_blocked.py
@@ -85,3 +85,21 @@ def test_successful_fetch_keeps_flag_clear():
         result = aoty._fetch("https://www.albumoftheyear.org/releases/this-week/")
     assert result == "<html></html>"
     assert aoty.is_scraper_blocked() is False
+
+
+def test_impersonate_profile_is_current_and_known_to_curl_cffi():
+    """Guard against shipping a Cloudflare-blocked impersonate
+    profile. `chrome120` is confirmed-403'd by AOTY's Cloudflare;
+    don't let a revert reintroduce it. A fixture test can't verify
+    Cloudflare *accepts* a profile (that needs the live site — see
+    the PR's probe), but it can pin that the configured value isn't
+    the known-bad one and is a profile curl_cffi actually recognises
+    (so a typo like "chorme" fails loudly instead of silently 403'ing
+    every request)."""
+    from curl_cffi.requests.impersonate import normalize_browser_type
+
+    assert aoty._CFFI_IMPERSONATE != "chrome120"
+    # normalize_browser_type resolves the "chrome" alias / a concrete
+    # version to curl_cffi's internal target; an unknown string raises.
+    resolved = normalize_browser_type(aoty._CFFI_IMPERSONATE)
+    assert resolved  # truthy target, not None/empty


### PR DESCRIPTION
## Summary

The Home page's AlbumOfTheYear discovery rows went empty — the reporter noticed "the AOTY endpoints seem to have changed." A **live probe** (per the project's verify-the-live-site rule for scrapers) shows it's not a URL or markup change: **Cloudflare started 403'ing the pinned `chrome120` impersonate profile** with `cf-mitigated: challenge`. It's the second time AOTY's anti-bot fingerprinting has moved out from under a frozen profile.

Probe of every curl_cffi profile against AOTY:

```
chrome       -> HTTP 200   (alias → chrome146)
chrome133a   -> HTTP 200
chrome131    -> HTTP 200
chrome124    -> HTTP 200
chrome123    -> HTTP 200
chrome120    -> HTTP 403 cf=challenge   ← what shipped
safari18_0   -> HTTP 200
edge101      -> HTTP 200
```

**Fix:** switch the impersonate target to curl_cffi's `"chrome"` alias, which resolves to its newest profile (chrome146 today). A pinned version inevitably ages out as Cloudflare drops old Chrome releases from its allowlist; the alias means a routine `curl_cffi` dependency bump refreshes the fingerprint for free. The existing block-detection early-warning still fires if even the newest profile gets challenged (→ time to upgrade curl_cffi). Scoped to AOTY only — the Tidal (`chrome131_android`) and Spotify (`chrome131`) transports use newer profiles and aren't the reported breakage, so I left them alone rather than speculatively touching the load-bearing Tidal path.

Verified live through the real functions, not just the raw fetch — all three surfaces return real data again, parsers unchanged:

```
top_albums_of_year(2025): 10 albums  (e.g. Clipse - Let God Sort Em Out, score 87)
recent_releases:          10 albums  (e.g. Olivia Rodrigo - ...)
genre_index:              51 genres
scraper_blocked:          False
```

## Test plan

- New regression guard in `tests/test_aoty_blocked.py`: the configured profile isn't the known-blocked `chrome120` and is one curl_cffi recognises via `normalize_browser_type` (so a typo like `"chorme"` fails loudly instead of silently 403'ing everything). A fixture *can't* verify Cloudflare acceptance — that's the manual live probe above.
- Full backend suite: **902 passed**, 2 skipped.

## Note

The fingerprint will eventually rot again — that's inherent to scraping a Cloudflare-protected site. The `"chrome"` alias + dependabot keeping curl_cffi current is the lowest-maintenance defense, and the in-app "report on GitHub" notice (driven by `is_scraper_blocked()`) is the early-warning when it does.
