### PR TITLE
Discover DLNA renderers with a single socket bound to port 1900

### DIFF
--- a/app/audio/upnp.py
+++ b/app/audio/upnp.py
@@ -51,10 +51,11 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import socket
 import threading
 import time
 from dataclasses import dataclass, field
-from typing import Callable, List, Optional
+from typing import Callable, List, Optional, Set, Tuple
 
 import numpy as np
 
@@ -83,36 +84,177 @@ log = logging.getLogger(__name__)
 try:
     from async_upnp_client.aiohttp import AiohttpRequester
     from async_upnp_client.client_factory import UpnpFactory
-    from async_upnp_client.search import async_search
 
     _UPNP_AVAILABLE = True
 except Exception as _exc:  # pragma: no cover - environment dependent
     log.warning("async-upnp-client unavailable: %s", _exc)
     AiohttpRequester = None  # type: ignore
     UpnpFactory = None  # type: ignore
-    async_search = None  # type: ignore
     _UPNP_AVAILABLE = False
 
 
-# SSDP search targets. We run two parallel M-SEARCHes:
-#
-#   MediaRenderer:1  — the canonical device-type search. Finds WiiM,
-#                      most Bluesound, Denon AVRs, LG/Samsung TVs, etc.
-#
-#   AVTransport:1    — service-type search. Some renderers (notably
-#                      USB Audio Player PRO on Android) respond only to
-#                      service-type M-SEARCHes, not device-type ones.
-#                      Running both catches the union without sending
-#                      ssdp:all noise across the whole LAN.
-#
-# Both searches feed the same dict keyed by UDN, so a device found
-# by both just deduplicates.
-_ST_MEDIA_RENDERER = "urn:schemas-upnp-org:device:MediaRenderer:1"
-_ST_AVTRANSPORT = "urn:schemas-upnp-org:service:AVTransport:1"
+# SSDP discovery is done with our own socket rather than
+# async-upnp-client's async_search(). The reason is a real-world
+# interop bug: async_search sends its M-SEARCH from a socket that, on
+# Linux, is never bound to the SSDP port (it binds only on win32), so
+# the OS gives it an ephemeral source port. Spec-compliant renderers
+# reply via unicast to that source port and are heard. But some
+# renderers — notably USB Audio Player PRO and other Android-based
+# devices — always reply to port 1900 of the requester regardless of
+# the M-SEARCH source port. Nothing is listening there, so their reply
+# is dropped and they never appear in the picker. gssdp-discover (the C
+# reference that works against these devices) binds a single socket to
+# 1900 for both send and receive; we mirror that. See GitHub #234 and
+# #220. The v1.18.1 attempt (a second async_search for the AVTransport
+# service type) didn't help because the lost-reply problem is in the
+# socket, not the search target.
+_SSDP_MCAST_ADDR = "239.255.255.250"
+_SSDP_PORT = 1900
+
+# Search targets we burst in one scan. Devices vary in which they
+# answer: most answer the MediaRenderer device type, some Android
+# renderers only answer a service-type or the catch-all queries.
+# Sending all four in one round catches the union; responses are
+# deduplicated by LOCATION before any descriptor fetch.
+_SSDP_SEARCH_TARGETS: Tuple[str, ...] = (
+    "urn:schemas-upnp-org:device:MediaRenderer:1",
+    "urn:schemas-upnp-org:service:AVTransport:1",
+    "upnp:rootdevice",
+    "ssdp:all",
+)
 
 # We only want devices that expose AVTransport. Any service-type URN
 # starting with this prefix qualifies (covers :1, :2, :3 etc.).
 _AVTRANSPORT_PREFIX = "urn:schemas-upnp-org:service:AVTransport:"
+
+
+def _build_msearch(search_target: str, mx: int) -> bytes:
+    """One SSDP M-SEARCH datagram for the given target. MX is the max
+    seconds a device may wait before replying; it must be smaller than
+    our receive window so late repliers still land inside it."""
+    return (
+        "M-SEARCH * HTTP/1.1\r\n"
+        f"HOST: {_SSDP_MCAST_ADDR}:{_SSDP_PORT}\r\n"
+        'MAN: "ssdp:discover"\r\n'
+        f"MX: {mx}\r\n"
+        f"ST: {search_target}\r\n"
+        "\r\n"
+    ).encode("ascii")
+
+
+def _parse_ssdp_location(data: bytes) -> Optional[str]:
+    """Pull the LOCATION header out of an SSDP response or NOTIFY.
+    Returns None for datagrams without one (e.g. byebye NOTIFYs)."""
+    try:
+        text = data.decode("utf-8", "replace")
+    except Exception:
+        return None
+    for line in text.split("\r\n"):
+        if line.lower().startswith("location:"):
+            return line.split(":", 1)[1].strip() or None
+    return None
+
+
+def _collect_ssdp_locations(
+    timeout: float, lan_ip: str
+) -> Tuple[Set[str], bool]:
+    """Blocking single-socket SSDP search. Binds one UDP socket to
+    port 1900, joins the SSDP multicast group, bursts an M-SEARCH for
+    every target, and collects LOCATION URLs from every reply (unicast
+    or multicast) until the timeout elapses.
+
+    Returns the set of discovered descriptor URLs and whether we
+    actually got port 1900. If 1900 is already held (another SSDP
+    listener on the box), we fall back to an ephemeral port: we lose
+    the port-1900-only repliers like UAPP but still find every
+    spec-compliant device via the unicast-to-source-port path, which is
+    strictly better than failing the whole scan.
+    """
+    deadline = time.monotonic() + timeout
+    locations: Set[str] = set()
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM, socket.IPPROTO_UDP)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    try:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
+    except (AttributeError, OSError):
+        # SO_REUSEPORT is absent on some platforms; without it a second
+        # listener on 1900 just means we take the fallback path.
+        pass
+
+    bound_1900 = True
+    try:
+        sock.bind(("", _SSDP_PORT))
+    except OSError as exc:
+        log.debug("upnp: port %d busy (%s); falling back to ephemeral",
+                  _SSDP_PORT, exc)
+        bound_1900 = False
+        try:
+            sock.bind(("", 0))
+        except OSError as exc2:
+            log.warning("upnp: could not bind any SSDP socket: %s", exc2)
+            sock.close()
+            return locations, False
+
+    # Join the multicast group and pin the outgoing interface to the LAN
+    # IP so the M-SEARCH leaves the right NIC on multi-homed machines.
+    iface = lan_ip if lan_ip and lan_ip != "127.0.0.1" else "0.0.0.0"
+    try:
+        mreq = socket.inet_aton(_SSDP_MCAST_ADDR) + socket.inet_aton(iface)
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP, mreq)
+        if iface != "0.0.0.0":
+            sock.setsockopt(
+                socket.IPPROTO_IP,
+                socket.IP_MULTICAST_IF,
+                socket.inet_aton(iface),
+            )
+        sock.setsockopt(socket.IPPROTO_IP, socket.IP_MULTICAST_TTL, 2)
+    except OSError as exc:
+        log.debug("upnp: multicast setup partial: %s", exc)
+
+    # MX must be < the receive window. Cap at 5 (the SSDP-recommended
+    # ceiling) and keep at least 1.
+    mx = max(1, min(5, int(timeout) - 1))
+
+    def _burst() -> None:
+        for st in _SSDP_SEARCH_TARGETS:
+            try:
+                sock.sendto(
+                    _build_msearch(st, mx),
+                    (_SSDP_MCAST_ADDR, _SSDP_PORT),
+                )
+            except OSError as exc:
+                log.debug("upnp: M-SEARCH send for %s failed: %s", st, exc)
+
+    print(
+        f"[upnp] ssdp scan: bound_1900={bound_1900} iface={iface} "
+        f"mx={mx} timeout={timeout:.0f}s",
+        flush=True,
+    )
+    _burst()
+    # A second burst partway through helps Android renderers that take a
+    # few seconds to acquire the multicast lock after the first probe.
+    second_burst_at = time.monotonic() + max(1.0, timeout / 2.0)
+    did_second = False
+
+    sock.settimeout(0.5)
+    try:
+        while time.monotonic() < deadline:
+            if not did_second and time.monotonic() >= second_burst_at:
+                _burst()
+                did_second = True
+            try:
+                data, _addr = sock.recvfrom(65535)
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            loc = _parse_ssdp_location(data)
+            if loc:
+                locations.add(loc)
+    finally:
+        sock.close()
+    return locations, bound_1900
 
 # Path the embedded HTTP server exposes for the live FLAC stream.
 # Devices use this as part of the URL we hand them in
@@ -669,29 +811,38 @@ class UpnpManager:
         self._loop_thread = t
 
     async def _discover_async(self, timeout: float) -> List[UpnpDevice]:
-        """SSDP multicast + per-device descriptor parse. Returns
-        only AVTransport-capable devices. Pure OpenHome devices
-        get filtered here so they don't pollute the DLNA picker."""
+        """Single-socket SSDP search + per-device descriptor parse.
+        Returns only AVTransport-capable devices. Pure OpenHome devices
+        get filtered here so they don't pollute the DLNA picker.
+
+        The M-SEARCH/listen step runs on a worker thread (blocking
+        socket bound to port 1900 — see _collect_ssdp_locations for
+        why); the descriptor fetch + parse stays on the asyncio loop so
+        it can reuse async-upnp-client's UpnpFactory.
+        """
         devices: dict[str, UpnpDevice] = {}
         requester = AiohttpRequester()
         factory = UpnpFactory(requester)
 
-        async def _handle_response(headers: dict) -> None:
-            location = headers.get("LOCATION") or headers.get("location")
-            if not location:
-                return
+        loop = asyncio.get_event_loop()
+        lan_ip = primary_lan_ip()
+        locations, _bound_1900 = await loop.run_in_executor(
+            None, _collect_ssdp_locations, timeout, lan_ip
+        )
+
+        for location in locations:
             try:
                 device = await factory.async_create_device(location)
             except Exception as exc:
                 log.debug("upnp: parse %s failed: %s", location, exc)
-                return
+                continue
             service_types = tuple(
                 sorted({s.service_type for s in device.all_services})
             )
             if not _filter_dlna_renderer(service_types):
                 # OpenHome-only or otherwise non-DLNA. Skip; the
                 # tidal_connect module's discovery handles those.
-                return
+                continue
             entry = UpnpDevice(
                 id=device.udn or location,
                 name=(
@@ -706,23 +857,6 @@ class UpnpManager:
                 has_avtransport=True,
             )
             devices[entry.id] = entry
-
-        results = await asyncio.gather(
-            async_search(
-                async_callback=_handle_response,
-                search_target=_ST_MEDIA_RENDERER,
-                timeout=timeout,
-            ),
-            async_search(
-                async_callback=_handle_response,
-                search_target=_ST_AVTRANSPORT,
-                timeout=timeout,
-            ),
-            return_exceptions=True,
-        )
-        for exc in results:
-            if isinstance(exc, Exception):
-                log.warning("upnp ssdp search raised: %s", exc)
 
         for d in devices.values():
             print(

--- a/tests/test_upnp_session.py
+++ b/tests/test_upnp_session.py
@@ -29,7 +29,9 @@ from app.audio.upnp import (
     UpnpDevice,
     UpnpManager,
     _SessionState,
+    _build_msearch,
     _filter_dlna_renderer,
+    _parse_ssdp_location,
 )
 
 
@@ -192,6 +194,76 @@ class TestFilterDlnaRenderer:
 
     def test_empty_service_list_rejected(self):
         assert _filter_dlna_renderer(()) is False
+
+
+# ---------------------------------------------------------------------
+# SSDP wire helpers (the UAPP single-socket fix)
+# ---------------------------------------------------------------------
+
+
+class TestParseSsdpLocation:
+    def test_extracts_location_from_msearch_response(self):
+        """A UAPP-style unicast M-SEARCH reply. The LOCATION header is
+        the descriptor URL we feed to the device factory."""
+        resp = (
+            b"HTTP/1.1 200 OK\r\n"
+            b"CACHE-CONTROL: max-age=1800\r\n"
+            b"LOCATION: http://192.168.17.33:36899/upnp/dev/UAPP/desc\r\n"
+            b"ST: urn:schemas-upnp-org:device:MediaRenderer:1\r\n"
+            b"\r\n"
+        )
+        assert (
+            _parse_ssdp_location(resp)
+            == "http://192.168.17.33:36899/upnp/dev/UAPP/desc"
+        )
+
+    def test_extracts_location_from_notify(self):
+        notify = (
+            b"NOTIFY * HTTP/1.1\r\n"
+            b"HOST: 239.255.255.250:1900\r\n"
+            b"LOCATION: http://192.168.1.50:8080/desc.xml\r\n"
+            b"NTS: ssdp:alive\r\n"
+            b"\r\n"
+        )
+        assert _parse_ssdp_location(notify) == "http://192.168.1.50:8080/desc.xml"
+
+    def test_header_name_is_case_insensitive(self):
+        resp = b"HTTP/1.1 200 OK\r\nlocation: http://x/desc\r\n\r\n"
+        assert _parse_ssdp_location(resp) == "http://x/desc"
+
+    def test_no_location_returns_none(self):
+        """A byebye NOTIFY carries no LOCATION; nothing to fetch."""
+        byebye = (
+            b"NOTIFY * HTTP/1.1\r\n"
+            b"NTS: ssdp:byebye\r\n"
+            b"USN: uuid:gone\r\n"
+            b"\r\n"
+        )
+        assert _parse_ssdp_location(byebye) is None
+
+    def test_empty_location_returns_none(self):
+        assert _parse_ssdp_location(b"HTTP/1.1 200 OK\r\nLOCATION: \r\n\r\n") is None
+
+    def test_garbage_bytes_do_not_raise(self):
+        assert _parse_ssdp_location(b"\xff\xfe\x00\x01not http") is None
+
+
+class TestBuildMsearch:
+    def test_targets_multicast_group_and_port(self):
+        msg = _build_msearch("ssdp:all", 3).decode("ascii")
+        assert msg.startswith("M-SEARCH * HTTP/1.1\r\n")
+        assert "HOST: 239.255.255.250:1900\r\n" in msg
+        assert 'MAN: "ssdp:discover"\r\n' in msg
+        assert "MX: 3\r\n" in msg
+        assert "ST: ssdp:all\r\n" in msg
+        # Must terminate with a blank line or devices reject the probe.
+        assert msg.endswith("\r\n\r\n")
+
+    def test_search_target_is_passed_through(self):
+        msg = _build_msearch(
+            "urn:schemas-upnp-org:device:MediaRenderer:1", 5
+        ).decode("ascii")
+        assert "ST: urn:schemas-upnp-org:device:MediaRenderer:1\r\n" in msg
 
 
 # ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- USB Audio Player PRO and other Android-based DLNA renderers never appeared in the picker. They reply to an M-SEARCH by unicast to port 1900 of the requester, not to the M-SEARCH's source port. `async-upnp-client`'s `async_search` binds its socket to 1900 only on win32, so on Linux it gets an ephemeral source port and the reply to 1900 is dropped.
- The v1.18.1 fix added a second `async_search` for the AVTransport service type. That changed the search target, not the socket, so it couldn't help.
- Replace `async_search` with our own SSDP search: one UDP socket bound to `0.0.0.0:1900` (SO_REUSEADDR/REUSEPORT) joined to the multicast group, bursting M-SEARCH for several targets and collecting LOCATION from every reply, unicast or multicast. Mirrors `gssdp-discover`. Descriptor fetch and parse still go through `async-upnp-client`'s `UpnpFactory`. If 1900 is held we fall back to an ephemeral port, losing only the port-1900-only repliers rather than failing the whole scan.

Fixes the detection half of #234 (and the underlying cause of #220).

## Test plan
- [x] `pytest tests/` green (added `TestParseSsdpLocation`, `TestBuildMsearch`)
- [x] Smoke test on macOS: binds 1900, runs a clean scan
- [ ] Confirm UAPP now appears in the DLNA picker (needs the reporter's device)