### PR TITLE
Persist webview storage across restarts

### DIFF
--- a/desktop.py
+++ b/desktop.py
@@ -1622,8 +1622,22 @@ def main(argv: Optional[list[str]] = None) -> int:
         # gui=None lets pywebview pick the native backend
         # (edgechromium/WebView2 on Windows, WebKit on macOS,
         # WebKitGTK / QtWebEngine on Linux).
+        #
+        # private_mode defaults to True, which gives the webview an
+        # ephemeral profile that's wiped on exit. That reset the
+        # "dismissed" flags the UI stores in localStorage every restart:
+        # the Last.fm connect nudge and the per-version update banner
+        # both came back on every launch (#276). Point storage at a
+        # stable dir under the app data folder so those flags — and any
+        # future localStorage/cookie state — survive restarts.
+        from app.paths import user_data_dir
+
+        webview_storage = user_data_dir() / "webview"
+        webview_storage.mkdir(parents=True, exist_ok=True)
         try:
-            webview.start()
+            webview.start(
+                private_mode=False, storage_path=str(webview_storage)
+            )
         except webview.errors.WebViewException as exc:
             # Linux only: pywebview needs GTK (with python-gobject +
             # gir1.2-webkit2) or QT (with PyQt5 + QtWebEngine) installed


### PR DESCRIPTION
## Summary

pywebview's `start()` defaults to `private_mode=True`, which gives the
native webview an ephemeral profile that's wiped on exit. The UI stores
its "dismissed" flags in `localStorage` — the Last.fm connect nudge and
the per-version update banner both do — so every restart wiped them and
the nudge/banner reappeared (#276).

This sets `private_mode=False` with a stable `storage_path` under the
app data dir, so localStorage (and cookies/IndexedDB) persist across
launches. The X on the Last.fm nudge now sticks permanently, which is
exactly what the reporter asked for.

## Test plan

- `python -m pytest tests/test_desktop_missing_dist.py` — passing.
- Storage dir resolves under `user_data_dir()/webview`; on Flatpak this
  is the persisted XDG data path.
- Behavioral confirmation (nudge stays dismissed after restart) needs a
  packaged desktop build; it can't be exercised from the browser dev
  server, which uses real browser localStorage that already persists.