### PR TITLE
Guard against the macOS 26 windowDidMove_ startup crash

### DIFF
--- a/desktop.py
+++ b/desktop.py
@@ -476,6 +476,56 @@ def _enable_webview_media_prefs() -> None:
     BrowserView.__init__ = patched_init
 
 
+def _guard_cocoa_window_move() -> None:
+    """Stop a macOS 26 (Tahoe) startup crash in pywebview's Cocoa
+    backend (issue #215).
+
+    pywebview sets the window frame inside BrowserView.__init__ —
+    move() when there's a restored position, else center() — and that
+    fires the `windowDidMove_` window-delegate callback. On macOS 26 the
+    NSWindow has not been ordered onto a display yet at that point, so
+    `NSWindow.screen()` returns None and pywebview's handler crashes
+    dereferencing `screen().frame()` (older macOS returned a screen
+    here). The dock icon flashes and the process dies before any window
+    appears, with no recovery.
+
+    Swap pywebview's WindowDelegate for a subclass whose windowDidMove_
+    skips the event while the window has no screen — a "moved" event for
+    a window that isn't on a display yet carries no usable geometry
+    anyway. Subclassing (rather than reassigning the method on the
+    existing class) registers the override cleanly through PyObjC so
+    AppKit actually dispatches to it, and pywebview instantiates the
+    delegate by reference — `BrowserView.WindowDelegate.alloc().init()`
+    — so swapping the class attribute before any window is created is
+    all it takes.
+
+    Best-effort and darwin-only: if a future pywebview restructures its
+    delegate the guard quietly no-ops, leaving the original behaviour
+    rather than introducing a new failure.
+    """
+    if sys.platform != "darwin":
+        return
+    try:
+        from webview.platforms.cocoa import BrowserView
+    except Exception:
+        return
+    base_delegate = getattr(BrowserView, "WindowDelegate", None)
+    if base_delegate is None or not hasattr(base_delegate, "windowDidMove_"):
+        return
+
+    class _GuardedWindowDelegate(base_delegate):  # type: ignore[misc,valid-type]
+        def windowDidMove_(self, notification):  # type: ignore[no-untyped-def]
+            i = BrowserView.get_instance("window", notification.object())
+            if i is not None:
+                win = getattr(i, "window", None)
+                # screen() is None until the window is placed on a
+                # display — which is exactly the __init__-time move that
+                # crashes on macOS 26. Skip it; there's nothing to emit.
+                if win is None or win.screen() is None:
+                    return
+            super(_GuardedWindowDelegate, self).windowDidMove_(notification)
+
+    BrowserView.WindowDelegate = _GuardedWindowDelegate
 
 
 def main(argv: Optional[list[str]] = None) -> int:
@@ -514,6 +564,7 @@ def main(argv: Optional[list[str]] = None) -> int:
     try:
         import webview  # pywebview
         _enable_webview_media_prefs()
+        _guard_cocoa_window_move()
     except ImportError:
         print(
             "[desktop] pywebview not installed; falling back to default browser. "

--- a/desktop.py
+++ b/desktop.py
@@ -506,6 +506,7 @@ def _guard_cocoa_window_move() -> None:
     if sys.platform != "darwin":
         return
     try:
+        import objc
         from webview.platforms.cocoa import BrowserView
     except Exception:
         return
@@ -523,7 +524,7 @@ def _guard_cocoa_window_move() -> None:
                 # crashes on macOS 26. Skip it; there's nothing to emit.
                 if win is None or win.screen() is None:
                     return
-            super(_GuardedWindowDelegate, self).windowDidMove_(notification)
+            objc.super(_GuardedWindowDelegate, self).windowDidMove_(notification)
 
     BrowserView.WindowDelegate = _GuardedWindowDelegate
 

--- a/tests/test_macos_window_guard.py
+++ b/tests/test_macos_window_guard.py
@@ -1,0 +1,32 @@
+"""Cross-platform contract for the macOS windowDidMove_ startup-crash
+guard (issue #215).
+
+The fix itself — a guarded pywebview WindowDelegate subclass — only
+*does* anything on macOS, where it overrides the delegate callback that
+crashes during window creation on macOS 26. What these tests pin is the
+contract that protects every *other* platform: the guard must be a
+safe, best-effort no-op off macOS, and must never let a Cocoa/PyObjC
+import failure escape and brick startup. The actual macOS dispatch
+(does AppKit call our override?) needs manual validation on a Mac.
+"""
+from __future__ import annotations
+
+import sys
+
+import desktop
+
+
+def test_guard_is_a_noop_off_darwin(monkeypatch):
+    # On Windows/Linux the guard must return immediately, before it ever
+    # reaches the Cocoa import — startup on those platforms can't regress.
+    monkeypatch.setattr(sys, "platform", "linux")
+    assert desktop._guard_cocoa_window_move() is None
+
+
+def test_guard_swallows_cocoa_import_failure(monkeypatch):
+    # Force the darwin branch on this non-mac box: importing
+    # webview.platforms.cocoa pulls in PyObjC/AppKit, which isn't present
+    # here, so the import raises. The guard must swallow that and return
+    # rather than take down the app at launch (best-effort contract).
+    monkeypatch.setattr(sys, "platform", "darwin")
+    assert desktop._guard_cocoa_window_move() is None


### PR DESCRIPTION
## Summary

- On macOS 26 (Tahoe) the app dies at launch before any window appears: the dock icon flashes and the process exits with `AttributeError: 'NoneType' object has no attribute 'frame'` inside pywebview's `windowDidMove_` (issue #215)
- pywebview fires `windowDidMove_` during `BrowserView.__init__` when it sets the initial frame; on macOS 26, `NSWindow.screen()` returns `None` at that point because the window hasn't been ordered onto a display yet
- Replaces pywebview's `WindowDelegate` with a subclass that skips the event when `screen()` is `None`; uses `objc.super` for correct PyObjC dispatch on the non-skipped path

## Test plan

- [ ] Run `pytest tests/test_macos_window_guard.py` — cross-platform contract (no-op off darwin, swallows missing Cocoa import)
- [ ] Launch the packaged app on macOS 26 and confirm the window appears without a crash
- [ ] Launch on macOS 14/15 and confirm normal startup is unaffected