### PR TITLE
Fix playback failing when saved output device index drifts (#245)

### DIFF
--- a/app/audio/output_devices.py
+++ b/app/audio/output_devices.py
@@ -90,6 +90,33 @@ def wasapi_host_api_index() -> Optional[int]:
     return None
 
 
+def _output_capable(d: dict) -> bool:
+    """True when a PortAudio device entry can play audio out. Shared by
+    the picker (`list_output_devices`) and the resolver so the two never
+    disagree about what counts as an output device."""
+    return int(d.get("max_output_channels", 0) or 0) > 0
+
+
+def _named_output_matches(devices: list, name: str) -> list[int]:
+    """Indices of output-capable devices named `name`, WASAPI-preferred
+    on Windows so we land on the same entry the picker showed. Other
+    Windows host APIs enumerate a duplicate of each device under the
+    same name, and `sd.query_devices` returns all of them; the picker
+    only ever offered the WASAPI copy, so prefer it here too."""
+    matches = [
+        i for i, d in enumerate(devices)
+        if d.get("name") == name and _output_capable(d)
+    ]
+    wasapi_idx = wasapi_host_api_index()
+    if wasapi_idx is not None:
+        wasapi_matches = [
+            i for i in matches if devices[i].get("hostapi") == wasapi_idx
+        ]
+        if wasapi_matches:
+            return wasapi_matches
+    return matches
+
+
 def list_output_devices(stream_active: bool) -> list[dict]:
     """Enumerate output devices for the picker, applying per-platform
     filters described in the module docstring.
@@ -163,7 +190,7 @@ def list_output_devices(stream_active: bool) -> list[dict]:
         name = d.get("name") or f"Device {i}"
         kind = "OUT" if ch_out > 0 else ("IN " if ch_in > 0 else "?  ")
 
-        if ch_out > 0:
+        if _output_capable(d):
             # Two filters, OR'd into a single accept decision. On
             # macOS the visibility set is the only signal; on
             # Windows the WASAPI host-api index is. On Linux both
@@ -187,5 +214,44 @@ def list_output_devices(stream_active: bool) -> list[dict]:
             flush=True,
         )
         if accepted:
-            out.append({"id": str(i), "name": name})
+            # Device identity is the name, not the PortAudio index.
+            # The index shifts whenever a device connects/disconnects,
+            # so a persisted index drifts onto whatever now sits in
+            # that slot (issue #245). resolve_output_device maps the
+            # saved name back to a live index at stream-open time.
+            out.append({"id": name, "name": name})
     return out
+
+
+def resolve_output_device(name: str) -> tuple[Optional[int], bool]:
+    """Map a saved output-device *name* to a live PortAudio index.
+
+    Returns `(index, available)`:
+      - empty name → `(None, True)`: use the system default.
+      - name matches a current output-capable device → `(index, True)`.
+      - name matches nothing usable, the device is unplugged or the
+        value is a legacy numeric index from before device identity
+        was name-based → `(None, False)`, so the caller can fall back
+        to the system default and tell the user.
+
+    Resolving by name at open time is what keeps a selection pinned to
+    the device the user actually chose. A stored PortAudio index would
+    silently drift onto another device when the enumeration changed,
+    which in issue #245 meant opening an output stream on a microphone
+    and failing with "Invalid number of channels". Matching (and the
+    Windows duplicate-name tie-break) lives in `_named_output_matches`.
+    Name collisions across genuinely distinct devices are a pre-existing
+    limitation of the device layer, which keys on name throughout.
+    """
+    if not name:
+        return None, True
+    try:
+        devices = sd.query_devices()
+    except Exception:
+        log.exception("query_devices failed resolving output device %r", name)
+        return None, False
+
+    matches = _named_output_matches(devices, name)
+    if not matches:
+        return None, False
+    return matches[0], True

--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -61,7 +61,7 @@ from app.audio.replaygain import (
     VALID_MODES as REPLAYGAIN_VALID_MODES,
     compute_gain_db as compute_replaygain_db,
 )
-from app.audio.output_devices import list_output_devices
+from app.audio.output_devices import list_output_devices, resolve_output_device
 from app.audio.segment_reader import SegmentReader
 
 # Optional audio output taps. Imported at module load (not lazily
@@ -2248,15 +2248,22 @@ class PCMPlayer:
             )
 
     def _open_output_stream(self, sample_rate: int, channels: int, dtype: str) -> None:
-        # If the user picked a specific output device, use it;
-        # otherwise pass device=None so sounddevice routes to the
-        # system default.
-        device: Optional[int] = None
-        if self._selected_device_id:
-            try:
-                device = int(self._selected_device_id)
-            except ValueError:
-                device = None
+        # If the user picked a specific output device, resolve its
+        # saved name to a live PortAudio index; otherwise device=None
+        # routes to the system default. When the chosen device is no
+        # longer present as an output (unplugged, or a legacy numeric
+        # id from before device identity was name-based), fall back to
+        # the default instead of hard-failing the load. Issue #245 was
+        # a drifted index landing on an input-only device, where
+        # sd.OutputStream raised "Invalid number of channels".
+        device, available = resolve_output_device(self._selected_device_id)
+        if self._selected_device_id and not available:
+            print(
+                f"[audio] saved output device "
+                f"{self._selected_device_id!r} is not available; "
+                "falling back to system default",
+                flush=True,
+            )
 
         # Decide the rate we'll actually feed sounddevice.
         # ─ Exclusive Mode: push the source rate straight at the device.
@@ -3584,8 +3591,8 @@ class PCMPlayer:
 
           A. The currently-selected device disappeared (headphones
              unplugged, USB DAC removed, AirPods drifted out of
-             range). The reopen on the original device fails; we
-             fall back to the system default.
+             range). resolve_output_device reports it gone, so we
+             drop the selection and reopen on the system default.
 
           B. The device list changed but the selected device is
              still around (a NEW device just plugged in — e.g.
@@ -3652,20 +3659,41 @@ class PCMPlayer:
             except Exception:
                 log.exception("device-recovery: PortAudio reinit failed")
 
-            # First attempt: original device. Succeeds in the
-            # "device list changed but my pick is still around"
-            # case (scenario B above).
+            # _open_output_stream now falls back to the system default
+            # on its own when the saved device is gone (it no longer
+            # raises), so scenario A can't be inferred from an exception
+            # any more. Ask the resolver directly: if the selection
+            # really vanished, drop it up front so the picker and status
+            # stop reporting a device that isn't there, and the reopen
+            # below lands on the default. A present-but-unopenable device
+            # still falls through to the second attempt via the except.
+            _, device_available = resolve_output_device(original_device_id)
+            device_gone = bool(original_device_id) and not device_available
+            if device_gone:
+                with self._lock:
+                    self._selected_device_id = ""
+
+            # First attempt: the resolved device (scenario B), or the
+            # system default when the pick vanished (scenario A).
             try:
                 with self._lock:
                     self._open_output_stream(
                         sample_rate, channels, sd_dtype
                     )
                 self._stream.start()
-                log.info(
-                    "device-recovery: reopened on original device "
-                    "id=%r (rate=%d, channels=%d)",
-                    original_device_id, sample_rate, channels,
-                )
+                if device_gone:
+                    log.info(
+                        "device-recovery: original device id=%r gone; "
+                        "reopened on system default (rate=%d, channels=%d)",
+                        original_device_id, sample_rate, channels,
+                    )
+                else:
+                    log.info(
+                        "device-recovery: reopened on device id=%r "
+                        "(rate=%d, channels=%d)",
+                        self._selected_device_id or "system default",
+                        sample_rate, channels,
+                    )
                 with self._lock:
                     self._replacing_stream = False
                 return

--- a/app/settings.py
+++ b/app/settings.py
@@ -341,6 +341,34 @@ def _migrate_eq_to_parametric(s: Settings) -> bool:
     return True
 
 
+def _migrate_output_device_index(s: Settings) -> bool:
+    """Clear a legacy PortAudio-index output-device selection.
+
+    Device identity used to be the raw PortAudio enumeration index
+    stored as a string ("0", "1", ...). That index is unstable: it
+    shifts whenever a device connects or disconnects, so a saved index
+    silently drifts onto whatever device now sits in that slot,
+    including input-only ones. Issue #245 was exactly this, a stored
+    "1" landed on a microphone and every play attempt raised "Invalid
+    number of channels".
+
+    Device identity is now the device *name*. A previously-saved
+    numeric value can't be reliably translated, the index it referred
+    to may already point elsewhere, so drop it and fall back to the
+    system default. The user re-picks once, and every pick after that
+    is a stable name. Real CoreAudio / WASAPI device names are always
+    descriptive strings, never bare digits, so a name selection is
+    never mistaken for a legacy index. Empty string (system default)
+    and name selections are left untouched. Returns True if it changed
+    anything so the caller re-saves.
+    """
+    value = s.audio_output_device
+    if value and value.isdigit():
+        s.audio_output_device = ""
+        return True
+    return False
+
+
 def load_settings() -> Settings:
     if SETTINGS_FILE.exists():
         try:
@@ -356,6 +384,7 @@ def load_settings() -> Settings:
         # entire settings file with defaults.
         changed = _migrate_default_paths(settings)
         changed = _migrate_eq_to_parametric(settings) or changed
+        changed = _migrate_output_device_index(settings) or changed
         if changed:
             try:
                 save_settings(settings)

--- a/tests/test_output_devices.py
+++ b/tests/test_output_devices.py
@@ -1,0 +1,94 @@
+"""Tests for name-based output-device resolution (issue #245).
+
+`resolve_output_device` is the fix for playback breaking when the saved
+PortAudio index drifts onto a different device. It maps a saved device
+*name* to a live output-capable index, and reports when the saved
+device is gone so the player can fall back to the system default
+instead of opening an output stream on, say, a microphone.
+"""
+from app.audio import output_devices
+
+
+# The exact device layout from the issue #245 diagnostic: the Bose is
+# output-capable, index 1 is the MacBook mic (input only), and the
+# built-in speakers are output-capable. A saved index of "1" used to
+# resolve to the mic and crash sd.OutputStream.
+_DEVICES = [
+    {"name": "Bose Flex SE SoundLink", "max_output_channels": 2,
+     "max_input_channels": 0, "hostapi": 0},
+    {"name": "MacBook Pro Microphone", "max_output_channels": 0,
+     "max_input_channels": 1, "hostapi": 0},
+    {"name": "MacBook Pro Speakers", "max_output_channels": 2,
+     "max_input_channels": 0, "hostapi": 0},
+]
+
+
+def _patch_devices(monkeypatch, devices):
+    monkeypatch.setattr(
+        output_devices.sd, "query_devices", lambda: devices
+    )
+
+
+def test_empty_name_is_system_default(monkeypatch):
+    _patch_devices(monkeypatch, _DEVICES)
+    assert output_devices.resolve_output_device("") == (None, True)
+
+
+def test_output_device_resolves_to_its_current_index(monkeypatch):
+    _patch_devices(monkeypatch, _DEVICES)
+    assert output_devices.resolve_output_device(
+        "MacBook Pro Speakers"
+    ) == (2, True)
+    assert output_devices.resolve_output_device(
+        "Bose Flex SE SoundLink"
+    ) == (0, True)
+
+
+def test_input_only_device_is_not_available(monkeypatch):
+    """The #245 crash: the saved slot now points at a microphone with
+    zero output channels. It must report unavailable, not hand back an
+    index we'd try to open an output stream on."""
+    _patch_devices(monkeypatch, _DEVICES)
+    assert output_devices.resolve_output_device(
+        "MacBook Pro Microphone"
+    ) == (None, False)
+
+
+def test_legacy_numeric_id_matches_nothing(monkeypatch):
+    """A pre-migration index string won't match any device name."""
+    _patch_devices(monkeypatch, _DEVICES)
+    assert output_devices.resolve_output_device("1") == (None, False)
+
+
+def test_unplugged_device_is_not_available(monkeypatch):
+    _patch_devices(monkeypatch, _DEVICES)
+    assert output_devices.resolve_output_device(
+        "USB DAC that got unplugged"
+    ) == (None, False)
+
+
+def test_query_failure_reports_unavailable(monkeypatch):
+    def _boom():
+        raise RuntimeError("PortAudio not initialized")
+
+    monkeypatch.setattr(output_devices.sd, "query_devices", _boom)
+    assert output_devices.resolve_output_device(
+        "MacBook Pro Speakers"
+    ) == (None, False)
+
+
+def test_duplicate_name_prefers_wasapi_on_windows(monkeypatch):
+    """When the same name appears under several host APIs (the Windows
+    duplicate-enumeration case), prefer the WASAPI copy so we land on
+    the entry the picker showed."""
+    devices = [
+        {"name": "Speakers", "max_output_channels": 2,
+         "max_input_channels": 0, "hostapi": 0},   # MME
+        {"name": "Speakers", "max_output_channels": 2,
+         "max_input_channels": 0, "hostapi": 3},   # WASAPI
+    ]
+    _patch_devices(monkeypatch, devices)
+    monkeypatch.setattr(
+        output_devices, "wasapi_host_api_index", lambda: 3
+    )
+    assert output_devices.resolve_output_device("Speakers") == (1, True)

--- a/tests/test_settings_migration.py
+++ b/tests/test_settings_migration.py
@@ -6,7 +6,11 @@ smoke tests.
 """
 from pathlib import Path
 
-from app.settings import Settings, _migrate_default_paths
+from app.settings import (
+    Settings,
+    _migrate_default_paths,
+    _migrate_output_device_index,
+)
 
 
 def test_default_tideway_music_path_migrates_to_tidal(monkeypatch, tmp_path):
@@ -75,3 +79,36 @@ def test_migration_is_idempotent(monkeypatch, tmp_path):
     changed_again = _migrate_default_paths(s)  # second is no-op
 
     assert changed_again is False
+
+
+def test_legacy_numeric_output_device_is_cleared():
+    """A saved PortAudio index (issue #245) resets to system default."""
+    s = Settings()
+    s.audio_output_device = "1"
+
+    changed = _migrate_output_device_index(s)
+
+    assert changed is True
+    assert s.audio_output_device == ""
+
+
+def test_system_default_output_device_is_untouched():
+    s = Settings()
+    s.audio_output_device = ""
+
+    changed = _migrate_output_device_index(s)
+
+    assert changed is False
+    assert s.audio_output_device == ""
+
+
+def test_named_output_device_is_untouched():
+    """A name selection under the new scheme is never mistaken for a
+    legacy index, so it survives the migration."""
+    s = Settings()
+    s.audio_output_device = "MacBook Pro Speakers"
+
+    changed = _migrate_output_device_index(s)
+
+    assert changed is False
+    assert s.audio_output_device == "MacBook Pro Speakers"


### PR DESCRIPTION
## Summary

Fixes #245. Playback broke with `Track load timed out` because the saved output device was a PortAudio enumeration index. That index is not stable, it shifts as devices connect and disconnect, so a saved `"1"` drifted onto the built-in microphone and every play opened a 2-channel output stream on an input-only device, failing with PortAudio's `Invalid number of channels (-9998)`.

Device identity is now the device **name**:

- The picker returns the name as the device id, and the player resolves that name to a live output-capable index at stream-open time (`resolve_output_device`).
- When the chosen device is no longer present (unplugged, or a legacy numeric id from before this change), the open falls back to the system default instead of hard-failing the load.
- A one-time settings migration clears any legacy numeric selection, so the first launch after upgrade plays on the default and the user re-picks once. Every pick after that is a stable name.
- `_recover_from_device_loss` used to distinguish "device gone" from "device present" by whether the reopen raised. Since the reopen no longer raises for a vanished device, it now asks the resolver directly and only drops the selection when the device is genuinely gone.

## Known tradeoff

Two distinct output devices that report the same PortAudio name (two identical USB DACs, an HDMI-out pair) now collapse to one selectable picker entry, and resolution always binds the first match. PortAudio does not expose a stable per-device UID through `query_devices`, so distinguishing same-named devices is out of scope here. This is rare hardware and no worse in practice than the previous behavior for anyone not in that setup.

## Test plan

- New `tests/test_output_devices.py` covers `resolve_output_device`, including the exact issue #245 layout (microphone at index 1), legacy numeric ids, unplugged devices, and the Windows WASAPI duplicate-name tie-break.
- New migration cases in `tests/test_settings_migration.py`.
- Full backend suite green (1013 passed) and preflight green (pytest, tsc, lint, vitest).
- Verified against real hardware matching the issue's device layout: `resolve('1')` and the microphone both report unavailable and fall back to the system default; a real output device resolves to its live index.