### PR TITLE
Show album art in Now Playing and MPRIS

### DIFF
--- a/web/src/hooks/usePlayer.ts
+++ b/web/src/hooks/usePlayer.ts
@@ -683,6 +683,14 @@ export function usePlayer() {
         artist: artistName,
         album: track.album?.name ?? "",
         duration_ms: Math.round((track.duration ?? 0) * 1000),
+        // `album.cover` is already a full resources.tidal.com URL
+        // (the backend expands the UUID when it serializes the
+        // track). MPRIS puts it in `mpris:artUrl` and macOS Now
+        // Playing fetches it, so desktop media widgets and Control
+        // Center show the album art. Omitted when the track has no
+        // cover — build_metadata drops an empty artUrl rather than
+        // sending "".
+        artwork_url: track.album?.cover ?? undefined,
       })
       .catch(() => {
         /* fire-and-forget */


### PR DESCRIPTION
## Summary

The `/api/now-playing` call from the player never forwarded the cover
URL, so the MPRIS bridge received an empty `artwork_url` and dropped
`mpris:artUrl`. Linux desktop media widgets showed no album art, and
since the same call feeds macOS Now Playing, Control Center had none
either. `track.album.cover` is already the full `resources.tidal.com`
URL the UI renders, so forwarding it is all that was missing — the
bridges and payload model already handle `artwork_url`.

Reported in #242 (MPRIS shipped in v1.19.0; this fills the album-art
gap the reporter asked about).

## Test plan

- `npx tsc -b --noEmit` — clean.
- `npm run lint:all` — 0 errors.
- `npm test` — 117 passing.
- The remote `https://` art URL is what KDE, GNOME, and Cinnamon MPRIS
  consumers fetch; end-to-end art rendering can only be confirmed on a
  real Linux desktop widget. If a specific widget ignores remote URLs,
  the follow-up is local-file caching of the cover.