### PR TITLE
Stop silently logging users out when a launch refresh blips

### DIFF
--- a/app/tidal_client.py
+++ b/app/tidal_client.py
@@ -567,11 +567,36 @@ class TidalClient:
             # token and refresh up front.
             now = datetime.now(expiry.tzinfo) if expiry and expiry.tzinfo else datetime.now()
             if expiry and refresh_token and expiry <= now:
+                # The stored access token is already expired, so this refresh
+                # is what keeps a relaunch (app was closed past the token
+                # lifetime) from bouncing the user to the login screen. It
+                # must NOT swallow its failure: a transient error (network
+                # not up yet at boot, 429, 5xx) has to defer-and-retry like
+                # the offline path, or the fall-through to a stale-token
+                # check_login() logs the user out for a blip. A genuine
+                # rejection is a real re-login, but we log it so it stops
+                # being invisible (#309).
+                _transient = (TransientRefreshError,) + _NETWORK_ERRORS
                 try:
                     if self._token_refresh_capturing(refresh_token):
                         self.save_session()
-                except Exception:
-                    pass
+                        _tlog("load_session: expired token refreshed on launch")
+                except tidalapi.exceptions.AuthenticationError as exc:
+                    _tlog(
+                        "load_session: stored refresh token rejected on "
+                        f"launch — re-login required ({exc})"
+                    )
+                    # fall through: check_login() below returns False.
+                except _transient as exc:
+                    _tlog(
+                        "load_session: launch refresh hit a transient error, "
+                        f"keeping session to retry: {exc!r}"
+                    )
+                    self._session_load_deferred = True
+                    return False
+                except Exception as exc:
+                    _tlog(f"load_session: unexpected launch-refresh error: {exc!r}")
+                    # fall through rather than hide it.
             self.session.load_oauth_session(
                 data["token_type"],
                 self.session.access_token or data["access_token"],

--- a/tests/test_login_persistence.py
+++ b/tests/test_login_persistence.py
@@ -1,0 +1,98 @@
+"""load_session()'s relaunch refresh must not silently log the user out
+(#309).
+
+When the app is reopened after the stored access token has expired,
+load_session refreshes up front. The previous code swallowed any failure
+with `except Exception: pass` and fell through to a stale-token
+check_login() — so a transient blip (network not up at boot, 429, 5xx)
+signed the user out exactly like a revoked token, with no log to tell
+them apart. These pin the corrected behavior:
+
+  - transient failure  -> keep the session, defer for retry (return False
+    but `_session_load_deferred` True, without touching the stale token)
+  - genuine rejection  -> fall through to check_login() (real re-login)
+  - success            -> refreshed and validated
+"""
+import json
+from datetime import datetime, timedelta
+
+import pytest
+import tidalapi
+
+from app import tidal_client
+from app.tidal_client import TransientRefreshError
+
+
+@pytest.fixture
+def expired_session(tmp_path, monkeypatch):
+    """Point SESSION_FILE at a file whose access token expired 2h ago."""
+    f = tmp_path / "tidal_session.json"
+    expiry = (datetime.now() - timedelta(hours=2)).isoformat()
+    f.write_text(json.dumps({
+        "token_type": "Bearer",
+        "access_token": "stale",
+        "refresh_token": "R1",
+        "expiry_time": expiry,
+        "is_pkce": False,
+    }))
+    monkeypatch.setattr(tidal_client, "SESSION_FILE", f)
+    return f
+
+
+@pytest.fixture
+def tidal(monkeypatch):
+    import server
+
+    t = server.tidal
+    monkeypatch.setattr(t, "_session_load_deferred", False)
+    # Neutralize disk + network side effects of the happy path.
+    monkeypatch.setattr(t, "save_session", lambda: None)
+    return t
+
+
+def _track_oauth(monkeypatch, tidal, check_result):
+    calls = {"load_oauth": 0}
+    monkeypatch.setattr(
+        tidal.session, "load_oauth_session",
+        lambda *a, **k: calls.__setitem__("load_oauth", calls["load_oauth"] + 1),
+    )
+    monkeypatch.setattr(tidal.session, "check_login", lambda: check_result)
+    return calls
+
+
+def test_transient_refresh_defers_and_keeps_session(expired_session, tidal, monkeypatch):
+    def _boom(_rt):
+        raise TransientRefreshError("HTTP 429")
+
+    monkeypatch.setattr(tidal, "_token_refresh_capturing", _boom)
+    calls = _track_oauth(monkeypatch, tidal, check_result=False)
+
+    result = tidal.load_session()
+
+    assert result is False
+    assert tidal._session_load_deferred is True  # kept for retry, not logged out
+    assert calls["load_oauth"] == 0  # returned before touching the stale token
+
+
+def test_auth_rejection_falls_through_to_relogin(expired_session, tidal, monkeypatch):
+    def _reject(_rt):
+        raise tidalapi.exceptions.AuthenticationError("invalid_grant")
+
+    monkeypatch.setattr(tidal, "_token_refresh_capturing", _reject)
+    calls = _track_oauth(monkeypatch, tidal, check_result=False)
+
+    result = tidal.load_session()
+
+    assert result is False
+    assert tidal._session_load_deferred is False  # genuine re-login, not deferred
+    assert calls["load_oauth"] == 1  # fell through to validate (which fails)
+
+
+def test_successful_launch_refresh_signs_in(expired_session, tidal, monkeypatch):
+    monkeypatch.setattr(tidal, "_token_refresh_capturing", lambda _rt: True)
+    calls = _track_oauth(monkeypatch, tidal, check_result=True)
+
+    result = tidal.load_session()
+
+    assert result is True
+    assert calls["load_oauth"] == 1


### PR DESCRIPTION
## Summary

Addresses #309 (repeated daily re-logins). A reporter's `audio.log` showed the app being reopened after its access token had already expired, with **no `[tidal]` entries** on the failed relaunch and a forced re-login.

Root cause: `load_session()` refreshes the expired token up front on launch, but wrapped that refresh in `except Exception: pass` ([tidal_client.py](app/tidal_client.py)). Any failure was swallowed and the code fell through to a stale-token `check_login()` that reported the user signed out — invisibly, and identically whether the failure was transient or permanent.

The fix splits the handling:
- **Transient** (network not up at boot, 429, 5xx) → keep the session and defer for the watchdog to retry (same as the existing offline path), instead of forcing a re-login.
- **`AuthenticationError`** (genuine `invalid_grant`) → still a real re-login, but now **logged** so recurring reports are debuggable.
- Success and unexpected-error paths log too.

Ruled out a PKCE/device-code client-id mismatch — `is_pkce` is persisted and re-applied before the refresh.

This both fixes a real bug (a boot-time blip should not log you out) and makes the remaining "genuine token death" case visible in the log for the next report.

## Test plan

- `tests/test_login_persistence.py` (new): transient failure defers + keeps the session without touching the stale token; auth rejection falls through to re-login; success signs in.
- `tests/test_auth_network_failure.py` still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)