### PR TITLE
Fail loudly when desktop.py runs without a frontend build

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,26 @@ the desktop shell. To launch it from source:
 
 `desktop.py` serves whatever is in `web/dist/`, so rebuild the
 frontend any time you change React code or the desktop window will
-show stale UI.
+show stale UI. If `web/dist/` doesn't exist yet, `desktop.py`
+refuses to start and tells you to build it, since the window would
+otherwise open blank.
+
+On Linux the native window needs a system webview backend that pip
+can't install portably. Install your distro's GTK bindings
+(preferred, it's what the Flatpak uses):
+
+```bash
+# Debian/Ubuntu
+sudo apt install python3-gi gir1.2-webkit2-4.1
+# Fedora
+sudo dnf install python3-gobject webkit2gtk4.1
+# Arch/Manjaro
+sudo pacman -S python-gobject webkit2gtk-4.1
+```
+
+or the Qt fallback via pip: `pip install qtpy PySide6`. Without
+either, `desktop.py` falls back to opening Tideway in your default
+browser and prints these same instructions.
 
 On first launch, click **Login with Tidal**. The login uses PKCE.
 Paste the redirect URL back into the app and Tideway exchanges it
@@ -432,6 +451,16 @@ running maintenance burden. And Atmos playback on a desktop needs
 either a Dolby-capable renderer on the OS side or a receiver on
 the other end of HDMI, which most setups do not have. If any of
 that changes, we can revisit.
+
+**Very old x86 CPUs can crash the audio math libraries.** The
+prebuilt numpy and scipy wheels on PyPI now target the x86-64-v2
+baseline, which needs SSE4.2. CPUs from before roughly 2009, such
+as the AMD Athlon II or first-generation Core, lack it and die
+with an illegal-instruction fault on import. That kills both the
+Flatpak and a stock source install. If you run source on hardware
+like that, install your distro's own numpy and scipy packages,
+which are compiled for the local baseline, and create the venv
+with `--system-site-packages` so they're picked up.
 
 **Network audio output is mostly there, with caveats.**
 Chromecast, Tidal Connect, and UPnP/DLNA all ship in the output

--- a/desktop.py
+++ b/desktop.py
@@ -543,6 +543,26 @@ def main(argv: Optional[list[str]] = None) -> int:
     )
     args = parser.parse_args(argv)
 
+    # The desktop shell serves the built frontend from web/dist. In a
+    # source checkout that folder only exists after a Vite build, and
+    # without it the window opens on a JSON 404 — which renders as a
+    # blank white page with no clue what went wrong (#262). Refuse to
+    # start with instructions instead. Frozen builds and the Flatpak
+    # bundle the folder, so this only ever trips a source run.
+    from app.paths import bundled_resource_dir
+
+    if not (bundled_resource_dir() / "web" / "dist" / "index.html").is_file():
+        print(
+            "[desktop] web/dist is missing — the frontend hasn't been "
+            "built, so the window would come up blank. Build it first:\n"
+            "  cd web && npm install && npm run build\n"
+            "then re-run desktop.py. (For day-to-day frontend work use "
+            "./run.sh, which serves the UI from Vite instead.)",
+            file=sys.stderr,
+            flush=True,
+        )
+        return 1
+
     # Single-instance guard: if /api/health responds, a sibling is
     # already up. Ask it to focus and exit quietly.
     if _probe_existing_instance():

--- a/tests/test_desktop_missing_dist.py
+++ b/tests/test_desktop_missing_dist.py
@@ -1,0 +1,34 @@
+"""Running desktop.py from a source checkout without a Vite build used
+to open a window on a JSON 404 — a blank white page with nothing
+actionable anywhere (#262). The shell must refuse to start and say how
+to build the frontend instead.
+"""
+from __future__ import annotations
+
+import desktop
+from app import paths
+
+
+def test_main_refuses_without_web_dist(monkeypatch, tmp_path, capsys):
+    monkeypatch.setattr(paths, "bundled_resource_dir", lambda: tmp_path)
+
+    rc = desktop.main([])
+
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "web/dist is missing" in err
+    assert "npm run build" in err
+
+
+def test_main_guard_passes_with_web_dist(monkeypatch, tmp_path):
+    """With an index.html in place the guard lets main() continue — it
+    should get as far as the single-instance probe, which we stub to
+    short-circuit the rest of startup."""
+    dist = tmp_path / "web" / "dist"
+    dist.mkdir(parents=True)
+    (dist / "index.html").write_text("<html></html>")
+    monkeypatch.setattr(paths, "bundled_resource_dir", lambda: tmp_path)
+    monkeypatch.setattr(desktop, "_probe_existing_instance", lambda: True)
+    monkeypatch.setattr(desktop, "_ask_existing_to_focus", lambda: None)
+
+    assert desktop.main([]) == 0


### PR DESCRIPTION
## Summary

Follow-ups from the Manjaro report in #262:

1. A source checkout has no `web/dist` until Vite builds one, and `desktop.py` happily opened a window on the JSON 404 the server returns without it: a blank white page with no hint anywhere. It now refuses to start and prints the build command. Frozen builds and the Flatpak bundle the folder, so the guard only ever trips a source run.
2. The README's from-source section documents the Linux native-window packages (GTK bindings per distro, or the Qt fallback via pip). They were only discoverable by hitting the runtime browser fallback's error message.
3. Known limits gains a note for pre-x86-64-v2 CPUs: the PyPI numpy and scipy wheels now target a baseline that needs SSE4.2, and older hardware dies on import with an illegal-instruction fault. The workaround (distro packages plus `--system-site-packages`) is spelled out.

The report's remaining ask, building the Flatpak for legacy CPUs, is upstream wheel policy rather than something the manifest controls.

## Test plan

- New `tests/test_desktop_missing_dist.py` pins the refusal (exit code 1, actionable message) and that the guard passes when `web/dist/index.html` exists
- `pytest tests/`: 1015 passed