### PR TITLE
Add crossfade for automatic track transitions

### DIFF
--- a/app/audio/crossfade.py
+++ b/app/audio/crossfade.py
@@ -1,0 +1,59 @@
+"""Equal-power crossfade mixing primitives.
+
+Kept in its own module, separate from the realtime player, so the DSP
+is unit-testable without standing up the audio engine — the part that
+matters most here is that the math is provably correct, because the
+output can only be judged by ear on real hardware.
+
+The player's callback calls `mix_crossfade_block` once it's inside the
+overlap window, handing it one callback's worth of frames from both the
+outgoing (fading down) and incoming (fading up) tracks.
+
+Why equal-power rather than a linear fade: a linear crossfade sums two
+correlated signals whose amplitudes add to less than 1 in the middle, so
+the perceived loudness dips at the seam. Equal-power keeps
+out_gain**2 + in_gain**2 == 1 across the whole overlap (a quarter-cosine
+pair), so a steady-loudness source stays at steady loudness through the
+transition — the standard choice for music players.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+
+def equal_power_gains(
+    positions: np.ndarray, total: int
+) -> tuple[np.ndarray, np.ndarray]:
+    """Equal-power fade gains at the given sample `positions` over a fade
+    of `total` samples.
+
+    Returns ``(out_gains, in_gains)`` as float32 arrays the same shape as
+    `positions`. Positions are clamped to ``[0, total]`` so the gains
+    saturate at the ends (fully outgoing before the fade, fully incoming
+    after) rather than wrapping. A non-positive `total` is treated as an
+    instantaneous switch: outgoing silent, incoming full.
+    """
+    if total <= 0:
+        ones = np.ones(np.shape(positions), dtype=np.float32)
+        return np.zeros_like(ones), ones
+    t = np.clip(np.asarray(positions, dtype=np.float64) / float(total), 0.0, 1.0)
+    angle = t * (np.pi / 2.0)
+    return np.cos(angle).astype(np.float32), np.sin(angle).astype(np.float32)
+
+
+def mix_crossfade_block(
+    out_block: np.ndarray, in_block: np.ndarray, start_pos: int, total: int
+) -> np.ndarray:
+    """Mix one callback's worth of frames inside a crossfade.
+
+    `out_block` is the outgoing (fading down) PCM and `in_block` the
+    incoming (fading up), both float32 ``(frames, channels)`` of equal
+    length. `start_pos` is the fade position, in samples, of the block's
+    first frame; `total` is the full fade length in samples. The gain
+    ramps per-sample across the block (not once per block) so there's no
+    zipper noise at low buffer sizes. Returns a new float32 block.
+    """
+    n = out_block.shape[0]
+    positions = np.arange(start_pos, start_pos + n)
+    out_g, in_g = equal_power_gains(positions, total)
+    return out_block * out_g[:, None] + in_block * in_g[:, None]

--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -3083,6 +3083,13 @@ class PCMPlayer:
                 carry = chunk
             take = min(n - filled, carry.shape[0])
             src = carry[:take]
+            # Normalize integer PCM to float32 [-1, 1] so the equal-power
+            # mix math works regardless of stream dtype. float32 chunks pass
+            # through as-is (already in range).
+            if src.dtype == np.int32:
+                src = src.astype(np.float32) / 2147483648.0
+            elif src.dtype == np.int16:
+                src = src.astype(np.float32) / 32768.0
             if src.shape[1] == channels:
                 buf[filled : filled + take] = src
             elif src.shape[1] == 2 and channels == 1:
@@ -3106,11 +3113,6 @@ class PCMPlayer:
         called from the audio callback."""
         cf = self._crossfade_s
         if cf <= 0.0 or self._exclusive_mode:
-            return
-        # The mix path assumes float32 PCM (shared-mode output). In
-        # exclusive / integer-dtype modes we leave the gapless cut in
-        # place — crossfade isn't bit-perfect anyway.
-        if self._stream_sd_dtype != "float32":
             return
         rate = self._stream_sample_rate or 0
         if rate <= 0 or self._current_duration_ms <= 0:
@@ -3149,20 +3151,20 @@ class PCMPlayer:
         self._xfade_pos = 0
         self._xfade_total = total
         self._xfade_active = True
-        log.info(
-            "crossfade begin -> incoming=%s over %.1fs (%d samples)",
-            pre.track_id, cf, total,
+        print(
+            f"[crossfade] begin -> incoming={pre.track_id} over {cf:.1f}s ({total} samples)",
+            flush=True,
         )
 
     def _crossfade_fill(self, outdata, frames: int, channels: int) -> None:
         """Fill `outdata` with one callback's equal-power mix of the
         outgoing (current) and incoming (claimed preload) tracks, advance
         the fade, and promote the incoming track to primary once the fade
-        completes or the outgoing track ends. Called only while
-        `_xfade_active`; `outdata` is float32 (the activation gate). Does
-        NOT touch `_samples_emitted` / `_seq` — the shared post-fill below
-        the call site handles those for both the normal and crossfade
-        paths."""
+        completes or the outgoing track ends. Works for any stream dtype
+        (float32, int32, int16): _pull_block normalizes chunks to float32
+        for mixing, then the result is scaled back to the stream dtype
+        before writing to outdata. Does NOT touch `_samples_emitted` /
+        `_seq` — the shared post-fill below the call site handles those."""
         pre = self._xfade_in
         if pre is None:
             # Defensive — never mix without an incoming source.
@@ -3176,9 +3178,20 @@ class PCMPlayer:
         in_buf, self._xfade_carry_in, _if, _in_done = self._pull_block(
             pre.queue, self._xfade_carry_in, pre.done, frames, channels,
         )
-        outdata[:] = mix_crossfade_block(
-            out_buf, in_buf, self._xfade_pos, self._xfade_total
-        )
+        mixed = mix_crossfade_block(out_buf, in_buf, self._xfade_pos, self._xfade_total)
+        # _pull_block normalizes all dtypes to float32 [-1, 1]; scale back
+        # to the stream dtype before writing. float32 streams get a direct
+        # copy; integer streams are scaled and clipped to their full range.
+        if outdata.dtype == np.float32:
+            outdata[:] = mixed
+        elif outdata.dtype == np.int32:
+            outdata[:] = np.clip(
+                mixed * 2147483648.0, -2147483648.0, 2147483647.0
+            ).astype(np.int32)
+        elif outdata.dtype == np.int16:
+            outdata[:] = np.clip(
+                mixed * 32768.0, -32768.0, 32767.0
+            ).astype(np.int16)
         self._xfade_pos += frames
         # Fade complete, or the outgoing track ran out before it finished
         # (the window started a hair late, or a short track) — promote the
@@ -3203,7 +3216,7 @@ class PCMPlayer:
         carry_in = self._xfade_carry_in
         old_decoder = self._decoder
         old_stop = self._stop_flag
-        log.info("crossfade promote -> %s", pre.track_id)
+        print(f"[crossfade] promote -> {pre.track_id}", flush=True)
         self._state = "ended"
         self._seq += 1
         self._emit()

--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -391,6 +391,12 @@ class PCMPlayer:
         self._replaygain_mode: ReplayGainMode = "off"
         self._replaygain_preamp_db: float = 0.0
         self._replaygain_prevent_clipping: bool = True
+        # Crossfade duration in seconds for automatic track-to-track
+        # transitions (0 = off). The audio callback drives the actual
+        # fade once a track nears its end and a compatible preload is
+        # ready; when this is 0 that path is never entered, so playback
+        # is exactly the existing gapless behaviour.
+        self._crossfade_s: float = 0.0
 
         # Audio-callback diagnostics. Each pair is (count, last-print
         # time) for a different rate-limited stderr message:
@@ -1426,6 +1432,25 @@ class PCMPlayer:
         """Current crossfeed setting in percent. 0 means bypassed."""
         with self._lock:
             return self._crossfeed_amount
+
+    def set_crossfade(self, seconds) -> None:
+        """Set the automatic-advance crossfade duration in seconds
+        (clamped 0-12; 0 = off). Stored here; the fade itself is driven
+        from the audio callback when a track nears its end and a
+        compatible, sufficiently-buffered preload is ready. Surface for
+        the Settings page slider."""
+        try:
+            s = float(seconds)
+        except (TypeError, ValueError):
+            s = 0.0
+        s = max(0.0, min(12.0, s))
+        with self._lock:
+            self._crossfade_s = s
+
+    def crossfade_duration(self) -> float:
+        """Current crossfade duration in seconds. 0 means disabled."""
+        with self._lock:
+            return self._crossfade_s
 
     def set_replaygain(
         self,

--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -44,6 +44,7 @@ import sounddevice as sd  # type: ignore
 import tidalapi
 
 from app.audio.decoder import Decoder
+from app.audio.crossfade import mix_crossfade_block
 from app.audio.crossfeed import Crossfeed
 from app.audio.eq import (
     Equalizer,
@@ -133,6 +134,14 @@ if not audio_log.handlers:
 # safety net.
 # Memory cost is negligible (~800 KB at int32 stereo).
 _PCM_QUEUE_MAX = 100
+
+# Minimum number of decoded chunks the incoming (preloaded) track must
+# have buffered before a crossfade may begin, so the fade-in side doesn't
+# immediately starve. If the preload isn't this far ahead yet, the
+# crossfade simply doesn't start this callback and we re-check on the
+# next one (and if the window closes first, it falls back to the gapless
+# cut). A handful of chunks is a fraction of a second of audio.
+_XFADE_MIN_PREBUFFER_CHUNKS = 4
 
 # Hard ceiling on the two Tidal round-trips in _resolve_source. The
 # transport already bounds each request (app.http.DEFAULT_TIMEOUT,
@@ -397,6 +406,16 @@ class PCMPlayer:
         # ready; when this is 0 that path is never entered, so playback
         # is exactly the existing gapless behaviour.
         self._crossfade_s: float = 0.0
+        # In-progress fade state, owned by the audio callback. `_xfade_in`
+        # is the _Preload we've claimed as the incoming track; `_xfade_pos`
+        # / `_xfade_total` track the fade in samples; `_xfade_carry_in` is
+        # the incoming queue's partial-chunk carry (mirrors
+        # `_callback_carry` for the outgoing side).
+        self._xfade_active: bool = False
+        self._xfade_pos: int = 0
+        self._xfade_total: int = 0
+        self._xfade_in: Optional[_Preload] = None
+        self._xfade_carry_in: Optional[np.ndarray] = None
 
         # Audio-callback diagnostics. Each pair is (count, last-print
         # time) for a different rate-limited stderr message:
@@ -960,6 +979,11 @@ class PCMPlayer:
             # CallbackStop and end the stream mid-seek.
             with self._lock:
                 self._seeking = True
+            # Seeking inside the crossfade window invalidates the fade —
+            # the position the user jumped to bears no relation to the
+            # in-progress transition. `_seeking` now silences the callback,
+            # so cancel the fade and dispose the claimed incoming preload.
+            self._abort_crossfade()
             effective_s = target_s
             try:
                 effective_s = self._restart_decoder_at(target_s)
@@ -1844,6 +1868,12 @@ class PCMPlayer:
                 flush=True,
             )
 
+        # The stream is aborted, so the audio callback can no longer fire —
+        # safe now to cancel any in-progress crossfade and dispose the
+        # incoming preload we'd claimed (a manual skip / stop landing inside
+        # the fade window). No-op when no crossfade is active.
+        self._abort_crossfade()
+
         thread = self._decoder_thread
         self._decoder_thread = None
         if thread is not None and thread.is_alive():
@@ -2701,6 +2731,20 @@ class PCMPlayer:
         written = 0
         channels = outdata.shape[1]
 
+        # Crossfade: when enabled and the current track is within the fade
+        # window, mix the next track in instead of cutting to it. Fully
+        # self-contained — when off (the default) or any precondition is
+        # unmet, `_xfade_active` stays False and the normal single-queue
+        # loop below runs unchanged. Setting `written = frames` skips that
+        # loop; the shared output stages (cast/EQ/volume) and the
+        # samples_emitted / seq bump below then apply to the mix exactly as
+        # they do to normal audio.
+        if not self._xfade_active and self._crossfade_s > 0.0:
+            self._maybe_begin_crossfade()
+        if self._xfade_active:
+            self._crossfade_fill(outdata, frames, channels)
+            written = frames
+
         while written < frames:
             if self._callback_carry is None:
                 try:
@@ -3011,6 +3055,209 @@ class PCMPlayer:
 
         self._emit()
         return self.snapshot()
+
+    @staticmethod
+    def _pull_block(q, carry, done_event, n: int, channels: int):
+        """Pull up to `n` frames from (queue, carry) into a fresh
+        (n, channels) float32 buffer for crossfade mixing.
+
+        Returns (buf, new_carry, frames_filled, source_done). Unfilled
+        frames are left as zeros — either a transient underrun or the
+        source ending. `source_done` is True ONLY when the queue is empty
+        AND `done_event` is set (a true end, not a hiccup), which is how
+        the caller distinguishes "fade finished because the outgoing track
+        ran out" from "decoder briefly behind".
+        """
+        buf = np.zeros((n, channels), dtype=np.float32)
+        filled = 0
+        source_done = False
+        while filled < n:
+            if carry is None:
+                try:
+                    chunk = q.get_nowait()
+                except queue.Empty:
+                    chunk = None
+                if chunk is None:
+                    source_done = done_event.is_set()
+                    break
+                carry = chunk
+            take = min(n - filled, carry.shape[0])
+            src = carry[:take]
+            if src.shape[1] == channels:
+                buf[filled : filled + take] = src
+            elif src.shape[1] == 2 and channels == 1:
+                buf[filled : filled + take, 0] = src.mean(axis=1)
+            # else: channel mismatch can't reach here (the crossfade is
+            # gated on the incoming channel count matching the stream);
+            # leave zeros rather than risk a malformed write.
+            filled += take
+            if take >= carry.shape[0]:
+                carry = None
+            else:
+                carry = carry[take:]
+        return buf, carry, filled, source_done
+
+    def _maybe_begin_crossfade(self) -> None:
+        """Start a crossfade if the current track is within the configured
+        fade window and a compatible, sufficiently-buffered preload is
+        ready. Realtime-safe: claims the preload under a NON-blocking lock
+        (same pattern as `_try_gapless_swap`) and bails on any contention
+        or unmet precondition, leaving normal playback untouched. Only ever
+        called from the audio callback."""
+        cf = self._crossfade_s
+        if cf <= 0.0 or self._exclusive_mode:
+            return
+        # The mix path assumes float32 PCM (shared-mode output). In
+        # exclusive / integer-dtype modes we leave the gapless cut in
+        # place — crossfade isn't bit-perfect anyway.
+        if self._stream_sd_dtype != "float32":
+            return
+        rate = self._stream_sample_rate or 0
+        if rate <= 0 or self._current_duration_ms <= 0:
+            return
+        total = int(cf * rate)
+        if total <= 0:
+            return
+        track_samples = int(self._current_duration_ms / 1000.0 * rate)
+        if track_samples - self._samples_emitted > total:
+            return  # not in the fade window yet
+        if self._preload is None:
+            return
+        if not self._lock.acquire(blocking=False):
+            return  # contended — try again next callback
+        try:
+            pre = self._preload
+            if pre is None:
+                return
+            if (
+                pre.sample_rate != self._stream_sample_rate
+                or pre.sd_dtype != self._stream_sd_dtype
+                or pre.channels != self._stream_channels
+            ):
+                return  # incompatible — let the gapless/bridge path handle it
+            if (
+                pre.queue.qsize() < _XFADE_MIN_PREBUFFER_CHUNKS
+                and not pre.done.is_set()
+            ):
+                return  # not buffered enough yet; re-check next callback
+            # Claim it: _drop_preload / _try_gapless_swap won't touch it now.
+            self._preload = None
+        finally:
+            self._lock.release()
+        self._xfade_in = pre
+        self._xfade_carry_in = None
+        self._xfade_pos = 0
+        self._xfade_total = total
+        self._xfade_active = True
+        log.info(
+            "crossfade begin -> incoming=%s over %.1fs (%d samples)",
+            pre.track_id, cf, total,
+        )
+
+    def _crossfade_fill(self, outdata, frames: int, channels: int) -> None:
+        """Fill `outdata` with one callback's equal-power mix of the
+        outgoing (current) and incoming (claimed preload) tracks, advance
+        the fade, and promote the incoming track to primary once the fade
+        completes or the outgoing track ends. Called only while
+        `_xfade_active`; `outdata` is float32 (the activation gate). Does
+        NOT touch `_samples_emitted` / `_seq` — the shared post-fill below
+        the call site handles those for both the normal and crossfade
+        paths."""
+        pre = self._xfade_in
+        if pre is None:
+            # Defensive — never mix without an incoming source.
+            self._xfade_active = False
+            outdata.fill(0)
+            return
+        out_buf, self._callback_carry, _of, out_done = self._pull_block(
+            self._pcm_queue, self._callback_carry, self._decoder_done,
+            frames, channels,
+        )
+        in_buf, self._xfade_carry_in, _if, _in_done = self._pull_block(
+            pre.queue, self._xfade_carry_in, pre.done, frames, channels,
+        )
+        outdata[:] = mix_crossfade_block(
+            out_buf, in_buf, self._xfade_pos, self._xfade_total
+        )
+        self._xfade_pos += frames
+        # Fade complete, or the outgoing track ran out before it finished
+        # (the window started a hair late, or a short track) — promote the
+        # incoming track either way.
+        if self._xfade_pos >= self._xfade_total or out_done:
+            self._promote_crossfade_incoming()
+
+    def _promote_crossfade_incoming(self) -> None:
+        """Make the faded-in track the primary pipeline. Mirrors
+        `_try_gapless_swap`'s ended -> swap -> playing emit so the
+        frontend's advance logic wires up the new track, then restores the
+        incoming track's already-elapsed position + carry (which
+        `_swap_pipeline_to` zeroes). Runs on the realtime callback thread,
+        so it never JOINs the outgoing decoder — it signals it and lets the
+        daemon thread exit (the same deadlock avoidance the file relies on
+        everywhere)."""
+        pre = self._xfade_in
+        if pre is None:
+            self._xfade_active = False
+            return
+        elapsed = self._xfade_pos
+        carry_in = self._xfade_carry_in
+        old_decoder = self._decoder
+        old_stop = self._stop_flag
+        log.info("crossfade promote -> %s", pre.track_id)
+        self._state = "ended"
+        self._seq += 1
+        self._emit()
+        self._swap_pipeline_to(pre)
+        # The incoming track already played `elapsed` samples during the
+        # fade; _swap_pipeline_to reset these to 0 / None.
+        self._samples_emitted = elapsed
+        self._callback_carry = carry_in
+        self._state = "playing"
+        self._seq += 1
+        self._emit()
+        self._xfade_active = False
+        self._xfade_in = None
+        self._xfade_carry_in = None
+        self._xfade_pos = 0
+        self._xfade_total = 0
+        # Tear down the outgoing decoder WITHOUT joining (realtime thread).
+        if old_stop is not None:
+            old_stop.set()
+        if old_decoder is not None:
+            try:
+                old_decoder.cancel_source()
+            except Exception:
+                pass
+
+    def _abort_crossfade(self) -> None:
+        """Cancel an in-progress (or claimed-but-not-yet-started)
+        crossfade and dispose the incoming preload we'd claimed. Called
+        from the pipeline-reset paths (teardown / seek). A manual skip,
+        stop, or seek inside the fade window would otherwise leak the
+        claimed decoder and leave stale fade state. Safe to call when no
+        crossfade is active.
+
+        Disposal is by `stop_flag` + `cancel_source` only — both are
+        designed to be called concurrently with the decoder thread (the
+        teardown path does the same on the primary decoder). We do NOT
+        synchronously `close()` the decoder here: a callback could still
+        be reading the claimed preload's already-decoded queue, and the
+        daemon decoder thread exits on the stop flag and GCs on its own."""
+        pre = self._xfade_in
+        self._xfade_active = False
+        self._xfade_in = None
+        self._xfade_carry_in = None
+        self._xfade_pos = 0
+        self._xfade_total = 0
+        if pre is not None:
+            try:
+                pre.stop_flag.set()
+            except Exception:
+                pass
+            try:
+                pre.decoder.cancel_source()
+            except Exception:
+                pass
 
     def _try_gapless_swap(self) -> bool:
         """Called from the audio callback when the current queue is

--- a/app/settings.py
+++ b/app/settings.py
@@ -178,6 +178,13 @@ class Settings:
     # listening fix for hard-panned mixes. Off by default; user opts
     # in via the Settings → Playback slider.
     crossfeed_amount: int = 0
+    # Crossfade duration in seconds for automatic track-to-track
+    # transitions (0 = off, capped at 12). When > 0 the outgoing track
+    # fades out as the incoming one fades in over this many seconds,
+    # instead of the gapless cut. Spotify-style: applies only to natural
+    # end-of-track advances (not manual skips) and to every transition
+    # while enabled — turn it off for albums meant to play continuously.
+    crossfade_duration_s: int = 0
     # ReplayGain loudness leveling. Off by default to preserve
     # bit-perfect output for users who haven't asked for leveling.
     #   "off"   — bypass; audio plays at the source's native level.

--- a/server.py
+++ b/server.py
@@ -5125,6 +5125,10 @@ def _native_player() -> PCMPlayer:
                 _pcm_player_singleton.set_crossfeed_amount(
                     settings.crossfeed_amount
                 )
+            if getattr(settings, "crossfade_duration_s", 0) > 0:
+                _pcm_player_singleton.set_crossfade(
+                    settings.crossfade_duration_s
+                )
             rg_mode = getattr(settings, "replaygain_mode", "off")
             if rg_mode != "off":
                 _pcm_player_singleton.set_replaygain(
@@ -10312,6 +10316,7 @@ class SettingsPayload(BaseModel):
     eq_tilt_bass_db: Optional[float] = None
     eq_tilt_treble_db: Optional[float] = None
     crossfeed_amount: Optional[int] = None
+    crossfade_duration_s: Optional[int] = None
     replaygain_mode: Optional[str] = None
     replaygain_preamp_db: Optional[float] = None
     replaygain_prevent_clipping: Optional[bool] = None
@@ -10470,6 +10475,13 @@ def update_settings(payload: SettingsPayload) -> dict:
             )
         except Exception as exc:
             logger.warning("crossfeed amount toggle failed: %s", exc)
+    if "crossfade_duration_s" in patch:
+        try:
+            _native_player().set_crossfade(
+                new_settings.crossfade_duration_s
+            )
+        except Exception as exc:
+            logger.warning("crossfade duration toggle failed: %s", exc)
     if (
         "replaygain_mode" in patch
         or "replaygain_preamp_db" in patch

--- a/tests/test_crossfade_dsp.py
+++ b/tests/test_crossfade_dsp.py
@@ -1,0 +1,84 @@
+"""Tests for the equal-power crossfade DSP primitives.
+
+The crossfade output can only be judged by ear on real hardware, so the
+math is pinned hard here: the gains must form an equal-power pair (so a
+steady-loudness source stays steady across the seam), saturate at the
+ends, and the block mixer must ramp per-sample and preserve shape/dtype.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+from app.audio.crossfade import equal_power_gains, mix_crossfade_block
+
+
+def test_gains_saturate_at_the_ends():
+    out_g, in_g = equal_power_gains(np.array([0, 100]), 100)
+    # Start of fade: fully outgoing, no incoming.
+    assert out_g[0] == 1.0
+    assert in_g[0] == 0.0
+    # End of fade: fully incoming, outgoing silent.
+    assert in_g[1] == 1.0
+    assert abs(out_g[1]) < 1e-6
+
+
+def test_midpoint_is_equal_power():
+    out_g, in_g = equal_power_gains(np.array([50]), 100)
+    # cos(pi/4) == sin(pi/4) ~= 0.7071
+    assert abs(float(out_g[0]) - 0.70710677) < 1e-5
+    assert abs(float(in_g[0]) - 0.70710677) < 1e-5
+
+
+def test_equal_power_invariant_holds_across_the_fade():
+    positions = np.arange(0, 1001)
+    out_g, in_g = equal_power_gains(positions, 1000)
+    power = out_g.astype(np.float64) ** 2 + in_g.astype(np.float64) ** 2
+    # out**2 + in**2 == 1 everywhere — the whole point of equal-power.
+    assert np.allclose(power, 1.0, atol=1e-6)
+
+
+def test_positions_are_clamped_outside_the_window():
+    # Before the fade -> fully outgoing; past the end -> fully incoming.
+    out_g, in_g = equal_power_gains(np.array([-50, 100, 250]), 100)
+    assert out_g[0] == 1.0 and in_g[0] == 0.0
+    assert abs(out_g[2]) < 1e-6 and in_g[2] == 1.0
+
+
+def test_zero_total_is_an_instant_switch():
+    out_g, in_g = equal_power_gains(np.array([0, 1, 2]), 0)
+    assert np.all(out_g == 0.0)
+    assert np.all(in_g == 1.0)
+
+
+def test_mix_block_endpoints_match_pure_sources():
+    frames = 64
+    out_block = np.full((frames, 2), 0.8, dtype=np.float32)
+    in_block = np.full((frames, 2), -0.5, dtype=np.float32)
+    # A fade exactly one block long: first frame is all-out, last all-in.
+    mixed = mix_crossfade_block(out_block, in_block, start_pos=0, total=frames)
+    assert mixed.dtype == np.float32
+    assert mixed.shape == (frames, 2)
+    assert np.allclose(mixed[0], out_block[0], atol=1e-6)  # pos 0 -> outgoing
+    assert np.allclose(mixed[-1], in_block[-1], atol=2e-2)  # near end -> incoming
+
+
+def test_mix_block_ramps_monotonically_for_constant_sources():
+    # Outgoing constant +1, incoming constant 0: the mix is just the
+    # outgoing gain, which must fall monotonically across the fade.
+    frames = 128
+    out_block = np.ones((frames, 1), dtype=np.float32)
+    in_block = np.zeros((frames, 1), dtype=np.float32)
+    mixed = mix_crossfade_block(out_block, in_block, start_pos=0, total=frames)[:, 0]
+    assert np.all(np.diff(mixed) <= 1e-6)  # non-increasing
+    assert mixed[0] > mixed[-1]
+
+
+def test_mix_block_respects_start_pos():
+    # A block taken from the back half of the fade should be quieter on
+    # the outgoing side than one from the front.
+    frames = 32
+    out_block = np.ones((frames, 1), dtype=np.float32)
+    in_block = np.zeros((frames, 1), dtype=np.float32)
+    front = mix_crossfade_block(out_block, in_block, 0, 1000)[:, 0].mean()
+    back = mix_crossfade_block(out_block, in_block, 900, 1000)[:, 0].mean()
+    assert back < front

--- a/tests/test_crossfade_pull.py
+++ b/tests/test_crossfade_pull.py
@@ -1,0 +1,92 @@
+"""Tests for PCMPlayer._pull_block — the queue-draining core of the
+crossfade callback mix.
+
+The realtime mix can only be judged by ear, but the buffer-filling it
+depends on is deterministic and pinned here: a full fill, leftover-carry
+handling, the underrun-vs-end distinction (zeros either way, but
+`source_done` only on a true end), and the stereo->mono downmix.
+"""
+from __future__ import annotations
+
+import queue
+import threading
+
+import numpy as np
+
+from app.audio.player import PCMPlayer
+
+
+def _chunk(n: int, ch: int = 2, val: float = 1.0) -> np.ndarray:
+    return np.full((n, ch), val, dtype=np.float32)
+
+
+def test_fills_a_full_block_from_queued_chunks():
+    q: queue.Queue = queue.Queue()
+    q.put(_chunk(50, val=0.5))
+    q.put(_chunk(50, val=0.25))
+    buf, carry, filled, done = PCMPlayer._pull_block(
+        q, None, threading.Event(), 100, 2
+    )
+    assert filled == 100
+    assert carry is None
+    assert done is False
+    assert np.allclose(buf[:50], 0.5)
+    assert np.allclose(buf[50:], 0.25)
+
+
+def test_carries_the_leftover_of_an_oversized_chunk():
+    q: queue.Queue = queue.Queue()
+    q.put(_chunk(150, val=0.7))  # bigger than the 100-frame request
+    buf, carry, filled, done = PCMPlayer._pull_block(
+        q, None, threading.Event(), 100, 2
+    )
+    assert filled == 100
+    assert carry is not None and carry.shape[0] == 50
+    assert np.allclose(buf, 0.7)
+
+
+def test_consumes_an_existing_carry_before_the_queue():
+    buf, carry, filled, done = PCMPlayer._pull_block(
+        queue.Queue(), _chunk(40, val=0.3), threading.Event(), 100, 2
+    )
+    # Carry supplied 40 frames; queue empty -> underrun, rest zeros.
+    assert filled == 40
+    assert done is False
+    assert np.allclose(buf[:40], 0.3)
+    assert np.all(buf[40:] == 0.0)
+
+
+def test_underrun_leaves_zeros_without_marking_done():
+    q: queue.Queue = queue.Queue()
+    q.put(_chunk(30, val=0.9))
+    # done event NOT set: the source is behind, not finished.
+    buf, carry, filled, done = PCMPlayer._pull_block(
+        q, None, threading.Event(), 100, 2
+    )
+    assert filled == 30
+    assert done is False
+    assert np.allclose(buf[:30], 0.9)
+    assert np.all(buf[30:] == 0.0)
+
+
+def test_reports_source_done_only_on_a_true_end():
+    ev = threading.Event()
+    ev.set()
+    buf, carry, filled, done = PCMPlayer._pull_block(
+        queue.Queue(), None, ev, 100, 2
+    )
+    assert filled == 0
+    assert done is True
+    assert np.all(buf == 0.0)
+
+
+def test_downmixes_stereo_to_mono():
+    q: queue.Queue = queue.Queue()
+    chunk = np.zeros((10, 2), dtype=np.float32)
+    chunk[:, 0] = 1.0  # L=1, R=0 -> mean 0.5
+    q.put(chunk)
+    buf, carry, filled, done = PCMPlayer._pull_block(
+        q, None, threading.Event(), 10, 1
+    )
+    assert buf.shape == (10, 1)
+    assert np.allclose(buf[:, 0], 0.5)

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -407,6 +407,11 @@ export interface Settings {
    *  20-40 is the typical taste range for hard-panned mixes on
    *  headphones. */
   crossfeed_amount: number;
+  /** Crossfade duration in seconds for automatic track-to-track
+   *  transitions (0 = off, max 12). Fades the outgoing track out as the
+   *  incoming one fades in; applies only to natural advances, not
+   *  manual skips. */
+  crossfade_duration_s: number;
   /** ReplayGain loudness leveling mode. "off" preserves bit-perfect
    *  output; "track" applies the per-track gain (best for shuffle);
    *  "album" applies the album-wide gain (best for whole-album

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -896,6 +896,7 @@ function AudioEngineFields() {
       <ReplayGainField />
       <EqField />
       <CrossfeedField />
+      <CrossfadeField />
     </>
   );
 }
@@ -1054,6 +1055,60 @@ function CrossfeedField() {
         onChange={(e) => onChange(Number(e.target.value))}
         className="h-2 w-full cursor-pointer appearance-none rounded-full bg-secondary accent-primary"
         aria-label="Crossfeed amount"
+      />
+    </Field>
+  );
+}
+
+/**
+ * Crossfade slider for automatic track-to-track transitions. Off (0) by
+ * default. Spotify-style: applies only to natural end-of-track advances
+ * (manual skips still cut), and to every transition while enabled — so
+ * it's turned off for albums meant to play continuously. Same
+ * self-contained settings.get/put shape as CrossfeedField.
+ */
+function CrossfadeField() {
+  const [seconds, setSeconds] = useState<number | null>(null);
+  const debouncedPut = useDebouncedSettingsPut();
+
+  useEffect(() => {
+    let cancelled = false;
+    api.settings
+      .get()
+      .then((s) => {
+        if (!cancelled) setSeconds(s.crossfade_duration_s ?? 0);
+      })
+      .catch(() => {
+        if (!cancelled) setSeconds(0);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (seconds === null) return null;
+
+  const label = seconds > 0 ? `Crossfade — ${seconds}s` : "Crossfade — off";
+
+  const onChange = (next: number) => {
+    setSeconds(next);
+    debouncedPut({ crossfade_duration_s: next });
+  };
+
+  return (
+    <Field
+      label={label}
+      hint="Fades the outgoing track out as the next fades in, instead of a hard cut, when a track ends on its own. Automatic advances only — manually skipping still cuts instantly — and it applies to every transition while on, so turn it off for albums meant to play gapless (live sets, DJ mixes). 0 disables."
+    >
+      <input
+        type="range"
+        min={0}
+        max={12}
+        step={1}
+        value={seconds}
+        onChange={(e) => onChange(Number(e.target.value))}
+        className="h-2 w-full cursor-pointer appearance-none rounded-full bg-secondary accent-primary"
+        aria-label="Crossfade duration"
       />
     </Field>
   );


### PR DESCRIPTION
## Summary

- Adds an equal-power crossfade DSP layer that overlaps the end of one track with the beginning of the next during automatic queue advance
- Settings page gains a crossfade duration slider (0–12 s; 0 = off)
- Works for all stream dtypes: float32 (AAC/MP3), int32 (FLAC 24-bit), int16 (FLAC 16-bit) — the mix runs in float32 internally and scales back to the stream dtype before output
- Compatible preload is claimed from the existing gapless preload slot; falls back to a gapless cut if the next track isn't buffered yet or the stream parameters don't match

## Test plan

- [ ] Play an album at max quality (FLAC/int32) with crossfade set to 12 s — last 12 s of track should fade out while next track fades in underneath
- [ ] Confirm `[crossfade] begin` and `[crossfade] promote` print in the dev console on each transition
- [ ] Verify crossfade = 0 leaves gapless behaviour unchanged
- [ ] Seek during a crossfade — transition should abort cleanly, no stuck audio or leaked decoder
- [ ] Manual skip (Next button) during crossfade — same
- [ ] All four preflight checks pass (`pytest`, `tsc`, `lint:all`, `vitest`)