### PR TITLE
Fix artist discography dropping same-name albums from different years

### DIFF
--- a/server.py
+++ b/server.py
@@ -8369,7 +8369,11 @@ def artist_detail(artist_id: int) -> dict:
         except Exception:
             artist_id = ""
         explicit = bool(getattr(a, "explicit", False))
-        return (name, version, artist_id, explicit)
+        rd = getattr(a, "release_date", None) or getattr(
+            a, "available_release_date", None
+        )
+        year: Optional[int] = rd.year if rd is not None else None
+        return (name, version, artist_id, explicit, year)
 
     seen_keys: set[tuple] = set()
     seen_ids: set[str] = set()


### PR DESCRIPTION
## Summary

- The album deduplication key was \`(name, version, artist_id, explicit)\`. Two genuinely distinct albums with the same title (e.g. a self-titled 1987 debut and a self-titled 2019 record) were collapsed into one, dropping whichever appeared second in the API response.
- Added the release year to the key: \`(name, version, artist_id, explicit, year)\`. Duplicate Tidal catalog uploads of the same release still collapse (same year), but albums that share a name across different years are now kept separately.

## Test plan

- [ ] Find an artist with two albums of the same name released in different years and confirm both appear on their discography page
- [ ] Confirm that genuinely duplicate catalog entries (same album uploaded twice under different IDs) still deduplicate to one