### PR TITLE
Surface DLNA stream-server requests and encoder death

### DIFF
--- a/app/audio/http_stream.py
+++ b/app/audio/http_stream.py
@@ -349,6 +349,16 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         # with a HEAD before GET to check Content-Type and confirm
         # the stream exists. Answer with the same response line
         # GET uses so they don't fall back or abort.
+        # High-signal: one line per connection (not per chunk), so it
+        # answers "did the renderer ever reach our stream URL?" when a
+        # device reportedly stays silent. UAPP and other Android DLNA
+        # renderers HEAD-probe before pulling; if this line never
+        # prints, the failure is upstream of the stream server.
+        print(
+            f"[http_stream] HEAD {self.path} from "
+            f"{self.client_address[0]}",
+            flush=True,
+        )
         server = self.server  # type: ignore[assignment]
         if not isinstance(server, StreamHTTPServer) or server.buffer is None:
             self.send_error(503, "stream session not ready")
@@ -363,6 +373,16 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         self.end_headers()
 
     def do_GET(self) -> None:  # noqa: N802 - stdlib API
+        # High-signal, one line per connection: the receiver's actual
+        # pull. Pairs with the encoder-failure print in UpnpManager so
+        # a "stream never plays" report can be split into "device never
+        # connected" (no line here) vs "device connected but got no
+        # audio" (this line prints, byte counter stays at 0).
+        print(
+            f"[http_stream] GET {self.path} from "
+            f"{self.client_address[0]}",
+            flush=True,
+        )
         server = self.server  # type: ignore[assignment]
         if not isinstance(server, StreamHTTPServer) or server.buffer is None:
             self.send_error(503, "stream session not ready")

--- a/app/audio/upnp.py
+++ b/app/audio/upnp.py
@@ -168,6 +168,7 @@ class _SessionState:
     bytes_encoded: int = 0
     media_loaded: bool = False
     stream_url: str = ""
+    encode_failed: bool = False
 
 
 def _filter_dlna_renderer(service_types: tuple[str, ...]) -> bool:
@@ -639,9 +640,29 @@ class UpnpManager:
                 # Same survival posture as Cast: don't crash the
                 # realtime thread, let the session run dry, frontend
                 # surfaces "0 bytes encoded" plateau.
-                log.debug("flac encode failed: %r", exc)
+                #
+                # But surface the FIRST failure loudly. A persistent
+                # encode failure (e.g. PyAV/FFmpeg dying on a device
+                # whose locale makes av.error mis-decode the message)
+                # means the device connects to our stream URL and then
+                # gets silence forever — the exact "stream never plays"
+                # symptom. Burying that at debug level left it
+                # undiagnosable. One print per session, then debug for
+                # the rest so the realtime thread isn't flooded.
+                if not session.encode_failed:
+                    session.encode_failed = True
+                    print(
+                        f"[upnp] flac encode failed (no audio will "
+                        f"reach the device until this clears): {exc!r}",
+                        flush=True,
+                    )
+                else:
+                    log.debug("flac encode failed: %r", exc)
                 return
         if encoded:
+            # A successful encode clears the failure latch so a later
+            # failure episode reports again instead of staying silent.
+            session.encode_failed = False
             session.buffer.write(encoded)
             session.bytes_encoded += len(encoded)
 

--- a/tests/test_upnp_session.py
+++ b/tests/test_upnp_session.py
@@ -502,6 +502,56 @@ class TestPushPcmEncoderReuse:
         assert sess.encoder_rate == 96000
 
 
+class TestPushPcmEncodeFailureLatch:
+    """A failing encoder (e.g. PyAV/FFmpeg dying on a device whose
+    locale makes av.error mis-decode the error message) leaves the
+    device connected to our stream URL with no audio ever arriving.
+    push_pcm must not crash the realtime thread, but the FIRST failure
+    has to be surfaced loudly so the symptom is diagnosable rather than
+    buried at debug level. The `encode_failed` latch is what gates the
+    one-shot loud report; a later success clears it.
+    """
+
+    def _attach_with_encoder(self, raises: bool):
+        mgr = UpnpManager()
+        sess = _attach_session(mgr)
+        sess.encoder = MagicMock()
+        sess.encoder_rate = 44100
+        sess.encoder_channels = 2
+        sess.encoder_dtype = "int16"
+        if raises:
+            sess.encoder.encode.side_effect = RuntimeError("ffmpeg boom")
+        else:
+            sess.encoder.encode.return_value = b""
+        return mgr, sess
+
+    def test_encode_failure_does_not_raise_and_latches(self):
+        mgr, sess = self._attach_with_encoder(raises=True)
+        pcm = np.zeros((1024, 2), dtype=np.int16)
+        mgr.push_pcm(pcm, sample_rate=44100, dtype="int16")  # no raise
+        assert sess.encode_failed is True
+
+    def test_repeated_failure_stays_latched(self):
+        mgr, sess = self._attach_with_encoder(raises=True)
+        pcm = np.zeros((1024, 2), dtype=np.int16)
+        for _ in range(5):
+            mgr.push_pcm(pcm, sample_rate=44100, dtype="int16")
+        assert sess.encode_failed is True
+
+    def test_successful_encode_clears_latch(self):
+        mgr, sess = self._attach_with_encoder(raises=True)
+        pcm = np.zeros((1024, 2), dtype=np.int16)
+        mgr.push_pcm(pcm, sample_rate=44100, dtype="int16")
+        assert sess.encode_failed is True
+        # Encoder recovers and returns real bytes; the latch clears so
+        # a future failure episode reports again.
+        sess.encoder.encode.side_effect = None
+        sess.encoder.encode.return_value = b"flacbytes"
+        mgr.push_pcm(pcm, sample_rate=44100, dtype="int16")
+        assert sess.encode_failed is False
+        assert sess.bytes_encoded == len(b"flacbytes")
+
+
 class TestPushPcmEmpty:
     def test_empty_array_no_session_is_noop(self):
         mgr = UpnpManager()


### PR DESCRIPTION
## Summary
- A user with USB Audio Player PRO reported audio never reaching the device, with no way to tell where the pipeline broke. Both failure points were invisible: stream-server requests went to a debug-only access log, and a fatal FLAC encode failure was swallowed at debug level, leaving the byte counter plateaued at zero with no explanation.
- Print one high-signal line per connection for HEAD and GET on the stream server (per connection, not per chunk).
- Print the first encode failure per session behind an `encode_failed` latch that a later successful encode clears, so a persistent encoder failure (e.g. PyAV/FFmpeg dying under a locale that makes `av.error` mis-decode the message) is reported once instead of buried. The realtime audio thread still never crashes on an encode error.
- Together these split a "stream never plays" report into "device never connected" (no GET line) versus "device connected but got no audio" (GET line + zero bytes + the encode-failure print).

Addresses the streaming half of #234. Deliberately does not change `Content-Type` or the DIDL-Lite `protocolInfo`: those can't be verified without the device and changing them blind risks regressing renderers that already work.

## Test plan
- [x] `pytest tests/` green (added `TestPushPcmEncodeFailureLatch`: no-raise + latch, stays-latched, success-clears)
- [x] Smoke test: live stream server prints the GET/HEAD lines and serves 200
- [ ] Confirm the new log lines pinpoint the failure on the reporter's UAPP setup (needs the device)