### PR TITLE
Drop separators next to empty template tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,10 @@ preferences. A downloaded playlist lands in a folder named after
 the playlist and is numbered in playlist order rather than by
 album track number, and the template understands `{playlist_num}`
 and `{playlist}` alongside the usual title, track, album, and
-artist tokens.
+artist tokens. A template like `{playlist_num} - {artist} - {title}`
+keeps playlist downloads in playlist order on disk; on album and
+single downloads the empty token and the separator next to it are
+dropped, so the same template renders a clean `Artist - Title`.
 
 ![Download quality picker](assets/screenshots/download-quality.png)
 

--- a/app/downloader.py
+++ b/app/downloader.py
@@ -1942,6 +1942,41 @@ def _explicit_marker(flag: bool) -> str:
     return " [E]" if flag else ""
 
 
+# Placeholder a conditionally-empty token renders as when it has no
+# value, so _absorb_empty_tokens can also swallow the separator the
+# template put next to it. NUL can never collide with real data:
+# _sanitize_segment replaces control bytes in every token value.
+_EMPTY_TOKEN = "\x00"
+
+# Separator literals templates put between tokens. When an empty token
+# sits next to a run of these, the run is absorbed along with it.
+_SEP_CHARS = " ._-"
+
+
+def _absorb_empty_tokens(rendered: str) -> str:
+    """Drop empty-token sentinels together with the separator literals
+    adjacent to them, so one template serves every download kind:
+    "{playlist_num} - {artist} - {title}" gives "05 - A - T" on a
+    playlist and a clean "A - T" (not " - A - T") on an album.
+
+    Works per path segment so a sentinel never absorbs a `/`. Rules:
+    a sentinel ending a segment absorbs the separator run before it;
+    a sentinel at segment start or after a separator absorbs the run
+    after it; a sentinel butted against text ("{artist}{playlist_num}")
+    just disappears, leaving the text and any following separator
+    intact."""
+    parts = re.split(r"([/\\]+)", rendered)
+    out: list[str] = []
+    for part in parts:
+        if part and part[0] in "/\\":
+            out.append(part)
+            continue
+        part = re.sub(rf"(?:[{_SEP_CHARS}]*{_EMPTY_TOKEN})+[{_SEP_CHARS}]*$", "", part)
+        part = re.sub(rf"(^|(?<=[{_SEP_CHARS}])){_EMPTY_TOKEN}[{_SEP_CHARS}]*", "", part)
+        out.append(part.replace(_EMPTY_TOKEN, ""))
+    return "".join(out)
+
+
 def _render_template(template: str, item: DownloadItem) -> str:
     """Interpolate the user's filename_template with sanitized token
     values. Each token's VALUE is sanitized for path-unsafe chars
@@ -1953,9 +1988,14 @@ def _render_template(template: str, item: DownloadItem) -> str:
     Unknown tokens render as the literal `{key}` (see _SafeTokens) so
     the user sees a wonky filename and fixes their template instead of
     the download just dying with a KeyError mid-batch.
+
+    Conditionally-empty tokens (playlist_num, playlist, year, the
+    explicit markers) render the _EMPTY_TOKEN sentinel when they have
+    no value; _absorb_empty_tokens then removes the sentinel along
+    with the separator the template placed next to it.
     """
     year_str = "" if item.year is None else str(item.year)
-    return template.format_map(
+    rendered = template.format_map(
         _SafeTokens(
             title=_sanitize_segment(item.title),
             track_title=_sanitize_segment(item.title),
@@ -1965,20 +2005,26 @@ def _render_template(template: str, item: DownloadItem) -> str:
             album_artist=_sanitize_segment(item.album_artist or item.artist),
             track_num=str(item.track_num).zfill(2),
             disc_num=str(item.disc_num or 1).zfill(2) if item.disc_num else "01",
-            year=year_str,
-            explicit=_explicit_marker(item.track_explicit),
-            album_explicit=_explicit_marker(item.album_explicit_flag),
-            # Playlist-order position; empty when the item isn't from
-            # a playlist so a template carrying {playlist_num} still
-            # renders cleanly for album / single downloads.
+            year=year_str or _EMPTY_TOKEN,
+            explicit=_explicit_marker(item.track_explicit) or _EMPTY_TOKEN,
+            album_explicit=_explicit_marker(item.album_explicit_flag) or _EMPTY_TOKEN,
+            # Playlist-order position; sentinel-empty when the item
+            # isn't from a playlist so a template carrying
+            # {playlist_num} still renders cleanly for album / single
+            # downloads — the separator next to it is absorbed too.
             playlist_num=(
                 str(item.playlist_index).zfill(2)
                 if item.playlist_index > 0
-                else ""
+                else _EMPTY_TOKEN
             ),
-            playlist=_sanitize_segment(item.playlist_name),
+            playlist=(
+                _sanitize_segment(item.playlist_name)
+                if item.playlist_name
+                else _EMPTY_TOKEN
+            ),
         )
     )
+    return _absorb_empty_tokens(rendered)
 
 
 def _split_template_path(rendered: str) -> list[str]:

--- a/tests/test_filename_template.py
+++ b/tests/test_filename_template.py
@@ -116,7 +116,53 @@ def test_render_playlist_tokens_empty_off_playlist():
     template carrying {playlist_num} still renders cleanly."""
     item = _item(title="Hello")  # playlist_index defaults to 0
     assert _render_template("{playlist_num}{title}", item) == "Hello"
-    assert _render_template("{playlist}", item) == "_"  # empty → sanitized
+    # A standalone {playlist} disappears entirely (it used to render
+    # the "_" sanitizer fallback, nesting album downloads under a
+    # junk "_" folder when the template had a {playlist}/ prefix).
+    assert _render_template("{playlist}", item) == ""
+
+
+def test_empty_tokens_absorb_adjacent_separators():
+    """One template has to serve every download kind, so the separator
+    a template puts next to a conditionally-empty token is dropped
+    with it: "{playlist_num} - {artist} - {title}" must not leave a
+    dangling " - " on album / single downloads (#263)."""
+    off = _item(title="Sicko Mode", artist="Travis Scott")
+    on = _item(
+        title="Sicko Mode",
+        artist="Travis Scott",
+        playlist_index=5,
+        playlist_name="Chill Mix",
+    )
+    template = "{playlist_num} - {artist} - {title}"
+    assert _render_template(template, on) == "05 - Travis Scott - Sicko Mode"
+    assert _render_template(template, off) == "Travis Scott - Sicko Mode"
+
+    # Trailing position: the separator BEFORE the empty token goes.
+    assert _render_template("{title} - {playlist_num}", off) == "Sicko Mode"
+    # Mid-template position: only one separator run survives.
+    assert (
+        _render_template("{artist} - {playlist_num} - {title}", off)
+        == "Travis Scott - Sicko Mode"
+    )
+    # Token butted against text keeps the text and the separator that
+    # belongs to the next token.
+    assert (
+        _render_template("{artist}{playlist_num} - {title}", off)
+        == "Travis Scott - Sicko Mode"
+    )
+    # Absorption never crosses a `/`: the empty segment is dropped by
+    # the path splitter, not merged into its neighbour.
+    assert (
+        _render_template("{playlist}/{playlist_num} - {title}", off)
+        == "/Sicko Mode"
+    )
+    # Missing year gets the same treatment.
+    no_year = _item(title="Hello", artist="A", year=None)
+    assert _render_template("{year} - {title}", no_year) == "Hello"
+    # Parentheses are not separators — a template wrapping an empty
+    # token in brackets keeps them (the author's choice to fix).
+    assert _render_template("{album} ({year})", no_year) == "Album Name ()"
 
 
 def test_render_track_title_alias_matches_title():

--- a/web/src/lib/filenameTemplate.ts
+++ b/web/src/lib/filenameTemplate.ts
@@ -170,10 +170,11 @@ export const TEMPLATE_TOKENS: ReadonlyArray<{
   {
     token: "{playlist_num}",
     description:
-      "Two-digit playlist position, e.g. 05 (empty unless downloading a playlist)",
+      "Two-digit playlist position, e.g. 05. Off a playlist it disappears along with the separator next to it",
   },
   {
     token: "{playlist}",
-    description: "Playlist name (empty unless downloading a playlist)",
+    description:
+      "Playlist name. Off a playlist it disappears along with the separator next to it",
   },
 ];


### PR DESCRIPTION
## Summary

One filename template serves every download kind, which made `{playlist_num}` unusable in practice: adding it put playlist downloads in playlist order on disk, but every album and single download then rendered with a dangling separator, like ` - Artist - Title`. So the one thing users ask for (files that sort in playlist order) required accepting junk names everywhere else.

Conditionally empty tokens (`playlist_num`, `playlist`, `year`, the explicit markers) now render a NUL sentinel when they have no value, and a per-segment cleanup pass absorbs the sentinel along with the separator run the template placed next to it. `{playlist_num} - {artist} - {title}` gives `05 - Artist - Title` on a playlist and a clean `Artist - Title` on an album. NUL can't collide with real data because the sanitizer strips control bytes from every token value.

A standalone `{playlist}` off a playlist now disappears instead of rendering the `_` sanitizer fallback, so a `{playlist}/` template prefix no longer nests album downloads under a junk folder. README and the settings token list document the behavior.

Fixes #263

## Test plan

- New cases in `tests/test_filename_template.py` cover leading, trailing, and mid-template empty tokens, tokens butted against text, the segment boundary, missing year, and the bracket case that intentionally stays as-is
- `pytest tests/`: 1014 passed
- `npm test`, `npx tsc -b --noEmit`, `npm run lint:all`: clean