### PR TITLE
Keep session on transient token-refresh failures

### DIFF
--- a/app/tidal_client.py
+++ b/app/tidal_client.py
@@ -69,6 +69,20 @@ class TidalBackoffError(Exception):
         )
 
 
+class TransientRefreshError(Exception):
+    """Raised when a token refresh fails for a transient reason — a 429
+    rate-limit, a 5xx from Tidal, or a network error — rather than a
+    genuinely dead refresh token.
+
+    The distinction matters because force_refresh logs the user out and
+    deletes the session file on a *permanent* auth failure
+    (AuthenticationError). A transient failure must NOT do that: the
+    refresh token is still valid, so we keep the session and let the
+    watchdog retry on its next tick. Conflating the two was silently
+    logging users out days later whenever a background refresh happened
+    to land during a rate-limit window or a Tidal outage."""
+
+
 def tidal_backoff_state() -> dict:
     """Snapshot for /api/tidal/backoff so the frontend can surface a
     banner explaining why things are blocked."""
@@ -518,9 +532,15 @@ class TidalClient:
         This mirrors tidalapi's refresh exactly — same OAuth params,
         same config (so device-code and PKCE both stay correct), same
         impersonated transport — but also carries a rotated refresh
-        token back onto the session so the subsequent save persists
-        it. Error semantics match tidalapi's so existing callers
-        (AuthenticationError → logout, False → give up) are unchanged.
+        token back onto the session so the subsequent save persists it.
+
+        Failures are split by cause. A genuine auth rejection (Tidal's
+        `invalid_grant` and friends, or a bare 401) raises
+        AuthenticationError so the caller logs the user out. A transient
+        transport failure (429 rate-limit, 5xx, non-JSON error page)
+        raises TransientRefreshError so the caller keeps the session and
+        retries later. Conflating the two used to delete a valid session
+        whenever a background refresh landed on a rate-limit or outage.
         """
         session = self.session
         config = session.config
@@ -538,14 +558,44 @@ class TidalClient:
             ),
         }
         resp = session.request_session.post(config.api_oauth2_token, params)
-        body = resp.json()
         if resp.status_code != 200:
-            raise tidalapi.exceptions.AuthenticationError(
-                "Authentication failed with error "
-                f"'{body.get('error')}: {body.get('error_description')}'"
+            # Split permanent auth rejection from transient transport
+            # failure. Only the former should log the user out and wipe
+            # the session file (force_refresh's AuthenticationError path).
+            # A 429 rate-limit or a 5xx is "retry shortly" and the refresh
+            # token is still valid — wrongly treating it as a dead token
+            # is what silently logged users out days later when a
+            # background refresh happened to hit a rate-limit window.
+            try:
+                body = resp.json()
+            except ValueError:
+                # Non-JSON body (e.g. an HTML 5xx error page). No OAuth
+                # error code to read; treat as transient.
+                body = {}
+            error = str(body.get("error") or "")
+            desc = body.get("error_description")
+            # The OAuth spec's permanent failure codes, plus a bare 401
+            # (bad client auth). Tidal returns `invalid_grant` when the
+            # refresh token is expired or revoked — the genuine re-login
+            # case. Anything else (429, 5xx, an unrecognized 4xx) is
+            # transient: keep the session and let the watchdog retry.
+            permanent = resp.status_code == 401 or error in (
+                "invalid_grant",
+                "invalid_request",
+                "invalid_client",
+                "unauthorized_client",
+                "unsupported_grant_type",
             )
-        if not resp.ok:
-            return False
+            if permanent:
+                raise tidalapi.exceptions.AuthenticationError(
+                    "Authentication failed with error "
+                    f"'{error}: {desc}'"
+                )
+            raise TransientRefreshError(
+                f"token refresh got HTTP {resp.status_code} "
+                f"(error={error or 'none'}); refresh token kept"
+            )
+        body = resp.json()
         session.access_token = body["access_token"]
         # Naive UTC, matching how tidalapi stores expiry_time
         # everywhere else. Mixing a tz-aware value here would make
@@ -577,10 +627,13 @@ class TidalClient:
         contending for the lock. Once we hold the lock, if the
         session's refresh token has already moved on — another thread
         refreshed and Tidal rotated — that refresh supersedes this one,
-        so we reuse it instead of re-POSTing the now-dead token. Raises
-        like _token_refresh_capturing (AuthenticationError on a rejected
-        token) so force_refresh's logout-on-auth-failure path is
-        preserved.
+        so we reuse it instead of re-POSTing the now-dead token.
+
+        A permanent AuthenticationError propagates so force_refresh's
+        logout-on-auth-failure path runs. A TransientRefreshError (429,
+        5xx, network) is swallowed to a False return: the refresh token
+        is still valid, so we keep the session and let the next watchdog
+        tick retry rather than wiping a good session over a blip.
         """
         with self._refresh_lock:
             current = getattr(self.session, "refresh_token", None)
@@ -592,7 +645,11 @@ class TidalClient:
                 # would be redundant, and re-POSTing `based_on` would
                 # use a token Tidal already invalidated.
                 return True
-            ok = self._token_refresh_capturing(current)
+            try:
+                ok = self._token_refresh_capturing(current)
+            except TransientRefreshError as exc:
+                _tlog(f"refresh: transient failure, session kept: {exc}")
+                return False
             if ok:
                 try:
                     self.save_session()

--- a/tests/test_token_refresh_rotation.py
+++ b/tests/test_token_refresh_rotation.py
@@ -170,6 +170,77 @@ def test_non_200_raises_authentication_error():
         client._token_refresh_capturing("dead_refresh")
 
 
+def test_400_invalid_grant_is_permanent():
+    # A dead/revoked refresh token comes back as 400 invalid_grant.
+    # That's the genuine re-login case and must raise AuthenticationError.
+    session = _Session(
+        _Resp(400, {"error": "invalid_grant", "error_description": "revoked"})
+    )
+    client = _client(session)
+
+    with pytest.raises(tidalapi.exceptions.AuthenticationError):
+        client._token_refresh_capturing("dead_refresh")
+
+
+def test_429_is_transient_not_auth_error():
+    # A rate-limit during a background refresh must NOT be mistaken for a
+    # dead token. Treating it as permanent is what deleted valid sessions
+    # and logged users out days later.
+    from app.tidal_client import TransientRefreshError
+
+    session = _Session(
+        _Resp(429, {"error": "rate_limit", "error_description": "slow down"})
+    )
+    client = _client(session)
+
+    with pytest.raises(TransientRefreshError):
+        client._token_refresh_capturing("good_refresh")
+    # The refresh token is untouched — it's still valid.
+    assert session.refresh_token == "old_refresh"
+
+
+def test_5xx_is_transient():
+    from app.tidal_client import TransientRefreshError
+
+    session = _Session(_Resp(503, {"error": "server_error"}))
+    client = _client(session)
+
+    with pytest.raises(TransientRefreshError):
+        client._token_refresh_capturing("good_refresh")
+    assert session.refresh_token == "old_refresh"
+
+
+def test_non_json_error_body_is_transient():
+    # A 5xx that returns an HTML error page (resp.json() raises) has no
+    # OAuth error code to read — treat as transient, not a logout.
+    from app.tidal_client import TransientRefreshError
+
+    class _HtmlResp(_Resp):
+        def json(self):
+            raise ValueError("not json")
+
+    session = _Session(_HtmlResp(502, {}))
+    client = _client(session)
+
+    with pytest.raises(TransientRefreshError):
+        client._token_refresh_capturing("good_refresh")
+    assert session.refresh_token == "old_refresh"
+
+
+def test_refresh_once_swallows_transient_to_false():
+    # _refresh_once is the chokepoint force_refresh relies on. A transient
+    # failure must come back as False (give up, keep session) rather than
+    # propagate — force_refresh logs the user out on a raised
+    # AuthenticationError, and a 429 must never reach that branch.
+    session = _Session(_Resp(429, {"error": "rate_limit"}))
+    client = _client(session)
+    client.save_session = MagicMock()
+
+    assert client._refresh_once(based_on="old_refresh") is False
+    assert session.refresh_token == "old_refresh"
+    client.save_session.assert_not_called()
+
+
 def test_concurrent_internal_refresh_is_single_flight():
     """Two parallel 401s through tidalapi's internal refresh path
     (_token_refresh_and_persist) must collapse to ONE network refresh.


### PR DESCRIPTION
## Summary

Fixes the long-standing "users get auto logged out after a few days" report.

The token-refresh path treated **any** non-200 from Tidal's OAuth endpoint as a dead refresh token: it raised `AuthenticationError`, which `force_refresh` handles by logging the user out and deleting the session file. But Tidal returns non-200 for transient reasons too:

- **429** when rate-limiting (this app already hits rate limits hard enough to risk account suspension)
- **5xx** on Tidal's own server errors

So a single blip during the hourly background watchdog refresh was wiping a perfectly valid session. It shows up "after a few days" because it takes a while for a watchdog refresh to roll the dice on landing in a rate-limit window or an outage.

This is the no-bandaids anti-pattern in action: a catch that turns a real transient error into a silent destructive fallback.

## What changed

- New `TransientRefreshError` to mark transport blips vs genuinely dead tokens.
- `_token_refresh_capturing` classifies a non-200:
  - **Permanent** (401, or an OAuth error code like `invalid_grant`) → `AuthenticationError` → logout. The genuine re-login case.
  - **Transient** (429, 5xx, non-JSON error page) → `TransientRefreshError`, refresh token left untouched.
- `_refresh_once` catches the transient case and returns `False` (with a `_tlog` line to `audio.log`) so the logout path never runs on a blip. The next watchdog tick retries.

## Test plan

- [x] `pytest tests/test_token_refresh_rotation.py` — 5 new cases: 400 `invalid_grant` is permanent; 429 / 5xx / non-JSON bodies are transient and keep the refresh token; `_refresh_once` swallows transient to `False` without persisting.
- [x] `pytest tests/test_tidal_backoff.py tests/test_tidal_request_gate.py tests/test_session_boot_deferral.py` — related auth/session suites still green.
- [ ] Manual: confirm a forced 429 on the refresh endpoint no longer bounces to Login.