### PR TITLE
Remove an unfavorited item from the library in real time

### DIFF
--- a/web/src/hooks/useApi.test.tsx
+++ b/web/src/hooks/useApi.test.tsx
@@ -6,7 +6,13 @@ import { createRoot, type Root } from "react-dom/client";
   globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
 ).IS_REACT_ACT_ENVIRONMENT = true;
 
-import { useApi, prefetchApi, clearApiCache, __cacheInternals } from "./useApi";
+import {
+  useApi,
+  prefetchApi,
+  mutateApiCache,
+  clearApiCache,
+  __cacheInternals,
+} from "./useApi";
 
 interface State<T> {
   data: T | null;
@@ -397,5 +403,36 @@ describe("prefetchApi", () => {
     prefetchApi("dedup:key", fetcher);
     await flush();
     expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("mutateApiCache", () => {
+  it("updates an existing entry's data and preserves its timestamp", () => {
+    __cacheInternals.cache.set("lib:albums", {
+      data: [{ id: "a" }, { id: "b" }, { id: "c" }],
+      timestamp: 1234,
+    });
+    mutateApiCache<{ id: string }[]>("lib:albums", (prev) =>
+      prev.filter((it) => it.id !== "b"),
+    );
+    expect(__cacheInternals.cache.get("lib:albums")).toEqual({
+      data: [{ id: "a" }, { id: "c" }],
+      timestamp: 1234, // not refreshed — we corrected, didn't refetch
+    });
+  });
+
+  it("is a no-op when the key isn't cached (updater never runs)", () => {
+    let ran = false;
+    mutateApiCache<number[]>("absent", (prev) => {
+      ran = true;
+      return prev;
+    });
+    expect(ran).toBe(false);
+    expect(__cacheInternals.cache.has("absent")).toBe(false);
+  });
+
+  it("ignores an empty cache key", () => {
+    mutateApiCache<number[]>("", (prev) => prev);
+    expect(__cacheInternals.cache.has("")).toBe(false);
   });
 });

--- a/web/src/hooks/useApi.ts
+++ b/web/src/hooks/useApi.ts
@@ -183,6 +183,34 @@ export function prefetchApi<T>(
   inflight.set(cacheKey, p);
 }
 
+/**
+ * Surgically update one cache entry's data in place, if present.
+ *
+ * Used to keep an optimistic mutation consistent with the SWR cache —
+ * e.g. when the user unfavorites an album, drop it from the cached
+ * library list so a later remount reads the corrected list instead of
+ * briefly re-rendering the stale one before the background revalidate
+ * catches up. No-op when the key isn't cached; the next fetch produces
+ * a correct entry anyway. Keeps the original timestamp: we corrected
+ * the data, we didn't refetch it, so this must not extend freshness.
+ *
+ * Note this updates the cache only, not any mounted component's state
+ * (that's a render-time snapshot) — callers that need the current view
+ * to react should also drive their own state.
+ */
+export function mutateApiCache<T>(
+  cacheKey: string,
+  updater: (prev: T) => T,
+): void {
+  if (!cacheKey) return;
+  const entry = cache.get(cacheKey) as CacheEntry<T> | undefined;
+  if (!entry) return;
+  cache.set(cacheKey, {
+    data: updater(entry.data),
+    timestamp: entry.timestamp,
+  });
+}
+
 /** Wipe the whole cache. Used on logout / session reset. */
 export function clearApiCache(): void {
   cache.clear();

--- a/web/src/hooks/useFavorites.test.tsx
+++ b/web/src/hooks/useFavorites.test.tsx
@@ -200,3 +200,62 @@ describe("FavoritesProvider visibility refetch", () => {
     expect(snapshotMock).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("FavoritesProvider toggle event detail", () => {
+  // The Library page listens for these and drops/restores the matching
+  // card in real time, so the detail (kind, id, favorited) is a
+  // contract, not incidental.
+  async function captureToggle(
+    snapshot: ReturnType<typeof emptySnapshot>,
+    kind: "track",
+    id: string,
+  ) {
+    snapshotMock.mockResolvedValue(snapshot);
+    addMock.mockResolvedValue({ ok: true });
+    removeMock.mockResolvedValue({ ok: true });
+    const events: Array<{ kind: string; id: string; favorited: boolean }> = [];
+    const listener = (e: Event) => {
+      const d = (e as CustomEvent).detail;
+      if (d) events.push(d);
+    };
+    window.addEventListener("tideway:favorite-toggled", listener);
+    let probe: ProbeHandle | null = null;
+    try {
+      await act(async () => {
+        root.render(
+          <FavoritesProvider>
+            <Probe
+              onMount={(h) => {
+                probe = h;
+              }}
+            />
+          </FavoritesProvider>,
+        );
+        await flush();
+      });
+      await act(async () => {
+        await probe!.toggle(kind, id);
+        await flush();
+      });
+    } finally {
+      window.removeEventListener("tideway:favorite-toggled", listener);
+    }
+    return events;
+  }
+
+  it("reports favorited:true when liking an item", async () => {
+    const events = await captureToggle(emptySnapshot(), "track", "xyz");
+    expect(addMock).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([{ kind: "track", id: "xyz", favorited: true }]);
+  });
+
+  it("reports favorited:false when unliking an item", async () => {
+    const events = await captureToggle(
+      { tracks: ["abc"], albums: [], artists: [], playlists: [], mixes: [] },
+      "track",
+      "abc",
+    );
+    expect(removeMock).toHaveBeenCalledTimes(1);
+    expect(events).toEqual([{ kind: "track", id: "abc", favorited: false }]);
+  });
+});

--- a/web/src/hooks/useFavorites.test.tsx
+++ b/web/src/hooks/useFavorites.test.tsx
@@ -206,7 +206,13 @@ describe("FavoritesProvider toggle event detail", () => {
   // card in real time, so the detail (kind, id, favorited) is a
   // contract, not incidental.
   async function captureToggle(
-    snapshot: ReturnType<typeof emptySnapshot>,
+    snapshot: {
+      tracks: string[];
+      albums: string[];
+      artists: string[];
+      playlists: string[];
+      mixes: string[];
+    },
     kind: "track",
     id: string,
   ) {

--- a/web/src/hooks/useFavorites.tsx
+++ b/web/src/hooks/useFavorites.tsx
@@ -154,8 +154,14 @@ export function FavoritesProvider({ children }: { children: ReactNode }) {
         // payload (e.g. `useLikedByArtist` on the artist page's
         // "You Liked" section) so they can refetch. The event is a
         // low-cost broadcast; only listeners on a current artist page
-        // actually do anything with it.
-        window.dispatchEvent(new CustomEvent("tideway:favorite-toggled"));
+        // actually do anything with it. The detail carries which item
+        // changed so a surface that lists favorites (the Library page)
+        // can drop/restore that one card in real time without a refetch.
+        window.dispatchEvent(
+          new CustomEvent("tideway:favorite-toggled", {
+            detail: { kind, id, favorited: !already },
+          }),
+        );
       } catch (err) {
         // Only roll back if the current state still reflects *our* optimistic
         // change. A rapid second click may have toggled again between the

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -19,6 +19,7 @@ import { api } from "@/api/client";
 import type {
   Album,
   Artist,
+  FavoriteKind,
   Playlist,
   PlaylistFolder,
   Track,
@@ -113,8 +114,25 @@ export function Library({ onDownload }: { onDownload: OnDownload }) {
   }
   const type = section as Section;
   const { title, emptyHint } = META[type];
+  // Which favorites set this section mirrors, so an unlike / unfollow
+  // on a card here can drop it from the list immediately.
+  const favoriteKind: FavoriteKind =
+    type === "albums"
+      ? "album"
+      : type === "artists"
+        ? "artist"
+        : type === "playlists"
+          ? "playlist"
+          : "track";
 
   const [folders, setFolders] = useState<PlaylistFolder[]>([]);
+  // Ids the user unfavorited this session, so the card leaves the grid
+  // the instant they click instead of lingering until the SWR list's
+  // 30s TTL or a tab refocus refetches. Keyed by `${kind}:${id}` so a
+  // removed album id can't accidentally hide an artist sharing that id.
+  // Re-favoriting deletes the key, so the card returns. Owned playlists
+  // never enter here (they aren't favorite toggles), so they're safe.
+  const [removed, setRemoved] = useState<Set<string>>(() => new Set());
   const [filter, setFilter] = useState("");
   const [sort, setSort] = useState<Sort>("recent");
   const [view, setView] = useState<View>(() => loadView(type));
@@ -171,6 +189,36 @@ export function Library({ onDownload }: { onDownload: OnDownload }) {
     setFilter("");
   }, [type]);
 
+  // Real-time removal: when any favorite is toggled — including a card
+  // on this very page — update the `removed` overlay so the grid drops
+  // (or restores) that one card without waiting for a refetch.
+  useEffect(() => {
+    const onToggled = (e: Event) => {
+      const detail = (
+        e as CustomEvent<{
+          kind: FavoriteKind;
+          id: string;
+          favorited: boolean;
+        }>
+      ).detail;
+      if (!detail) return;
+      const key = `${detail.kind}:${detail.id}`;
+      setRemoved((prev) => {
+        const present = prev.has(key);
+        // favorited → key absent; unfavorited → key present. Bail if
+        // already in the right state to avoid a needless re-render.
+        if (detail.favorited === !present) return prev;
+        const next = new Set(prev);
+        if (detail.favorited) next.delete(key);
+        else next.add(key);
+        return next;
+      });
+    };
+    window.addEventListener("tideway:favorite-toggled", onToggled);
+    return () =>
+      window.removeEventListener("tideway:favorite-toggled", onToggled);
+  }, []);
+
   // Folders are only relevant on /library/playlists. Small payload +
   // mutation-coupled (CreateFolderDialog calls `refreshFolders` after
   // an add), so we leave them on a raw fetch instead of routing them
@@ -221,6 +269,11 @@ export function Library({ onDownload }: { onDownload: OnDownload }) {
             .includes(q),
         )
       : data;
+    // Drop anything the user just unfavorited this session (see
+    // `removed`) so the grid reflects the click without a refetch.
+    if (removed.size > 0) {
+      base = base.filter((item) => !removed.has(`${favoriteKind}:${item.id}`));
+    }
     // Audio-format filter. Only applies to sections whose items have
     // format tags (albums + tracks); artists / playlists ignore it
     // because the tags aren't meaningful at their level.
@@ -235,7 +288,7 @@ export function Library({ onDownload }: { onDownload: OnDownload }) {
       );
     }
     return base; // "recent" — backend already returns newest-first
-  }, [data, filter, sort, format, type]);
+  }, [data, filter, sort, format, type, removed, favoriteKind]);
 
   // Hide the format filter entirely when the dataset has no tagged
   // items — otherwise it'd be a dead row of chips.

--- a/web/src/pages/Library.tsx
+++ b/web/src/pages/Library.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { useApi } from "@/hooks/useApi";
+import { useApi, mutateApiCache } from "@/hooks/useApi";
 import { queryKeys } from "@/api/queryKeys";
 import {
   Disc3,
@@ -104,6 +104,17 @@ const META: Record<
 
 type LibraryItem = Album | Artist | Playlist | Track;
 
+// The SWR cache lane each favorite kind feeds, so an unfavorite can
+// drop the item from the cached list (not just the live render) and a
+// later remount reads the corrected list with no stale-flash. `mix`
+// has no library section, so it's intentionally absent.
+const LIBRARY_CACHE_KEY: Partial<Record<FavoriteKind, string>> = {
+  album: queryKeys.libraryAlbums,
+  artist: queryKeys.libraryArtists,
+  playlist: queryKeys.libraryPlaylists,
+  track: queryKeys.libraryTracks,
+};
+
 export function Library({ onDownload }: { onDownload: OnDownload }) {
   const { section = "albums" } = useParams<{ section: string }>();
   // Guard against stale bookmarks like /library/typo — without this the
@@ -128,10 +139,13 @@ export function Library({ onDownload }: { onDownload: OnDownload }) {
   const [folders, setFolders] = useState<PlaylistFolder[]>([]);
   // Ids the user unfavorited this session, so the card leaves the grid
   // the instant they click instead of lingering until the SWR list's
-  // 30s TTL or a tab refocus refetches. Keyed by `${kind}:${id}` so a
-  // removed album id can't accidentally hide an artist sharing that id.
-  // Re-favoriting deletes the key, so the card returns. Owned playlists
-  // never enter here (they aren't favorite toggles), so they're safe.
+  // 30s TTL or a tab refocus refetches. This drives the *live* render;
+  // the matching SWR cache entry is corrected in parallel (see the
+  // toggle handler) so a remount doesn't flash the card back. Keyed by
+  // `${kind}:${id}` so a removed album id can't accidentally hide an
+  // artist sharing that id. Re-favoriting deletes the key, so the card
+  // returns. Owned playlists never enter here (they aren't favorite
+  // toggles), so they're safe.
   const [removed, setRemoved] = useState<Set<string>>(() => new Set());
   const [filter, setFilter] = useState("");
   const [sort, setSort] = useState<Sort>("recent");
@@ -213,6 +227,18 @@ export function Library({ onDownload }: { onDownload: OnDownload }) {
         else next.add(key);
         return next;
       });
+      // Keep the SWR cache in step on unfavorite so a remount reads a
+      // list that already excludes the item (no flash before the
+      // revalidate). Re-favoriting can't re-add it here — we don't hold
+      // the full item object — but the on-mount revalidate restores it.
+      if (!detail.favorited) {
+        const cacheKey = LIBRARY_CACHE_KEY[detail.kind];
+        if (cacheKey) {
+          mutateApiCache<LibraryItem[]>(cacheKey, (prev) =>
+            prev.filter((it) => String(it.id) !== detail.id),
+          );
+        }
+      }
     };
     window.addEventListener("tideway:favorite-toggled", onToggled);
     return () =>


### PR DESCRIPTION
## Summary

Unliking an album (or artist / playlist / track) from the library left the card on the page until the SWR list's 30s TTL or a tab refocus refetched — so to the user "it didn't go away."

The library sections render their own SWR-cached list (`api.library.albums()` etc.), independent of the favorites set, so the optimistic heart flipped but the card stayed. This fix makes the card leave the grid the instant the unlike confirms:

- `useFavorites.toggle` now carries which item changed (`kind`, `id`, `favorited`) in the `tideway:favorite-toggled` event detail.
- The library page keeps a session-scoped `removed` overlay, keyed by `${kind}:${id}`, driven by that event, and filters the rendered list through it. The card leaves immediately and returns if the user re-likes it. Keying by kind+id avoids an album id hiding an artist that shares it; owned playlists never produce a favorite toggle, so they're never hidden.
- To avoid a one-round-trip flash when leaving the library and returning within the cache TTL, a new `mutateApiCache(key, updater)` drops the item from the matching SWR cache lane on unfavorite, so a remount reads a list that already excludes it. The overlay drives the live view; the cache mutation keeps remounts consistent. (Re-favoriting can't re-add to the cache without the full item object — the on-mount revalidate restores it.)

Fires only after the server confirms the toggle, so a *failed* unlike leaves the card in place. Covers every heart surface — album grid and list rows, artists, playlists, and Liked Songs tracks — since all route through `useFavorites.toggle`.

## Test plan

- `cd web && npx tsc -b --noEmit` — clean.
- `cd web && npm run lint:all` — 0 errors (pre-existing rules-of-hooks warnings only).
- `cd web && npm test` — 109 passed, incl. new `useFavorites` event-detail tests (favorited true/false) and `mutateApiCache` tests (updates + preserves timestamp, no-op when absent, ignores empty key).
- Manual: on Library → Albums, unlike a card → it leaves the grid immediately; re-like from elsewhere → it returns; switch sections and back → no flash.
