### PR TITLE
Re-advertise end-of-track state so playback advances after every song

### DIFF
--- a/server.py
+++ b/server.py
@@ -7357,6 +7357,65 @@ def upnp_devices() -> dict:
 # startup so the pynput listener thread can fan events out.
 
 
+def _snapshot_needs_client_action(state: Optional[str]) -> bool:
+    """Player states the client must *respond* to, not merely display.
+
+    `ended` -> the client advances the queue to the next track;
+    `error` -> the client skips the dead track (when continue-playing
+    is on). The player parks in these states and emits the transition
+    exactly once. Auto-advance therefore hinges on the client catching
+    that single edge — and if it's missed (a frame coalesced away under
+    backpressure, a dropped SSE message, a reconnect gap) the player
+    strands at end-of-track with no recovery, which is the "song ended
+    and didn't advance" hang.
+
+    So these states are re-advertised on every poll instead of deduped.
+    The client's monotonic `seq` guard makes the repeat a no-op for a
+    client that already acted, while a client that missed the edge
+    finally sees it and advances.
+    """
+    return state in ("ended", "error")
+
+
+def _should_forward_snapshot(seq, last_seq, state: Optional[str]) -> bool:
+    """Whether a polled snapshot should be sent, given the last seq we
+    already put on the wire.
+
+    A new seq always goes out. A *repeat* seq is normally deduped to
+    keep idle keepalive ticks off the wire — except for states the
+    client must respond to (`ended`/`error`), which keep flowing so a
+    client that missed the one transition edge still receives it and
+    advances. The client's own monotonic seq guard makes the repeats a
+    no-op once it has acted.
+    """
+    if seq != last_seq:
+        return True
+    return _snapshot_needs_client_action(state)
+
+
+def _put_latest(queue: "asyncio.Queue", payload) -> None:
+    """Enqueue `payload`, dropping the OLDEST buffered snapshot when the
+    queue is full.
+
+    Snapshots are a last-writer-wins stream: losing an intermediate
+    position tick under backpressure is harmless, but the *newest*
+    snapshot must never be dropped — it is sometimes the one `ended`
+    edge that drives auto-advance. The previous code did the opposite:
+    `put_nowait` raised `QueueFull` on the newest and the surrounding
+    `except: pass` swallowed it, so a busy event loop at a track
+    boundary could silently strand playback.
+    """
+    while True:
+        try:
+            queue.put_nowait(payload)
+            return
+        except asyncio.QueueFull:
+            try:
+                queue.get_nowait()
+            except asyncio.QueueEmpty:
+                return
+
+
 @app.get("/api/player/events")
 async def player_events(request: Request):
     """SSE stream of player snapshots.
@@ -7375,8 +7434,12 @@ async def player_events(request: Request):
     def _on_snapshot(snap) -> None:
         payload = _snapshot_dict(snap)
         try:
-            loop.call_soon_threadsafe(queue.put_nowait, payload)
-        except Exception:
+            loop.call_soon_threadsafe(_put_latest, queue, payload)
+        except RuntimeError:
+            # Event loop already closed: the SSE connection is tearing
+            # down and unsubscribe() is about to detach us. Nothing to
+            # deliver. (Narrow catch — we do NOT want to swallow a
+            # QueueFull here; _put_latest handles backpressure itself.)
             pass
 
     unsubscribe = player.subscribe(_on_snapshot)
@@ -7399,8 +7462,11 @@ async def player_events(request: Request):
                 if payload is None:
                     break
                 seq = payload.get("seq", 0)
-                if seq == last_seq and payload.get("state") != "playing":
-                    # Dedupe keepalive ticks while nothing is happening.
+                if not _should_forward_snapshot(seq, last_seq, payload.get("state")):
+                    # Dedupe keepalive ticks while nothing actionable is
+                    # pending. States the client must respond to
+                    # (`ended`/`error`) keep flowing so a client that
+                    # missed the transition can still act.
                     continue
                 last_seq = seq
                 yield f"data: {json.dumps(payload)}\n\n"

--- a/tests/test_player_events_sse.py
+++ b/tests/test_player_events_sse.py
@@ -1,0 +1,102 @@
+"""Tests for the /api/player/events SSE stream's delivery guarantees.
+
+Auto-advance in Tideway is client-driven: the backend plays a track to
+its end, parks at `state="ended"`, and emits that transition exactly
+once. The frontend catches the edge and drives the next track. The
+whole chain therefore hinges on the `ended` snapshot actually reaching
+the client — if it's lost, the player sits at end-of-track forever with
+no recovery ("the song ended and didn't go to the next song").
+
+Two regressions this pins:
+
+1. `_put_latest` must never drop the NEWEST snapshot under backpressure.
+   The old producer did `put_nowait` inside a bare `except: pass`, so a
+   full queue silently discarded the very snapshot (`ended`) that drives
+   the advance.
+
+2. The stream must keep re-advertising a parked `ended`/`error` state
+   instead of deduping it away, so a client that missed the single edge
+   still sees it on the next poll.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import server
+
+
+# ---------------------------------------------------------------------------
+# _put_latest — backpressure must sacrifice the OLDEST, keep the newest
+# ---------------------------------------------------------------------------
+
+
+def test_put_latest_keeps_newest_when_full():
+    q: asyncio.Queue = asyncio.Queue(maxsize=2)
+    server._put_latest(q, {"seq": 1, "state": "playing"})
+    server._put_latest(q, {"seq": 2, "state": "playing"})
+    # Queue is now full. The newest snapshot must still land — the old
+    # code would have dropped this one on the floor.
+    server._put_latest(q, {"seq": 3, "state": "ended"})
+
+    drained = [q.get_nowait() for _ in range(q.qsize())]
+    seqs = [p["seq"] for p in drained]
+    assert seqs == [2, 3], f"expected oldest (1) dropped, newest kept: {seqs}"
+    # The critical invariant: the terminal `ended` snapshot survived.
+    assert drained[-1]["state"] == "ended"
+
+
+def test_put_latest_normal_case_appends():
+    q: asyncio.Queue = asyncio.Queue(maxsize=8)
+    server._put_latest(q, {"seq": 1, "state": "playing"})
+    server._put_latest(q, {"seq": 2, "state": "ended"})
+    assert q.qsize() == 2
+    assert q.get_nowait()["seq"] == 1
+    assert q.get_nowait()["seq"] == 2
+
+
+# ---------------------------------------------------------------------------
+# _snapshot_needs_client_action — which states must keep flowing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("state", ["ended", "error"])
+def test_states_that_require_a_client_response_are_actionable(state):
+    assert server._snapshot_needs_client_action(state) is True
+
+
+@pytest.mark.parametrize("state", ["playing", "paused", "idle", "loading", None])
+def test_display_only_states_are_not_actionable(state):
+    assert server._snapshot_needs_client_action(state) is False
+
+
+# ---------------------------------------------------------------------------
+# _should_forward_snapshot — the poll-loop gate that parks or re-sends
+# ---------------------------------------------------------------------------
+#
+# This is the exact decision the SSE generator makes on every poll tick.
+# A live end-to-end stream test can't cover it cleanly: the generator
+# loops forever and Starlette's TestClient never satisfies
+# `request.is_disconnected()` on teardown, so the client hangs. Pinning
+# the pure decision instead keeps the regression covered deterministically.
+
+
+def test_new_seq_is_always_forwarded():
+    assert server._should_forward_snapshot(6, 5, "playing") is True
+
+
+def test_repeat_seq_of_a_display_state_is_deduped():
+    # Idle/paused/playing keepalive ticks with an unchanged seq stay off
+    # the wire so we don't spam identical frames.
+    assert server._should_forward_snapshot(5, 5, "playing") is False
+    assert server._should_forward_snapshot(5, 5, "paused") is False
+
+
+@pytest.mark.parametrize("state", ["ended", "error"])
+def test_repeat_seq_of_an_actionable_state_is_re_advertised(state):
+    # The regression: a client that missed the single `ended`/`error`
+    # edge must keep being offered it on subsequent polls, even though
+    # the seq hasn't advanced. Before the fix this returned False and
+    # the player hung at end-of-track forever.
+    assert server._should_forward_snapshot(9179, 9179, state) is True


### PR DESCRIPTION
## Summary

Fixes a hang where a track finishes and playback stops instead of advancing to the next song (reported from a user activity report: backend correctly parked at `state="ended"`, but no follow-up play command ever arrived).

Auto-advance is client-driven — the player runs a track to its end, parks at `ended`, and emits that transition exactly once; the frontend catches the edge and drives the next track. That made the whole chain hinge on a single transient SSE frame reaching the client. Two producer-side defects turned a momentarily-lost frame into a *permanent* hang:

- The SSE poll deduped every non-`playing` repeat by seq, so once the player sat at `ended` the state was never re-sent on that connection. A client that missed the one edge got no second chance ([server.py](../blob/main/server.py)).
- The snapshot enqueue swallowed `QueueFull` in a bare `except`, dropping the *newest* snapshot under backpressure — sometimes the very `ended` frame that drives the advance.

### Fix

Make the terminal signal a **level, not an edge**:

- `_snapshot_needs_client_action` / `_should_forward_snapshot`: keep re-advertising states the client must respond to (`ended`/`error`) on every poll, so a client that missed the transition still acts. The client's monotonic `seq` guard makes the repeats a no-op once it has advanced — re-delivery is free when unneeded.
- `_put_latest`: coalesce under backpressure by dropping the **oldest** buffered snapshot instead of the newest, and narrow the enqueue catch to `RuntimeError` (loop-closed teardown) instead of swallowing everything.

No frontend changes — the client's existing seq guard already makes the re-delivered frames idempotent.

## Test plan

- `tests/test_player_events_sse.py` (new): backpressure keeps the newest snapshot, `ended`/`error` are actionable, and a repeat-seq terminal state is re-advertised while display-only states stay deduped.
- Full backend suite green (`pytest tests/`).
- `tsc -b --noEmit`, `eslint` (0 errors), `vitest` (117) all green — diff is Python-only.
- **End-to-end on a live server** (not TestClient): played a track, seeked near the end to force natural EOF, and confirmed on the real SSE wire that the parked `ended` frame is re-advertised ~1/sec (vs. once before); on sending the next `play_track`, the stream cleanly moved to the new track and re-advertising stopped — no double-advance, no stuck frames, no errors in the log.