### PR TITLE
Give shuffle a stable order instead of re-rolling per call

### DIFF
--- a/web/src/hooks/usePlayer.test.ts
+++ b/web/src/hooks/usePlayer.test.ts
@@ -7,7 +7,15 @@
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
 import { api } from "@/api/client";
-import { fetchRadioTakeover, pickPrevIndex, shuffleTracks } from "./usePlayer";
+import {
+  buildShuffleOrder,
+  fetchRadioTakeover,
+  pickNextIndex,
+  pickPrevIndex,
+  shuffleOrderAfterInsert,
+  shuffleOrderAfterRemove,
+  shuffleTracks,
+} from "./usePlayer";
 import type { PlayerState } from "./usePlayer";
 import type { Track } from "@/api/types";
 
@@ -37,6 +45,7 @@ function _state(overrides: Partial<PlayerState>): PlayerState {
     queue: [],
     queueIndex: -1,
     shuffle: false,
+    shuffleOrder: [],
     repeat: "off",
     streamInfo: null,
     source: null,
@@ -103,6 +112,108 @@ describe("pickPrevIndex", () => {
       shuffle: true,
     });
     expect(pickPrevIndex(s)).toBe(0);
+  });
+});
+
+describe("pickNextIndex with shuffle", () => {
+  const queueOf = (n: number) =>
+    Array.from(
+      { length: n },
+      (_, i) => ({ id: String(i) }) as unknown as PlayerState["queue"][number],
+    );
+
+  it("gives the same answer every time it is asked", () => {
+    // The bug behind #291. "What plays next?" is asked twice per
+    // track — once ~10s in to prime the preload the crossfade will
+    // fade into, once when the track actually ends — and shuffle used
+    // to answer with a fresh Math.random() each time. The crossfade
+    // then faded into one track while the queue advanced to another,
+    // which the user hears as an interruption at every song change.
+    const s = _state({
+      queue: queueOf(8),
+      queueIndex: 3,
+      shuffle: true,
+      shuffleOrder: buildShuffleOrder(8, 3),
+    });
+    const answers = new Set(
+      Array.from({ length: 20 }, () => pickNextIndex(s, true)),
+    );
+    expect(answers.size).toBe(1);
+  });
+
+  it("plays every track once before any repeats", () => {
+    const order = buildShuffleOrder(6, 0);
+    let s = _state({
+      queue: queueOf(6),
+      queueIndex: 0,
+      shuffle: true,
+      shuffleOrder: order,
+    });
+    const visited = [0];
+    for (let i = 0; i < 5; i++) {
+      const next = pickNextIndex(s, true);
+      expect(next).not.toBeNull();
+      visited.push(next as number);
+      s = { ...s, queueIndex: next as number };
+    }
+    expect([...visited].sort((a, b) => a - b)).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
+  it("ends the queue at the end of the order unless repeat is on", () => {
+    const order = buildShuffleOrder(4, 0);
+    const last = order[order.length - 1];
+    const s = _state({
+      queue: queueOf(4),
+      queueIndex: last,
+      shuffle: true,
+      shuffleOrder: order,
+    });
+    expect(pickNextIndex(s, true)).toBeNull();
+    expect(pickNextIndex({ ...s, repeat: "all" }, true)).toBe(order[0]);
+  });
+
+  it("keeps the current track first so enabling shuffle doesn't skip", () => {
+    const order = buildShuffleOrder(10, 7);
+    expect(order[0]).toBe(7);
+    expect([...order].sort((a, b) => a - b)).toEqual([
+      0, 1, 2, 3, 4, 5, 6, 7, 8, 9,
+    ]);
+  });
+
+  it("plays an appended radio tail after the shuffled queue", () => {
+    // End-of-queue autoplay appends to the queue the user is already
+    // shuffling through; the new positions aren't in the order yet.
+    const s = _state({
+      queue: queueOf(5),
+      queueIndex: 2,
+      shuffle: true,
+      shuffleOrder: [2, 0, 1],
+    });
+    expect(pickNextIndex(s, true)).toBe(0);
+    expect(pickNextIndex({ ...s, queueIndex: 1 }, true)).toBe(3);
+  });
+
+  it("ignores order entries left over from a shorter queue", () => {
+    const s = _state({
+      queue: queueOf(2),
+      queueIndex: 0,
+      shuffle: true,
+      shuffleOrder: [0, 9, 1],
+    });
+    expect(pickNextIndex(s, true)).toBe(1);
+  });
+});
+
+describe("shuffle order under queue edits", () => {
+  it("moves a play-next insert to right after the current track", () => {
+    // Queue [A,B,C,D] playing B (index 1), order B,D,A,C. Inserting at
+    // index 2 shifts C and D up one.
+    const next = shuffleOrderAfterInsert([1, 3, 0, 2], 2, 1);
+    expect(next).toEqual([1, 2, 4, 0, 3]);
+  });
+
+  it("closes the gap when a track is removed", () => {
+    expect(shuffleOrderAfterRemove([1, 3, 0, 2], 2)).toEqual([1, 2, 0]);
   });
 });
 

--- a/web/src/hooks/usePlayer.test.ts
+++ b/web/src/hooks/usePlayer.test.ts
@@ -204,6 +204,49 @@ describe("pickNextIndex with shuffle", () => {
   });
 });
 
+describe("hasNext under shuffle", () => {
+  // hasNext has to agree with pickNextIndex or the Next button lies.
+  // The old queue-position test disabled the button whenever the
+  // current track sat at the last *queue* index, regardless of how
+  // much of the shuffle order was left.
+  const queueOf = (n: number) =>
+    Array.from(
+      { length: n },
+      (_, i) => ({ id: String(i) }) as unknown as PlayerState["queue"][number],
+    );
+  const hasNext = (s: PlayerState) => {
+    if (s.queueIndex < 0) return false;
+    const n = pickNextIndex(s);
+    return n !== null && n !== s.queueIndex;
+  };
+
+  it("is true on the last queue position when the order has more", () => {
+    const s = _state({
+      queue: queueOf(4),
+      queueIndex: 3,
+      shuffle: true,
+      shuffleOrder: [3, 1, 0, 2],
+    });
+    expect(hasNext(s)).toBe(true);
+  });
+
+  it("is false at the end of the order with repeat off", () => {
+    const s = _state({
+      queue: queueOf(4),
+      queueIndex: 2,
+      shuffle: true,
+      shuffleOrder: [3, 1, 0, 2],
+    });
+    expect(hasNext(s)).toBe(false);
+    expect(hasNext({ ...s, repeat: "all" })).toBe(true);
+  });
+
+  it("is false on a single-track queue", () => {
+    const s = _state({ queue: queueOf(1), queueIndex: 0, shuffle: true });
+    expect(hasNext(s)).toBe(false);
+  });
+});
+
 describe("shuffle order under queue edits", () => {
   it("moves a play-next insert to right after the current track", () => {
     // Queue [A,B,C,D] playing B (index 1), order B,D,A,C. Inserting at

--- a/web/src/hooks/usePlayer.test.ts
+++ b/web/src/hooks/usePlayer.test.ts
@@ -258,6 +258,15 @@ describe("shuffle order under queue edits", () => {
   it("closes the gap when a track is removed", () => {
     expect(shuffleOrderAfterRemove([1, 3, 0, 2], 2)).toEqual([1, 2, 0]);
   });
+
+  it("shifts the current track too when the insert lands before it", () => {
+    // Queue [A,B,C,D] playing C (index 2), order C,A,D,B. Inserting at
+    // index 1 pushes C to 3, so the new track must land after 3 — not
+    // after whatever happens to sit at the stale index 2.
+    expect(shuffleOrderAfterInsert([2, 0, 3, 1], 1, 2)).toEqual([
+      3, 1, 0, 4, 2,
+    ]);
+  });
 });
 
 describe("shuffleTracks", () => {

--- a/web/src/hooks/usePlayer.ts
+++ b/web/src/hooks/usePlayer.ts
@@ -73,6 +73,16 @@ export interface PlayerState {
   queue: Track[];
   queueIndex: number;
   shuffle: boolean;
+  /** Playback order while `shuffle` is on: a permutation of queue
+   *  indices. Empty when shuffle is off.
+   *
+   *  This has to be state rather than a fresh random pick per call,
+   *  because "what plays next" is asked twice per track and the two
+   *  answers must agree: once ~10s in to preload/crossfade into the
+   *  next track, and again when the current one ends. Two independent
+   *  random draws meant the track that faded in was almost never the
+   *  track that then loaded (#291). */
+  shuffleOrder: number[];
   repeat: RepeatMode;
   /** What's actually audible — codec + sample rate. Null while
    *  loading, idle, or when the backend couldn't determine it. */
@@ -104,12 +114,115 @@ const INITIAL: PlayerState = {
   queue: [],
   queueIndex: -1,
   shuffle: false,
+  shuffleOrder: [],
   repeat: "off",
   streamInfo: null,
   source: null,
   forceVolume: false,
   pausedByDevice: null,
 };
+
+/**
+ * Build a shuffle order for `length` tracks, with `currentIndex` placed
+ * first so the track already playing stays put and the shuffle applies
+ * to what comes after it.
+ */
+export function buildShuffleOrder(
+  length: number,
+  currentIndex: number,
+): number[] {
+  const rest: number[] = [];
+  for (let i = 0; i < length; i++) if (i !== currentIndex) rest.push(i);
+  for (let i = rest.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [rest[i], rest[j]] = [rest[j], rest[i]];
+  }
+  return currentIndex >= 0 && currentIndex < length
+    ? [currentIndex, ...rest]
+    : rest;
+}
+
+/**
+ * Remap a shuffle order across an insertion at `insertAt`, placing the
+ * inserted track directly after `currentIndex` in the play order.
+ *
+ * The order holds queue *positions*, so an insert shifts every entry at
+ * or past it. Track ids would sidestep the remapping, but the queue
+ * deliberately allows the same track twice, which makes ids ambiguous.
+ */
+export function shuffleOrderAfterInsert(
+  order: number[],
+  insertAt: number,
+  currentIndex: number,
+): number[] {
+  const shifted = order.map((i) => (i >= insertAt ? i + 1 : i));
+  const pos = shifted.indexOf(currentIndex);
+  // "Play next" means next in the order the user is actually hearing.
+  const at = pos < 0 ? shifted.length : pos + 1;
+  return [...shifted.slice(0, at), insertAt, ...shifted.slice(at)];
+}
+
+/** Remap a shuffle order across a removal at `removedAt`. */
+export function shuffleOrderAfterRemove(
+  order: number[],
+  removedAt: number,
+): number[] {
+  return order
+    .filter((i) => i !== removedAt)
+    .map((i) => (i > removedAt ? i - 1 : i));
+}
+
+/**
+ * Recover the shuffle order from a persisted snapshot.
+ *
+ * Snapshots written by older versions have no `shuffleOrder` at all,
+ * and localStorage is user-writable, so nothing about the stored value
+ * can be assumed. A snapshot with shuffle on but no usable order gets a
+ * freshly dealt one rather than silently falling back to sequential
+ * play — the user left shuffle on and expects it honored.
+ */
+function restoreShuffleOrder(
+  persisted: Partial<PersistedState>,
+  queue: Track[],
+  currentIndex: number,
+): number[] {
+  if (!persisted.shuffle) return [];
+  const stored = persisted.shuffleOrder;
+  if (
+    Array.isArray(stored) &&
+    stored.length > 0 &&
+    stored.every((i) => Number.isInteger(i) && i >= 0 && i < queue.length)
+  ) {
+    return stored;
+  }
+  return buildShuffleOrder(queue.length, currentIndex);
+}
+
+/**
+ * The shuffle order to actually walk, reconciled against the current
+ * queue. Total and deterministic — no RNG — so the two callers that ask
+ * "what's next?" for the same track always get the same answer.
+ *
+ * Reconciliation matters because the queue can grow underneath a live
+ * order: end-of-queue autoplay appends a radio tail to the queue the
+ * user is already shuffling through. Known positions keep the order
+ * they were dealt; anything the order doesn't cover yet (an appended
+ * tail, or a queue that changed without a reshuffle) goes on the end in
+ * queue order. Stale entries past the end of a shrunken queue drop out.
+ */
+function resolveShuffleOrder(state: PlayerState): number[] {
+  const len = state.queue.length;
+  const seen = new Set<number>();
+  const order: number[] = [];
+  for (const i of state.shuffleOrder) {
+    if (i >= 0 && i < len && !seen.has(i)) {
+      seen.add(i);
+      order.push(i);
+    }
+  }
+  for (let i = 0; i < len; i++) if (!seen.has(i)) order.push(i);
+  return order;
+}
 
 /**
  * Pick the next queue index given the current state.
@@ -131,11 +244,16 @@ export function pickNextIndex(
     return 0;
   }
   if (state.shuffle) {
-    let next = state.queueIndex;
-    while (next === state.queueIndex) {
-      next = Math.floor(Math.random() * state.queue.length);
-    }
-    return next;
+    const order = resolveShuffleOrder(state);
+    const pos = order.indexOf(state.queueIndex);
+    // Not in the order yet (queue just replaced): start at its head.
+    if (pos < 0) return order[0] ?? null;
+    if (pos + 1 < order.length) return order[pos + 1];
+    // Walked the whole shuffled queue. Same end-of-queue rule as
+    // sequential play: wrap only if the user asked for repeat, else
+    // hand off to the autoplay/stop branch.
+    if (state.repeat === "all") return order[0];
+    return null;
   }
   const next = state.queueIndex + 1;
   if (next < state.queue.length) return next;
@@ -226,11 +344,12 @@ export function pickPrevIndex(state: PlayerState): number | null {
   if (state.queue.length === 0) return null;
   if (state.shuffle) {
     if (state.queue.length === 1) return 0;
-    let prev = state.queueIndex;
-    while (prev === state.queueIndex) {
-      prev = Math.floor(Math.random() * state.queue.length);
-    }
-    return prev;
+    // Walk the same order backwards, so Previous returns to the track
+    // that actually just played rather than a fresh random one.
+    const order = resolveShuffleOrder(state);
+    const pos = order.indexOf(state.queueIndex);
+    if (pos < 0) return null;
+    return pos > 0 ? order[pos - 1] : null;
   }
   const prev = state.queueIndex - 1;
   return prev >= 0 ? prev : null;
@@ -291,6 +410,7 @@ export function usePlayer() {
       duration: restoreTrack?.duration ?? 0,
       volume: typeof persisted.volume === "number" ? persisted.volume : 1,
       shuffle: !!persisted.shuffle,
+      shuffleOrder: restoreShuffleOrder(persisted, queue, restoreIndex),
       repeat,
     };
   });
@@ -343,6 +463,7 @@ export function usePlayer() {
         volume:
           typeof persisted.volume === "number" ? persisted.volume : s.volume,
         shuffle: !!persisted.shuffle,
+        shuffleOrder: restoreShuffleOrder(persisted, queue, restoreIndex),
         repeat,
       }));
     })();
@@ -816,6 +937,13 @@ export function usePlayer() {
           error: null,
           currentTime: 0,
           duration: track.duration ?? 0,
+          // A new queue invalidates the old order — its indices point
+          // into a list that no longer exists. Deal a fresh one from
+          // the track the user picked.
+          shuffleOrder:
+            queueOverride && s.shuffle
+              ? buildShuffleOrder(queue.length, index)
+              : s.shuffleOrder,
           source:
             sourceOverride !== undefined
               ? sourceOverride
@@ -873,6 +1001,10 @@ export function usePlayer() {
           error: null,
           currentTime: 0,
           duration: track.duration ?? 0,
+          shuffleOrder:
+            queueOverride && s.shuffle
+              ? buildShuffleOrder(queue.length, index)
+              : s.shuffleOrder,
           source:
             sourceOverride !== undefined
               ? sourceOverride
@@ -1120,7 +1252,19 @@ export function usePlayer() {
   }, []);
 
   const toggleShuffle = useCallback(() => {
-    setState((s) => ({ ...s, shuffle: !s.shuffle }));
+    setState((s) => {
+      const shuffle = !s.shuffle;
+      return {
+        ...s,
+        shuffle,
+        // Deal a fresh order on every enable, so turning shuffle off
+        // and on again re-randomizes instead of replaying the order
+        // from last time.
+        shuffleOrder: shuffle
+          ? buildShuffleOrder(s.queue.length, s.queueIndex)
+          : [],
+      };
+    });
   }, []);
 
   const cycleRepeat = useCallback(() => {
@@ -1230,7 +1374,13 @@ export function usePlayer() {
         track,
         ...s.queue.slice(insertAt),
       ];
-      return { ...s, queue: nextQueue };
+      return {
+        ...s,
+        queue: nextQueue,
+        shuffleOrder: s.shuffle
+          ? shuffleOrderAfterInsert(s.shuffleOrder, insertAt, s.queueIndex)
+          : s.shuffleOrder,
+      };
     });
   }, []);
 
@@ -1248,14 +1398,26 @@ export function usePlayer() {
       const nextQueue = [...s.queue];
       nextQueue.splice(index, 1);
       const nextIdx = index < s.queueIndex ? s.queueIndex - 1 : s.queueIndex;
-      return { ...s, queue: nextQueue, queueIndex: nextIdx };
+      return {
+        ...s,
+        queue: nextQueue,
+        queueIndex: nextIdx,
+        shuffleOrder: s.shuffle
+          ? shuffleOrderAfterRemove(s.shuffleOrder, index)
+          : s.shuffleOrder,
+      };
     });
   }, []);
 
   const clearQueue = useCallback(() => {
     setState((s) => {
-      if (s.queueIndex < 0) return { ...s, queue: [] };
-      return { ...s, queue: [s.queue[s.queueIndex]], queueIndex: 0 };
+      if (s.queueIndex < 0) return { ...s, queue: [], shuffleOrder: [] };
+      return {
+        ...s,
+        queue: [s.queue[s.queueIndex]],
+        queueIndex: 0,
+        shuffleOrder: s.shuffle ? [0] : [],
+      };
     });
   }, []);
 

--- a/web/src/hooks/usePlayer.ts
+++ b/web/src/hooks/usePlayer.ts
@@ -496,11 +496,18 @@ export function usePlayer() {
   // call pickNextIndex against the freshest state without reinstalling
   // the subscription every queue change.
   const advanceRef = useRef<() => void>(() => {});
-  // Tracks which track_id we've already preloaded-next-for so we
-  // don't fire /api/player/preload once per position tick after
-  // crossing the 15s-remaining threshold. Resets when track_id
-  // changes.
-  const preloadedForTrackIdRef = useRef<string | null>(null);
+  // The track id we last asked the backend to preload, so we don't
+  // fire /api/player/preload once per position tick.
+  //
+  // This keys on what we preloaded rather than what we preloaded FOR,
+  // which is what makes the preload self-correcting: anything that
+  // changes the answer to "what plays next" mid-track — toggling
+  // shuffle, Play next, removing a queue item, changing repeat —
+  // makes the recomputed next differ from this, and we re-preload.
+  // Keying on the current track instead meant the first answer stood
+  // for the rest of the track, so the crossfade faded into a track
+  // the queue was no longer going to play (#291).
+  const preloadedNextIdRef = useRef<string | null>(null);
   // Track ids we've already kicked off a rehydrate fetch for. Keeps
   // us from firing the same GET /api/track/{id} on every position
   // tick when the frontend has no cached Track for the current id.
@@ -686,12 +693,7 @@ export function usePlayer() {
     // buffer is freed as soon as the swap completes or the queue
     // changes.
     const triggerPreloadIfNeeded = (snap: PlayerSnapshot) => {
-      if (
-        snap.state !== "playing" ||
-        snap.track_id === null ||
-        preloadedForTrackIdRef.current === snap.track_id
-      )
-        return;
+      if (snap.state !== "playing" || snap.track_id === null) return;
       const currentTime = snap.position_ms / 1000;
       if (currentTime < 10) return;
       const s = stateRef.current;
@@ -699,26 +701,15 @@ export function usePlayer() {
       if (nextIdx === null || nextIdx === s.queueIndex) return;
       const nextTrack = s.queue[nextIdx];
       if (!nextTrack || nextTrack.id === snap.track_id) return;
-      preloadedForTrackIdRef.current = snap.track_id;
+      // Already primed with this exact track — nothing to do. Cheap
+      // enough to re-check every tick (SSE runs at ~4Hz) and that is
+      // the point: it's what notices the answer changing mid-track.
+      if (preloadedNextIdRef.current === nextTrack.id) return;
+      preloadedNextIdRef.current = nextTrack.id;
       api.player.preload(nextTrack.id, qualityRef.current).catch(() => {
         /* fire-and-forget; failure falls back to the slow-path
            load on track-end. */
       });
-    };
-
-    // Reset the preload guard when track_id changes so the next
-    // track's own preload fires at its own 10-second trigger
-    // point. Only resets when we've moved PAST the track we
-    // preloaded FOR — re-firing mid-track would re-preload the
-    // same next track repeatedly.
-    const resetPreloadGuardOnTrackChange = (snap: PlayerSnapshot) => {
-      if (
-        snap.track_id !== null &&
-        preloadedForTrackIdRef.current !== null &&
-        preloadedForTrackIdRef.current !== snap.track_id
-      ) {
-        preloadedForTrackIdRef.current = null;
-      }
     };
 
     const applySnapshot = (snap: PlayerSnapshot) => {
@@ -738,7 +729,6 @@ export function usePlayer() {
         advanceRef.current();
       }
       triggerPreloadIfNeeded(snap);
-      resetPreloadGuardOnTrackChange(snap);
     };
 
     const connect = () => {
@@ -1423,7 +1413,15 @@ export function usePlayer() {
 
   return {
     ...state,
-    hasNext: state.queueIndex >= 0 && state.queueIndex < state.queue.length - 1,
+    // Ask the same function playback asks. A queue-position test
+    // (`queueIndex < queue.length - 1`) describes sequential play
+    // only: under shuffle, sitting on the last queue position with
+    // most of the order still unplayed would disable the button.
+    hasNext: (() => {
+      if (state.queueIndex < 0) return false;
+      const n = pickNextIndex(state);
+      return n !== null && n !== state.queueIndex;
+    })(),
     // True whenever ANY track is loaded — pressing prev on the first
     // track restarts it (see the `prev` callback above), so the button
     // shouldn't be disabled in that state. Matches Spotify, Apple Music,

--- a/web/src/hooks/usePlayer.ts
+++ b/web/src/hooks/usePlayer.ts
@@ -156,7 +156,13 @@ export function shuffleOrderAfterInsert(
   currentIndex: number,
 ): number[] {
   const shifted = order.map((i) => (i >= insertAt ? i + 1 : i));
-  const pos = shifted.indexOf(currentIndex);
+  // The current track moves too when the insert lands at or before it.
+  // Today's only caller inserts at queueIndex + 1 so this is a no-op,
+  // but looking up the pre-shift index in a post-shift array would
+  // silently splice after the wrong track for any caller that doesn't.
+  const shiftedCurrent =
+    currentIndex >= insertAt ? currentIndex + 1 : currentIndex;
+  const pos = shifted.indexOf(shiftedCurrent);
   // "Play next" means next in the order the user is actually hearing.
   const at = pos < 0 ? shifted.length : pos + 1;
   return [...shifted.slice(0, at), insertAt, ...shifted.slice(at)];
@@ -170,6 +176,24 @@ export function shuffleOrderAfterRemove(
   return order
     .filter((i) => i !== removedAt)
     .map((i) => (i > removedAt ? i - 1 : i));
+}
+
+/**
+ * The shuffle order for a load that may be replacing the queue.
+ *
+ * A replacement invalidates the old order outright — its indices point
+ * into a list that no longer exists — so deal a fresh one anchored on
+ * the track being loaded. Advancing within the existing queue keeps the
+ * order it's already walking.
+ */
+function shuffleOrderForLoad(
+  s: PlayerState,
+  queue: Track[],
+  index: number,
+  queueReplaced: boolean,
+): number[] {
+  if (!queueReplaced || !s.shuffle) return s.shuffleOrder;
+  return buildShuffleOrder(queue.length, index);
 }
 
 /**
@@ -927,13 +951,7 @@ export function usePlayer() {
           error: null,
           currentTime: 0,
           duration: track.duration ?? 0,
-          // A new queue invalidates the old order — its indices point
-          // into a list that no longer exists. Deal a fresh one from
-          // the track the user picked.
-          shuffleOrder:
-            queueOverride && s.shuffle
-              ? buildShuffleOrder(queue.length, index)
-              : s.shuffleOrder,
+          shuffleOrder: shuffleOrderForLoad(s, queue, index, !!queueOverride),
           source:
             sourceOverride !== undefined
               ? sourceOverride
@@ -991,10 +1009,7 @@ export function usePlayer() {
           error: null,
           currentTime: 0,
           duration: track.duration ?? 0,
-          shuffleOrder:
-            queueOverride && s.shuffle
-              ? buildShuffleOrder(queue.length, index)
-              : s.shuffleOrder,
+          shuffleOrder: shuffleOrderForLoad(s, queue, index, !!queueOverride),
           source:
             sourceOverride !== undefined
               ? sourceOverride

--- a/web/src/hooks/usePlayerPersistence.ts
+++ b/web/src/hooks/usePlayerPersistence.ts
@@ -17,6 +17,10 @@ export interface PersistedState {
   currentTime: number;
   volume: number;
   shuffle: boolean;
+  /** The shuffle order in play when the app closed. Persisted with
+   *  the queue it indexes into, so relaunching mid-queue resumes the
+   *  same order instead of re-dealing one. */
+  shuffleOrder: number[];
   repeat: RepeatMode;
   /** Id of the track that was loaded when the user closed the app.
    *  Used as a sanity-check against the persisted queue so that on
@@ -142,6 +146,7 @@ export function usePlayerPersistence(
         currentTime: s.currentTime,
         volume: s.volume,
         shuffle: s.shuffle,
+        shuffleOrder: s.shuffleOrder,
         repeat: s.repeat,
         trackId: s.track?.id ?? null,
         track: s.track,


### PR DESCRIPTION
## Summary

With shuffle and crossfade both on, every track change is audibly interrupted (#291).

"What plays next?" gets asked twice per track:

1. ~10s in, `triggerPreloadIfNeeded` calls `pickNextIndex` and preloads the result — the track the backend crossfade will fade into.
2. When the track ends, `advanceRef` calls `pickNextIndex` again to advance the queue.

Shuffle answered each call with a fresh `Math.random()`:

```ts
if (state.shuffle) {
  let next = state.queueIndex;
  while (next === state.queueIndex) next = Math.floor(Math.random() * state.queue.length);
  return next;
}
```

On a queue of N the two answers agreed one time in N-1. The backend faded into the track it was handed, the frontend then loaded a different one over the top, and the fade became a cut. The reporter read this as "crossfade predicts the next song in line" — it isn't picking sequentially, it's picking a second unrelated random track. Gapless was hitting the same mismatch without crossfade to make it obvious: the preload was discarded and the next track cold-loaded every time.

Deal the order once when shuffle is enabled, and walk it. Beyond fixing the mismatch this makes shuffle behave the way people expect: every track plays once before any repeats, Previous returns to the track that actually just played, and the order survives a relaunch because it persists alongside the queue it indexes into.

The order holds queue positions, so the edits that shift positions — play-next inserts, removals, clearing down to the current track — remap it. Track ids would avoid the remapping, but the queue deliberately allows the same track twice and that makes ids ambiguous. `resolveShuffleOrder` reconciles against the live queue, which is what lets an appended radio tail play after the shuffled queue rather than invalidating the order.

## Also in here

A stable shuffle order fixes the common trigger for the preload landing on the wrong track, not the general one. **Anything** that changes the next track mid-play — toggling shuffle, Play next, removing a queue item, changing repeat — left the backend primed with the track picked ten seconds in. The preload guard keyed on the track we preloaded *for*, so the first answer stood for the rest of the track. It now keys on what we actually preloaded and re-fires whenever the recomputed next differs, which makes it self-correcting for any cause rather than the ones we thought to enumerate.

`hasNext` had the matching problem: it tested queue position, which only describes sequential play. Under shuffle, a listener sitting on the last queue index with most of the order unplayed got a disabled Next button. It now asks `pickNextIndex`.

## Behaviour change worth flagging

**Shuffle used to play forever; it now ends after one pass.** The old code could never return `null` under shuffle, so shuffled playback ran indefinitely and never reached the end-of-queue path. Walking a finite order means it now does.

For the default setup (continue-playing ON) this is an improvement and matches Spotify: one pass through the queue, then radio takeover. But with continue-playing OFF, a shuffled queue that previously played random tracks indefinitely will now stop — re-priming track 0 paused for an album source, stopping and clearing otherwise. That's the correct behaviour and the same rule sequential play already follows, but it is a change, and anyone relying on infinite shuffle will notice.

## Test plan

- `web/src/hooks/usePlayer.test.ts`: repeated `pickNextIndex` calls for one track return one answer (the regression); every track plays once before any repeats; the order ends the queue unless repeat is on; the current track stays first so enabling shuffle mid-track doesn't skip; an appended radio tail plays after the shuffled queue; stale entries from a shrunken queue are ignored; insert/remove remapping including an insert landing before the current track; `hasNext` on the last queue position, at the end of the order, and on a single-track queue.
- `npx tsc -b --noEmit` clean, `npm test` 129 passed, eslint clean on the touched files (one pre-existing exhaustive-deps warning).
- **Not yet verified by ear.** Shuffle + 5s crossfade on a real queue, confirming the track that fades in is the one that keeps playing, still needs a manual pass before this ships.

Fixes the problem reported in #291.
