### PR TITLE
Isolate cover-art proxy from the shared HTTP session

### DIFF
--- a/app/http.py
+++ b/app/http.py
@@ -143,3 +143,18 @@ SESSION = build_impersonated_session() or _build_requests_session()
 # When False, login and other Tidal calls are more likely to be
 # blocked by anti-abuse heuristics or local AV that targets Python.
 IMPERSONATED = type(SESSION).__module__.startswith("curl_cffi")
+
+# Dedicated transport for cover-art proxying (`/api/image`). A grid of
+# album/artist cards fires dozens of image fetches at once, and routing
+# those through the single shared SESSION makes them contend with the
+# latency-sensitive audio path — DASH segment reads, manifest resolves,
+# and tidalapi calls all draw from the same connection pool. Under that
+# contention covers queue behind streaming traffic (slow to appear) or
+# trip their timeout and 502 (the card renders a broken image). Giving
+# images their own session with an independent, generously-sized pool
+# means cover traffic and audio traffic never starve each other. Tidal's
+# resources.tidal.com CDN is public and doesn't fingerprint-block, so the
+# plain pooled requests session is sufficient; keeping images off the
+# impersonated transport also leaves more curl-cffi capacity for the
+# calls that actually need it.
+IMAGE_SESSION = _build_requests_session()

--- a/server.py
+++ b/server.py
@@ -19,6 +19,7 @@ import threading
 import time
 import traceback
 import uuid
+from collections import OrderedDict
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from dataclasses import asdict
@@ -61,7 +62,7 @@ from app import playlist_import
 from app import spotify_import
 from app import tidal_realtime
 from app.downloader import DownloadItem, DownloadStatus, Downloader
-from app.http import SESSION, network_error_classes
+from app.http import IMAGE_SESSION, SESSION, network_error_classes
 from app.lastfm import LastFmClient
 from app.local_index import LocalIndex
 from app import now_playing_state
@@ -11925,10 +11926,69 @@ def move_track_in_playlist(playlist_id: str, req: MoveTrackRequest) -> dict:
 
 MAX_IMAGE_BYTES = 5 * 1024 * 1024  # 5 MB — covers even oversized Tidal covers
 
+# In-process byte cache for proxied cover art. The browser already caches
+# each cover for a day (Cache-Control below), but that cache is per-browser
+# and doesn't survive a hard reload, a second window pointed at the same
+# local server, or the browser evicting it — and every one of those misses
+# is a fresh round-trip to Tidal's CDN. Holding recently-served covers here
+# turns those back into instant local hits and, on a cache hit, skips the
+# upstream fetch entirely so the request never occupies a connection. Bound
+# by both entry count and total bytes so it can't grow without limit; covers
+# are small (tens of KB) so a few hundred MB ceiling holds thousands of them.
+_IMAGE_CACHE_MAX_ENTRIES = 2048
+_IMAGE_CACHE_MAX_BYTES = 256 * 1024 * 1024
+# url -> (content_type, body). OrderedDict as an LRU: move_to_end on hit,
+# popitem(last=False) evicts the coldest.
+_image_cache: "OrderedDict[str, tuple[str, bytes]]" = OrderedDict()
+_image_cache_bytes = 0
+_image_cache_lock = threading.Lock()
+
+
+def _image_cache_get(url: str) -> Optional[tuple[str, bytes]]:
+    with _image_cache_lock:
+        entry = _image_cache.get(url)
+        if entry is not None:
+            _image_cache.move_to_end(url)
+        return entry
+
+
+def _image_cache_put(url: str, content_type: str, body: bytes) -> None:
+    global _image_cache_bytes
+    with _image_cache_lock:
+        if url in _image_cache:
+            # A concurrent request already populated it; don't double-count.
+            return
+        _image_cache[url] = (content_type, body)
+        _image_cache_bytes += len(body)
+        while _image_cache and (
+            len(_image_cache) > _IMAGE_CACHE_MAX_ENTRIES
+            or _image_cache_bytes > _IMAGE_CACHE_MAX_BYTES
+        ):
+            _, (_ct, evicted) = _image_cache.popitem(last=False)
+            _image_cache_bytes -= len(evicted)
+
+
+def _image_response(content_type: str, body: bytes) -> Response:
+    return Response(
+        content=body,
+        media_type=content_type,
+        headers={
+            "Cache-Control": "public, max-age=86400",
+            # Explicit CORS header so fast-average-color on the frontend
+            # can read pixel data even when the image is cross-origin in dev.
+            "Access-Control-Allow-Origin": "*",
+        },
+    )
+
 
 @app.get("/api/image")
 def image_proxy(url: str) -> Response:
     _require_auth()
+
+    cached = _image_cache_get(url)
+    if cached is not None:
+        return _image_response(*cached)
+
     parsed = urlparse(url)
     if parsed.scheme != "https":
         raise HTTPException(status_code=400, detail="Only https URLs allowed")
@@ -11940,11 +12000,12 @@ def image_proxy(url: str) -> Response:
     if parsed.hostname not in ALLOWED_IMAGE_HOSTS:
         raise HTTPException(status_code=403, detail=f"Host not allowed: {parsed.hostname}")
     try:
-        # allow_redirects=False — a redirect from a Tidal CDN to an internal
-        # host would otherwise be followed by requests and turn this into an
-        # SSRF probe. Tidal covers are direct URLs so this should never fire
-        # on legitimate traffic.
-        resp = SESSION.get(url, timeout=10, stream=True, allow_redirects=False)
+        # IMAGE_SESSION is a dedicated pool so cover fetches don't contend
+        # with the audio path on the shared SESSION. allow_redirects=False —
+        # a redirect from a Tidal CDN to an internal host would otherwise be
+        # followed and turn this into an SSRF probe. Tidal covers are direct
+        # URLs so this should never fire on legitimate traffic.
+        resp = IMAGE_SESSION.get(url, timeout=10, stream=True, allow_redirects=False)
         if resp.status_code in (301, 302, 303, 307, 308):
             resp.close()
             raise HTTPException(status_code=502, detail="Upstream redirect refused")
@@ -11954,49 +12015,36 @@ def image_proxy(url: str) -> Response:
             resp.close()
             raise HTTPException(status_code=413, detail="Image too large")
         content_type = resp.headers.get("Content-Type", "image/jpeg")
-    except HTTPException:
-        raise
-    except Exception as exc:
-        raise HTTPException(status_code=502, detail=str(exc))
-
-    # Stream the bytes straight to the client instead of buffering
-    # the entire image into memory before responding. This cuts
-    # first-byte latency for every cover on every page, and keeps
-    # peak memory flat regardless of concurrent image requests.
-    # The MAX_IMAGE_BYTES safety check moves into the generator.
-    def _iter() -> Generator[bytes, None, None]:
+        # Buffer the whole cover (covers are small) so we can hand back a
+        # complete, cacheable body. Bounded by MAX_IMAGE_BYTES; a stream
+        # that lies about its size and runs long is cut off rather than
+        # allowed to fill memory.
+        chunks: list[bytes] = []
         streamed = 0
+        oversized = False
         try:
             for chunk in resp.iter_content(chunk_size=65536):
                 if not chunk:
                     continue
                 streamed += len(chunk)
                 if streamed > MAX_IMAGE_BYTES:
-                    # We've already started writing to the socket, so
-                    # we can't raise HTTPException here. Just stop
-                    # emitting; the client gets a truncated payload
-                    # which is harmless for an already-oversized
-                    # response the client shouldn't have trusted
-                    # anyway. Tidal's covers never come close to
-                    # 5 MB in practice.
-                    return
-                yield chunk
+                    oversized = True
+                    break
+                chunks.append(chunk)
         finally:
-            try:
-                resp.close()
-            except Exception:
-                pass
+            resp.close()
+    except HTTPException:
+        raise
+    except Exception as exc:
+        raise HTTPException(status_code=502, detail=str(exc))
 
-    return StreamingResponse(
-        _iter(),
-        media_type=content_type,
-        headers={
-            "Cache-Control": "public, max-age=86400",
-            # Explicit CORS header so fast-average-color on the frontend
-            # can read pixel data even when the image is cross-origin in dev.
-            "Access-Control-Allow-Origin": "*",
-        },
-    )
+    body = b"".join(chunks)
+    # Only cache complete, sanely-sized covers. An oversized/truncated body
+    # is served once but never stored, so a bad upstream can't poison the
+    # cache with a broken image.
+    if not oversized and body:
+        _image_cache_put(url, content_type, body)
+    return _image_response(content_type, body)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_image_proxy_cache.py
+++ b/tests/test_image_proxy_cache.py
@@ -1,0 +1,209 @@
+"""Tests for the cover-art proxy cache and its dedicated transport.
+
+The `/api/image` proxy fronts every album/artist/playlist cover. Two
+properties matter for the "covers load slow or not at all" report
+(#306):
+
+  - Cover fetches must not ride the shared audio/API `SESSION`. They
+    go through a dedicated `IMAGE_SESSION` so a page full of covers
+    can't starve DASH-segment / manifest / tidalapi traffic (and vice
+    versa). This test pins that the endpoint calls `IMAGE_SESSION`.
+  - A served cover is cached in-process, so a reload / second window /
+    browser-cache eviction becomes an instant local hit instead of a
+    fresh Tidal round-trip. The cache is a bounded LRU (by entry count
+    and by total bytes) so it can't grow without limit.
+
+The SSRF allowlist (https-only, no userinfo, host allowlist) is
+unchanged by the cache work; the last test pins that a disallowed host
+is still rejected without any upstream fetch.
+"""
+import pytest
+from fastapi import HTTPException
+
+
+@pytest.fixture(autouse=True)
+def _clean_image_cache():
+    import server
+
+    with server._image_cache_lock:
+        server._image_cache.clear()
+        server._image_cache_bytes = 0
+    yield
+    with server._image_cache_lock:
+        server._image_cache.clear()
+        server._image_cache_bytes = 0
+
+
+@pytest.fixture
+def stub_auth(monkeypatch):
+    import server
+
+    monkeypatch.setattr(server, "_require_auth", lambda: None)
+
+
+class _FakeResp:
+    """Minimal stand-in for the streamed requests/curl-cffi response the
+    proxy consumes: status, headers, raise_for_status, iter_content,
+    close."""
+
+    def __init__(self, body: bytes, content_type: str = "image/jpeg",
+                 status_code: int = 200, content_length: str | None = None):
+        self._body = body
+        self.status_code = status_code
+        self.headers = {"Content-Type": content_type}
+        if content_length is not None:
+            self.headers["Content-Length"] = content_length
+        self.closed = False
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+    def iter_content(self, chunk_size=65536):
+        for i in range(0, len(self._body), chunk_size):
+            yield self._body[i:i + chunk_size]
+
+    def close(self):
+        self.closed = True
+
+
+def _counting_session(resp: _FakeResp, calls: dict):
+    class _Sess:
+        def get(self, url, **kwargs):
+            calls["n"] = calls.get("n", 0) + 1
+            return resp
+
+    return _Sess()
+
+
+_URL = "https://resources.tidal.com/images/ab/cd/ef/640x640.jpg"
+
+
+# ---------------------------------------------------------------------------
+# Cache primitives
+# ---------------------------------------------------------------------------
+
+
+def test_put_then_get_roundtrips():
+    import server
+
+    server._image_cache_put(_URL, "image/png", b"pixels")
+    assert server._image_cache_get(_URL) == ("image/png", b"pixels")
+
+
+def test_get_missing_returns_none():
+    import server
+
+    assert server._image_cache_get("https://images.tidal.com/nope.jpg") is None
+
+
+def test_double_put_does_not_double_count_bytes():
+    import server
+
+    server._image_cache_put(_URL, "image/jpeg", b"1234")
+    server._image_cache_put(_URL, "image/jpeg", b"ZZZZZZZZ")  # ignored
+    with server._image_cache_lock:
+        assert server._image_cache_bytes == 4
+        # Original entry is kept; the second put is a no-op.
+        assert server._image_cache[_URL] == ("image/jpeg", b"1234")
+
+
+def test_evicts_coldest_by_entry_count(monkeypatch):
+    import server
+
+    monkeypatch.setattr(server, "_IMAGE_CACHE_MAX_ENTRIES", 2)
+    server._image_cache_put("u1", "image/jpeg", b"a")
+    server._image_cache_put("u2", "image/jpeg", b"b")
+    server._image_cache_put("u3", "image/jpeg", b"c")  # evicts u1
+    assert server._image_cache_get("u1") is None
+    assert server._image_cache_get("u2") is not None
+    assert server._image_cache_get("u3") is not None
+
+
+def test_get_marks_recently_used(monkeypatch):
+    import server
+
+    monkeypatch.setattr(server, "_IMAGE_CACHE_MAX_ENTRIES", 2)
+    server._image_cache_put("u1", "image/jpeg", b"a")
+    server._image_cache_put("u2", "image/jpeg", b"b")
+    server._image_cache_get("u1")  # u1 now most-recent
+    server._image_cache_put("u3", "image/jpeg", b"c")  # should evict u2
+    assert server._image_cache_get("u2") is None
+    assert server._image_cache_get("u1") is not None
+
+
+def test_evicts_by_total_bytes(monkeypatch):
+    import server
+
+    monkeypatch.setattr(server, "_IMAGE_CACHE_MAX_BYTES", 10)
+    server._image_cache_put("u1", "image/jpeg", b"x" * 6)
+    server._image_cache_put("u2", "image/jpeg", b"y" * 6)  # 12 > 10, evict u1
+    assert server._image_cache_get("u1") is None
+    assert server._image_cache_get("u2") is not None
+    with server._image_cache_lock:
+        assert server._image_cache_bytes == 6
+
+
+# ---------------------------------------------------------------------------
+# Endpoint behavior
+# ---------------------------------------------------------------------------
+
+
+def test_endpoint_uses_image_session_and_caches(stub_auth, monkeypatch):
+    import server
+
+    calls: dict = {}
+    resp = _FakeResp(b"JPEGBYTES", content_type="image/jpeg")
+    monkeypatch.setattr(server, "IMAGE_SESSION", _counting_session(resp, calls))
+
+    r1 = server.image_proxy(_URL)
+    assert r1.body == b"JPEGBYTES"
+    assert r1.media_type == "image/jpeg"
+    # Second request is served from cache — no second upstream fetch.
+    r2 = server.image_proxy(_URL)
+    assert r2.body == b"JPEGBYTES"
+    assert calls["n"] == 1
+
+
+def test_endpoint_does_not_touch_shared_session(stub_auth, monkeypatch):
+    """Regression guard: covers must never draw from the audio/API
+    SESSION. If the proxy ever reaches for it, this fails loudly."""
+    import server
+
+    calls: dict = {}
+    resp = _FakeResp(b"IMG")
+    monkeypatch.setattr(server, "IMAGE_SESSION", _counting_session(resp, calls))
+
+    class _Boom:
+        def get(self, *a, **k):
+            raise AssertionError("image proxy used the shared SESSION")
+
+    monkeypatch.setattr(server, "SESSION", _Boom())
+    server.image_proxy(_URL)
+    assert calls["n"] == 1
+
+
+def test_disallowed_host_rejected_without_fetch(stub_auth, monkeypatch):
+    import server
+
+    calls: dict = {}
+    resp = _FakeResp(b"IMG")
+    monkeypatch.setattr(server, "IMAGE_SESSION", _counting_session(resp, calls))
+
+    with pytest.raises(HTTPException) as exc:
+        server.image_proxy("https://evil.example.com/internal")
+    assert exc.value.status_code == 403
+    assert calls.get("n", 0) == 0
+
+
+def test_oversized_body_served_once_but_not_cached(stub_auth, monkeypatch):
+    import server
+
+    monkeypatch.setattr(server, "MAX_IMAGE_BYTES", 8)
+    calls: dict = {}
+    resp = _FakeResp(b"x" * 64)  # exceeds the 8-byte ceiling
+    monkeypatch.setattr(server, "IMAGE_SESSION", _counting_session(resp, calls))
+
+    server.image_proxy(_URL)
+    # Not stored: a truncated/oversized body must not poison the cache.
+    assert server._image_cache_get(_URL) is None


### PR DESCRIPTION
## Summary

Fixes #306 — album/artist covers loading slowly or not at all on a good connection.

Every cover routes through `/api/image`, a synchronous proxy that drew from the single global `SESSION` shared with the audio path (DASH segment reads, manifest resolves, tidalapi calls). A grid of cards fires dozens of cover fetches at once, so covers queued behind latency-sensitive streaming traffic (slow to appear) or tripped their 10s timeout and 502'd (broken image). The ceiling was connection-pool contention, not bandwidth — which is why it shows up even on fast internet.

Two changes:

1. **Dedicated transport (`IMAGE_SESSION`).** Cover fetches now use their own pooled session instead of the shared audio/API one, so image traffic and audio traffic can no longer starve each other. `resources.tidal.com` is a public CDN that doesn't fingerprint-block, so the plain pooled requests session is sufficient — and keeping covers off the impersonated transport leaves more curl-cffi capacity for the calls that need it.
2. **Bounded in-process LRU byte cache.** The browser already caches each cover for a day, but that cache is per-browser and doesn't survive a hard reload, a second window, or eviction — each of which was a fresh Tidal round-trip. Caching served covers turns those into instant local hits and, on a hit, skips the upstream fetch entirely so the request never occupies a connection. Oversized/truncated bodies are served once but never stored, so a bad upstream can't poison the cache. Bounded by both entry count and total bytes.

No retry-count / sleep bandaids — the fix removes the contention rather than papering over its symptoms.

## Test plan

- `tests/test_image_proxy_cache.py` (new, 10 tests): cache put/get roundtrip, LRU eviction by entry count and by total bytes, recency on hit, double-put not double-counting, endpoint serves from cache without a second upstream fetch, endpoint never touches the shared `SESSION`, SSRF host rejection still fires without a fetch, oversized body served once but not cached.
- `pytest tests/` — full backend suite green.
- SSRF allowlist (https-only, no userinfo, host allowlist) unchanged and still covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)