### PR TITLE
Theme native controls with color-scheme (fixes white dropdown)

### DIFF
--- a/web/src/index.css
+++ b/web/src/index.css
@@ -22,6 +22,14 @@
    *  for light mode; Tailwind classes that reference `bg-background`,
    *  `text-foreground`, etc. pick up whichever set is active. */
   :root {
+    /* Tell the engine the app is dark so UA-rendered controls (the
+     *  native <select> option popup, scrollbars, form widgets) paint
+     *  in a dark scheme. Without this, WebKitGTK falls back to the OS
+     *  default (usually light) and the dropdown popup renders white,
+     *  often white-on-white and unreadable (#274). `.light` flips it
+     *  back below. */
+    color-scheme: dark;
+
     --background: 0 0% 2%;
     --foreground: 0 0% 98%;
     --card: 0 0% 4%;
@@ -52,6 +60,8 @@
   }
 
   .light {
+    color-scheme: light;
+
     /* Off-white base with a cool tint so `bg-card` (pure white) reads
      *  as elevated against it — the old palette had background at 100%
      *  and card at 98%, which left surfaces indistinguishable. The


### PR DESCRIPTION
## Summary

On the dark theme under WebKitGTK, the native `<select>` option popup
rendered white (white-on-white, unreadable) because the app never
declared a `color-scheme` — so the engine used the OS default. Setting
`color-scheme: dark` on `:root` and `color-scheme: light` on `.light`
makes WebKitGTK paint the dropdown popup, scrollbars, and other
UA-rendered widgets in the active theme's scheme. Reported in #274.

## Test plan

- `npx stylelint src/index.css` — clean.
- `npx prettier --check` — clean.
- Verified in the dev server that computed `color-scheme` on the root
  is `dark` by default and flips to `light` when the `.light` theme
  class is applied.
- The original white popup is WebKitGTK-specific; macOS/Chromium theme
  native selects regardless, so the visible fix lands on the Linux
  build.