### PR TITLE
Keep the session signed in when Tidal is unreachable at boot

### DIFF
--- a/app/tidal_client.py
+++ b/app/tidal_client.py
@@ -505,6 +505,9 @@ class TidalClient:
         # yet. Read by the server's auth check (offline ≠ signed out)
         # and cleared by the watchdog's retry once the network is back.
         self._session_load_deferred = False
+        # Serializes the deferred-load retry across the watchdog tick
+        # and connectivity-triggered retries, which can land together.
+        self._deferred_retry_lock = threading.Lock()
         # Cached subscription-tier result. Populated on first call and
         # refreshed every _SUB_TTL_SEC. Subscription almost never changes
         # within a session, so a long TTL is fine.
@@ -851,17 +854,53 @@ class TidalClient:
         signed in?" should treat this as yes-but-offline."""
         return self._session_load_deferred
 
+    def retry_deferred_load_async(self) -> bool:
+        """Retry a deferred session load on a background thread.
+
+        Called when something observed connectivity returning, so
+        recovery tracks the actual event instead of waiting out the
+        watchdog's poll interval. Runs off-thread because the retry
+        makes a Tidal round-trip and the caller is an HTTP handler.
+
+        Returns True when a retry was started. No-ops when there's
+        nothing deferred, or when a retry is already in flight — the
+        browser fires `online` in bursts and each one must not stack
+        another round-trip.
+        """
+        if not self._session_load_deferred:
+            return False
+        if self._deferred_retry_lock.locked():
+            return False
+        threading.Thread(
+            target=self._retry_deferred_load,
+            daemon=True,
+            name="tidal-session-retry",
+        ).start()
+        return True
+
     def _retry_deferred_load(self) -> None:
         """Re-run the session load that a dead network aborted at boot.
 
         Until this succeeds, session.user and session.session_id are
         unset and every check_login() returns False, so the app would
         stay in its offline degraded state for the rest of the process
-        even after the network came back."""
-        _tlog("session load was deferred (offline at boot) — retrying")
-        if self.load_session():
-            _tlog("deferred session load succeeded")
-            self._notify_session_restored()
+        even after the network came back.
+
+        Serialized: the watchdog tick and a connectivity-triggered
+        retry can land together, and two concurrent load_session calls
+        would race on the same session object.
+        """
+        if not self._deferred_retry_lock.acquire(blocking=False):
+            return  # another retry is already in flight
+        try:
+            if not self._session_load_deferred:
+                return  # a racing retry already recovered it
+            _tlog("session load was deferred (offline at boot) — retrying")
+            if self.load_session():
+                _tlog("deferred session load succeeded")
+                self._notify_session_restored()
+        finally:
+            self._deferred_retry_lock.release()
 
     def _refresh_watchdog(self) -> None:
         """Background loop that refreshes the token before it expires.

--- a/app/tidal_client.py
+++ b/app/tidal_client.py
@@ -492,6 +492,10 @@ class TidalClient:
         # when a hard refresh failure logs the user out, so the UI
         # bounces to Login immediately instead of after the cache TTL.
         self.on_auth_lost: Optional[Callable[[], None]] = None
+        # Set by the server. Invoked when a deferred session load
+        # finally succeeds, so the boot-time work that was skipped
+        # because we looked signed out still happens.
+        self.on_session_restored: Optional[Callable[[], None]] = None
         self._login_future: Optional[Future] = None
         # True when a persisted session exists on disk but the network
         # was unreachable when we tried to validate it, so
@@ -770,6 +774,18 @@ class TidalClient:
         transport on this object."""
         self.session.token_refresh = self._token_refresh_and_persist
 
+    def _notify_session_restored(self) -> None:
+        """Tell the server a session that couldn't be validated at boot
+        is now live, so the boot work that was skipped for a
+        signed-out-looking session can run. Counterpart to
+        _notify_auth_lost."""
+        cb = getattr(self, "on_session_restored", None)
+        if cb is not None:
+            try:
+                cb()
+            except Exception:
+                pass
+
     def _notify_auth_lost(self) -> None:
         """Tell the server its cached auth state is stale (refresh
         token dead, user logged out) so the next /auth/status flips
@@ -845,6 +861,7 @@ class TidalClient:
         _tlog("session load was deferred (offline at boot) — retrying")
         if self.load_session():
             _tlog("deferred session load succeeded")
+            self._notify_session_restored()
 
     def _refresh_watchdog(self) -> None:
         """Background loop that refreshes the token before it expires.

--- a/app/tidal_client.py
+++ b/app/tidal_client.py
@@ -15,6 +15,7 @@ from typing import Callable, Optional, Tuple
 
 import tidalapi
 
+from app.http import network_error_classes
 from app.paths import user_data_dir
 
 # audio.log is bound to the "tideway.audio" logger in
@@ -39,6 +40,11 @@ def _tlog(msg: str) -> None:
         pass
 
 SESSION_FILE = user_data_dir() / "tidal_session.json"
+
+# Connection-level failures from either HTTP transport. Loading a
+# persisted session over a dead network has to be told apart from
+# Tidal rejecting the credentials — see load_session.
+_NETWORK_ERRORS = network_error_classes()
 
 
 # --- Tidal request gate + abuse/rate-limit backoff ---------------------
@@ -487,6 +493,14 @@ class TidalClient:
         # bounces to Login immediately instead of after the cache TTL.
         self.on_auth_lost: Optional[Callable[[], None]] = None
         self._login_future: Optional[Future] = None
+        # True when a persisted session exists on disk but the network
+        # was unreachable when we tried to validate it, so
+        # `session.user` / `session.session_id` were never populated.
+        # Distinct from "no session" and from "Tidal rejected us": the
+        # credentials are fine, we just haven't been able to use them
+        # yet. Read by the server's auth check (offline ≠ signed out)
+        # and cleared by the watchdog's retry once the network is back.
+        self._session_load_deferred = False
         # Cached subscription-tier result. Populated on first call and
         # refreshed every _SUB_TTL_SEC. Subscription almost never changes
         # within a session, so a long TTL is fine.
@@ -558,7 +572,23 @@ class TidalClient:
                 self.session.expiry_time or expiry,
                 is_pkce=is_pkce,
             )
+            # Reaching here means load_oauth_session got an answer from
+            # Tidal, so whatever check_login() says is the real verdict
+            # — including a False, which is a genuine rejection and not
+            # something a retry would fix.
+            self._session_load_deferred = False
             return self.session.check_login()
+        except _NETWORK_ERRORS:
+            # No route to Tidal. load_oauth_session never populated
+            # session.user / session_id, which makes check_login()
+            # return False from then on — with no exception for callers
+            # to distinguish from a real rejection. Flag it so the auth
+            # check reads this as "signed in, offline" and the watchdog
+            # retries the load once the network is back. Without the
+            # flag, launching offline 401s the local-library endpoints
+            # and the session stays dead until the app restarts (#292).
+            self._session_load_deferred = bool(refresh_token)
+            return False
         except Exception:
             return False
 
@@ -788,13 +818,32 @@ class TidalClient:
         _tlog("force_refresh: success")
         return True
 
+    def session_load_deferred(self) -> bool:
+        """True when a persisted session couldn't be validated because
+        the network was down. The credentials are intact; we just
+        haven't reached Tidal yet. Callers gating on "is this user
+        signed in?" should treat this as yes-but-offline."""
+        return self._session_load_deferred
+
+    def _retry_deferred_load(self) -> None:
+        """Re-run the session load that a dead network aborted at boot.
+
+        Until this succeeds, session.user and session.session_id are
+        unset and every check_login() returns False, so the app would
+        stay in its offline degraded state for the rest of the process
+        even after the network came back."""
+        _tlog("session load was deferred (offline at boot) — retrying")
+        if self.load_session():
+            _tlog("deferred session load succeeded")
+
     def _refresh_watchdog(self) -> None:
         """Background loop that refreshes the token before it expires.
 
         Sleeps for _REFRESH_CHECK_INTERVAL_SEC between checks. Each tick:
-        if we're logged in and the stored expiry is within the window,
-        fire force_refresh. Errors inside force_refresh are already
-        logged there; the watchdog swallows its own errors so a transient
+        retry a session load the network aborted at boot, then, if we're
+        logged in and the stored expiry is within the window, fire
+        force_refresh. Errors inside force_refresh are already logged
+        there; the watchdog swallows its own errors so a transient
         network blip doesn't kill the thread.
         """
         while not self._refresh_stop.is_set():
@@ -802,6 +851,8 @@ class TidalClient:
             if self._refresh_stop.wait(self._REFRESH_CHECK_INTERVAL_SEC):
                 return
             try:
+                if self._session_load_deferred:
+                    self._retry_deferred_load()
                 expiry = getattr(self.session, "expiry_time", None)
                 refresh_token = getattr(self.session, "refresh_token", None)
                 if not expiry or not refresh_token:
@@ -982,6 +1033,10 @@ class TidalClient:
     def logout(self):
         if SESSION_FILE.exists():
             SESSION_FILE.unlink()
+        # There is no longer a session to defer-load; leaving this set
+        # would have the watchdog retry a file we just deleted and the
+        # auth check report a signed-out user as offline-signed-in.
+        self._session_load_deferred = False
         config = tidalapi.Config(quality=tidalapi.Quality.high_lossless)
         config.client_id = _DEVICE_CODE_CLIENT_ID
         config.client_secret = _DEVICE_CODE_CLIENT_SECRET

--- a/app/tidal_client.py
+++ b/app/tidal_client.py
@@ -589,6 +589,16 @@ class TidalClient:
             # and the session stays dead until the app restarts (#292).
             self._session_load_deferred = bool(refresh_token)
             return False
+        except TidalBackoffError:
+            # We refused to make the call ourselves — a rate-limit or
+            # abuse-detection window is still open. Same situation as
+            # no network: the credentials are untouched and the session
+            # simply never got validated, so defer and retry rather
+            # than reporting the user signed out for the rest of the
+            # process. Backoff windows outlast a launch (30 minutes for
+            # the abuse case), so this is reachable on a normal start.
+            self._session_load_deferred = bool(refresh_token)
+            return False
         except Exception:
             return False
 

--- a/server.py
+++ b/server.py
@@ -658,12 +658,22 @@ def _restore_pending_downloads() -> None:
         )
 
 
-# A session that couldn't be validated at boot (no network, or a Tidal
-# backoff window) leaves this undone — `logged_in` is False, so the boot
-# thread skips it. Without this hook the user's pending downloads stay
-# lost for the rest of the process even after the watchdog gets the
-# session back.
-tidal.on_session_restored = _restore_pending_downloads
+def _on_session_restored() -> None:
+    """A session deferred at boot (no network, or a Tidal backoff
+    window) has finally validated.
+
+    Two things were left undone while it looked signed out. The auth
+    cache holds the stand-in answer the deferral produced, whose
+    username reads "Tidal User" because session.user was unset; drop it
+    so the next /auth/status reports the real account. And the boot
+    thread skipped re-enqueueing pending downloads, which nothing else
+    re-runs — without this they stay lost for the rest of the process.
+    """
+    _invalidate_auth_cache()
+    _restore_pending_downloads()
+
+
+tidal.on_session_restored = _on_session_restored
 
 
 def _boot_tidal_session() -> None:
@@ -3087,6 +3097,27 @@ def video_downloads_list() -> list[dict]:
 
 
 # /api/notify route moved to `app/routers/notify.py`.
+
+@app.post("/api/auth/session/retry")
+def auth_session_retry() -> dict:
+    """Retry a session load that a dead network or a backoff window
+    aborted at boot.
+
+    The frontend pokes this when the browser reports connectivity back,
+    so recovery follows the actual event instead of waiting out the
+    watchdog's poll interval (up to a minute). The watchdog stays as the
+    fallback for what `navigator.onLine` can't see — a captive portal
+    clearing, or a Tidal-side outage ending while the LAN was fine
+    throughout.
+
+    Deliberately not behind `_require_auth`: the whole point is that it
+    runs while the app is reporting itself signed-in-but-offline, and
+    gating it on the auth check it exists to repair would deadlock the
+    recovery. It starts a retry of a session already on disk and takes
+    no input.
+    """
+    return {"started": tidal.retry_deferred_load_async()}
+
 
 @app.get("/api/auth/status")
 def auth_status() -> dict:

--- a/server.py
+++ b/server.py
@@ -363,6 +363,16 @@ def _is_logged_in() -> bool:
             return bool(_auth_cache["ok"])
     try:
         ok = bool(tidal.session.check_login())
+        if not ok and tidal.session_load_deferred():
+            # check_login() short-circuits to False — no exception, no
+            # round-trip — when session.user / session_id are unset,
+            # which is exactly the state a boot with no network leaves
+            # behind. The credentials on disk are fine, so this is the
+            # same "signed in, but offline" case the except-branch below
+            # handles; it just arrives as a return value instead of a
+            # raise. Reporting it as logged-out 401'd the local library
+            # for anyone who launched offline (#292).
+            ok = True
     except _NETWORK_ERRORS:
         # Network unreachable is not "logged out". check_login() only
         # gets as far as the HTTP round-trip when the session has

--- a/server.py
+++ b/server.py
@@ -639,6 +639,33 @@ downloader = Downloader(
     on_file_ready=_on_file_ready,
 )
 
+def _restore_pending_downloads() -> None:
+    """Re-enqueue downloads left pending from a previous run.
+
+    Gated on a valid session by every caller: submits without one each
+    fail in their expand thread and surface as loud FAILED rows the user
+    can't act on until they sign in.
+    """
+    import sys as _sys
+
+    try:
+        downloader.restore()
+    except Exception as exc:  # noqa: BLE001
+        print(
+            f"[server] downloader.restore() failed: {exc!r}",
+            file=_sys.stderr,
+            flush=True,
+        )
+
+
+# A session that couldn't be validated at boot (no network, or a Tidal
+# backoff window) leaves this undone — `logged_in` is False, so the boot
+# thread skips it. Without this hook the user's pending downloads stay
+# lost for the rest of the process even after the watchdog gets the
+# session back.
+tidal.on_session_restored = _restore_pending_downloads
+
+
 def _boot_tidal_session() -> None:
     """Load the persisted Tidal session, then re-enqueue pending
     downloads — both off the import critical path so the app window can
@@ -666,14 +693,7 @@ def _boot_tidal_session() -> None:
     finally:
         _session_ready.set()
     if logged_in:
-        try:
-            downloader.restore()
-        except Exception as exc:  # noqa: BLE001
-            print(
-                f"[server] downloader.restore() failed: {exc!r}",
-                file=_sys.stderr,
-                flush=True,
-            )
+        _restore_pending_downloads()
 
 
 threading.Thread(

--- a/tests/test_auth_network_failure.py
+++ b/tests/test_auth_network_failure.py
@@ -23,7 +23,10 @@ from app.tidal_client import TidalBackoffError
 def _fresh_auth_cache():
     server._session_ready.set()
     server._invalidate_auth_cache()
+    was_deferred = server.tidal._session_load_deferred
+    server.tidal._session_load_deferred = False
     yield
+    server.tidal._session_load_deferred = was_deferred
     server._invalidate_auth_cache()
 
 
@@ -53,6 +56,15 @@ def test_network_failure_keeps_session_signed_in(monkeypatch, exc):
 
 def test_auth_rejection_still_signs_out(monkeypatch):
     assert _check(monkeypatch, False) is False
+
+
+def test_deferred_session_load_keeps_session_signed_in(monkeypatch):
+    """Booting offline leaves session.user unset, which makes
+    check_login() return False with no exception to catch — the same
+    "offline, not signed out" case arriving as a return value instead of
+    a raise (#292)."""
+    server.tidal._session_load_deferred = True
+    assert _check(monkeypatch, False) is True
 
 
 def test_unexpected_error_still_signs_out(monkeypatch):

--- a/tests/test_offline_session_deferral.py
+++ b/tests/test_offline_session_deferral.py
@@ -1,0 +1,131 @@
+"""Launching with no network must not look like being signed out.
+
+`load_oauth_session` validates a restored session with a round-trip to
+Tidal. Offline, that raises, so `session.user` and `session.session_id`
+are never populated — and from then on tidalapi's `check_login()`
+returns False *without* raising, because it short-circuits on those
+attributes before it would make a request. The connection-error guard in
+`_is_logged_in` therefore never fires, the user is reported signed out,
+and `_require_local_access` 401s the on-disk library the offline mode
+exists to serve (#292).
+
+These tests pin the flag that tells the two cases apart, and the
+watchdog retry that gets the session back once the network returns —
+without it, a boot with no network leaves the session dead for the rest
+of the process.
+"""
+from __future__ import annotations
+
+import json
+
+import curl_cffi.requests.exceptions as curl_exc
+import pytest
+import requests.exceptions as req_exc
+
+from app import tidal_client
+from app.tidal_client import TidalClient
+
+
+@pytest.fixture
+def client():
+    c = TidalClient()
+    # Stop the watchdog thread; these tests drive the retry directly.
+    c._refresh_stop.set()
+    return c
+
+
+@pytest.fixture
+def session_file(tmp_path, monkeypatch):
+    path = tmp_path / "tidal_session.json"
+    path.write_text(
+        json.dumps(
+            {
+                "token_type": "Bearer",
+                "access_token": "at",
+                "refresh_token": "rt",
+                "expiry_time": "2099-01-01T00:00:00",
+                "is_pkce": False,
+            }
+        )
+    )
+    monkeypatch.setattr(tidal_client, "SESSION_FILE", path)
+    return path
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        req_exc.ConnectionError("dns down"),
+        req_exc.ReadTimeout("stalled"),
+        curl_exc.ConnectionError("dns down"),
+        curl_exc.Timeout("stalled"),
+    ],
+)
+def test_network_failure_defers_the_load(client, session_file, monkeypatch, exc):
+    def unreachable(*a, **kw):
+        raise exc
+
+    monkeypatch.setattr(client.session, "load_oauth_session", unreachable)
+
+    assert client.load_session() is False
+    assert client.session_load_deferred() is True
+
+
+def test_rejected_session_is_not_deferred(client, session_file, monkeypatch):
+    """Tidal answered and said no. Retrying that on a timer would be
+    pointless, and reporting it as offline would hide a real logout."""
+    monkeypatch.setattr(
+        client.session, "load_oauth_session", lambda *a, **kw: True
+    )
+    monkeypatch.setattr(client.session, "check_login", lambda: False)
+
+    assert client.load_session() is False
+    assert client.session_load_deferred() is False
+
+
+def test_successful_load_clears_the_flag(client, session_file, monkeypatch):
+    client._session_load_deferred = True
+    monkeypatch.setattr(
+        client.session, "load_oauth_session", lambda *a, **kw: True
+    )
+    monkeypatch.setattr(client.session, "check_login", lambda: True)
+
+    assert client.load_session() is True
+    assert client.session_load_deferred() is False
+
+
+def test_watchdog_retry_recovers_the_session(client, session_file, monkeypatch):
+    """The whole point of the flag: once the network is back, the load
+    that was skipped at boot has to actually happen. Nothing else in the
+    process re-runs it."""
+    calls = {"n": 0}
+
+    def flaky(*a, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise req_exc.ConnectionError("dns down")
+        return True
+
+    monkeypatch.setattr(client.session, "load_oauth_session", flaky)
+    monkeypatch.setattr(client.session, "check_login", lambda: calls["n"] > 1)
+
+    assert client.load_session() is False
+    assert client.session_load_deferred() is True
+
+    client._retry_deferred_load()
+
+    assert calls["n"] == 2
+    assert client.session_load_deferred() is False
+
+
+def test_logout_clears_the_flag(client, session_file, monkeypatch):
+    def unreachable(*a, **kw):
+        raise req_exc.ConnectionError("dns down")
+
+    monkeypatch.setattr(client.session, "load_oauth_session", unreachable)
+    assert client.load_session() is False
+    assert client.session_load_deferred() is True
+
+    client.logout()
+
+    assert client.session_load_deferred() is False

--- a/tests/test_offline_session_deferral.py
+++ b/tests/test_offline_session_deferral.py
@@ -17,6 +17,8 @@ of the process.
 from __future__ import annotations
 
 import json
+import threading
+import time
 
 import curl_cffi.requests.exceptions as curl_exc
 import pytest
@@ -182,6 +184,67 @@ def test_failed_retry_does_not_fire_the_restored_hook(
 
     assert calls["restored"] == 0
     assert client.session_load_deferred() is True
+
+
+def test_connectivity_retry_recovers_without_waiting_for_the_poll(
+    client, session_file, monkeypatch
+):
+    """The watchdog only ticks once a minute. When the browser tells us
+    the network is back we retry immediately instead."""
+    calls = {"n": 0}
+
+    def flaky(*a, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise req_exc.ConnectionError("dns down")
+        return True
+
+    monkeypatch.setattr(client.session, "load_oauth_session", flaky)
+    monkeypatch.setattr(client.session, "check_login", lambda: calls["n"] > 1)
+
+    assert client.load_session() is False
+    assert client.retry_deferred_load_async() is True
+
+    deadline = time.monotonic() + 5.0
+    while client.session_load_deferred() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert client.session_load_deferred() is False
+
+
+def test_connectivity_retry_noops_when_nothing_is_deferred(client):
+    """`online` fires on every reconnect, including ones where the
+    session was fine all along. Those must not hit Tidal."""
+    assert client.session_load_deferred() is False
+    assert client.retry_deferred_load_async() is False
+
+
+def test_concurrent_retries_do_not_stack(client, session_file, monkeypatch):
+    """The browser fires `online` in bursts. Each one must not start
+    another round-trip against the same session object."""
+    started = threading.Event()
+    release = threading.Event()
+    calls = {"n": 0}
+
+    def blocking(*a, **kw):
+        calls["n"] += 1
+        started.set()
+        release.wait(5.0)
+        raise req_exc.ConnectionError("still down")
+
+    monkeypatch.setattr(client.session, "load_oauth_session", blocking)
+    client._session_load_deferred = True
+
+    assert client.retry_deferred_load_async() is True
+    assert started.wait(5.0)
+    # Second and third pokes land while the first is still in flight.
+    assert client.retry_deferred_load_async() is False
+    assert client.retry_deferred_load_async() is False
+    release.set()
+
+    deadline = time.monotonic() + 5.0
+    while client._deferred_retry_lock.locked() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert calls["n"] == 1
 
 
 def test_logout_clears_the_flag(client, session_file, monkeypatch):

--- a/tests/test_offline_session_deferral.py
+++ b/tests/test_offline_session_deferral.py
@@ -135,6 +135,55 @@ def test_watchdog_retry_recovers_the_session(client, session_file, monkeypatch):
     assert client.session_load_deferred() is False
 
 
+def test_recovery_fires_the_session_restored_hook(
+    client, session_file, monkeypatch
+):
+    """The boot thread skips re-enqueueing pending downloads when the
+    session looks signed out, and nothing else re-runs it. Without this
+    hook a user who launched offline loses their pending downloads for
+    the rest of the process even after the session comes back."""
+    calls = {"n": 0, "restored": 0}
+    client.on_session_restored = lambda: calls.__setitem__(
+        "restored", calls["restored"] + 1
+    )
+
+    def flaky(*a, **kw):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise req_exc.ConnectionError("dns down")
+        return True
+
+    monkeypatch.setattr(client.session, "load_oauth_session", flaky)
+    monkeypatch.setattr(client.session, "check_login", lambda: calls["n"] > 1)
+
+    assert client.load_session() is False
+    assert calls["restored"] == 0
+
+    client._retry_deferred_load()
+
+    assert calls["restored"] == 1
+
+
+def test_failed_retry_does_not_fire_the_restored_hook(
+    client, session_file, monkeypatch
+):
+    calls = {"restored": 0}
+    client.on_session_restored = lambda: calls.__setitem__(
+        "restored", calls["restored"] + 1
+    )
+
+    def unreachable(*a, **kw):
+        raise req_exc.ConnectionError("dns down")
+
+    monkeypatch.setattr(client.session, "load_oauth_session", unreachable)
+
+    assert client.load_session() is False
+    client._retry_deferred_load()
+
+    assert calls["restored"] == 0
+    assert client.session_load_deferred() is True
+
+
 def test_logout_clears_the_flag(client, session_file, monkeypatch):
     def unreachable(*a, **kw):
         raise req_exc.ConnectionError("dns down")

--- a/tests/test_offline_session_deferral.py
+++ b/tests/test_offline_session_deferral.py
@@ -23,7 +23,7 @@ import pytest
 import requests.exceptions as req_exc
 
 from app import tidal_client
-from app.tidal_client import TidalClient
+from app.tidal_client import TidalBackoffError, TidalClient
 
 
 @pytest.fixture
@@ -66,6 +66,23 @@ def test_network_failure_defers_the_load(client, session_file, monkeypatch, exc)
         raise exc
 
     monkeypatch.setattr(client.session, "load_oauth_session", unreachable)
+
+    assert client.load_session() is False
+    assert client.session_load_deferred() is True
+
+
+def test_backoff_window_defers_the_load(client, session_file, monkeypatch):
+    """A rate-limit / abuse backoff refuses the call inside our own
+    request gate, before any HTTP leaves the process. The session is
+    every bit as intact as it is when the network is down, and the
+    abuse window runs 30 minutes — long enough to still be open at the
+    next launch — so this must defer and retry too, not report the user
+    signed out until they restart."""
+
+    def gated(*a, **kw):
+        raise TidalBackoffError(1800.0, "abuse-detected (HTTP 403)")
+
+    monkeypatch.setattr(client.session, "load_oauth_session", gated)
 
     assert client.load_session() is False
     assert client.session_load_deferred() is True

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -126,6 +126,12 @@ export const api = {
         "/api/auth/login/poll",
       ),
     logout: () => req<{ ok: true }>("/api/auth/logout", { method: "POST" }),
+    /** Tell the backend connectivity is back so it can retry a session
+     *  load that a dead network aborted at launch. No-ops server-side
+     *  when nothing is deferred. `started` reports whether a retry
+     *  actually kicked off. */
+    retrySession: () =>
+      req<{ started: boolean }>("/api/auth/session/retry", { method: "POST" }),
     pkceUrl: () => req<{ url: string }>("/api/auth/pkce/url"),
     pkceComplete: (redirect_url: string) =>
       req<{ status: "ok"; username: string | null }>(

--- a/web/src/hooks/useOfflineMode.tsx
+++ b/web/src/hooks/useOfflineMode.tsx
@@ -73,7 +73,16 @@ export function OfflineProvider({ children }: { children: React.ReactNode }) {
   // will surface its own errors if it's the Tidal side that's
   // unreachable while the LAN is fine.
   useEffect(() => {
-    const onOnline = () => setAutoOffline(false);
+    const onOnline = () => {
+      setAutoOffline(false);
+      // Launching with no network leaves the backend holding a Tidal
+      // session it never got to validate, which it treats as
+      // signed-in-but-offline. It polls to recover, but this is the
+      // moment we actually know the network is back, so tell it rather
+      // than letting the user wait out the poll. Fire-and-forget: the
+      // poll is still there if this request doesn't land.
+      api.auth.retrySession().catch(() => {});
+    };
     const onOffline = () => setAutoOffline(true);
     window.addEventListener("online", onOnline);
     window.addEventListener("offline", onOffline);


### PR DESCRIPTION
## Summary

Launching Tideway with no network 401s the local library — the one surface offline mode exists to serve. Reported in #292 with a screenshot showing the offline banner rendering correctly above `Couldn't load local library: 401: {"detail":"Not authenticated"}`.

The #261 fix taught `_is_logged_in` that a connection-level *exception* means "offline", not "signed out". That only covers the case where `check_login()` gets far enough to attempt a request. Restoring a persisted session goes through `load_oauth_session`, which validates with a round-trip; offline that raises, `load_session` swallows it, and `session.user` / `session.session_id` are never populated. tidalapi 0.8.11:

```python
def check_login(self) -> bool:
    if self.user is None or not self.user.id or not self.session_id:
        return False          # returns False, raises nothing
    return self.request.basic_request(...).ok
```

So the network-error guard never sees anything, the user is reported signed out, and `_require_local_access` refuses the on-disk library.

Rather than trying to infer that state from a bare `False`, track it. A session load aborted by a connection error is flagged deferred, which the auth check reads as signed-in-but-offline. A load that *reached* Tidal and got rejected is not flagged, so a genuine logout still bounces to Login.

## Recovery

The other half of the bug: with `session.user` unset, nothing else in the process re-runs the load, so the session stayed dead until the app restarted even after the network came back. Three pieces make recovery actually work:

- **The frontend tells us when connectivity returns.** `useOfflineMode` already listens for the browser's `online` event to clear the offline banner; it now also pokes `POST /api/auth/session/retry`. The retry runs off-thread (it makes a Tidal round-trip and the caller is an HTTP handler) and is serialized against the watchdog — `online` fires in bursts and two concurrent `load_session` calls would race on the same session object. The endpoint is deliberately not behind `_require_auth`: it exists to repair the auth state, so gating it on that check would deadlock the recovery.
- **The watchdog stays as the fallback poll**, for what `navigator.onLine` can't see — a captive portal clearing, or a Tidal-side outage ending while the LAN was fine throughout.
- **Pending downloads are re-enqueued.** The boot thread only restores them when the session validated, and nothing else runs it. An `on_session_restored` hook (mirroring `on_auth_lost`) points at the same restore, and fires only on a retry that actually succeeded — a still-offline retry would submit downloads that fail in their expand thread and surface as FAILED rows. It also drops the auth cache, which was holding the stand-in answer the deferral produced (its username reads "Tidal User" because `session.user` was unset).

## A backoff window hits the same dead end

The request gate raises `TidalBackoffError` before any HTTP leaves the process, so `load_oauth_session` never populates the session and the call lands in the bare `except Exception` with the flag unset — signed out, nothing scheduled to retry. The abuse backoff runs 30 minutes, comfortably outliving a launch, so this is reachable on an ordinary start. It defers the same way now; retrying re-enters the gate, which refuses without making a request, so it costs nothing and can't extend the window.

## Test plan

- `tests/test_offline_session_deferral.py` (new, 14 tests): a network failure defers the load; a backoff window defers it; a rejection doesn't; a successful load clears the flag; the watchdog retry recovers the session; a connectivity-triggered retry recovers it without waiting for the poll; that retry no-ops when nothing is deferred and doesn't stack under concurrent pokes; recovery fires the restore hook and a still-failing retry doesn't; logout clears the flag.
- `tests/test_auth_network_failure.py`: adds the case where `check_login()` returns `False` with a deferred load, alongside the existing raise-path cases.
- Full backend suite green locally (`pytest tests/`, exit 0); `tsc` clean; `npm test` 117 passed; eslint 0 errors on the touched files (two pre-existing warnings in `useOfflineMode.tsx`, unchanged from main).

Fixes the problem reported in #292.
