### PR TITLE
Make Flatpak downloads land on the host filesystem

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -1,5 +1,6 @@
 import json
 import os
+import re
 import sys
 import tempfile
 from dataclasses import asdict, dataclass, field
@@ -9,6 +10,51 @@ from typing import Optional
 from app.paths import user_data_dir
 
 SETTINGS_FILE = user_data_dir() / "settings.json"
+
+
+def _xdg_user_dir(key: str, fallback: Path) -> Path:
+    """Resolve an XDG user directory (MUSIC, VIDEOS, ...) on Linux.
+
+    Reads ${XDG_CONFIG_HOME:-~/.config}/user-dirs.dirs, the file the
+    xdg-user-dirs tooling maintains and that Flatpak exposes inside
+    the sandbox. This is what makes the defaults land in the real
+    localized folder ("~/Música", "~/Musik") instead of a literal
+    ~/Music that only exists on English-locale systems — and, under
+    Flatpak, the only paths the manifest's xdg-music / xdg-videos
+    grants actually map to the host. A hardcoded ~/Music inside the
+    sandbox is unmounted tmpfs: downloads "succeed" and vanish on
+    restart (#261).
+
+    Falls back when the file or key is missing, or when the entry is
+    disabled (the spec disables a dir by pointing it at $HOME or a
+    relative path).
+    """
+    if not sys.platform.startswith("linux"):
+        return fallback
+    config_home = Path(os.environ.get("XDG_CONFIG_HOME") or Path.home() / ".config")
+    try:
+        text = (config_home / "user-dirs.dirs").read_text(encoding="utf-8")
+    except OSError:
+        return fallback
+    match = re.search(rf'^XDG_{key}_DIR="(.*)"$', text, re.MULTILINE)
+    if not match:
+        return fallback
+    raw = match.group(1).replace("$HOME", str(Path.home()))
+    resolved = Path(raw)
+    if not resolved.is_absolute() or resolved == Path.home():
+        return fallback
+    return resolved
+
+
+def _default_output_dir() -> str:
+    """Default audio download folder: the platform music directory
+    plus a Tidal subfolder. On Linux the music directory comes from
+    the XDG user-dirs config so it matches what the desktop (and the
+    Flatpak sandbox grant) consider the Music folder."""
+    music = Path.home() / "Music"
+    if sys.platform.startswith("linux"):
+        music = _xdg_user_dir("MUSIC", music)
+    return str(music / "Tidal")
 
 
 def _default_videos_dir() -> str:
@@ -30,7 +76,13 @@ def _default_videos_dir() -> str:
         return str(movies / "Tidal")
     if sys.platform.startswith("win"):
         return str(videos / "Tidal")
-    # Linux — pick whichever exists, prefer Videos which is XDG standard.
+    # Linux — resolve through the XDG user-dirs config first (it's
+    # what the desktop and the Flatpak sandbox grant treat as the
+    # Videos folder); fall back to whichever of the conventional
+    # names exists, preferring Videos which is the XDG default.
+    xdg = _xdg_user_dir("VIDEOS", videos)
+    if xdg != videos:
+        return str(xdg / "Tidal")
     if videos.is_dir() or not movies.is_dir():
         return str(videos / "Tidal")
     return str(movies / "Tidal")
@@ -38,7 +90,7 @@ def _default_videos_dir() -> str:
 
 @dataclass
 class Settings:
-    output_dir: str = str(Path.home() / "Music" / "Tidal")
+    output_dir: str = field(default_factory=_default_output_dir)
     videos_dir: str = field(default_factory=_default_videos_dir)
     filename_template: str = "{artist} - {title}"
     create_album_folders: bool = True
@@ -310,6 +362,24 @@ def _migrate_default_paths(s: Settings) -> bool:
     }
     if s.videos_dir in legacy_videos:
         s.videos_dir = _default_videos_dir()
+        changed = True
+
+    # The Linux defaults became XDG-aware (#261): on a localized
+    # system the music dir is e.g. ~/Música, and under Flatpak that
+    # XDG dir is the only one the manifest grant maps to the host.
+    # Installs that persisted the old hardcoded default get moved to
+    # the real dir; custom paths are untouched as usual.
+    default_music = _default_output_dir()
+    if s.output_dir == new_music and default_music != new_music:
+        s.output_dir = default_music
+        changed = True
+    shipped_default_videos = {
+        str(home / "Videos" / "Tidal"),
+        str(home / "Movies" / "Tidal"),
+    }
+    default_videos = _default_videos_dir()
+    if s.videos_dir in shipped_default_videos and default_videos not in shipped_default_videos:
+        s.videos_dir = default_videos
         changed = True
 
     return changed

--- a/flatpak/com.tidaldownloader.Tideway.yaml
+++ b/flatpak/com.tidaldownloader.Tideway.yaml
@@ -33,7 +33,15 @@ finish-args:
   - --socket=wayland                      # native window
   - --socket=fallback-x11                 # X11 fallback
   - --device=dri                          # WebKitGTK GPU compositing
-  - --filesystem=xdg-download             # downloads -> ~/Downloads
+  # Download folders. The app's defaults are the Music and Videos
+  # user dirs (~/Music/Tidal, ~/Videos/Tidal, localized via
+  # user-dirs.dirs); without these grants those paths are unmounted
+  # tmpfs inside the sandbox, so downloads "complete" and then
+  # vanish on restart (#261). xdg-download stays granted for users
+  # who point output_dir at ~/Downloads instead.
+  - --filesystem=xdg-music:create
+  - --filesystem=xdg-videos:create
+  - --filesystem=xdg-download
   - --talk-name=org.freedesktop.Notifications  # libnotify
 
 cleanup:

--- a/tests/test_xdg_user_dirs.py
+++ b/tests/test_xdg_user_dirs.py
@@ -1,0 +1,107 @@
+"""Tests for the XDG-aware Linux download-folder defaults (#261).
+
+The Flatpak manifest grants xdg-music / xdg-videos, which map to the
+directories named in user-dirs.dirs. The defaults have to resolve
+through that same file or, on a localized system, they'd point at a
+literal ~/Music that only exists as unmounted tmpfs in the sandbox —
+downloads would "complete" and vanish on restart.
+"""
+import sys
+from pathlib import Path
+
+from app.settings import (
+    _default_output_dir,
+    _default_videos_dir,
+    _migrate_default_paths,
+    _xdg_user_dir,
+    Settings,
+)
+
+
+def _write_user_dirs(config_home: Path, body: str) -> None:
+    config_home.mkdir(parents=True, exist_ok=True)
+    (config_home / "user-dirs.dirs").write_text(body, encoding="utf-8")
+
+
+def _linux(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+
+
+def test_xdg_user_dir_reads_localized_entry(monkeypatch, tmp_path):
+    _linux(monkeypatch, tmp_path)
+    _write_user_dirs(
+        tmp_path / ".config",
+        'XDG_MUSIC_DIR="$HOME/Música"\nXDG_VIDEOS_DIR="$HOME/Vídeos"\n',
+    )
+    fallback = tmp_path / "Music"
+    assert _xdg_user_dir("MUSIC", fallback) == tmp_path / "Música"
+    assert _xdg_user_dir("VIDEOS", tmp_path / "Videos") == tmp_path / "Vídeos"
+
+
+def test_xdg_user_dir_falls_back_without_config(monkeypatch, tmp_path):
+    _linux(monkeypatch, tmp_path)
+    fallback = tmp_path / "Music"
+    assert _xdg_user_dir("MUSIC", fallback) == fallback
+
+
+def test_xdg_user_dir_ignores_disabled_entry(monkeypatch, tmp_path):
+    """The spec disables a user dir by pointing it at $HOME (or a
+    relative path) — treat both as 'no such dir', not as a target."""
+    _linux(monkeypatch, tmp_path)
+    _write_user_dirs(
+        tmp_path / ".config",
+        'XDG_MUSIC_DIR="$HOME/"\nXDG_VIDEOS_DIR="Videos"\n',
+    )
+    fallback = tmp_path / "Music"
+    assert _xdg_user_dir("MUSIC", fallback) == fallback
+    assert _xdg_user_dir("VIDEOS", tmp_path / "Videos") == tmp_path / "Videos"
+
+
+def test_xdg_user_dir_is_linux_only(monkeypatch, tmp_path):
+    monkeypatch.setattr(sys, "platform", "darwin")
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path / ".config"))
+    _write_user_dirs(tmp_path / ".config", 'XDG_MUSIC_DIR="$HOME/Música"\n')
+    fallback = tmp_path / "Music"
+    assert _xdg_user_dir("MUSIC", fallback) == fallback
+
+
+def test_default_dirs_follow_user_dirs_config(monkeypatch, tmp_path):
+    _linux(monkeypatch, tmp_path)
+    _write_user_dirs(
+        tmp_path / ".config",
+        'XDG_MUSIC_DIR="$HOME/Música"\nXDG_VIDEOS_DIR="$HOME/Vídeos"\n',
+    )
+    assert _default_output_dir() == str(tmp_path / "Música" / "Tidal")
+    assert _default_videos_dir() == str(tmp_path / "Vídeos" / "Tidal")
+
+
+def test_default_dirs_without_config_keep_conventional_names(monkeypatch, tmp_path):
+    _linux(monkeypatch, tmp_path)
+    assert _default_output_dir() == str(tmp_path / "Music" / "Tidal")
+    assert _default_videos_dir() == str(tmp_path / "Videos" / "Tidal")
+
+
+def test_migration_moves_old_default_to_xdg_dir(monkeypatch, tmp_path):
+    """A persisted old hardcoded default follows the music dir the
+    user-dirs config names; a custom path stays put."""
+    _linux(monkeypatch, tmp_path)
+    _write_user_dirs(
+        tmp_path / ".config",
+        'XDG_MUSIC_DIR="$HOME/Música"\nXDG_VIDEOS_DIR="$HOME/Vídeos"\n',
+    )
+    s = Settings()
+    s.output_dir = str(tmp_path / "Music" / "Tidal")
+    s.videos_dir = str(tmp_path / "Videos" / "Tidal")
+
+    assert _migrate_default_paths(s) is True
+    assert s.output_dir == str(tmp_path / "Música" / "Tidal")
+    assert s.videos_dir == str(tmp_path / "Vídeos" / "Tidal")
+
+    custom = Settings()
+    custom.output_dir = str(tmp_path / "stash")
+    custom.videos_dir = str(tmp_path / "stash-video")
+    assert _migrate_default_paths(custom) is False
+    assert custom.output_dir == str(tmp_path / "stash")


### PR DESCRIPTION
## Summary

The manifest only granted `xdg-download`, but the app's default download folders are the Music and Videos user dirs. Inside the sandbox those paths are unmounted tmpfs: a download reports success, the file is invisible on the host, and a restart wipes it together with the on-device list. That's the disappearing-downloads half of #261.

Two changes:

1. The manifest grants `xdg-music:create` and `xdg-videos:create`, keeping `xdg-download` for users who point `output_dir` there.
2. The Linux defaults resolve through the `user-dirs.dirs` config instead of hardcoding `~/Music` and `~/Videos`. On localized systems the grant maps the real folder (`~/Música`), so a hardcoded English name would still miss it. Installs that persisted the old hardcoded default are migrated to the XDG-resolved dir by the existing default-paths migration; custom paths stay untouched.

The 401-when-offline half of #261 is a separate concern, fixed in its own PR.

## Test plan

- New `tests/test_xdg_user_dirs.py` covers the user-dirs parsing (localized entries, missing config, disabled entries, non-Linux no-op), the default resolution, and the migration including the custom-path guard
- `pytest tests/`: 1020 passed
- Needs a Linux Flatpak build for end-to-end confirmation; the flatpak-build-check workflow triggers on `flatpak/**`