### PR TITLE
Tolerate DLNA renderer query params on the stream URL

### DIFF
--- a/app/audio/http_stream.py
+++ b/app/audio/http_stream.py
@@ -38,6 +38,7 @@ import socket
 import socketserver
 import threading
 import time
+import urllib.parse
 from typing import Optional
 
 import numpy as np
@@ -325,6 +326,10 @@ class StreamHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
     buffer: Optional["RingBuffer"] = None
     stream_path: str = "/stream"
     content_type: str = "audio/flac"
+    # DLNA renderers negotiate transferMode.dlna.org; Cast receivers
+    # don't and shouldn't see the header. Set per session so the
+    # shared handler only emits DLNA-specific headers on DLNA streams.
+    dlna: bool = False
 
 
 class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
@@ -344,60 +349,98 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         # drown in per-chunk access-log lines during streaming.
         log.debug("http_stream: " + format, *args)
 
-    def do_HEAD(self) -> None:  # noqa: N802 - stdlib API
-        # Some receivers (and plenty of middleboxes) probe headers
-        # with a HEAD before GET to check Content-Type and confirm
-        # the stream exists. Answer with the same response line
-        # GET uses so they don't fall back or abort.
-        # High-signal: one line per connection (not per chunk), so it
-        # answers "did the renderer ever reach our stream URL?" when a
-        # device reportedly stays silent. UAPP and other Android DLNA
-        # renderers HEAD-probe before pulling; if this line never
-        # prints, the failure is upstream of the stream server.
+    # DLNA renderers carry their intent in these request headers. We
+    # echo/answer the ones a strict renderer (UAPP, Hisense TVs)
+    # checks, and log the lot so a "device stays silent" report comes
+    # with the exact bytes the renderer sent instead of guesswork.
+    _DLNA_REQUEST_HEADERS = (
+        "transferMode.dlna.org",
+        "getcontentFeatures.dlna.org",
+        "getAvailableSeekRange.dlna.org",
+        "getMediaInfo.sec",
+        "Range",
+        "User-Agent",
+    )
+
+    def _request_path(self) -> str:
+        """Path portion of the request, query string stripped.
+
+        Strict renderers append their own query params to the URL we
+        hand them (Hisense pulls `/dlna/stream?mediaPlayerId=1&playMode=2`).
+        Compare on the path alone so those params don't 404 the stream.
+        """
+        return urllib.parse.urlsplit(self.path).path
+
+    def _log_connection(self, method: str) -> None:
+        # One high-signal line per connection (not per chunk): did the
+        # renderer reach our stream URL, and with what DLNA intent?
+        # Pairs with the encoder-failure print in UpnpManager so a
+        # "stream never plays" report splits into "device never
+        # connected" (no line) vs "connected but got no audio" (line
+        # prints, byte counter stays at 0). The header dump turns
+        # "UAPP won't play" into the renderer's literal request.
+        headers = []
+        for name in self._DLNA_REQUEST_HEADERS:
+            value = self.headers.get(name)
+            if value is not None:
+                headers.append(f"{name}={value}")
+        suffix = f" [{', '.join(headers)}]" if headers else ""
         print(
-            f"[http_stream] HEAD {self.path} from "
-            f"{self.client_address[0]}",
+            f"[http_stream] {method} {self.path} from "
+            f"{self.client_address[0]}{suffix}",
             flush=True,
         )
-        server = self.server  # type: ignore[assignment]
-        if not isinstance(server, StreamHTTPServer) or server.buffer is None:
-            self.send_error(503, "stream session not ready")
-            return
-        if self.path != server.stream_path:
-            self.send_error(404, "not found")
-            return
+
+    def _send_stream_headers(self, server: "StreamHTTPServer") -> None:
+        """Send the 200 + headers shared by HEAD and GET.
+
+        Takes the isinstance-validated server so it never reaches
+        through the unnarrowed self.server for the session config.
+        """
         self.send_response(200)
         self.send_header("Content-Type", server.content_type)
+        # Chunked transfer lets us keep writing audio frames as long
+        # as the session is alive. Tells the receiver it's a stream,
+        # not a file with a known length.
         self.send_header("Transfer-Encoding", "chunked")
+        if server.dlna:
+            # DLNA's transferMode.dlna.org negotiation: a renderer asks
+            # for a mode and a compliant server states the mode it
+            # granted. We always serve an open-ended FLAC, which IS
+            # Streaming, so we grant Streaming regardless of what was
+            # requested rather than echoing the request value back
+            # (echoing would both claim a mode we don't honor and
+            # reflect an unvalidated client string into a response
+            # header). Cast receivers aren't DLNA and never see this.
+            self.send_header("transferMode.dlna.org", "Streaming")
         self.send_header("Connection", "close")
         self.end_headers()
 
-    def do_GET(self) -> None:  # noqa: N802 - stdlib API
-        # High-signal, one line per connection: the receiver's actual
-        # pull. Pairs with the encoder-failure print in UpnpManager so
-        # a "stream never plays" report can be split into "device never
-        # connected" (no line here) vs "device connected but got no
-        # audio" (this line prints, byte counter stays at 0).
-        print(
-            f"[http_stream] GET {self.path} from "
-            f"{self.client_address[0]}",
-            flush=True,
-        )
+    def do_HEAD(self) -> None:  # noqa: N802 - stdlib API
+        # Some receivers (and plenty of middleboxes) probe headers
+        # with a HEAD before GET to check Content-Type and confirm
+        # the stream exists. Answer with the same response line GET
+        # uses so they don't fall back or abort.
+        self._log_connection("HEAD")
         server = self.server  # type: ignore[assignment]
         if not isinstance(server, StreamHTTPServer) or server.buffer is None:
             self.send_error(503, "stream session not ready")
             return
-        if self.path != server.stream_path:
+        if self._request_path() != server.stream_path:
             self.send_error(404, "not found")
             return
-        self.send_response(200)
-        self.send_header("Content-Type", server.content_type)
-        # Chunked transfer lets us keep writing audio frames as
-        # long as the session is alive. Tells the receiver it's a
-        # stream, not a file with a known length.
-        self.send_header("Transfer-Encoding", "chunked")
-        self.send_header("Connection", "close")
-        self.end_headers()
+        self._send_stream_headers(server)
+
+    def do_GET(self) -> None:  # noqa: N802 - stdlib API
+        self._log_connection("GET")
+        server = self.server  # type: ignore[assignment]
+        if not isinstance(server, StreamHTTPServer) or server.buffer is None:
+            self.send_error(503, "stream session not ready")
+            return
+        if self._request_path() != server.stream_path:
+            self.send_error(404, "not found")
+            return
+        self._send_stream_headers(server)
         buf = server.buffer
         # Become the sole consumer. A later GET (the Cast per-track
         # reload's new connection) supersedes this one so two threads
@@ -436,6 +479,7 @@ def start_stream_http_server(
     buffer: RingBuffer,
     stream_path: str = "/stream",
     content_type: str = "audio/flac",
+    dlna: bool = False,
 ) -> StreamHTTPServer:
     """Start a stream-serving HTTP listener on an ephemeral port.
 
@@ -443,11 +487,17 @@ def start_stream_http_server(
     out and build the URL handed to the receiver. Caller is
     responsible for `shutdown()` + `server_close()` when the session
     ends.
+
+    Set `dlna=True` for UPnP/DLNA sessions so the handler emits the
+    DLNA-specific response headers (transferMode.dlna.org). Cast
+    sessions leave it False; Chromecast isn't DLNA and shouldn't see
+    those headers.
     """
     server = StreamHTTPServer(("0.0.0.0", 0), _StreamRequestHandler)
     server.buffer = buffer
     server.stream_path = stream_path
     server.content_type = content_type
+    server.dlna = dlna
     thread = threading.Thread(
         target=server.serve_forever,
         name=f"http-stream{stream_path}",

--- a/app/audio/upnp.py
+++ b/app/audio/upnp.py
@@ -536,6 +536,7 @@ class UpnpManager:
                 session.buffer,
                 stream_path=_STREAM_PATH,
                 content_type="audio/flac",
+                dlna=True,
             )
             host_port = session.http_server.server_address[1]
             session.stream_url = (

--- a/tests/test_http_stream.py
+++ b/tests/test_http_stream.py
@@ -296,3 +296,173 @@ class TestStreamHTTPServerProtocol:
             server.shutdown()
             server.server_close()
             buffer.close()
+
+
+# ---------------------------------------------------------------------
+# DLNA HTTP compliance (issue #239)
+# ---------------------------------------------------------------------
+
+
+class TestDlnaHttpCompliance:
+    """A strict DLNA renderer (UAPP, Hisense TVs) appends its own
+    query params to the stream URL and negotiates transferMode.
+    These tests pin the server's compliance behaviour without a real
+    device: spin up a loopback server and read the raw response."""
+
+    @staticmethod
+    def _seeded_server(dlna: bool = True):
+        buffer = RingBuffer()
+        # Seed bytes so do_GET's first buffer.read() returns at once
+        # instead of racing the 2s read timeout.
+        buffer.write(b"\x00" * 256)
+        server = start_stream_http_server(
+            buffer,
+            stream_path="/dlna/stream",
+            content_type="audio/flac",
+            dlna=dlna,
+        )
+        return server, buffer
+
+    @staticmethod
+    def _request(server, raw_request: bytes) -> bytes:
+        import socket as _socket
+
+        port = server.server_address[1]
+        sock = _socket.create_connection(("127.0.0.1", port), timeout=3.0)
+        try:
+            sock.sendall(raw_request)
+            chunks = []
+            # Read just the header block — stop once we've seen the
+            # blank line that terminates the headers.
+            while b"\r\n\r\n" not in b"".join(chunks):
+                part = sock.recv(256)
+                if not part:
+                    break
+                chunks.append(part)
+            return b"".join(chunks)
+        finally:
+            sock.close()
+
+    def test_query_params_do_not_404(self):
+        """Hisense pulls `/dlna/stream?mediaPlayerId=1&playMode=2`.
+        The handler must match on the path alone, not the raw target,
+        or the stream 404s and the device stays silent."""
+        server, buffer = self._seeded_server()
+        try:
+            data = self._request(
+                server,
+                b"GET /dlna/stream?mediaPlayerId=1&playMode=2 HTTP/1.1\r\n"
+                b"Host: localhost\r\n\r\n",
+            )
+            assert data.startswith(b"HTTP/1.1 200"), (
+                f"query-param URL should serve 200, got: {data!r}"
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()
+
+    def test_transfer_mode_granted_streaming(self):
+        """transferMode.dlna.org negotiation: a compliant server states
+        the mode it granted. We always serve an open-ended FLAC, which
+        IS Streaming, so a renderer that asks for Streaming gets it
+        back. Strict renderers abort when the header is absent."""
+        server, buffer = self._seeded_server()
+        try:
+            data = self._request(
+                server,
+                b"GET /dlna/stream HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"transferMode.dlna.org: Streaming\r\n\r\n",
+            )
+            assert b"transferMode.dlna.org: Streaming" in data, (
+                f"expected transferMode grant, got: {data!r}"
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()
+
+    def test_transfer_mode_present_when_unrequested(self):
+        """A renderer that doesn't send transferMode still gets one
+        back — that's what an open-ended FLAC is, and some renderers
+        want it present regardless."""
+        server, buffer = self._seeded_server()
+        try:
+            data = self._request(
+                server,
+                b"GET /dlna/stream HTTP/1.1\r\n"
+                b"Host: localhost\r\n\r\n",
+            )
+            assert b"transferMode.dlna.org: Streaming" in data, (
+                f"expected default transferMode, got: {data!r}"
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()
+
+    def test_transfer_mode_not_echoed_verbatim(self):
+        """The server grants the mode it actually serves (Streaming),
+        not whatever the client asked for. Echoing the request value
+        would both claim a mode we don't honor and reflect an
+        unvalidated client string into a response header."""
+        server, buffer = self._seeded_server()
+        try:
+            data = self._request(
+                server,
+                b"GET /dlna/stream HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"transferMode.dlna.org: Interactive\r\n\r\n",
+            )
+            assert b"transferMode.dlna.org: Streaming" in data, (
+                f"expected granted Streaming, got: {data!r}"
+            )
+            assert b"Interactive" not in data, (
+                f"client value must not be reflected, got: {data!r}"
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()
+
+    def test_transfer_mode_absent_on_non_dlna_stream(self):
+        """Cast sessions register with dlna=False; Chromecast isn't
+        DLNA and must not receive the transferMode.dlna.org header even
+        if a client sends it."""
+        server, buffer = self._seeded_server(dlna=False)
+        try:
+            data = self._request(
+                server,
+                b"GET /dlna/stream HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"transferMode.dlna.org: Streaming\r\n\r\n",
+            )
+            assert data.startswith(b"HTTP/1.1 200"), (
+                f"expected 200, got: {data!r}"
+            )
+            assert b"transferMode.dlna.org" not in data, (
+                f"non-DLNA stream must not send transferMode, got: {data!r}"
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()
+
+    def test_wrong_path_still_404s(self):
+        """Query-param tolerance must not turn into matching any
+        path — a genuinely wrong path still 404s."""
+        server, buffer = self._seeded_server()
+        try:
+            data = self._request(
+                server,
+                b"GET /wrong/path?x=1 HTTP/1.1\r\n"
+                b"Host: localhost\r\n\r\n",
+            )
+            assert data.startswith(b"HTTP/1.1 404"), (
+                f"wrong path should 404, got: {data!r}"
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()

--- a/tests/test_upnp_session.py
+++ b/tests/test_upnp_session.py
@@ -157,7 +157,9 @@ def mock_http_server(monkeypatch):
     fake_server = MagicMock()
     fake_server.server_address = ("0.0.0.0", 54321)
 
-    def _fake_start(buffer, stream_path="/stream", content_type="audio/flac"):
+    def _fake_start(
+        buffer, stream_path="/stream", content_type="audio/flac", dlna=False
+    ):
         return fake_server
 
     monkeypatch.setattr("app.audio.upnp.start_stream_http_server", _fake_start)


### PR DESCRIPTION
## Summary

Follow-up to issue #239 ("stream not reaching the renderer"). The empirical investigation disproved the reporter's STREAMINFO theory: our FLAC output is byte-identical to ffmpeg's standard non-seekable streaming output (`total_samples=0` is the spec's correct "unknown" value), and ffmpeg decodes it cleanly. The real, verifiable issues are DLNA HTTP compliance, not the FLAC bytes.

- **Query-param 404.** Strict renderers append their own query string to the URL we hand them (Hisense pulls `/dlna/stream?mediaPlayerId=1&playMode=2`). The handler compared the raw request target against the registered path, so those pulls 404'd and the device stayed silent. It now matches on the path component alone via `urllib.parse.urlsplit`, so renderer-appended params no longer reject the stream.
- **transferMode.dlna.org.** Strict renderers negotiate this header and abort when the response omits it. The server now states the mode it actually grants — always `Streaming` for an open-ended FLAC — rather than echoing the client's requested value. Echoing would both claim a mode we don't honor and reflect an unvalidated client string into a response header. The header is scoped to DLNA sessions (`dlna=True`), so it never lands on Chromecast responses, which aren't DLNA.
- **Diagnostics.** The connection log now dumps the renderer's DLNA-relevant request headers (transferMode, getcontentFeatures, Range, User-Agent, etc.) so the next "device stays silent" report arrives with the literal bytes the renderer sent instead of guesswork.

Deliberately NOT done: faking STREAMINFO `total_samples` (disproven, would be a bandaid) and shipping speculative `DLNA.ORG_FLAGS` hex (unverifiable without the reporter's device — the header logging is the honest path to that data first).

## Test plan

- [x] `pytest tests/` — green
- [x] New `TestDlnaHttpCompliance` cases: query-param URL serves 200, wrong path still 404s, transferMode granted/present/not-echoed-verbatim, and absent on non-DLNA (Cast) streams
- [x] `./scripts/preflight.sh` — pytest, tsc, lint:all, vitest (114/114) all green
- [ ] On-device: confirm UAPP / Hisense now play, and capture the new request-header log lines