### PR TITLE
Add MPRIS support for the Linux desktop

### DIFF
--- a/.github/workflows/update-flatpak-python-sources.yml
+++ b/.github/workflows/update-flatpak-python-sources.yml
@@ -71,11 +71,17 @@ jobs:
         # The pip generator ships as a standalone script in
         # flatpak-builder-tools (not a PyPI console script like
         # flatpak-node-generator). Pull it from the upstream repo and
-        # install its one runtime dependency.
+        # install its one runtime dependency. The historical
+        # `pip/flatpak-pip-generator` path is now a git symlink to the
+        # .py file, and raw.githubusercontent serves a symlink as its
+        # one-line target text — fetch the real file.
         run: |
           curl -fsSL -o flatpak-pip-generator \
-            https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/pip/flatpak-pip-generator
-          python3 -m pip install --quiet requirements-parser
+            https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/pip/flatpak-pip-generator.py
+          head -1 flatpak-pip-generator | grep -q python || {
+            echo "downloaded file is not the generator script:"; head -3 flatpak-pip-generator; exit 1; }
+          # Matches the script's PEP 723 inline metadata block.
+          python3 -m pip install --quiet "requirements-parser<1.0.0,>=0.11.0" "packaging>=23.0"
 
       - name: Regenerate python3-requirements.json
         # --requirements-file mirrors docs/linux-flatpak.md ("generated

--- a/.github/workflows/update-flatpak-python-sources.yml
+++ b/.github/workflows/update-flatpak-python-sources.yml
@@ -100,10 +100,16 @@ jobs:
         # build-check failing on a missing build backend is the
         # symptom). Pure-Python packages build fine from sdists and
         # don't need listing.
+        # --ignore-pkg drops build-only tools from the runtime set:
+        # pyinstaller freezes the macOS/Windows bundles and has no
+        # place inside the Flatpak (docs/linux-flatpak.md: "there is
+        # no freeze step in this path"); its module also fails to pip
+        # install in the sandbox, which is how its inclusion surfaces.
         run: |
           python3 flatpak-pip-generator \
             --runtime="org.gnome.Sdk//49" \
             --prefer-wheels="aiohttp,av,cffi,curl-cffi,httptools,numpy,orjson,pillow,pydantic-core,pyyaml,rapidfuzz,scipy,uvloop,watchfiles,zeroconf" \
+            --ignore-pkg=pyinstaller \
             --requirements-file=requirements.txt \
             --output=flatpak/python3-requirements
 

--- a/.github/workflows/update-flatpak-python-sources.yml
+++ b/.github/workflows/update-flatpak-python-sources.yml
@@ -88,16 +88,22 @@ jobs:
         # offline+hashed from requirements.txt"). Platform markers in
         # requirements.txt are resolved for the Linux/GNOME target, so
         # the darwin-only pyobjc drops out and the linux-only dbus-next
-        # is included automatically. --prefer-wheels forces prebuilt
-        # wheels over sdists (the Rust/Cython transitives — orjson,
-        # curl-cffi, av, numpy, scipy, pydantic-core, ... — have no
-        # PEP-517 build backend in the sandbox); it falls back to an
-        # sdist only where no wheel exists. Output name matches the
-        # module the manifest references (python3-requirements).
+        # is included automatically.
+        #
+        # --prefer-wheels takes a per-package list upstream now (it
+        # used to be a boolean): these are the native-extension
+        # packages that have no PEP-517 build backend inside the
+        # sandbox, so their sdists can't build and the prebuilt
+        # manylinux wheel is required. The list is every package that
+        # ships as a platform wheel in the current source set; when a
+        # new native dep joins requirements.txt, add it here (the
+        # build-check failing on a missing build backend is the
+        # symptom). Pure-Python packages build fine from sdists and
+        # don't need listing.
         run: |
           python3 flatpak-pip-generator \
             --runtime="org.gnome.Sdk//49" \
-            --prefer-wheels \
+            --prefer-wheels="aiohttp,av,cffi,curl-cffi,httptools,numpy,orjson,pillow,pydantic-core,pyyaml,rapidfuzz,scipy,uvloop,watchfiles,zeroconf" \
             --requirements-file=requirements.txt \
             --output=flatpak/python3-requirements
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,11 @@ network AVRs, and a long tail of cheaper Hi-Fi network bridges.
 See [docs/dlna-renderer.md](docs/dlna-renderer.md) for the
 DLNA-side details. Global media keys for play, pause, next, and previous
 work even when the window is minimized. There is an opt-in desktop
-notification on every track change.
+notification on every track change. On Linux, Tideway registers as
+an MPRIS player on the session bus, so GNOME and KDE media widgets,
+the lock screen, and `playerctl` can see the current track and
+drive playback. On macOS the same job is done through the native
+Now Playing integration in Control Center.
 
 **Browsing and library.** Search, a unified Charts page (Popular,
 Top, Rising, and New Releases as tabs), and dedicated album,

--- a/app/mpris.py
+++ b/app/mpris.py
@@ -1,0 +1,591 @@
+"""MPRIS integration (Linux).
+
+Without this module, Tideway is invisible to the Linux desktop's
+media layer: GNOME and KDE media widgets, the lock screen, desklets,
+hardware media keys routed through the desktop, and `playerctl` all
+talk MPRIS (`org.mpris.MediaPlayer2.*` on the session bus), and no
+one is answering for us.
+
+This bridge is the Linux counterpart of the macOS Now Playing bridge
+in `app/audio/macos_now_playing.py`, structurally the same, different
+transport:
+
+  1. Owns `org.mpris.MediaPlayer2.tideway` on the session bus and
+     exports the two standard interfaces at /org/mpris/MediaPlayer2.
+
+  2. Routes Play / Pause / PlayPause / Next / Previous / Stop / Seek
+     and volume writes to the same local HTTP endpoints the macOS
+     remote commands and the pynput hotkey listener use, so the audio
+     engine doesn't have to know anything about D-Bus.
+
+  3. Mirrors the player's state, position, volume, and the display
+     metadata (pushed by the frontend via /api/now-playing) into the
+     Player interface's properties, emitting PropertiesChanged so
+     desktop widgets update live and Seeked when playback position
+     jumps discontinuously.
+
+Cleanly degrades:
+  - Non-Linux: `start()` is a no-op.
+  - Linux without dbus-next or without a session bus (headless SSH,
+    stripped build): logs one line and no-ops. Playback is unaffected.
+
+The service runs a dedicated thread with its own asyncio loop, since
+dbus-next is asyncio-native and the player callbacks arrive on
+arbitrary threads. Cross-thread property updates hop onto the loop
+via call_soon_threadsafe.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import threading
+import time
+from typing import Any, Optional
+from urllib import request as urlrequest
+
+log = logging.getLogger(__name__)
+
+BUS_NAME = "org.mpris.MediaPlayer2.tideway"
+OBJECT_PATH = "/org/mpris/MediaPlayer2"
+
+# mpris:trackid for "nothing loaded". The spec reserves this exact
+# path as the sentinel; clients like playerctl special-case it.
+_NO_TRACK = "/org/mpris/MediaPlayer2/TrackList/NoTrack"
+
+# A position delta bigger than this between the extrapolated and the
+# reported position is a seek, not clock drift. Snapshots arrive on
+# state transitions rather than a fixed tick, so the tolerance is
+# generous.
+_SEEK_JUMP_MS = 1500
+
+
+def _say(msg: str) -> None:
+    """Visible log line — same convention as the macOS bridge:
+    Python's `logging` isn't routed to a visible sink in this app, so
+    high-signal lines use bare print."""
+    print(f"[mpris] {msg}", flush=True)
+
+
+def playback_status(state: str) -> str:
+    """Map the PCMPlayer state string onto the MPRIS enum. Everything
+    that isn't actively playing or paused (idle, error, loading) is
+    Stopped as far as the desktop is concerned."""
+    return {"playing": "Playing", "paused": "Paused"}.get(state, "Stopped")
+
+
+def track_object_path(track_id: Any) -> str:
+    """Render a track id as a valid D-Bus object path. Tidal ids are
+    numeric, but local files could feed anything through here, so
+    every non-alphanumeric byte is folded to `_`."""
+    if track_id is None:
+        return _NO_TRACK
+    safe = "".join(c if c.isalnum() else "_" for c in str(track_id))
+    return f"/org/tideway/track/{safe or '_'}"
+
+
+def build_metadata(
+    track_id: Any,
+    title: str,
+    artist: str,
+    album: str,
+    duration_ms: int,
+    artwork_url: str,
+) -> dict[str, Any]:
+    """Assemble the xesam/mpris metadata dict with plain Python
+    values. Empty fields are omitted rather than sent as empty
+    strings — clients render "" literally. The caller wraps values in
+    D-Bus Variants; keeping this pure makes it testable without a
+    bus."""
+    md: dict[str, Any] = {"mpris:trackid": track_object_path(track_id)}
+    if duration_ms > 0:
+        # MPRIS lengths and positions are microseconds.
+        md["mpris:length"] = int(duration_ms) * 1000
+    if title:
+        md["xesam:title"] = title
+    if artist:
+        md["xesam:artist"] = [artist]
+    if album:
+        md["xesam:album"] = album
+    if artwork_url:
+        md["mpris:artUrl"] = artwork_url
+    return md
+
+
+class MprisBridge:
+    """Owns the session-bus service. Constructed at module import by
+    server.py (like the macOS bridge); safe to instantiate anywhere —
+    start() is where the platform check happens."""
+
+    def __init__(self, base_url: str = ""):
+        self._base_url = base_url.rstrip("/")
+        self._lock = threading.Lock()
+        self._enabled = False
+        self._loop: Any = None
+        self._bus: Any = None
+        self._player_iface: Any = None
+        self._thread: Optional[threading.Thread] = None
+        # Display metadata, pushed by /api/now-playing on track
+        # change. The PlayerSnapshot carries track_id but not
+        # title/artist/album — same split as the macOS bridge.
+        self._title = ""
+        self._artist = ""
+        self._album = ""
+        self._meta_duration_ms = 0
+        self._artwork_url = ""
+        # Latest snapshot state. position is cached with the
+        # monotonic instant it was true, so the Position property can
+        # extrapolate between snapshots instead of serving stale
+        # values to `playerctl position` pollers.
+        self._state = "idle"
+        self._track_id: Any = None
+        self._duration_ms = 0
+        self._position_ms = 0
+        self._position_at = time.monotonic()
+        self._volume = 100
+        self._muted = False
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def set_base_url(self, base_url: str) -> None:
+        """Set the local HTTP base URL after construction — server.py
+        knows the port only at lifespan time."""
+        self._base_url = base_url.rstrip("/")
+
+    def start(self) -> None:
+        """Spin up the D-Bus service thread. Idempotent; no-ops off
+        Linux or when dbus-next isn't importable."""
+        if not sys.platform.startswith("linux"):
+            return
+        with self._lock:
+            if self._enabled:
+                return
+            try:
+                import dbus_next  # noqa: F401
+            except ImportError as exc:
+                _say(f"dbus-next unavailable, MPRIS disabled: {exc!r}")
+                return
+            self._thread = threading.Thread(
+                target=self._run, name="mpris", daemon=True
+            )
+            self._thread.start()
+            self._enabled = True
+
+    def stop(self) -> None:
+        """Disconnect from the bus and stop the loop thread. Called
+        from desktop.py's shutdown path; safe when never started."""
+        with self._lock:
+            if not self._enabled:
+                return
+            self._enabled = False
+            loop, bus = self._loop, self._bus
+            self._loop = None
+            self._bus = None
+            self._player_iface = None
+        if loop is not None:
+            def _shutdown() -> None:
+                if bus is not None:
+                    try:
+                        bus.disconnect()
+                    except Exception:
+                        pass
+                loop.stop()
+
+            try:
+                loop.call_soon_threadsafe(_shutdown)
+            except RuntimeError:
+                # Loop already closed on its own (bus error path).
+                pass
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+            self._thread = None
+
+    def _run(self) -> None:
+        import asyncio
+
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(self._serve())
+            self._loop = loop
+            loop.run_forever()
+        except Exception as exc:
+            # No session bus (headless), name taken, bus died — one
+            # line, then the app carries on without MPRIS.
+            _say(f"service unavailable: {exc!r}")
+            with self._lock:
+                self._enabled = False
+                self._loop = None
+        finally:
+            try:
+                loop.close()
+            except Exception:
+                pass
+
+    async def _serve(self) -> None:
+        from dbus_next.aio import MessageBus
+        from dbus_next.constants import BusType
+
+        bus = await MessageBus(bus_type=BusType.SESSION).connect()
+        root, player = _build_interfaces(self)
+        bus.export(OBJECT_PATH, root)
+        bus.export(OBJECT_PATH, player)
+        await bus.request_name(BUS_NAME)
+        self._bus = bus
+        self._player_iface = player
+        _say(f"registered on session bus as {BUS_NAME}")
+
+    # ------------------------------------------------------------------
+    # State + metadata updates (called from player / HTTP threads)
+    # ------------------------------------------------------------------
+
+    def update_state(self, snap: Any) -> None:
+        """PCMPlayer subscribe() listener. Mirrors state, position,
+        and volume into the Player properties and detects seeks."""
+        now = time.monotonic()
+        with self._lock:
+            expected_ms = self._extrapolated_position_ms(now)
+            new_pos = int(getattr(snap, "position_ms", 0) or 0)
+            was_track = self._track_id
+            seeked = (
+                self._state in ("playing", "paused")
+                and getattr(snap, "state", "") in ("playing", "paused")
+                and was_track == getattr(snap, "track_id", None)
+                and abs(new_pos - expected_ms) > _SEEK_JUMP_MS
+            )
+            self._state = getattr(snap, "state", "idle") or "idle"
+            self._track_id = getattr(snap, "track_id", None)
+            self._duration_ms = int(getattr(snap, "duration_ms", 0) or 0)
+            self._position_ms = new_pos
+            self._position_at = now
+            self._volume = int(getattr(snap, "volume", self._volume))
+            self._muted = bool(getattr(snap, "muted", False))
+            changed = {
+                "PlaybackStatus": playback_status(self._state),
+                "Metadata": self._metadata_variants(),
+                "Volume": self._volume_double(),
+            }
+        self._emit(changed, seeked=seeked)
+
+    def update_metadata(
+        self,
+        *,
+        title: str = "",
+        artist: str = "",
+        album: str = "",
+        duration_ms: int = 0,
+        artwork_url: str = "",
+    ) -> None:
+        """Push display metadata — called from /api/now-playing on
+        every track change, alongside the macOS and Cast mirrors."""
+        with self._lock:
+            self._title = title or ""
+            self._artist = artist or ""
+            self._album = album or ""
+            self._meta_duration_ms = int(duration_ms or 0)
+            self._artwork_url = artwork_url or ""
+            changed = {"Metadata": self._metadata_variants()}
+        self._emit(changed, seeked=False)
+
+    # ------------------------------------------------------------------
+    # Property material (bridge-side so interfaces stay thin)
+    # ------------------------------------------------------------------
+
+    def _extrapolated_position_ms(self, now: Optional[float] = None) -> int:
+        """Position right now, advanced from the last snapshot when
+        playing. Snapshots only arrive on state transitions, so
+        without this every `playerctl position` poll would read the
+        position frozen at the last event."""
+        if now is None:
+            now = time.monotonic()
+        pos = self._position_ms
+        if self._state == "playing":
+            pos += int((now - self._position_at) * 1000)
+        if self._duration_ms > 0:
+            pos = min(pos, self._duration_ms)
+        return max(0, pos)
+
+    def current_position_us(self) -> int:
+        with self._lock:
+            return self._extrapolated_position_ms() * 1000
+
+    def volume_double(self) -> float:
+        with self._lock:
+            return self._volume_double()
+
+    def _volume_double(self) -> float:
+        return 0.0 if self._muted else max(0.0, min(1.0, self._volume / 100.0))
+
+    def metadata_variants(self) -> dict:
+        with self._lock:
+            return self._metadata_variants()
+
+    def _metadata_variants(self) -> dict:
+        try:
+            from dbus_next import Variant
+        except ImportError:
+            # Off Linux (or stripped build) there is no bus to emit
+            # to; update_state still runs unconditionally from the
+            # player's listener list, so degrade instead of raising
+            # into the player's emit loop.
+            return {}
+
+        md = build_metadata(
+            self._track_id,
+            self._title,
+            self._artist,
+            self._album,
+            self._meta_duration_ms or self._duration_ms,
+            self._artwork_url,
+        )
+        out: dict[str, Any] = {}
+        for key, value in md.items():
+            if key == "mpris:trackid":
+                out[key] = Variant("o", value)
+            elif key == "mpris:length":
+                out[key] = Variant("x", value)
+            elif key == "xesam:artist":
+                out[key] = Variant("as", value)
+            else:
+                out[key] = Variant("s", value)
+        return out
+
+    def playback_status_str(self) -> str:
+        with self._lock:
+            return playback_status(self._state)
+
+    # ------------------------------------------------------------------
+    # Command routing (bus thread -> local HTTP, same as macOS bridge)
+    # ------------------------------------------------------------------
+
+    def post(self, path: str, body: Optional[dict] = None) -> None:
+        """Fire-and-forget POST to the local API on a worker thread —
+        D-Bus method handlers must not block on HTTP."""
+        threading.Thread(
+            target=_safe_post,
+            args=(self._base_url, path, body),
+            daemon=True,
+        ).start()
+
+    def seek_relative_us(self, offset_us: int) -> None:
+        with self._lock:
+            duration_ms = self._duration_ms
+            target_ms = self._extrapolated_position_ms() + offset_us // 1000
+        self._post_seek_ms(target_ms, duration_ms)
+
+    def seek_absolute_us(self, position_us: int) -> None:
+        with self._lock:
+            duration_ms = self._duration_ms
+        self._post_seek_ms(position_us // 1000, duration_ms)
+
+    def _post_seek_ms(self, target_ms: int, duration_ms: int) -> None:
+        if duration_ms <= 0:
+            return
+        fraction = max(0.0, min(1.0, target_ms / duration_ms))
+        self.post("/api/player/seek", {"fraction": fraction})
+
+    def set_volume_double(self, value: float) -> None:
+        volume = int(round(max(0.0, min(1.0, float(value))) * 100))
+        self.post("/api/player/volume", {"volume": volume})
+
+    # ------------------------------------------------------------------
+    # Cross-thread emission
+    # ------------------------------------------------------------------
+
+    def _emit(self, changed: dict, *, seeked: bool) -> None:
+        loop = self._loop
+        iface = self._player_iface
+        if loop is None or iface is None:
+            return
+
+        def _do() -> None:
+            try:
+                iface.emit_properties_changed(changed)
+                if seeked:
+                    iface.Seeked(self.current_position_us())
+            except Exception as exc:
+                log.debug("mpris emit failed: %r", exc)
+
+        try:
+            loop.call_soon_threadsafe(_do)
+        except RuntimeError:
+            # Loop shut down between the check and the call.
+            pass
+
+
+def _build_interfaces(bridge: MprisBridge) -> tuple:
+    """Construct the two MPRIS interfaces bound to `bridge`. Kept in a
+    factory so dbus_next only imports on the Linux start() path."""
+    from dbus_next.service import (
+        ServiceInterface,
+        dbus_property,
+        method,
+        signal,
+    )
+    from dbus_next.constants import PropertyAccess
+
+    class _Root(ServiceInterface):
+        def __init__(self) -> None:
+            super().__init__("org.mpris.MediaPlayer2")
+
+        @method()
+        def Raise(self):
+            bridge.post("/api/_internal/focus")
+
+        @method()
+        def Quit(self):
+            # CanQuit is False; some clients call it anyway. Ignore —
+            # quitting the whole app from a media applet is hostile.
+            return None
+
+        @dbus_property(access=PropertyAccess.READ)
+        def CanQuit(self) -> "b":  # noqa: F821
+            return False
+
+        @dbus_property(access=PropertyAccess.READ)
+        def CanRaise(self) -> "b":  # noqa: F821
+            return True
+
+        @dbus_property(access=PropertyAccess.READ)
+        def HasTrackList(self) -> "b":  # noqa: F821
+            return False
+
+        @dbus_property(access=PropertyAccess.READ)
+        def Identity(self) -> "s":  # noqa: F821
+            return "Tideway"
+
+        @dbus_property(access=PropertyAccess.READ)
+        def DesktopEntry(self) -> "s":  # noqa: F821
+            # Matches the .desktop file the Flatpak installs; harmless
+            # when running from source without one.
+            return "com.tidaldownloader.Tideway"
+
+        @dbus_property(access=PropertyAccess.READ)
+        def SupportedUriSchemes(self) -> "as":  # noqa: F821
+            return []
+
+        @dbus_property(access=PropertyAccess.READ)
+        def SupportedMimeTypes(self) -> "as":  # noqa: F821
+            return []
+
+    class _Player(ServiceInterface):
+        def __init__(self) -> None:
+            super().__init__("org.mpris.MediaPlayer2.Player")
+
+        @method()
+        def Next(self):
+            bridge.post("/api/hotkey/next")
+
+        @method()
+        def Previous(self):
+            bridge.post("/api/hotkey/previous")
+
+        @method()
+        def Pause(self):
+            bridge.post("/api/player/pause")
+
+        @method()
+        def PlayPause(self):
+            bridge.post("/api/hotkey/play_pause")
+
+        @method()
+        def Stop(self):
+            bridge.post("/api/player/stop")
+
+        @method()
+        def Play(self):
+            bridge.post("/api/player/play")
+
+        @method()
+        def Seek(self, offset: "x"):  # noqa: F821
+            bridge.seek_relative_us(offset)
+
+        @method()
+        def SetPosition(self, track_id: "o", position: "x"):  # noqa: F821
+            bridge.seek_absolute_us(position)
+
+        @method()
+        def OpenUri(self, uri: "s"):  # noqa: F821
+            # No URI ingestion — Tideway plays from its own catalog.
+            return None
+
+        @signal()
+        def Seeked(self, position: "x") -> "x":  # noqa: F821
+            return position
+
+        @dbus_property(access=PropertyAccess.READ)
+        def PlaybackStatus(self) -> "s":  # noqa: F821
+            return bridge.playback_status_str()
+
+        @dbus_property(access=PropertyAccess.READ)
+        def Rate(self) -> "d":  # noqa: F821
+            return 1.0
+
+        @dbus_property(access=PropertyAccess.READ)
+        def MinimumRate(self) -> "d":  # noqa: F821
+            return 1.0
+
+        @dbus_property(access=PropertyAccess.READ)
+        def MaximumRate(self) -> "d":  # noqa: F821
+            return 1.0
+
+        @dbus_property(access=PropertyAccess.READ)
+        def Metadata(self) -> "a{sv}":  # noqa: F821
+            return bridge.metadata_variants()
+
+        @dbus_property(access=PropertyAccess.READWRITE)
+        def Volume(self) -> "d":  # noqa: F821
+            return bridge.volume_double()
+
+        @Volume.setter
+        def Volume(self, value: "d"):  # noqa: F821
+            bridge.set_volume_double(value)
+
+        @dbus_property(access=PropertyAccess.READ)
+        def Position(self) -> "x":  # noqa: F821
+            return bridge.current_position_us()
+
+        @dbus_property(access=PropertyAccess.READ)
+        def CanGoNext(self) -> "b":  # noqa: F821
+            return True
+
+        @dbus_property(access=PropertyAccess.READ)
+        def CanGoPrevious(self) -> "b":  # noqa: F821
+            return True
+
+        @dbus_property(access=PropertyAccess.READ)
+        def CanPlay(self) -> "b":  # noqa: F821
+            return True
+
+        @dbus_property(access=PropertyAccess.READ)
+        def CanPause(self) -> "b":  # noqa: F821
+            return True
+
+        @dbus_property(access=PropertyAccess.READ)
+        def CanSeek(self) -> "b":  # noqa: F821
+            return True
+
+        @dbus_property(access=PropertyAccess.READ)
+        def CanControl(self) -> "b":  # noqa: F821
+            return True
+
+    return _Root(), _Player()
+
+
+def _safe_post(base_url: str, path: str, body: Optional[dict] = None) -> None:
+    """POST to the local API, swallowing failures — a dead endpoint
+    during startup/shutdown shouldn't take the bus thread with it."""
+    if not base_url:
+        return
+    url = f"{base_url}{path}"
+    try:
+        data = json.dumps(body).encode() if body is not None else None
+        req = urlrequest.Request(url, data=data, method="POST")
+        if data is not None:
+            req.add_header("Content-Type", "application/json")
+        with urlrequest.urlopen(req, timeout=5.0):
+            pass
+    except Exception as exc:
+        log.debug("mpris post %s failed: %r", path, exc)

--- a/desktop.py
+++ b/desktop.py
@@ -319,6 +319,18 @@ def _graceful_shutdown(server: "uvicorn.Server") -> None:  # type: ignore[name-d
     except Exception as exc:
         print(f"[desktop] shutdown: Now Playing stop failed: {exc!r}", file=sys.stderr, flush=True)
 
+    # Same for the Linux MPRIS service: disconnect from the session
+    # bus so desktop widgets drop the player entry immediately instead
+    # of showing a dead "Tideway" until the bus notices the connection
+    # is gone. No-op off Linux or when the service never started.
+    try:
+        import server as _server
+        mpris = getattr(_server, "mpris_bridge", None)
+        if mpris is not None:
+            mpris.stop()
+    except Exception as exc:
+        print(f"[desktop] shutdown: MPRIS stop failed: {exc!r}", file=sys.stderr, flush=True)
+
     # Close the audio OutputStream before the interpreter exits.
     # sounddevice registers an atexit Pa_Terminate(); if a stream is
     # still open when Python finalizes, PortAudio tears it down from

--- a/flatpak/com.tidaldownloader.Tideway.yaml
+++ b/flatpak/com.tidaldownloader.Tideway.yaml
@@ -35,6 +35,9 @@ finish-args:
   - --device=dri                          # WebKitGTK GPU compositing
   - --filesystem=xdg-download             # downloads -> ~/Downloads
   - --talk-name=org.freedesktop.Notifications  # libnotify
+  # MPRIS: the app owns this well-known name on the session bus so
+  # desktop media widgets / playerctl can find it (app/mpris.py).
+  - --own-name=org.mpris.MediaPlayer2.tideway
 
 cleanup:
   - /include

--- a/flatpak/python3-requirements.json
+++ b/flatpak/python3-requirements.json
@@ -12,18 +12,18 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl",
-                    "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"
+                    "url": "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl",
+                    "sha256": "2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl",
-                    "sha256": "3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"
+                    "url": "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl",
+                    "sha256": "68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
-                    "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
+                    "url": "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl",
+                    "sha256": "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
                 },
                 {
                     "type": "file",
@@ -67,8 +67,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl",
-                    "sha256": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+                    "url": "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl",
+                    "sha256": "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"
                 },
                 {
                     "type": "file",
@@ -81,13 +81,13 @@
             "name": "python3-mutagen",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"mutagen>=1.47.0\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"mutagen>=1.48.1\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/b0/7a/620f945b96be1f6ee357d211d5bf74ab1b7fe72a9f1525aafbfe3aee6875/mutagen-1.47.0-py3-none-any.whl",
-                    "sha256": "edd96f50c5907a9539d8e5bba7245f62c9f520aef333d13392a79a4f70aca719"
+                    "url": "https://files.pythonhosted.org/packages/47/d8/a29e4e3991765e7ce4ed1f7e4074fe1ba9da03e0048639734de60f9cadb9/mutagen-1.48.1-py3-none-any.whl",
+                    "sha256": "4f077fe87d3fc7fba259aa63d8c026b18382ca6a42ef37c61e16f1b1b5b82fe7"
                 }
             ]
         },
@@ -95,23 +95,23 @@
             "name": "python3-requests",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"requests>=2.33.1\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"requests>=2.34.2\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl",
-                    "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"
+                    "url": "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl",
+                    "sha256": "2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl",
-                    "sha256": "3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"
+                    "url": "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl",
+                    "sha256": "68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
-                    "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
+                    "url": "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl",
+                    "sha256": "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
                 },
                 {
                     "type": "file",
@@ -129,7 +129,7 @@
             "name": "python3-orjson",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"orjson>=3.10.0\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"orjson>=3.11.9\" --no-build-isolation"
             ],
             "sources": [
                 {
@@ -154,26 +154,26 @@
             "name": "python3-curl-cffi",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"curl-cffi>=0.7.0\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"curl-cffi>=0.15.0\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl",
-                    "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"
+                    "url": "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl",
+                    "sha256": "2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
-                    "sha256": "c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26",
+                    "url": "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+                    "sha256": "799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224",
                     "only-arches": [
                         "x86_64"
                     ]
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
-                    "sha256": "d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b",
+                    "url": "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+                    "sha256": "ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f",
                     "only-arches": [
                         "aarch64"
                     ]
@@ -225,21 +225,21 @@
             "name": "python3-pillow",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pillow>=10.0.0\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pillow>=12.2.0\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
-                    "sha256": "03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9",
+                    "url": "https://files.pythonhosted.org/packages/f7/62/de5bdd77d935331f4f802edc11e4d82950f642caad6cb2f949837b8560e2/pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+                    "sha256": "0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3",
                     "only-arches": [
                         "x86_64"
                     ]
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
-                    "sha256": "f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed",
+                    "url": "https://files.pythonhosted.org/packages/1f/01/e18aff37cb0b4aac47ac90f016d347a49aca667ef97f190b06ac2aabc928/pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65",
                     "only-arches": [
                         "aarch64"
                     ]
@@ -250,7 +250,7 @@
             "name": "python3-fastapi",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"fastapi>=0.110.0\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"fastapi>=0.139.0\" --no-build-isolation"
             ],
             "sources": [
                 {
@@ -265,18 +265,18 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl",
-                    "sha256": "08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"
+                    "url": "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl",
+                    "sha256": "9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/5a/ff/2e4eca3ade2c22fe1dea7043b8ee9dabe47753349eb1b56a202de8af6349/fastapi-0.136.1-py3-none-any.whl",
-                    "sha256": "a6e9d7eeada96c93a4d69cb03836b44fa34e2854accb7244a1ece36cd4781c3f"
+                    "url": "https://files.pythonhosted.org/packages/5f/c7/cb03251d9dfb177246a9809a76f189d21df32dbd4a845951881d11323b7f/fastapi-0.139.2-py3-none-any.whl",
+                    "sha256": "b9ad015a835173d59865e2f5d8296fbc2b317bf56a2ba1a5bfbdd03de2fd4b1c"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
-                    "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
+                    "url": "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl",
+                    "sha256": "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
                 },
                 {
                     "type": "file",
@@ -301,13 +301,13 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl",
-                    "sha256": "d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b"
+                    "url": "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl",
+                    "sha256": "c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl",
-                    "sha256": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+                    "url": "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl",
+                    "sha256": "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"
                 },
                 {
                     "type": "file",
@@ -320,18 +320,18 @@
             "name": "python3-uvicorn",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"uvicorn[standard]>=0.27.0\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"uvicorn[standard]>=0.49.0\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl",
-                    "sha256": "08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"
+                    "url": "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl",
+                    "sha256": "9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/ee/ae/8e92f8058baf87f6c7d86ee7e457668690195cc77efedb8d3797a06e3940/click-8.4.0-py3-none-any.whl",
-                    "sha256": "40c50b7c6c6adac2823d411041ec84f3f103f1b280d5e9ce0d7f998995832f81"
+                    "url": "https://files.pythonhosted.org/packages/fb/e2/79c688af8b210d232694e31e59da9f6ec747bae31c3f5946e4e9b98860d5/click-8.4.2-py3-none-any.whl",
+                    "sha256": "e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"
                 },
                 {
                     "type": "file",
@@ -340,24 +340,24 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/32/6a/6aaa91937f0010d288d3d124ca2946d48d60c3a5ee7ca62afe870e3ea011/httptools-0.7.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl",
-                    "sha256": "04c6c0e6c5fb0739c5b8a9eb046d298650a0ff38cf42537fc372b28dc7e4472c",
+                    "url": "https://files.pythonhosted.org/packages/2e/1b/46f1cecf06b9bbde8e4b8c88034ac7908989e5ff7a3a388ef38392949c1f/httptools-0.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl",
+                    "sha256": "eb3028cca2fc0a6d720e52ef61d8ebb62fcbfeb1de56874546d858d3f25a26b7",
                     "only-arches": [
                         "x86_64"
                     ]
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/6d/70/023d7ce117993107be88d2cbca566a7c1323ccbaf0af7eabf2064fe356f6/httptools-0.7.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
-                    "sha256": "69d4f9705c405ae3ee83d6a12283dc9feba8cc6aaec671b412917e644ab4fa66",
+                    "url": "https://files.pythonhosted.org/packages/77/00/258bfc0837221f81d9725c45f9b948a6a6b2994a147a4fb66e85100c668f/httptools-0.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "88bdd940f2b5d487b4d032c6afa5489a7dc4694410d43de3c38c4fb3af0dc45d",
                     "only-arches": [
                         "aarch64"
                     ]
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
-                    "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
+                    "url": "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl",
+                    "sha256": "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
                 },
                 {
                     "type": "file",
@@ -382,8 +382,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/15/41/ac2dfdbc1f60c7af4f994c7a335cfa7040c01642b605d65f611cecc2a1e4/uvicorn-0.47.0-py3-none-any.whl",
-                    "sha256": "2c5715bc12d1892d84752049f400cd1c3cb018514967fdfeb97640443a6a9432"
+                    "url": "https://files.pythonhosted.org/packages/45/ec/dbb7e5a6b91f86bfb9eb7d2988a2730907b6a729875b949c7f022e8b88fa/uvicorn-0.51.0-py3-none-any.whl",
+                    "sha256": "5d38af6cd620f2ae3849fb44fd4879e0890aa1febe8d47eb355fb45d93fe6a5b"
                 },
                 {
                     "type": "file",
@@ -419,8 +419,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl",
-                    "sha256": "1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec"
+                    "url": "https://files.pythonhosted.org/packages/66/58/bd83247f39ddc26ffc2c24eb05087a3b749e00cb4509fc6d19daa23c8495/websockets-16.1-py3-none-any.whl",
+                    "sha256": "c5149dfe490ec7e5ee5dbf624c642fb725f93a5575c7f00ab594ca9eddb8dd81"
                 }
             ]
         },
@@ -428,28 +428,28 @@
             "name": "python3-sse-starlette",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"sse-starlette>=3.4.1\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"sse-starlette>=3.4.4\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl",
-                    "sha256": "08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"
+                    "url": "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl",
+                    "sha256": "9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
-                    "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
+                    "url": "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl",
+                    "sha256": "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/dc/67/805710444ea8cc75fbf70b920ed431a560c4bf9c57f7d5a3117213189399/sse_starlette-3.4.4-py3-none-any.whl",
-                    "sha256": "3f4dd50d8aed2771a091f3a83000323fc3844541c16b4fe585ae2420cc6df973"
+                    "url": "https://files.pythonhosted.org/packages/78/75/c88d3f5dafd59c791da1ce27650d30bf5b70cbf1cbf01cd00e5f9e360915/sse_starlette-3.4.5-py3-none-any.whl",
+                    "sha256": "e71bad53323f65573c3864a6c3bd0c1eb6e5f092b2e48082b0c35927d19ca296"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl",
-                    "sha256": "d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b"
+                    "url": "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl",
+                    "sha256": "c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6"
                 }
             ]
         },
@@ -477,8 +477,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl",
-                    "sha256": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+                    "url": "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl",
+                    "sha256": "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"
                 }
             ]
         },
@@ -486,21 +486,21 @@
             "name": "python3-av",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"av>=12.0.0\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"av>=18.0.0\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/02/28/167b291356c2cc315a2d62a95b0ceace72b5b0bf547de30b89313110f032/av-17.0.1-cp311-abi3-manylinux_2_28_x86_64.whl",
-                    "sha256": "c58c71bffd9383908c85695ac61d3184c668accb04a5bd1b262e0fb8d09f60a5",
+                    "url": "https://files.pythonhosted.org/packages/6d/b9/7708c43fed7ae28b4a1bad060b4221e3334cd827cec24f7165902a6ac1f4/av-18.0.0-cp311-abi3-manylinux_2_28_x86_64.whl",
+                    "sha256": "ae56b40b6f8b067a8ad2dac664fbfbabac7f7a55b9a7bb031eb99289252bc017",
                     "only-arches": [
                         "x86_64"
                     ]
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a8/8b/8de3fd21c4b0b74d44337421abeab0e71462337fb6a28fff888e0c356cbd/av-17.0.1-cp311-abi3-manylinux_2_28_aarch64.whl",
-                    "sha256": "e6eee84afa48d0e9321047cd3e4facd44b401493f6bdc753e2e1d1e7c9e6d13e",
+                    "url": "https://files.pythonhosted.org/packages/84/74/6732f17b96dc23fd23b876b2805435855abdc8a3b397142be4e581165de8/av-18.0.0-cp311-abi3-manylinux_2_28_aarch64.whl",
+                    "sha256": "4d683b7747a0ba9222b8a5f81e41db5f796e7f64473454ec4fe2548e083c2fa0",
                     "only-arches": [
                         "aarch64"
                     ]
@@ -516,16 +516,16 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
-                    "sha256": "c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26",
+                    "url": "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+                    "sha256": "799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224",
                     "only-arches": [
                         "x86_64"
                     ]
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
-                    "sha256": "d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b",
+                    "url": "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+                    "sha256": "ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f",
                     "only-arches": [
                         "aarch64"
                     ]
@@ -551,16 +551,16 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
-                    "sha256": "a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089",
+                    "url": "https://files.pythonhosted.org/packages/ed/a7/2bcd3fdbb87804755c35b729bf8709d62025c5f4cfd7d5b2415997097515/numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+                    "sha256": "9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a",
                     "only-arches": [
                         "x86_64"
                     ]
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl",
-                    "sha256": "72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b",
+                    "url": "https://files.pythonhosted.org/packages/2e/20/1ee6614d64332a1bba6411f38e68cb79eec1b2459e20a623777c5c5492a2/numpy-2.5.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "1c6759f538fb912fc46de0a6b1758ccf7b57bc7c7ebebc23974fdac3de8db0cd",
                     "only-arches": [
                         "aarch64"
                     ]
@@ -571,37 +571,37 @@
             "name": "python3-scipy",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"scipy>=1.17.1\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"scipy>=1.18.0\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
-                    "sha256": "a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089",
+                    "url": "https://files.pythonhosted.org/packages/ed/a7/2bcd3fdbb87804755c35b729bf8709d62025c5f4cfd7d5b2415997097515/numpy-2.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+                    "sha256": "9726558e8db4a5bf7929a70ae50f63abda4daf0efe810e3bfbab95976f75fc1a",
                     "only-arches": [
                         "x86_64"
                     ]
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl",
-                    "sha256": "72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b",
+                    "url": "https://files.pythonhosted.org/packages/2e/20/1ee6614d64332a1bba6411f38e68cb79eec1b2459e20a623777c5c5492a2/numpy-2.5.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "1c6759f538fb912fc46de0a6b1758ccf7b57bc7c7ebebc23974fdac3de8db0cd",
                     "only-arches": [
                         "aarch64"
                     ]
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/f5/5f/f17563f28ff03c7b6799c50d01d5d856a1d55f2676f537ca8d28c7f627cd/scipy-1.17.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
-                    "sha256": "581b2264fc0aa555f3f435a5944da7504ea3a065d7029ad60e7c3d1ae09c5464",
+                    "url": "https://files.pythonhosted.org/packages/f6/af/e8fe5fb136f51e2b01678b92cb4106d10d8cd68ec147ead2e7cb0ac75398/scipy-1.18.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+                    "sha256": "a46f9273dbd0eb1cefba61c9b8648b4dfe3cbc14a080176f9a73e44b8336dc7f",
                     "only-arches": [
                         "x86_64"
                     ]
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/b4/e0/e58fbde4a1a594c8be8114eb4aac1a55bcd6587047efc18a61eb1f5c0d30/scipy-1.17.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl",
-                    "sha256": "2b64ca7d4aee0102a97f3ba22124052b4bd2152522355073580bf4845e2550b6",
+                    "url": "https://files.pythonhosted.org/packages/ea/b2/e83ea34279a52c03374477c74006256ec78df65fc877baa4617d6de1d202/scipy-1.18.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "0d13bca67c096d89fb95ced0d8921807300fce0275643aef9533cc63a0773468",
                     "only-arches": [
                         "aarch64"
                     ]
@@ -612,7 +612,7 @@
             "name": "python3-rapidfuzz",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"rapidfuzz>=3.0.0\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"rapidfuzz>=3.14.5\" --no-build-isolation"
             ],
             "sources": [
                 {
@@ -637,7 +637,7 @@
             "name": "python3-pynput",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pynput>=1.8.1\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pynput>=1.8.2\" --no-build-isolation"
             ],
             "sources": [
                 {
@@ -671,18 +671,34 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl",
-                    "sha256": "0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb"
+                    "url": "https://files.pythonhosted.org/packages/88/c6/92fcd42f1ba33e1184263f25bfabf3d27c383410470f169e4b8163bf9c17/beautifulsoup4-4.15.0-py3-none-any.whl",
+                    "sha256": "d6f88de62e1d4e38ecb1077eb9724cd0eff29d2a08ca16a401e9b9e93f117cf9"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl",
-                    "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"
+                    "url": "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl",
+                    "sha256": "2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl",
-                    "sha256": "3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"
+                    "url": "https://files.pythonhosted.org/packages/6f/08/f2e7d62c460faae0926f2d6e423694aa409ced3bc1fe2927a0a6e5f05416/cffi-2.1.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+                    "sha256": "799416bae98336e400981ff6e532d67d5c709cfb30afb79865a1315f94b0e224",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/3a/a6/e879bb68cc23a2bc9ba8f4b7d8019f0c2694bad2ab6c4a3701d429439f58/cffi-2.1.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+                    "sha256": "ff067a8d8d880e7809e4ac88eb009bb848870115317b306666502ccad30b147f",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl",
+                    "sha256": "68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5"
                 },
                 {
                     "type": "file",
@@ -691,29 +707,65 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
-                    "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a8/68/b93e09e5e8549019e61acf49f65b1a8530765a7f812c77a7461bca7e4494/pillow-12.2.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
-                    "sha256": "03f6fab9219220f041c74aeaa2939ff0062bd5c364ba9ce037197f4c6d498cd9",
+                    "url": "https://files.pythonhosted.org/packages/5c/12/c70b835487ace3b9ba1502631912e3440082b8ae3a162f60b59cb0b6444d/curl_cffi-0.15.0-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl",
+                    "sha256": "2b6c847d86283b07ae69bb72c82eb8a59242277142aa35b89850f89e792a02fc",
                     "only-arches": [
                         "x86_64"
                     ]
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/73/dd/42107efcb777b16fa0393317eac58f5b5cf30e8392e266e76e51cff28c3d/pillow-12.2.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
-                    "sha256": "f1c943e96e85df3d3478f7b691f229887e143f81fedab9b20205349ab04d73ed",
+                    "url": "https://files.pythonhosted.org/packages/2a/b3/9d2f1057749a1b07ba1989db3c1503ce8bed998310bae9aea2c43aa64f20/curl_cffi-0.15.0-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl",
+                    "sha256": "582e570aa2586b96ed47cf4a17586b9a3c462cbe43f780487c3dc245c6ef1527",
                     "only-arches": [
                         "aarch64"
                     ]
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/c3/c0/c33c8792c3e50193ef55adb95c1c3c2786fe281123291c2dbf0eaab95a6f/pyotp-2.9.0-py3-none-any.whl",
-                    "sha256": "81c2e5865b8ac55e825b0358e496e1d9387c811e85bb40e71a3b29b288963612"
+                    "url": "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl",
+                    "sha256": "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl",
+                    "sha256": "9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl",
+                    "sha256": "84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/f7/62/de5bdd77d935331f4f802edc11e4d82950f642caad6cb2f949837b8560e2/pillow-12.3.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl",
+                    "sha256": "0847a763afefb695bc912d7c131e7e0632d4edc1d8698f58ddabec8e46b8b6d3",
+                    "only-arches": [
+                        "x86_64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/1f/01/e18aff37cb0b4aac47ac90f016d347a49aca667ef97f190b06ac2aabc928/pillow-12.3.0-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "f7401aebd7f581d7f83a439d87d474999317ee099218e5ad25d125290990ba65",
+                    "only-arches": [
+                        "aarch64"
+                    ]
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl",
+                    "sha256": "b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl",
+                    "sha256": "81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/65/33/7b83bde70eddaaaaef487751a9c3a5cc0c0be54620ded0e120ebdc401ff9/pyotp-2.10.0-py3-none-any.whl",
+                    "sha256": "1df2f6a1bcc3bb0716172a5215ddc2f8c7c7fd26a13df9927d52e1746934836c"
                 },
                 {
                     "type": "file",
@@ -727,23 +779,23 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/46/2c/1462b1d0a634697ae9e55b3cecdcb64788e8b7d63f54d923fcd0bb140aed/soupsieve-2.8.3-py3-none-any.whl",
-                    "sha256": "ed64f2ba4eebeab06cc4962affce381647455978ffc1e36bb79a545b91f45a95"
+                    "url": "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl",
+                    "sha256": "33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/f6/e9/758080fa98dd27e872fa9811980f9b2f6563a3c4e55c2b70200314fef047/spotapi-1.2.7-py3-none-any.whl",
-                    "sha256": "9b8b11b1d4fd34473b2124ed1c03bc8ae55b86faba762d892031d3afd159a4f6"
+                    "url": "https://files.pythonhosted.org/packages/5e/f5/0c41cb68dcae6b7de4fac4188a3a9589e21fb31df21ea3a2e888db95e6c9/soupsieve-2.8.4-py3-none-any.whl",
+                    "sha256": "e7e6b0769c8f51ed59acab6e994b00621096cfb1c640a7509295987388fbaf65"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/75/cd/5c735818692927e07980357445569adb6ee204c3332d19c516bae01c6cfa/tls_client-1.0.1-py3-none-any.whl",
-                    "sha256": "2f8915c0642c2226c9e33120072a2af082812f6310d32f4ea4da322db7d3bb1c"
+                    "url": "https://files.pythonhosted.org/packages/3e/ff/0491c208050d5aaab26ede9df11e4e8ff2e1cc0cf0421c8e18deff37c974/spotapi-1.2.8-py3-none-any.whl",
+                    "sha256": "dc5716b215ef207b97249a70347965981c30102899dbe727b1b5f1e643ba179e"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl",
-                    "sha256": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+                    "url": "https://files.pythonhosted.org/packages/49/d3/b8441a820a491ddfc024b0b0cf0393375b75ea13866d9c66727e54c2fc80/typing_extensions-4.16.0-py3-none-any.whl",
+                    "sha256": "481caa481374e813c1b176ada14e97f1f67a4539ce9cfeb3f350d78d6370c2e8"
                 },
                 {
                     "type": "file",
@@ -758,6 +810,20 @@
             ]
         },
         {
+            "name": "python3-dbus-next",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"dbus-next>=0.2.3\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d2/fc/c0a3f4c4eaa5a22fbef91713474666e13d0ea2a69c84532579490a9f2cc8/dbus_next-0.2.3-py3-none-any.whl",
+                    "sha256": "58948f9aff9db08316734c0be2a120f6dc502124d9642f55e90ac82ffb16a18b"
+                }
+            ]
+        },
+        {
             "name": "python3-async-upnp-client",
             "buildsystem": "simple",
             "build-commands": [
@@ -766,21 +832,21 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/0f/15/5bf3b99495fb160b63f95972b81750f18f7f4e02ad051373b669d17d44f2/aiohappyeyeballs-2.6.1-py3-none-any.whl",
-                    "sha256": "f349ba8f4b75cb25c99c5c2d84e997e485204d2902a9597802b0371f09331fb8"
+                    "url": "https://files.pythonhosted.org/packages/71/43/1947f06babed6b3f1d7f38b0c767f52df66bfb2bc10b468c4a7de9eceff2/aiohappyeyeballs-2.7.1-py3-none-any.whl",
+                    "sha256": "9243213661e29250eb41368e5daa826fc017156c3b8a11440826b2e3ed376472"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/f0/d2/e2f77eef1acb7111405433c707dc735e63f67a56e176e72e9e7a2cd3f493/aiohttp-3.13.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
-                    "sha256": "3df334e39d4c2f899a914f1dba283c1aadc311790733f705182998c6f7cae665",
+                    "url": "https://files.pythonhosted.org/packages/9d/6e/dbf1d0625dc711fb2851f4f3c3055c39ed58bae92082d8c627dbe6013736/aiohttp-3.14.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+                    "sha256": "faccab372e66bc76d5731525e7f1143c922271725b9d38c9f97edcc66266b451",
                     "only-arches": [
                         "x86_64"
                     ]
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/3b/86/b7c870053e36a94e8951b803cb5b909bfbc9b90ca941527f5fcafbf6b0fa/aiohttp-3.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
-                    "sha256": "57653eac22c6a4c13eb22ecf4d673d64a12f266e72785ab1c8b8e5940d0e8090",
+                    "url": "https://files.pythonhosted.org/packages/e8/ed/3c0fb5c500fdd8e7ebc10d1889c04384fffa1a9163eac1356088ca9da1b1/aiohttp-3.14.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "bd869c427324e5cb15195793de951295710db28be7d818247f3097b4ab5d4b96",
                     "only-arches": [
                         "aarch64"
                     ]
@@ -812,8 +878,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
-                    "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
+                    "url": "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl",
+                    "sha256": "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
                 },
                 {
                     "type": "file",
@@ -856,18 +922,18 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/22/30/7cd8fdcdfbc5b869528b079bfb76dcdf6056b1a2097a662e5e8c04f42965/certifi-2026.4.22-py3-none-any.whl",
-                    "sha256": "3cb2210c8f88ba2318d29b0388d1023c8492ff72ecdde4ebdaddbb13a31b1c4a"
+                    "url": "https://files.pythonhosted.org/packages/ef/2f/c5464532e965badff2f4c4c1a3a83f5697f0d7c407ed0cda44aaa99bb451/certifi-2026.6.17-py3-none-any.whl",
+                    "sha256": "2227dcbaafe0d2f59279d1762ddddc37783ed4354594f194ffc31d20f41fc3db"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl",
-                    "sha256": "3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d"
+                    "url": "https://files.pythonhosted.org/packages/98/2b/f97f1c193fb855c345d678f5077d6926034db0722df74c8f057020e05a25/charset_normalizer-3.4.9-py3-none-any.whl",
+                    "sha256": "68e5f26a1ad57ded6d1cfb85331d1c1a195314756471d97758c48498bb4dcdf5"
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/d2/23/408243171aa9aaba178d3e2559159c24c1171a641aa83b67bdd3394ead8e/idna-3.15-py3-none-any.whl",
-                    "sha256": "048adeaf8c2d788c40fee287673ccaa74c24ffd8dcf09ffa555a2fbb59f10ac8"
+                    "url": "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl",
+                    "sha256": "7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2"
                 },
                 {
                     "type": "file",
@@ -876,8 +942,8 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/88/95/608f665226bca68b736b79e457fded9a2a38c4f4379a4a7614303d9db3bc/protobuf-7.34.1-py3-none-any.whl",
-                    "sha256": "bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11"
+                    "url": "https://files.pythonhosted.org/packages/19/c7/5f7c636ec43e0c545e28d1f1db71990108306f7bdcb89f069ba97e428e7f/protobuf-7.35.1-py3-none-any.whl",
+                    "sha256": "4bc97768d8fe4ad6743c8a19403e314511ed9f6d13205b687e52421c023ac1b9"
                 },
                 {
                     "type": "file",
@@ -896,19 +962,43 @@
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/51/44/4601cc6f6a3c97344c35abc00a0e9ba2ddc8e1048572c5343de3f06c3715/zeroconf-0.149.8-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
-                    "sha256": "73ad77937f02dafe1722a42ff347af633169be7477828a6d74bbbc519538da82",
+                    "url": "https://files.pythonhosted.org/packages/43/2d/60a04c3cf7e243e47d60152394a5e29a4839ea8fd1c260868ff7af08240d/zeroconf-0.150.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl",
+                    "sha256": "489a51320d20e7f07b2f447cd515f3645d17ceced0212f7249a83ce6d3b748e0",
                     "only-arches": [
                         "x86_64"
                     ]
                 },
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/d3/f5/6c1da0ed1e22f7e33acf6e9e656ea6423a9b1b3453735f58ca102aaad19c/zeroconf-0.149.8-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
-                    "sha256": "267ed7fbfd2076971bbdbb485914daaba6e4a2e16a640e29a2fa4f8b4ac02713",
+                    "url": "https://files.pythonhosted.org/packages/84/78/83b5825eb1d7fd4d32b7acbff5f3becca11c544403fc7f05835d9b3aa3f3/zeroconf-0.150.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl",
+                    "sha256": "8f9ba6980ad92820f56a02a5035e21338c116145db44749462fc46f8f50028bb",
                     "only-arches": [
                         "aarch64"
                     ]
+                }
+            ]
+        },
+        {
+            "name": "python3-pyinstaller",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pyinstaller>=6.21.0\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl",
+                    "sha256": "f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d5/4d/ec706c3fcf39e26888c35b39615ff4d5865d184069666c47492cff1fbe50/pyinstaller-6.21.0.tar.gz",
+                    "sha256": "bb9fab705983e393a2d1cac77d6972513057ad800215fd861dc15ff5272e98fd"
+                },
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/e7/31/f2d7343d8ed5f7c4678377886f6ce533e6eaaa131b252ce950114c2a7efa/pyinstaller_hooks_contrib-2026.6-py3-none-any.whl",
+                    "sha256": "fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3"
                 }
             ]
         }

--- a/flatpak/python3-requirements.json
+++ b/flatpak/python3-requirements.json
@@ -977,30 +977,6 @@
                     ]
                 }
             ]
-        },
-        {
-            "name": "python3-pyinstaller",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"pyinstaller>=6.21.0\" --no-build-isolation"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl",
-                    "sha256": "f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/d5/4d/ec706c3fcf39e26888c35b39615ff4d5865d184069666c47492cff1fbe50/pyinstaller-6.21.0.tar.gz",
-                    "sha256": "bb9fab705983e393a2d1cac77d6972513057ad800215fd861dc15ff5272e98fd"
-                },
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/e7/31/f2d7343d8ed5f7c4678377886f6ce533e6eaaa131b252ce950114c2a7efa/pyinstaller_hooks_contrib-2026.6-py3-none-any.whl",
-                    "sha256": "fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3"
-                }
-            ]
         }
     ]
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -84,6 +84,12 @@ spotapi>=1.2.7
 # environment marker so a Linux / Windows install doesn't pull
 # them.
 pyobjc-framework-MediaPlayer>=12.2.1; sys_platform == "darwin"
+# MPRIS media-player service on the D-Bus session bus (app/mpris.py):
+# the Linux counterpart of the macOS Now Playing bridge, so GNOME and
+# KDE media widgets, the lock screen, and playerctl can see and drive
+# Tideway. Pure Python and asyncio-native; no libdbus binding needed.
+# Skipped off Linux via the environment marker.
+dbus-next>=0.2.3; sys_platform == "linux"
 # UPnP / DLNA MediaRenderer output. Same library Home Assistant's
 # DLNA integration uses. Covers SSDP discovery, AVTransport control
 # (play/pause/seek), RenderingControl (volume), and OpenHome for

--- a/server.py
+++ b/server.py
@@ -54,6 +54,7 @@ from app.audio.eq import (
     parse_parametric_bands,
 )
 from app.audio.macos_now_playing import MacOSNowPlayingBridge
+from app.mpris import MprisBridge
 from app.audio.player import PCMPlayer
 from app import playlist_import
 from app import spotify_import
@@ -179,6 +180,11 @@ play_reporter = PlayReporter(tidal)
 # fills in base_url and calls .start(). No-ops on non-macOS so this
 # is safe to instantiate unconditionally.
 macos_now_playing_bridge = MacOSNowPlayingBridge()
+# Linux counterpart: exposes org.mpris.MediaPlayer2 on the session
+# bus so desktop media widgets, the lock screen, and playerctl can
+# see and drive playback. Same lifecycle contract as the macOS
+# bridge — constructed empty, no-ops off Linux.
+mpris_bridge = MprisBridge()
 settings: Settings = load_settings()
 # Guards the `settings` rebind + downloader.settings swap so workers never
 # see a torn state (new global, old downloader field or vice versa).
@@ -716,6 +722,17 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
         macos_now_playing_bridge.start()
     except Exception as exc:
         print(f"[macos-np] startup failed: {exc}", flush=True)
+
+    # Linux: register on the session bus as an MPRIS player so the
+    # desktop's media layer (GNOME/KDE widgets, lock screen, media
+    # keys, playerctl) can see and drive playback. No-ops off Linux
+    # or without dbus-next. See app/mpris.py.
+    try:
+        port = int(os.environ.get("TIDAL_DL_PORT", "47823"))
+        mpris_bridge.set_base_url(f"http://127.0.0.1:{port}")
+        mpris_bridge.start()
+    except Exception as exc:
+        print(f"[mpris] startup failed: {exc}", flush=True)
 
     # Begin Cast device discovery in the background. Cheap — opens
     # one zeroconf browser thread that gets pruned on shutdown. The
@@ -5034,6 +5051,10 @@ def _native_player() -> PCMPlayer:
         # MediaPlayer framework isn't available, so unconditional
         # subscription is safe.
         _pcm_player_singleton.subscribe(macos_now_playing_bridge.update_state)
+        # Same mirror for the Linux desktop via MPRIS. update_state()
+        # caches everywhere and only emits when the D-Bus service is
+        # actually up, so unconditional subscription is safe here too.
+        _pcm_player_singleton.subscribe(mpris_bridge.update_state)
 
     # One-shot: re-apply persisted EQ + output device so users who
     # set a USB-DAC preference or an EQ preset keep it across restart.
@@ -5410,6 +5431,15 @@ def now_playing_update(payload: _NowPlayingMetadata) -> dict:
     """
     _require_local_access()
     macos_now_playing_bridge.update_metadata(
+        title=payload.title,
+        artist=payload.artist,
+        album=payload.album,
+        duration_ms=payload.duration_ms,
+        artwork_url=payload.artwork_url,
+    )
+    # Mirror the same metadata into MPRIS so Linux desktop widgets
+    # show title / artist / album / artwork. No-op off Linux.
+    mpris_bridge.update_metadata(
         title=payload.title,
         artist=payload.artist,
         album=payload.album,

--- a/tests/test_mpris.py
+++ b/tests/test_mpris.py
@@ -1,0 +1,238 @@
+"""Tests for the MPRIS bridge (app/mpris.py).
+
+The D-Bus service itself needs a session bus, which CI containers and
+macOS dev machines don't have, so these tests cover everything up to
+the bus edge: state mapping, metadata assembly, position
+extrapolation, seek-fraction math, volume conversion, and the command
+routing payloads. The interface classes are additionally
+smoke-constructed when dbus-next is importable so a signature typo
+fails in CI rather than on a user's desktop.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+from app.mpris import (
+    MprisBridge,
+    build_metadata,
+    playback_status,
+    track_object_path,
+)
+
+dbus_next = pytest.importorskip("dbus_next", reason="dbus-next not installed")
+
+
+def _snap(**overrides):
+    base = dict(
+        state="playing",
+        track_id=156951,
+        position_ms=10_000,
+        duration_ms=200_000,
+        volume=80,
+        muted=False,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class TestMapping:
+    def test_playback_status(self):
+        assert playback_status("playing") == "Playing"
+        assert playback_status("paused") == "Paused"
+        assert playback_status("idle") == "Stopped"
+        assert playback_status("") == "Stopped"
+
+    def test_track_object_path(self):
+        assert track_object_path(156951) == "/org/tideway/track/156951"
+        # Non-alphanumerics fold to underscores so the path stays valid.
+        assert track_object_path("a/b c.flac") == "/org/tideway/track/a_b_c_flac"
+        assert (
+            track_object_path(None)
+            == "/org/mpris/MediaPlayer2/TrackList/NoTrack"
+        )
+
+    def test_build_metadata_full(self):
+        md = build_metadata(
+            42, "Sicko Mode", "Travis Scott", "Astroworld", 312_000, "https://x/a.jpg"
+        )
+        assert md["mpris:trackid"] == "/org/tideway/track/42"
+        assert md["mpris:length"] == 312_000_000  # microseconds
+        assert md["xesam:title"] == "Sicko Mode"
+        assert md["xesam:artist"] == ["Travis Scott"]
+        assert md["xesam:album"] == "Astroworld"
+        assert md["mpris:artUrl"] == "https://x/a.jpg"
+
+    def test_build_metadata_omits_empty_fields(self):
+        md = build_metadata(None, "", "", "", 0, "")
+        assert md == {
+            "mpris:trackid": "/org/mpris/MediaPlayer2/TrackList/NoTrack"
+        }
+
+
+class TestBridgeState:
+    def test_update_state_caches_and_position_extrapolates(self):
+        bridge = MprisBridge()
+        bridge.update_state(_snap(position_ms=10_000))
+        # Frozen while paused / at the cached instant.
+        assert bridge.current_position_us() >= 10_000_000
+        # Playing: advances with the wall clock.
+        bridge._position_at = time.monotonic() - 2.0
+        pos = bridge.current_position_us()
+        assert 11_500_000 < pos < 13_500_000
+
+    def test_position_frozen_when_paused(self):
+        bridge = MprisBridge()
+        bridge.update_state(_snap(state="paused", position_ms=30_000))
+        bridge._position_at = time.monotonic() - 5.0
+        assert bridge.current_position_us() == 30_000_000
+
+    def test_position_clamped_to_duration(self):
+        bridge = MprisBridge()
+        bridge.update_state(_snap(position_ms=199_500))
+        bridge._position_at = time.monotonic() - 10.0
+        assert bridge.current_position_us() == 200_000_000
+
+    def test_volume_double_and_mute(self):
+        bridge = MprisBridge()
+        bridge.update_state(_snap(volume=80))
+        assert bridge.volume_double() == pytest.approx(0.8)
+        bridge.update_state(_snap(volume=80, muted=True))
+        assert bridge.volume_double() == 0.0
+
+    def test_metadata_variants_wrap_types(self):
+        from dbus_next import Variant
+
+        bridge = MprisBridge()
+        bridge.update_state(_snap())
+        bridge.update_metadata(
+            title="Song",
+            artist="Artist",
+            album="Album",
+            duration_ms=200_000,
+            artwork_url="https://x/a.jpg",
+        )
+        md = bridge.metadata_variants()
+        assert isinstance(md["mpris:trackid"], Variant)
+        assert md["mpris:trackid"].signature == "o"
+        assert md["mpris:length"].signature == "x"
+        assert md["mpris:length"].value == 200_000_000
+        assert md["xesam:artist"].signature == "as"
+        assert md["xesam:artist"].value == ["Artist"]
+
+
+class TestSeekDetection:
+    def test_discontinuous_jump_flags_seek(self, monkeypatch):
+        bridge = MprisBridge()
+        emitted = []
+        monkeypatch.setattr(
+            bridge, "_emit", lambda changed, seeked: emitted.append(seeked)
+        )
+        bridge.update_state(_snap(position_ms=10_000))
+        # Same track, position leaps 60s: a seek.
+        bridge.update_state(_snap(position_ms=70_000))
+        assert emitted == [False, True]
+
+    def test_track_change_is_not_a_seek(self, monkeypatch):
+        bridge = MprisBridge()
+        emitted = []
+        monkeypatch.setattr(
+            bridge, "_emit", lambda changed, seeked: emitted.append(seeked)
+        )
+        bridge.update_state(_snap(track_id=1, position_ms=190_000))
+        bridge.update_state(_snap(track_id=2, position_ms=0))
+        assert emitted == [False, False]
+
+
+class TestCommandRouting:
+    def test_seek_relative_posts_fraction(self, monkeypatch):
+        bridge = MprisBridge(base_url="http://127.0.0.1:1")
+        posts = []
+        monkeypatch.setattr(
+            bridge, "post", lambda path, body=None: posts.append((path, body))
+        )
+        bridge.update_state(_snap(state="paused", position_ms=100_000))
+        bridge.seek_relative_us(10_000_000)  # +10s
+        assert posts == [("/api/player/seek", {"fraction": pytest.approx(0.55)})]
+
+    def test_seek_absolute_clamps(self, monkeypatch):
+        bridge = MprisBridge()
+        posts = []
+        monkeypatch.setattr(
+            bridge, "post", lambda path, body=None: posts.append((path, body))
+        )
+        bridge.update_state(_snap(state="paused"))
+        bridge.seek_absolute_us(999_000_000_000)
+        assert posts == [("/api/player/seek", {"fraction": 1.0})]
+
+    def test_seek_without_duration_is_dropped(self, monkeypatch):
+        bridge = MprisBridge()
+        posts = []
+        monkeypatch.setattr(
+            bridge, "post", lambda path, body=None: posts.append((path, body))
+        )
+        bridge.update_state(_snap(state="idle", duration_ms=0))
+        bridge.seek_relative_us(10_000_000)
+        assert posts == []
+
+    def test_volume_write_converts_to_percent(self, monkeypatch):
+        bridge = MprisBridge()
+        posts = []
+        monkeypatch.setattr(
+            bridge, "post", lambda path, body=None: posts.append((path, body))
+        )
+        bridge.set_volume_double(0.35)
+        bridge.set_volume_double(1.7)  # out-of-range writes clamp
+        assert posts == [
+            ("/api/player/volume", {"volume": 35}),
+            ("/api/player/volume", {"volume": 100}),
+        ]
+
+
+class TestInterfaceConstruction:
+    def test_interfaces_build_and_expose_mpris_members(self):
+        """Constructing the ServiceInterfaces validates every dbus
+        signature annotation via dbus-next's own introspection — a
+        typo in a property type fails here, not on a user's desktop."""
+        from app.mpris import _build_interfaces
+
+        bridge = MprisBridge()
+        bridge.update_state(_snap())
+        root, player = _build_interfaces(bridge)
+        assert root.name == "org.mpris.MediaPlayer2"
+        assert player.name == "org.mpris.MediaPlayer2.Player"
+
+        root_props = {p.name for p in root._get_properties(root)}
+        assert {"Identity", "CanRaise", "DesktopEntry"} <= root_props
+        player_props = {p.name for p in player._get_properties(player)}
+        assert {
+            "PlaybackStatus",
+            "Metadata",
+            "Position",
+            "Volume",
+            "CanSeek",
+            "CanControl",
+        } <= player_props
+        methods = {m.name for m in player._get_methods(player)}
+        assert {
+            "Play",
+            "Pause",
+            "PlayPause",
+            "Stop",
+            "Next",
+            "Previous",
+            "Seek",
+            "SetPosition",
+        } <= methods
+
+    def test_property_getters_read_bridge_state(self):
+        from app.mpris import _build_interfaces
+
+        bridge = MprisBridge()
+        bridge.update_state(_snap(state="paused", volume=50))
+        _, player = _build_interfaces(bridge)
+        assert player.PlaybackStatus == "Paused"
+        assert player.Volume == pytest.approx(0.5)
+        assert player.CanControl is True


### PR DESCRIPTION
## Summary

Tideway was invisible to the Linux desktop's media layer: GNOME and KDE media widgets, the lock screen, desklets, and `playerctl` all talk MPRIS on the session bus, and nothing answered for us.

`app/mpris.py` is the Linux counterpart of the macOS Now Playing bridge, structurally the same with a different transport. It owns `org.mpris.MediaPlayer2.tideway` via dbus-next and exports both standard interfaces:

- Player snapshots and the `/api/now-playing` metadata pushes mirror into the Player properties. Position extrapolates from the last snapshot while playing, so `playerctl position` pollers read live values instead of the position frozen at the last state change.
- `PropertiesChanged` fires on every state or metadata change and `Seeked` on discontinuous position jumps, so widgets update without polling.
- Play, Pause, PlayPause, Next, Previous, Stop, Seek, SetPosition, and volume writes route to the same local HTTP endpoints the macOS remote commands and the pynput hotkey listener already use. Raise focuses the window through `/api/_internal/focus`.

The service runs a dedicated thread with its own asyncio loop (dbus-next is asyncio-native; player callbacks arrive on arbitrary threads). It degrades cleanly: no-op off Linux, one log line and no-op when dbus-next is missing or there's no session bus. desktop.py disconnects it at shutdown so widgets drop the entry immediately.

Packaging: `dbus-next>=0.2.3; sys_platform == "linux"` in requirements, `--own-name=org.mpris.MediaPlayer2.tideway` in the Flatpak manifest, and the Flatpak pip source set regenerated via the new update-flatpak-python-sources workflow (#258).

Closes #242

## Test plan

- `tests/test_mpris.py` (17 tests): state and metadata mapping, variant typing, position extrapolation and clamping, seek detection vs track change, seek fraction and volume conversion payloads, and interface construction, which validates every D-Bus signature annotation through dbus-next's own parser
- `pytest tests/`: 1030 passed
- Needs a manual pass on a real Linux desktop: `playerctl -p tideway status/metadata/position`, GNOME or KDE widget, lock screen, and the Flatpak build with the regenerated pip sources