### PR TITLE
Match the collection button to its action-row siblings

### DIFF
--- a/web/src/components/AddToCollectionButton.tsx
+++ b/web/src/components/AddToCollectionButton.tsx
@@ -94,14 +94,19 @@ export function AddToCollectionButton({ album }: { album: Album }) {
     <>
       <DropdownMenu onOpenChange={loadOnOpen}>
         <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
+          {/* Same bare icon-over-caption pattern as the sibling row
+              controls (AddToLibraryButton / ShareButton), not the
+              shadcn <Button> — that rendered a smaller icon (the button
+              base class forces svg to size-4 over our h-5), no caption,
+              a stray hover pill, and the wrong height. */}
+          <button
+            className="flex flex-col items-center gap-1 text-muted-foreground transition-colors hover:text-foreground data-[state=open]:text-primary"
             aria-label="Add to collection"
-            title="Add to collection"
+            title="Save this album to one of your own on-device collections — personal groups of albums that Tidal can't do (like folders or tags), and that work offline"
           >
             <Layers className="h-5 w-5" />
-          </Button>
+            <div className="text-xs font-semibold">Collection</div>
+          </button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="max-h-80 overflow-y-auto">
           <DropdownMenuLabel>Add to collection</DropdownMenuLabel>


### PR DESCRIPTION
## Summary

The "add to collection" control on the album page (from the local-collections feature, #243, shipped in v1.21.0) renders unlike every other control in its action row. It was built with the shadcn `<Button variant="ghost" size="icon">` while Library, Download, Credits, Share, and More are all the bare icon-over-caption pattern. Four visible defects came out of that one mismatch:

- **Icon too small.** The `<Button>` base class carries `[&_svg]:size-4`, which overrides the `h-5 w-5` on the `<Layers>` icon — so it rendered at 16px next to five 20px siblings.
- **No caption.** The only icon in the row with no word under it, leaving an empty-looking slot.
- **Stray hover pill.** `variant="ghost"` is `hover:bg-accent`; a rounded-full background appeared on hover that nothing else in the row has.
- **Wrong height / float.** `size="icon"` is `h-10 w-10`; against the taller two-line siblings in an `items-center` row it sat too high.

Two of the siblings (`AddToLibraryButton`, `DownloadAlbumButton`) even carry comments saying they match `ShareButton`'s "icon above, small text" pattern — the new button just didn't follow it.

Switched it to that same bare-button pattern with a "Collection" caption. Also reworded the tooltip to explain the feature rather than restate the label: collections aren't a Tidal concept, so "Add to collection" alone doesn't tell a new user these are their own on-device album groups (folders/tags Tidal can't do) that also work offline.

## Test plan

Verified in the running app on a real album page, measuring the fixed button against the Share button beside it:

| | Collection (fixed) | Share (sibling) |
|---|---|---|
| Height | 40px | 40px |
| Vertical top | 302 | 302 |
| Icon size | 20×20 | 20×20 |
| Caption | "Collection" | "Share" |
| Hover background | transparent | transparent |

Confirmed the dropdown still opens (trigger goes to `data-state="open"`, driving the active-color style) and the tooltip is attached. `tsc` clean, eslint clean on the file, `npm test` 117 passed.

Addresses the styling regression in the #243 feature.