### PR TITLE
Serialize token refreshes so parallel 401s can't break the session

### DIFF
--- a/app/tidal_client.py
+++ b/app/tidal_client.py
@@ -433,9 +433,13 @@ class TidalClient:
         # within a session, so a long TTL is fine.
         self._sub_cache: tuple[float, Optional[str]] = (0.0, None)
         self._sub_lock = threading.Lock()
-        # Serializes force_refresh calls so concurrent 401s from parallel
-        # workers don't fire two token_refresh RPCs at once (second one
-        # would race and potentially invalidate the first's token).
+        # Serializes EVERY token refresh — the watchdog's force_refresh
+        # AND tidalapi's internal auto-refresh-on-401 — through one lock,
+        # so concurrent 401s from parallel workers can't fire two
+        # token_refresh RPCs at once. With rotating refresh tokens the
+        # second POST would carry a token Tidal just invalidated and then
+        # persist that broken lineage, logging the user out days later.
+        # The single-flight check lives in _refresh_once.
         self._refresh_lock = threading.Lock()
         # Background watchdog: refreshes the token a few minutes before
         # it's due to expire. Without this, a long-running session (user
@@ -558,6 +562,47 @@ class TidalClient:
             session.refresh_token = new_refresh
         return True
 
+    def _refresh_once(self, based_on: Optional[str]) -> bool:
+        """Locked, single-flight refresh shared by every runtime path
+        (the watchdog's force_refresh and tidalapi's internal
+        auto-refresh-on-401). Holding one lock across both is what
+        actually delivers the "no two concurrent refresh RPCs"
+        guarantee: previously only force_refresh took the lock, so two
+        parallel 401s going through tidalapi's path both POSTed the
+        same refresh token. With rotation, the second POST carries a
+        token Tidal just invalidated, and persisting that broken
+        lineage logs the user out a few days later.
+
+        `based_on` is the refresh token the caller observed before
+        contending for the lock. Once we hold the lock, if the
+        session's refresh token has already moved on — another thread
+        refreshed and Tidal rotated — that refresh supersedes this one,
+        so we reuse it instead of re-POSTing the now-dead token. Raises
+        like _token_refresh_capturing (AuthenticationError on a rejected
+        token) so force_refresh's logout-on-auth-failure path is
+        preserved.
+        """
+        with self._refresh_lock:
+            current = getattr(self.session, "refresh_token", None)
+            if not current:
+                return False
+            if based_on is not None and current != based_on:
+                # A parallel refresh already rotated the token we were
+                # going to use; its result stands. Re-POSTing `current`
+                # would be redundant, and re-POSTing `based_on` would
+                # use a token Tidal already invalidated.
+                return True
+            ok = self._token_refresh_capturing(current)
+            if ok:
+                try:
+                    self.save_session()
+                except Exception:
+                    # Best-effort: the in-memory session is already
+                    # valid, and the watchdog / next refresh re-persists.
+                    # Don't fail the refresh over a transient disk error.
+                    pass
+            return ok
+
     def _token_refresh_and_persist(self, refresh_token: str) -> bool:
         """token_refresh that captures rotation AND persists.
 
@@ -566,21 +611,11 @@ class TidalClient:
         tidalapi's native implementation drops a rotated refresh
         token, so a few days later the next refresh fails and the
         user is silently logged out. Routing that internal path
-        through the capturing implementation — and saving the
-        result so a process exit right after a mid-session
-        auto-refresh doesn't lose the rotated token — is what makes
-        the session durable rather than expiring every few days.
+        through _refresh_once captures the rotation, persists it, and
+        — crucially — serializes it against every other refresh path
+        so parallel 401s can't clobber each other's rotated token.
         """
-        ok = self._token_refresh_capturing(refresh_token)
-        if ok:
-            try:
-                self.save_session()
-            except Exception:
-                # Persisting is best-effort here; the in-memory
-                # session is already correct and the watchdog /
-                # explicit force_refresh will re-save shortly.
-                pass
-        return ok
+        return self._refresh_once(based_on=refresh_token)
 
     def _install_capturing_refresh(self) -> None:
         """Shadow tidalapi's Session.token_refresh on this session
@@ -620,34 +655,36 @@ class TidalClient:
         workers don't fire two token_refresh RPCs at once. The second
         caller will see the fresh token after the first finishes.
         """
-        with self._refresh_lock:
-            refresh_token = getattr(self.session, "refresh_token", None)
-            if not refresh_token:
-                _tlog("force_refresh: no refresh_token on session")
-                return False
-            try:
-                ok = self._token_refresh_capturing(refresh_token)
-            except Exception as exc:
-                _tlog(f"force_refresh: token_refresh raised: {exc!r}")
-                # AuthenticationError means the refresh token itself is
-                # dead. Blow the session away so the user is prompted to
-                # log in again rather than chasing 401s forever, and tell
-                # the server to drop its cached auth state so the very
-                # next /auth/status bounces the UI to Login immediately
-                # instead of waiting out the cache TTL.
-                if type(exc).__name__ == "AuthenticationError":
-                    try:
-                        self.logout()
-                    except Exception:
-                        pass
-                    self._notify_auth_lost()
-                return False
-            if not ok:
-                _tlog("force_refresh: token_refresh returned False")
-                return False
-            self.save_session()
-            _tlog("force_refresh: success")
-            return True
+        refresh_token = getattr(self.session, "refresh_token", None)
+        if not refresh_token:
+            _tlog("force_refresh: no refresh_token on session")
+            return False
+        try:
+            # _refresh_once takes _refresh_lock and single-flights: if a
+            # parallel refresh already rotated the token, it reuses that
+            # result instead of re-POSTing this now-stale one. It also
+            # persists on success, so there's no save_session() here.
+            ok = self._refresh_once(based_on=refresh_token)
+        except Exception as exc:
+            _tlog(f"force_refresh: token_refresh raised: {exc!r}")
+            # AuthenticationError means the refresh token itself is
+            # dead. Blow the session away so the user is prompted to
+            # log in again rather than chasing 401s forever, and tell
+            # the server to drop its cached auth state so the very
+            # next /auth/status bounces the UI to Login immediately
+            # instead of waiting out the cache TTL.
+            if type(exc).__name__ == "AuthenticationError":
+                try:
+                    self.logout()
+                except Exception:
+                    pass
+                self._notify_auth_lost()
+            return False
+        if not ok:
+            _tlog("force_refresh: token_refresh returned False")
+            return False
+        _tlog("force_refresh: success")
+        return True
 
     def _refresh_watchdog(self) -> None:
         """Background loop that refreshes the token before it expires.

--- a/tests/test_token_refresh_rotation.py
+++ b/tests/test_token_refresh_rotation.py
@@ -10,7 +10,9 @@ session; these tests pin that contract.
 """
 from __future__ import annotations
 
+import threading
 from datetime import datetime
+from unittest.mock import MagicMock
 
 import pytest
 import tidalapi
@@ -60,9 +62,28 @@ class _Session:
         self.expiry_time = None
 
 
+class _BlockingReqSession(_ReqSession):
+    """A request session whose POST blocks until released, so a test
+    can pin a second thread *inside* the contended window. Records
+    every POST so the test can assert how many actually fired."""
+
+    def __init__(self, resp: _Resp):
+        super().__init__(resp)
+        self.entered = threading.Event()
+        self.release = threading.Event()
+
+    def post(self, url, params):
+        self.entered.set()
+        self.release.wait(timeout=5)
+        return super().post(url, params)
+
+
 def _client(session: _Session) -> TidalClient:
     c = TidalClient.__new__(TidalClient)
     c.session = session
+    # __new__ bypasses __init__, so the lock the refresh paths rely on
+    # isn't created; supply it. Harmless to the direct-call tests.
+    c._refresh_lock = threading.Lock()
     return c
 
 
@@ -147,3 +168,52 @@ def test_non_200_raises_authentication_error():
 
     with pytest.raises(tidalapi.exceptions.AuthenticationError):
         client._token_refresh_capturing("dead_refresh")
+
+
+def test_concurrent_internal_refresh_is_single_flight():
+    """Two parallel 401s through tidalapi's internal refresh path
+    (_token_refresh_and_persist) must collapse to ONE network refresh.
+
+    This is the regression that logs users out every few days: that
+    path used to take no lock, so both threads POSTed the same refresh
+    token. Tidal rotates on the first POST and invalidates the old
+    token; the second POST (or its persisted result) then carries a
+    dead-lineage token, and the next refresh fails. The blocking POST
+    pins the first thread inside the contended window so a lockless
+    regression deterministically fires a second POST.
+    """
+    body = {
+        "access_token": "new_access",
+        "refresh_token": "rotated_refresh",
+        "expires_in": 86400,
+        "token_type": "Bearer",
+    }
+    session = _Session(_Resp(200, body))
+    blocking = _BlockingReqSession(_Resp(200, body))
+    session.request_session = blocking
+    client = _client(session)
+    client.save_session = MagicMock()
+
+    results: list[bool] = []
+
+    def worker():
+        results.append(client._token_refresh_and_persist("old_refresh"))
+
+    t1 = threading.Thread(target=worker, name="refresh-1")
+    t2 = threading.Thread(target=worker, name="refresh-2")
+    t1.start()
+    # t1 is now inside post(), holding _refresh_lock. Start the
+    # contender; it blocks on the lock (fixed) or races into post()
+    # (regressed). Either way, releasing lets the truth show.
+    assert blocking.entered.wait(timeout=5), "first refresh never reached the network"
+    t2.start()
+    blocking.release.set()
+    t1.join(timeout=5)
+    t2.join(timeout=5)
+
+    # Exactly one network refresh; the contender reused the rotated
+    # result rather than re-POSTing the invalidated token.
+    assert len(blocking.calls) == 1
+    assert results == [True, True]
+    assert session.refresh_token == "rotated_refresh"
+    client.save_session.assert_called_once()


### PR DESCRIPTION
## Summary

Fixes the "Tideway logs me out every few days" symptom.

Tidal rotates refresh tokens: a refresh sometimes returns a new refresh token and invalidates the old one server-side. Dropping the rotated token is already handled (`_token_refresh_capturing` carries it back onto the session). But the serialization protecting it had a hole.

`_refresh_lock` only wrapped `force_refresh` (the download/player 401 path). tidalapi's own internal auto-refresh-on-401 — used by search, browsing, album loads, stream-URL fetches — calls `session.token_refresh`, which we shadow with `_token_refresh_and_persist`, and **that took no lock**. So when several requests hit 401 at the same instant (the token expired while the app sat idle, then multiple home-page shelves or a download burst all refresh at once), two refreshes raced on the same token: Tidal rotated on the first and invalidated it, and the second POSTed — and persisted — a token from the now-dead lineage. The next refresh then failed and the user was logged out. Sporadic, idle-wake-triggered: "every few days" by feel.

This funnels every runtime refresh path through a new `_refresh_once` that holds `_refresh_lock` and single-flights on the refresh-token identity: once it has the lock, if the session's token already moved on (another thread refreshed and Tidal rotated), it reuses that result instead of re-POSTing the invalidated token. `force_refresh` and the tidalapi-internal path both delegate to it, so the lock now actually delivers the "no two concurrent refresh RPCs" guarantee its comment always claimed.

Notes for the reviewer:
- Single-flight only collapses *successful* (rotating) refreshes — by design. A failed refresh doesn't rotate, so there's no lineage to clobber; the double-POST/`logout()` on a dead token is guarded by `try/except`.
- `force_refresh`'s `save_session()` is now best-effort (a disk error after a valid in-memory refresh no longer fails the refresh; the watchdog re-persists).
- `load_session`'s startup proactive refresh deliberately stays on the direct call — the token isn't on the session object yet at load time, and startup is single-threaded.

## Test plan

- `pytest tests/` — 928 passed, 2 skipped.
- New `test_concurrent_internal_refresh_is_single_flight` fires two parallel 401s through tidalapi's internal path and asserts exactly one network refresh. Mutation-tested: against the old lockless body it fails `assert 2 == 1` (both threads POST the same token), so it genuinely catches the regression.
