### PR TITLE
Treat network failure as offline, not logged out

### DIFF
--- a/app/http.py
+++ b/app/http.py
@@ -30,6 +30,27 @@ _READ_TIMEOUT_S = 30.0
 DEFAULT_TIMEOUT = (_CONNECT_TIMEOUT_S, _READ_TIMEOUT_S)
 
 
+def network_error_classes() -> tuple:
+    """Exception classes that mean "the network is unreachable, the
+    request never got an answer" — as opposed to a server that
+    answered with a rejection. Covers both transports the app can be
+    running on: plain requests (urllib3) and curl-cffi's impersonated
+    session, whose exception hierarchy mirrors requests' but shares
+    no base class with it. Callers that need to tell offline-ness
+    apart from a real auth rejection catch this tuple."""
+    import requests.exceptions as _rex
+
+    classes: list[type] = [_rex.ConnectionError, _rex.Timeout]
+    try:
+        from curl_cffi.requests import exceptions as _cex
+    except ImportError:
+        # curl-cffi is optional — build_impersonated_session already
+        # falls back to plain requests without it.
+        return tuple(classes)
+    classes += [_cex.ConnectionError, _cex.Timeout]
+    return tuple(classes)
+
+
 def build_impersonated_session():
     """Return a curl-cffi Session with the shared impersonation
     profile, or None if curl-cffi can't be loaded. Also installs the

--- a/server.py
+++ b/server.py
@@ -59,7 +59,7 @@ from app import playlist_import
 from app import spotify_import
 from app import tidal_realtime
 from app.downloader import DownloadItem, DownloadStatus, Downloader
-from app.http import SESSION
+from app.http import SESSION, network_error_classes
 from app.lastfm import LastFmClient
 from app.local_index import LocalIndex
 from app import now_playing_state
@@ -334,6 +334,12 @@ def _install_stream_cache(key: tuple[int, str], path: Path, mime: str) -> None:
             pass
 
 
+# Connection-level failures from either HTTP transport (requests or
+# curl-cffi). _is_logged_in must tell these apart from a real auth
+# rejection: no network ≠ signed out.
+_NETWORK_ERRORS = network_error_classes()
+
+
 def _is_logged_in() -> bool:
     import time
 
@@ -350,6 +356,20 @@ def _is_logged_in() -> bool:
             return bool(_auth_cache["ok"])
     try:
         ok = bool(tidal.session.check_login())
+    except _NETWORK_ERRORS:
+        # Network unreachable is not "logged out". check_login() only
+        # gets as far as the HTTP round-trip when the session has
+        # credentials loaded (it returns False early otherwise), so a
+        # connection-level failure means "signed in, but offline".
+        # Treating it as logged-out used to 401 the local-only
+        # endpoints (downloaded library, cached playback) the moment
+        # the wifi dropped, and flash the login screen at a user
+        # whose session is fine (#261).
+        ok = True
+    except TidalBackoffError:
+        # Same reasoning: a rate-limit backoff window refuses the
+        # check before it leaves the process. The session is intact.
+        ok = True
     except Exception:
         ok = False
     with _auth_cache_lock:

--- a/tests/test_auth_network_failure.py
+++ b/tests/test_auth_network_failure.py
@@ -1,0 +1,59 @@
+"""`_is_logged_in` must distinguish "the network is unreachable" from
+"Tidal rejected the session".
+
+check_login() returns False on its own (no round-trip) when the session
+has no credentials, so a connection-level exception can only happen for
+a session that IS signed in. Turning that into "logged out" 401'd the
+local-only endpoints (downloaded library, cached playback) the moment
+the wifi dropped and flashed the login screen at a signed-in user
+(#261). Same for a Tidal rate-limit backoff window, which refuses the
+check before it leaves the process.
+"""
+from __future__ import annotations
+
+import curl_cffi.requests.exceptions as curl_exc
+import requests.exceptions as req_exc
+import pytest
+
+import server
+from app.tidal_client import TidalBackoffError
+
+
+@pytest.fixture(autouse=True)
+def _fresh_auth_cache():
+    server._session_ready.set()
+    server._invalidate_auth_cache()
+    yield
+    server._invalidate_auth_cache()
+
+
+def _check(monkeypatch, effect) -> bool:
+    def check_login():
+        if isinstance(effect, BaseException):
+            raise effect
+        return effect
+
+    monkeypatch.setattr(server.tidal.session, "check_login", check_login)
+    return server._is_logged_in()
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        req_exc.ConnectionError("dns down"),
+        req_exc.ReadTimeout("stalled"),
+        curl_exc.ConnectionError("dns down"),
+        curl_exc.Timeout("stalled"),
+        TidalBackoffError(60.0, "rate_limited"),
+    ],
+)
+def test_network_failure_keeps_session_signed_in(monkeypatch, exc):
+    assert _check(monkeypatch, exc) is True
+
+
+def test_auth_rejection_still_signs_out(monkeypatch):
+    assert _check(monkeypatch, False) is False
+
+
+def test_unexpected_error_still_signs_out(monkeypatch):
+    assert _check(monkeypatch, ValueError("boom")) is False

--- a/tests/test_session_boot_deferral.py
+++ b/tests/test_session_boot_deferral.py
@@ -24,6 +24,13 @@ def test_boot_thread_signals_session_ready():
 
 
 def test_is_logged_in_blocks_until_session_ready():
+    # The boot thread spawned at import sets _session_ready when it
+    # finishes. If it's still running when this test clears the event,
+    # it re-sets it mid-test and the probe below doesn't block. Join
+    # it first so the clear is authoritative.
+    for t in threading.enumerate():
+        if t.name == "tidal-session-boot":
+            t.join(timeout=30.0)
     server._invalidate_auth_cache()
     server._session_ready.clear()
     try:


### PR DESCRIPTION
## Summary

`_is_logged_in()` swallowed every `check_login()` exception into "logged out" and cached that for 30 seconds. A connection-level failure can only happen for a session that has credentials loaded, since `check_login` returns False early otherwise. So the moment the network dropped, a signed-in user got 401s from the local-only endpoints (downloaded library, cached playback, settings) plus a login-screen flash, exactly when offline browsing is the point. That's the "error 401 going offline" half of #261. A Tidal rate-limit backoff window behaved the same way, since the request gate refuses the check before it leaves the process.

The check now catches the connection-level classes from both HTTP transports the app can run on (requests and curl-cffi share no exception base, so `app/http.py` exposes the combined tuple) and the backoff refusal, and keeps the session signed in for those. Real auth rejections and unexpected errors still sign out.

Includes a synchronization fix for the session-boot-deferral test: it cleared `_session_ready` while the import-time boot thread could still be running, and the thread's own `set()` then landed mid-test. Joining the boot thread first makes the clear authoritative; the new auth tests shifted server import timing enough to hit that race.

## Test plan

- New `tests/test_auth_network_failure.py` parametrizes both transports' ConnectionError and Timeout plus `TidalBackoffError` (stay signed in), and pins that a False return or an unexpected exception still signs out
- `pytest tests/`: 1020 passed, including the previously order-dependent boot-deferral test run directly after the new module