### PR TITLE
Cache the artist drill-down; prefetch track-row links on hover

### DIFF
--- a/web/src/components/TrackList.tsx
+++ b/web/src/components/TrackList.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import type { Track } from "@/api/types";
 import type { OnDownload } from "@/api/download";
+import { prefetch } from "@/api/queryKeys";
 import { formatDuration, imageProxy } from "@/lib/utils";
 import { DownloadButton } from "@/components/DownloadButton";
 import { EmptyState } from "@/components/EmptyState";
@@ -522,7 +523,11 @@ function TrackRow({
                 {track.artists.map((a, i) => (
                   <span key={a.id}>
                     {i > 0 && ", "}
-                    <Link to={`/artist/${a.id}`} className="hover:underline">
+                    <Link
+                      to={`/artist/${a.id}`}
+                      className="hover:underline"
+                      onMouseEnter={() => prefetch.artist(a.id)}
+                    >
                       {a.name}
                     </Link>
                   </span>
@@ -539,14 +544,24 @@ function TrackRow({
           )}
           <div className="truncate text-xs text-muted-foreground">
             {showAlbum && track.album ? (
-              <Link to={`/album/${track.album.id}`} className="hover:underline">
+              <Link
+                to={`/album/${track.album.id}`}
+                className="hover:underline"
+                onMouseEnter={() =>
+                  track.album && prefetch.album(track.album.id)
+                }
+              >
                 {track.album.name}
               </Link>
             ) : (
               track.artists.map((a, i) => (
                 <span key={a.id}>
                   {i > 0 && ", "}
-                  <Link to={`/artist/${a.id}`} className="hover:underline">
+                  <Link
+                    to={`/artist/${a.id}`}
+                    className="hover:underline"
+                    onMouseEnter={() => prefetch.artist(a.id)}
+                  >
                     {a.name}
                   </Link>
                 </span>

--- a/web/src/pages/ArtistSection.tsx
+++ b/web/src/pages/ArtistSection.tsx
@@ -5,6 +5,7 @@ import { api } from "@/api/client";
 import type { Album, Artist, Track, Video } from "@/api/types";
 import type { OnDownload } from "@/api/download";
 import { useApi } from "@/hooks/useApi";
+import { queryKeys } from "@/api/queryKeys";
 import { useLikedByArtist } from "@/hooks/useLikedByArtist";
 import { useVideoPlayer } from "@/hooks/useVideoPlayer";
 import { Grid } from "@/components/Grid";
@@ -160,7 +161,16 @@ export function ArtistSection({ onDownload }: { onDownload: OnDownload }) {
     id: string;
     section: string;
   }>();
-  const { data: artist, loading, error } = useApi(() => api.artist(id), [id]);
+  // Share ArtistDetail's cache key for the same api.artist(id) fetch, so
+  // arriving here via the artist page's "View more" link is an instant
+  // cache hit instead of re-fetching the artist we just had.
+  const {
+    data: artist,
+    loading,
+    error,
+  } = useApi(() => api.artist(id), [id], {
+    cacheKey: queryKeys.artist(id),
+  });
   const meta = SECTIONS[section as ArtistSectionKey];
   // Liked source: pull from the user's library filtered to this
   // artist. Returns null while the library fetch is loading.


### PR DESCRIPTION
## Summary

- The artist "View more" drill-down page re-fetched the same artist data fresh on every visit, even though the artist page the user came from had it cached — give it the same `queryKeys.artist(id)` key so the drill-down is an instant cache hit
- Track row artist and album links now call `prefetch.artist` / `prefetch.album` on hover, so detail pages start loading on mouseover rather than on click
- Both changes reuse existing cache and prefetch infrastructure; no new fetchers or keys introduced

## Test plan

- [ ] Open an artist page, click "View more" on any section — confirm it loads instantly with no spinner
- [ ] Hover over an artist or album link in a track row, then click — confirm the detail page appears faster than without prefetch
- [ ] Verify no regressions: artist pages, album pages, and radio pages load correctly