### PR TITLE
Fix add-to-playlist menu coming up empty

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -27,7 +27,7 @@ import { ToastProvider, useToast } from "@/components/toast";
 import { DownloadedProvider } from "@/hooks/useDownloadedSet";
 import { DownloadStreamProvider } from "@/hooks/useDownloadStream";
 import { FavoritesProvider } from "@/hooks/useFavorites";
-import { MyPlaylistsProvider } from "@/hooks/useMyPlaylists";
+import { MyPlaylistsProvider, useMyPlaylists } from "@/hooks/useMyPlaylists";
 import { RecentsProvider } from "@/hooks/useRecentlyPlayed";
 import { TrackSelectionProvider } from "@/hooks/useTrackSelection";
 import { UiPreferencesProvider } from "@/hooks/useUiPreferences";
@@ -210,6 +210,7 @@ export default function App() {
 function AppInner() {
   const auth = useAuth();
   const { offline } = useOfflineMode();
+  const { refresh: refreshMyPlaylists } = useMyPlaylists();
 
   // Warm the Home page cache as soon as auth resolves. The Home
   // component is the default route and it lazy-loads its chunk
@@ -219,11 +220,19 @@ function AppInner() {
   // calls useApi, the response is usually already in the cache
   // (or in-flight, in which case useApi dedupes onto the same
   // promise) and renders without the spinner flash.
+  //
+  // The my-playlists cache is loaded here too, not in its provider:
+  // the provider mounts before auth resolves, so a mount-time fetch
+  // 401s during session restore (and always 401s on a fresh login,
+  // which happens after mount) and the add-to-playlist menu stays
+  // empty for the whole session. Keying the fetch to logged_in fires
+  // it once auth is actually confirmed, and again after each login.
   useEffect(() => {
     if (auth.logged_in && !offline) {
       prefetch.pageHome();
+      refreshMyPlaylists().catch(() => {});
     }
-  }, [auth.logged_in, offline]);
+  }, [auth.logged_in, offline, refreshMyPlaylists]);
 
   // Hold the spinner until both probes resolve — rendering Login
   // prematurely would flash the sign-in screen for users who'd land

--- a/web/src/hooks/useMyPlaylists.tsx
+++ b/web/src/hooks/useMyPlaylists.tsx
@@ -2,7 +2,6 @@ import {
   createContext,
   useCallback,
   useContext,
-  useEffect,
   useMemo,
   useRef,
   useState,
@@ -33,10 +32,15 @@ const Ctx = createContext<MyPlaylistsContextValue>({
  * Caches the user's own playlists. Shared via context because multiple
  * consumers need the list (sidebar, add-to-playlist menu, playlist detail)
  * and we'd rather not fetch more than once.
+ *
+ * The provider does NOT fetch on mount: it sits above the component that
+ * owns auth state, and a mount-time fetch races the backend's session
+ * restore (and always loses on a fresh login). AppInner calls refresh()
+ * once auth resolves to logged-in.
  */
 export function MyPlaylistsProvider({ children }: { children: ReactNode }) {
   const [playlists, setPlaylists] = useState<Playlist[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(false);
 
   // Monotonic token used to discard stale refresh responses. Two nearly-
   // simultaneous refresh() calls (e.g. Create + Edit dialogs firing in
@@ -55,10 +59,6 @@ export function MyPlaylistsProvider({ children }: { children: ReactNode }) {
       if (token === refreshToken.current) setLoading(false);
     }
   }, []);
-
-  useEffect(() => {
-    refresh().catch(() => setLoading(false));
-  }, [refresh]);
 
   const optimisticAdd = useCallback((p: Playlist) => {
     setPlaylists((prev) => [p, ...prev.filter((x) => x.id !== p.id)]);


### PR DESCRIPTION
## Summary

MyPlaylistsProvider fired its only fetch when the provider mounted. That races the backend's session restore on cold start and always loses on a fresh login, since login happens after mount. The 401 was swallowed, so the add-to-playlist submenu showed "No playlists yet" for the rest of the session even though the library page, which fetches on navigation, listed the playlists fine.

The provider sits above the component that owns auth state, so it can't key the fetch itself. AppInner already warms the Home cache when `logged_in` flips true; the playlist cache now loads from that same effect, so it fires once auth is confirmed and again after each login.

Fixes #259

## Test plan

- `npm test`: 117 passed
- `npx tsc -b --noEmit`, `npm run lint:all`: clean
- `pytest tests/`: 1014 passed
- Manual: fresh login lands with playlists populated in the track context menu; cold start with a saved session no longer depends on winning the session-restore race