### PR TITLE
Rank For You rows by listening instead of serving genre charts

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ sounddevice audio engine behind a single pywebview window.
 ## Contents
 
 - [What's inside](#whats-inside)
+- [How For You works](#how-for-you-works)
 - [Support](#support)
 - [Install a released build](#install-a-released-build)
   - [Why the OS warns you on first launch](#why-the-os-warns-you-on-first-launch)
@@ -237,6 +238,117 @@ the status Tidal returned for each one.
 newer version is available a banner surfaces across the top of the
 UI, and clicking Install downloads the right asset for your OS and
 runs it.
+
+## How For You works
+
+For You is built from your own listening rather than from Tidal's
+recommendations. Three sources feed it: **Last.fm** supplies what you
+play, the community tags on those artists, and its similar-artist graph.
+**AlbumOfTheYear.org** supplies ratings and release listings.
+**Tidal** supplies the catalogue, your saved albums, and playback. No
+AI or language model is involved anywhere in the path.
+
+Most of the page needs Last.fm connected under Settings. Without it only
+the rows that lean on your Tidal library can render.
+
+### Working out your taste
+
+**Which artists count.** Your Last.fm top artists are read over two
+windows and blended: the last month at double weight, the last six
+months at single weight. Each window is normalised against its own top
+artist first, because a six-month play count dwarfs a one-month one and
+the longer window would otherwise always win. The recent window is what
+lets the page follow what you are into now, and the longer one stops a
+single evening on one artist from redefining everything.
+
+**Which genres count.** Each of those artists carries community tags on
+Last.fm, and the twelve strongest are read per artist. A tag's weight is
+divided by how widely it is applied across all of Last.fm, so broad
+labels lose to specific ones. Without that step the ranking just
+recovers whichever vague tag every artist carries, since breadth and tag
+strength rise together. It is the difference between being told you
+listen to "electronic" and being told you listen to IDM.
+
+A tag carried by only one of your artists has to be that artist's
+defining genre, scoring at least 80 out of 100, or it is ignored. One
+artist's passing association is not a genre you have.
+
+Surviving tags are matched against AOTY's genre taxonomy, which knows
+around 360 genres. Anything AOTY does not recognise drops out here,
+which also discards Last.fm descriptors that are not genres at all.
+
+**Your orbit.** Your top eight artists are expanded through Last.fm's
+similar-artist graph into roughly four hundred artists, each carrying a
+score for how strongly it connects back to what you play. This is what
+separates a recommendation from a chart: without it, everyone who
+listens to shoegaze sees the same shoegaze albums.
+
+### The rows
+
+**Recommended For You.** Takes the strongest remaining pick from every
+other row in turn. It deliberately does not score across sources, since
+an AOTY rating and a Last.fm match score measure different things and
+forcing them onto one scale lets a weak pick outrank a strong one.
+Round-robin needs no shared scale and makes it impossible for one source
+to dominate. Every card keeps the reason it came from.
+
+**New Releases For You.** AOTY's recent releases for each of your top
+genres, interleaved. Scoped to your genres rather than re-ranking a
+global chart of everything released that week. This row moves as music
+is actually released rather than on a schedule.
+
+**From Your Genres.** AOTY's highest user-rated albums of all time in
+each of your top six genres, not restricted to any year. Within a genre
+the order is not AOTY's ranking. Candidates are scored on three things:
+whether the artist sits in your orbit, the album's rating once thin vote
+counts are discounted, and a penalty for artists already in your heavy
+rotation. A row of albums by people you already play is a mirror rather
+than a recommendation. **View more** opens a page giving each of your
+top twelve genres its own row, which you can keep loading further into.
+
+**Popular in Your Orbit.** AOTY's highest user-rated albums of the
+current year, re-ordered by how well each fits your genres. The balance
+between raw rating and genre fit shifts with how mainstream your
+listening is, measured as how much your top artists overlap Last.fm's
+global charts. A niche listener gets genre fit weighted more heavily, or
+the row would collapse into the global chart.
+
+**Fans Also Like.** Artists that listeners of your top artists also
+play, from Last.fm's similar-artist graph, resolved to their albums.
+Because that graph is built from listening rather than from who has
+played in a band together, an artist nobody listens to never enters the
+pool. Picks are taken from each seed artist in turn so one seed sitting
+in a dense corner of the graph cannot fill the shelf.
+
+### Rules that apply everywhere
+
+**Albums already in your Tidal favorites are never recommended back to
+you**, in any row. At most two albums by the same artist appear in a
+row, and reissues of the same record collapse together.
+
+**Rows rotate weekly.** Charts move slowly, and an all-time ranking does
+not move at all, so each row walks further into its candidates on a
+weekly schedule. Rotation is bucketed by week rather than randomised, so
+the page is stable across a refresh and within a session, and changes on
+a schedule instead of under your cursor. For the genre rows the rotation
+stays inside the best-ranked candidates, so the variety does not come at
+the cost of fit.
+
+**Ratings are discounted by how many people voted.** A 95 from eleven
+listeners is weaker evidence than an 88 from three thousand, so scores
+are pulled toward the middle until the vote count earns them.
+
+### Refresh and caching
+
+The assembled page is cached for 15 minutes. Underneath, a genre's
+all-time ranking is cached for 24 hours, recent releases for 30 minutes,
+the current year's chart for an hour, and the mapping from an AOTY album
+to a Tidal one for 30 days. A first ever load is therefore slower than
+later ones, and does a lot of catalogue lookups.
+
+AOTY is scraped rather than read through an API, since it does not offer
+one. Requests can be rate limited, in which case rows come back shorter
+than usual or drop out entirely until the limit clears.
 
 ## Support
 

--- a/server.py
+++ b/server.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import os
 import platform
 import re
@@ -12018,7 +12019,84 @@ _SECTION_RESOLVE_POOL = 36
 # Genres blended into each genre-scoped row. AOTY lists only a handful of
 # albums per genre section, so one genre can't fill a shelf; five covers
 # the shelf while still reflecting the listener's actual spread.
-_GENRE_BLEND_SEEDS = 5
+# Genres blended into each genre-scoped row on the main page. Kept small
+# because every genre here costs AOTY fetches and Tidal resolutions on
+# every page build.
+_GENRE_BLEND_SEEDS = 6
+
+# Genres the taste profile ranks. Costs nothing beyond tag arithmetic —
+# no fetches — so it runs deep and lets each surface take the slice it can
+# afford. A real profile ranks around fifty, far past what any row shows.
+_TASTE_GENRE_MAX = 20
+
+# Genre rows on the drill-down. More than the main page because that's the
+# point of drilling in, but still bounded: each row is an AOTY page plus a
+# Tidal search per album it resolves.
+_GENRE_HUB_MAX = 12
+
+# A genre row below this on the drill-down is dropped rather than shown.
+# The other rows already refuse to render a stub; the drill-down didn't,
+# so a throttled AOTY or Tidal fetch produced one-album shelves that read
+# as broken rather than as temporarily unavailable.
+_GENRE_HUB_MIN_ALBUMS = 4
+
+# Listing rows pulled per genre on the drill-down. One AOTY page, sized so
+# the weekly rotation has room to move a shelf-sized window around.
+_GENRE_PAGE_POOL = 25
+
+# How often the rotating rows advance through their candidate pool. A
+# chart that only moves annually still leaves the page looking frozen
+# between updates, so the rows walk deeper into it over time instead of
+# always showing the same head. Bucketed rather than random so a row is
+# stable across a session and a refresh — it changes on a schedule, not
+# under the cursor.
+_ROTATION_PERIOD_SEC = 7 * 86400.0
+# Candidates skipped per rotation. Smaller than a shelf so consecutive
+# weeks overlap rather than swapping the row out wholesale.
+_ROTATION_STRIDE = 6
+# Candidates taken per genre before interleaving. Enough that five genres
+# more than fill a shelf, so the rotation has slack to work with.
+_GENRE_ROTATION_WINDOW = 12
+# Genres advance more gently than the single-source rows. Each genre only
+# contributes a couple of albums to the finished shelf, so a stride near
+# the window size compounds across five of them and swaps the row out
+# wholesale — which reads as a different row each week rather than the
+# same row moving.
+_GENRE_ROTATION_STRIDE = 2
+# Rotation happens inside this many of the best-ranked candidates rather
+# than across the whole listing. Ranking then rotating over everything
+# put the row's best matches at the front and immediately walked past
+# them — the shelf varied, but by trading fit for novelty every week.
+# Bounding it keeps every week's slice drawn from the strongest picks.
+_GENRE_RANK_POOL = 24
+
+
+def _rotation_offset(pool_size: int, stride: int = _ROTATION_STRIDE) -> int:
+    """Where in a ranked pool this week's slice starts.
+
+    Wraps so a pool smaller than the stride still rotates rather than
+    pinning to zero, and returns 0 for pools too small to slice.
+    """
+    if pool_size <= 0:
+        return 0
+    bucket = int(time.time() // _ROTATION_PERIOD_SEC)
+    return (bucket * stride) % pool_size
+
+
+def _rotate(items: list, window: int, stride: int = _ROTATION_STRIDE) -> list:
+    """Take this week's `window` items from a ranked pool, wrapping.
+
+    Wrapping matters: without it the tail of the pool would only ever be
+    reachable in the weeks the offset happened to land there, and the
+    last few entries never at all.
+    """
+    if not items or window <= 0:
+        return []
+    if len(items) <= window:
+        return items
+    start = _rotation_offset(len(items), stride)
+    doubled = items + items
+    return doubled[start:start + window]
 # Similar artists to resolve for "Fans Also Like". Each costs a Tidal
 # search plus an album fetch, and yields up to 2 albums, so this sits
 # comfortably above _SECTION_SIZE to survive unavailable albums and the
@@ -12129,54 +12207,267 @@ def _aoty_genre_slug_map() -> dict:
     return mapping
 
 
+# Listening windows blended into the taste profile, and how much each
+# counts. The recent window is what makes the page move with you; the
+# longer one is ballast so a single evening on one artist doesn't
+# redefine your taste. Play counts aren't comparable between windows (a
+# six-month count dwarfs a one-month one), so each window is normalised
+# against its own top artist before these weights apply.
+_TASTE_WINDOWS: tuple[tuple[str, float], ...] = (("1month", 2.0), ("6month", 1.0))
+
+# Tags pulled per artist. Last.fm orders them strongest-first, and the
+# specific ones a listener actually cares about ("slowcore", "emo rap")
+# sit below the broad ones, so a shallow read only ever sees "rock".
+_TASTE_TAGS_PER_ARTIST = 12
+
+# How hard a tag's global reach discounts it. A logarithmic discount
+# barely separates anything — the broadest tag on Last.fm and one absent
+# from the chart entirely differ by about 1.5x, which higher tag counts
+# on broad tags simply cancel out, so "rock" and "electronic" kept
+# winning. A square root spreads them roughly 9x and lets the sub-genres
+# through. Measured across a real profile's top genres, broad tags in the
+# top twelve: log10 4, **0.25 3, **0.5 1, **0.6 0 — but 0.6 also drops
+# "ambient", which genuinely describes part of that listening. 0.5 keeps
+# the descriptive ones and still surfaces dariacore and experimental hip
+# hop.
+_TAG_REACH_EXPONENT = 0.5
+
+# A tag's reach in Last.fm's global chart, used to discount broad tags.
+# Tags outside the global top chart report no reach at all, which is the
+# common case for exactly the sub-genres worth surfacing — they're scored
+# as if they had this reach rather than as infinitely specific, so a
+# typo'd or junk tag can't outrank a real one on obscurity alone.
+_TAG_REACH_FLOOR = 5000.0
+
+# A tag carried by only one of the listener's artists needs to be that
+# artist's defining genre to count, not a footnote on them. Last.fm's
+# 0..100 tag strength makes the distinction: Quadeca is "art pop" and
+# "folktronica" at 100 and "emo rap" at 59, and a single artist's
+# third-strongest tag was enough to put emo rap on a listener's page as a
+# genre they don't recognise. The niche bonus above made it worse, since
+# a rarely-used tag is exactly the kind that gets boosted.
+#
+# A plain "two or more artists" rule doesn't work: breadth and backer
+# count rise together, so it readmits "electronic" and "indie rock" while
+# still dropping genuinely specific single-artist genres.
+_SOLO_TAG_MIN_STRENGTH = 80.0
+
+
+def _seed_artists() -> list[dict]:
+    """Top artists blended across listening windows, most relevant first.
+
+    Reading a single six-month window made the page effectively static:
+    the same five artists drove it for months. Blending a recent window
+    over a longer one lets it follow what someone is actually listening
+    to now while staying stable against one night's binge.
+    """
+    merged: dict[str, dict] = {}
+    for period, weight in _TASTE_WINDOWS:
+        rows = _rec_safe(lambda p=period: lastfm.get_top_artists(p, limit=15), [])
+        if not rows:
+            continue
+        top_count = max((float(r.get("playcount") or 0) for r in rows), default=0.0)
+        if top_count <= 0:
+            top_count = 1.0
+        for row in rows:
+            name = (row.get("name") or "").strip()
+            if not name:
+                continue
+            # Normalised within its own window so the windows are
+            # comparable before weighting.
+            score = (float(row.get("playcount") or 0) / top_count) * weight
+            entry = merged.get(name.lower())
+            if entry is None:
+                merged[name.lower()] = {"name": name, "score": score}
+            else:
+                entry["score"] += score
+    return sorted(merged.values(), key=lambda e: e["score"], reverse=True)
+
+
+# How far each signal counts when ranking candidates inside a genre.
+# Genre affinity is deliberately absent: every candidate in a genre row
+# shares that genre, so it can't separate them — it does its work when
+# choosing which genres to show at all.
+_SCORE_W_ORBIT = 0.45
+_SCORE_W_QUALITY = 0.30
+_SCORE_W_NOVELTY = 0.25
+
+# Ratings shrink toward this until enough people have voted. AOTY lets a
+# 95 from eleven listeners outrank an 88 from three thousand, which is
+# noise winning over evidence; the prior pulls thin ratings back toward
+# the middle until they've earned their score.
+_QUALITY_PRIOR = 70.0
+_QUALITY_PRIOR_WEIGHT = 60.0
+
+
+def _listening_orbit(seeds: list[dict]) -> dict:
+    """`artist (lower) -> affinity` for everyone within one hop of the
+    listener's top artists on Last.fm's similar-artist graph.
+
+    This is the signal that turns a genre chart into a recommendation.
+    Without it a genre row is the same list for everyone who happens to
+    share that genre; with it, "highly rated shoegaze" becomes "highly
+    rated shoegaze by artists your listening actually connects to". On a
+    real profile about a fifth of a genre's candidates land in here —
+    dense enough to rank on, sparse enough to discriminate.
+
+    """
+    orbit: dict[str, float] = {}
+    if not seeds:
+        return orbit
+
+    def _sims(entry):
+        return entry, _rec_safe(
+            lambda: lastfm.get_similar_artists(entry["name"], limit=50), []
+        )
+
+    with ThreadPoolExecutor(max_workers=6, thread_name_prefix="orbit") as pool:
+        for entry, sims in pool.map(_sims, seeds[:_ORBIT_SEEDS]):
+            affinity = float(entry.get("score") or 0) or 1.0
+            for s in sims:
+                nm = (s.get("name") or "").strip().lower()
+                if not nm:
+                    continue
+                try:
+                    match = float(s.get("match") or 0.0)
+                except (TypeError, ValueError):
+                    match = 0.0
+                orbit[nm] = orbit.get(nm, 0.0) + affinity * match
+    # The seeds are deliberately NOT boosted into their own orbit. Doing
+    # that made a listener's own top artists lead every genre row —
+    # Quadeca headed both "Art Pop" and "Folktronica" for someone whose
+    # most-played artist is Quadeca. They still appear when the graph
+    # links them to another seed, which is a real signal; they just don't
+    # get a free ride to the top of a discovery row.
+    # Normalise so the weights below mean the same thing regardless of how
+    # many seeds contributed or how heavily they're played.
+    peak = max(orbit.values(), default=0.0)
+    if peak > 0:
+        for k in orbit:
+            orbit[k] /= peak
+    return orbit
+
+
+# Seeds expanded into the orbit. Each costs one Last.fm call, and the
+# graph saturates quickly — eight seeds already reach ~400 artists.
+_ORBIT_SEEDS = 8
+
+
+def _rank_by_taste(rows: list, orbit: dict, played: set) -> list:
+    """Order AOTY listing rows by how well they fit this listener.
+
+    Three parts: whether the artist sits in the listener's orbit, how
+    well-rated the album is once thin rating counts are discounted, and a
+    penalty for artists already in heavy rotation — a row of albums by
+    people you already play is a mirror, not a recommendation.
+    """
+    if not rows:
+        return []
+
+    def _score(row) -> float:
+        artist = (row.get("artist") or "").strip().lower()
+        orbit_fit = orbit.get(artist, 0.0)
+
+        raw = float(row.get("score") or 0.0)
+        votes = float(row.get("rating_count") or 0.0)
+        # Bayesian shrink toward the prior until the vote count earns it.
+        quality = (raw * votes + _QUALITY_PRIOR * _QUALITY_PRIOR_WEIGHT) / (
+            votes + _QUALITY_PRIOR_WEIGHT
+        ) / 100.0
+
+        novelty = 0.0 if artist in played else 1.0
+        return (
+            _SCORE_W_ORBIT * orbit_fit
+            + _SCORE_W_QUALITY * quality
+            + _SCORE_W_NOVELTY * novelty
+        )
+
+    return sorted(rows, key=_score, reverse=True)
+
+
 def _taste_profile() -> dict:
-    """Infer taste from Last.fm: play-weighted top artists, and their most
-    common community tags aggregated into top genres mapped to AOTY slugs
-    (the full taxonomy, so sub-genres survive). A disconnected or empty
-    profile is fine — sections that depend on it just don't render. This
-    is the "listening history" half of the popularity-x-history ranking
-    (#307)."""
+    """Infer taste from Last.fm: recency-blended top artists, and their
+    community tags aggregated into genres mapped to AOTY slugs (the full
+    taxonomy, so sub-genres survive). A disconnected or empty profile is
+    fine — sections that depend on it just don't render. This is the
+    "listening history" half of the popularity-x-history ranking (#307).
+    """
     connected = bool(_rec_safe(lambda: lastfm.status().get("connected"), False))
     if not connected:
         return {"connected": False, "artist_names": set(), "genres": []}
-    top = _rec_safe(lambda: lastfm.get_top_artists("6month", limit=15), [])
-    artist_names = {
-        (t.get("name") or "").strip().lower() for t in top if t.get("name")
+    top = _seed_artists()
+    artist_names = {e["name"].strip().lower() for e in top if e.get("name")}
+
+    # How widely each tag is applied across all of Last.fm. Broad tags
+    # ("rock", "electronic") are enormous and say almost nothing about an
+    # individual; the sub-genres worth acting on are far rarer.
+    chart_tags = _rec_safe(lambda: lastfm.get_chart_top_tags(limit=250), [])
+    tag_reach = {
+        (t.get("name") or "").strip().lower(): float(t.get("reach") or 0)
+        for t in chart_tags
     }
 
-    # Aggregate genre tags across top artists, weighting each tag by the
-    # artist's playcount and the tag's 0..100 strength.
-    def _tags_for(t):
-        nm = (t.get("name") or "").strip()
+    def _tags_for(entry):
+        nm = (entry.get("name") or "").strip()
         if not nm:
             return []
-        pc = float(t.get("playcount") or 0) or 1.0
-        tags = _rec_safe(lambda: lastfm.get_artist_top_tags(nm, limit=4), [])
-        return [
-            ((tag.get("name") or "").strip().lower(),
-             pc * (float(tag.get("count") or 0) / 100.0))
-            for tag in tags
-        ]
+        affinity = float(entry.get("score") or 0) or 1.0
+        tags = _rec_safe(
+            lambda: lastfm.get_artist_top_tags(nm, limit=_TASTE_TAGS_PER_ARTIST), []
+        )
+        out = []
+        for tag in tags:
+            name = (tag.get("name") or "").strip().lower()
+            if not name:
+                continue
+            raw_strength = float(tag.get("count") or 0)
+            strength = raw_strength / 100.0
+            # Discount by how commonly the tag is applied globally. Without
+            # this the ranking just recovers the broadest tag every artist
+            # carries, because breadth and tag strength rise together —
+            # Boards of Canada is tagged "electronic" (84) as strongly as
+            # "ambient" (100), and "idm" is the one that actually describes
+            # them. Log so the discount is gentle rather than a cliff.
+            reach = max(tag_reach.get(name, 0.0), _TAG_REACH_FLOOR)
+            out.append((
+                name,
+                affinity * strength / (reach ** _TAG_REACH_EXPONENT),
+                nm,
+                raw_strength,
+            ))
+        return out
 
     weights: dict[str, float] = {}
+    backers: dict[str, set] = {}
+    peak_strength: dict[str, float] = {}
     if top:
         with ThreadPoolExecutor(max_workers=6, thread_name_prefix="taste") as pool:
-            for pairs in pool.map(_tags_for, top[:12]):
-                for name, w in pairs:
-                    if name:
-                        weights[name] = weights.get(name, 0.0) + w
+            for pairs in pool.map(_tags_for, top[:15]):
+                for name, w, artist, raw in pairs:
+                    if not name:
+                        continue
+                    weights[name] = weights.get(name, 0.0) + w
+                    backers.setdefault(name, set()).add(artist)
+                    peak_strength[name] = max(peak_strength.get(name, 0.0), raw)
 
     # Map inferred genre names to AOTY's full-taxonomy slugs so specific
     # sub-genres (shoegaze, slowcore, art pop) survive instead of dropping.
+    # Anything AOTY doesn't recognise falls out here, which also discards
+    # Last.fm descriptors that aren't genres at all ("japanese", "seen
+    # live") without needing a blocklist.
     name_to_slug = _aoty_genre_slug_map()
     genres: list = []
     seen_slugs: set = set()
     for gname, _w in sorted(weights.items(), key=lambda kv: kv[1], reverse=True):
+        # One artist's passing association isn't a genre the listener has.
+        if len(backers.get(gname, ())) < 2 and \
+                peak_strength.get(gname, 0.0) < _SOLO_TAG_MIN_STRENGTH:
+            continue
         hit = name_to_slug.get(gname)
         if hit and hit[0] and hit[0] not in seen_slugs:
             seen_slugs.add(hit[0])
             genres.append((hit[0], hit[1], _w))
-        if len(genres) >= _GENRE_BLEND_SEEDS:
+        if len(genres) >= _TASTE_GENRE_MAX:
             break
 
     # Obscurity: how much of your top rotation overlaps Last.fm's global
@@ -12195,11 +12486,15 @@ def _taste_profile() -> dict:
         "artist_names": artist_names,
         "genres": genres,
         "mainstream_ratio": mainstream_ratio,
+        # Computed once here and handed to every row: it costs eight
+        # Last.fm calls, and each row re-deriving it would multiply that
+        # for no benefit.
+        "orbit": _listening_orbit(top),
     }
 
 
 def _aoty_section(key, title, subtitle, listing, profile, taste_rank, deep=False,
-                  owned: Optional[set] = None) -> dict:
+                  owned: Optional[set] = None, rotate: bool = False) -> dict:
     """Build one AOTY-backed section. When `taste_rank`, re-order the
     (cheap) AOTY listing by a blend of popularity (AOTY score) and genre
     affinity before resolving only the top slice to Tidal.
@@ -12229,7 +12524,10 @@ def _aoty_section(key, title, subtitle, listing, profile, taste_rank, deep=False
                 return pop * pop_w + aff
 
         items.sort(key=_score, reverse=True)
-    items = items[:_SECTION_RESOLVE_POOL]
+    # Rotate rather than always resolving the head of the ranking. The
+    # underlying chart barely moves week to week, so without this the row
+    # shows the same albums until the year turns over.
+    items = _rotate(items, _SECTION_RESOLVE_POOL) if rotate else items[:_SECTION_RESOLVE_POOL]
     resolved = _rec_safe(lambda: aoty_resolver.resolve_listing(items), []) or []
     albums = [
         it["tidal_album"]
@@ -12258,7 +12556,10 @@ def _section_fans_also_like(owned: Optional[set] = None) -> dict:
     Cross-seed corroboration: an artist that several of your favorites share
     ranks highest (their Last.fm `match` scores sum across seeds).
     Opportunistic — drops out when there's too little to fill a shelf."""
-    top = _rec_safe(lambda: lastfm.get_top_artists("6month", limit=8), [])
+    # Same recency-blended seeds the rest of the page uses. Reading a raw
+    # six-month window here left this row anchored to whatever dominated
+    # half a year while the genre rows had already moved on.
+    top = _seed_artists()
     seeds = [(t.get("name") or "").strip() for t in top[:6]]
     seeds = [s for s in seeds if s]
     # Everything the user already plays — this row is for discovery, so we
@@ -12375,15 +12676,25 @@ def _genre_blend(key: str, title: str, subtitle: str, fetch, profile,
     if not genres:
         return {"key": key, "title": title, "subtitle": subtitle, "albums": []}
 
+    orbit = profile.get("orbit") or {}
+    played = profile.get("artist_names") or set()
+
     def _for(seed):
         slug, name, _w = seed
-        return name, _rec_safe(lambda s=slug: fetch(s), []) or []
+        rows = _rec_safe(lambda s=slug: fetch(s), []) or []
+        # Rank by fit before rotating, so the rotation walks through a
+        # list ordered for this listener rather than through AOTY's
+        # ranking. Without this the row is the same chart for everyone
+        # who happens to share the genre.
+        rows = _rank_by_taste(rows, orbit, played)
+        return name, _rotate(rows[:_GENRE_RANK_POOL], _GENRE_ROTATION_WINDOW,
+                             _GENRE_ROTATION_STRIDE)
 
     per_genre: "OrderedDict[str, list]" = OrderedDict()
     with ThreadPoolExecutor(max_workers=5, thread_name_prefix="genreblend") as pool:
         for name, rows in pool.map(_for, genres):
             if rows:
-                per_genre[name] = rows
+                per_genre[name] = list(rows)
 
     interleaved: list[dict] = []
     while True:
@@ -12430,7 +12741,7 @@ def _build_recommendation_sections() -> list[dict]:
         ("new", lambda: _genre_blend(
             "new_releases", "New Releases For You",
             "Fresh in the genres you listen to",
-            lambda s: aoty_module.recent_releases_by_genre(s, 20), profile,
+            lambda s: aoty_module.recent_releases_by_genre(s, 30), profile,
             owned=owned,
         )),
         # The genre canon, all-time rather than "best of <this year>".
@@ -12438,7 +12749,7 @@ def _build_recommendation_sections() -> list[dict]:
             **_genre_blend(
                 "from_your_genres", "From Your Genres",
                 "Highest rated in the genres you listen to",
-                lambda s: aoty_module.top_albums_by_genre(s, 20), profile,
+                lambda s: aoty_module.top_albums_by_genre(s, 50), profile,
                 owned=owned,
             ),
             # Drill-down: a row per genre instead of one blended shelf.
@@ -12447,8 +12758,8 @@ def _build_recommendation_sections() -> list[dict]:
         ("popular", lambda: _aoty_section(
             "popular", "Popular in Your Orbit",
             "Highly rated this year, tuned to your genres",
-            _rec_safe(lambda: aoty_module.top_albums_of_year(year, 60), []), profile, True,
-            owned=owned,
+            _rec_safe(lambda: aoty_module.top_albums_of_year(year, 100), []), profile, True,
+            owned=owned, rotate=True,
         )),
     ]
     # Listener-overlap discovery — only when Last.fm is connected (that's
@@ -12589,25 +12900,35 @@ def _genre_drilldown_sections() -> list[dict]:
     beyond resolving the extra albums to Tidal.
     """
     profile = _taste_profile()
-    genres = profile.get("genres", [])[:_GENRE_BLEND_SEEDS]
+    genres = profile.get("genres", [])[:_GENRE_HUB_MAX]
     if not genres:
         return []
     owned = _owned_album_ids()
+    orbit = profile.get("orbit") or {}
+    played = profile.get("artist_names") or set()
 
     def _build(seed):
         slug, name, _w = seed
-        return _genre_page(slug, name, 0, _GENRE_PAGE_SIZE, owned)
+        return _genre_page(slug, name, 0, _GENRE_PAGE_SIZE, owned, orbit, played)
 
     with ThreadPoolExecutor(max_workers=5, thread_name_prefix="genredrill") as pool:
-        return [s for s in pool.map(_build, genres) if s["albums"]]
+        return [
+            s for s in pool.map(_build, genres)
+            if len(s["albums"]) >= _GENRE_HUB_MIN_ALBUMS
+        ]
 
 
 # Albums per genre row on the drill-down, and per "load more" press.
-_GENRE_PAGE_SIZE = 18
+# Deliberately below a full shelf: the drill-down now carries a dozen
+# genre rows, and each album resolved costs a Tidal search on a cold
+# cache. Twelve rows of twelve is comparable to what five rows of
+# eighteen cost before, and every row can page deeper on demand.
+_GENRE_PAGE_SIZE = 12
 
 
 def _genre_page(slug: str, name: str, offset: int, limit: int,
-                owned: Optional[set] = None) -> dict:
+                owned: Optional[set] = None, orbit: Optional[dict] = None,
+                played: Optional[set] = None) -> dict:
     """One window of a genre's canon, for paging in from the drill-down.
 
     Pagination is over AOTY's listing, not over the rendered albums: an
@@ -12618,10 +12939,31 @@ def _genre_page(slug: str, name: str, offset: int, limit: int,
     runs out.
     """
     want = offset + limit
-    # One extra row purely to answer "is there another page after this".
-    listing = _rec_safe(lambda: aoty_module.top_albums_by_genre(slug, want + 1), [])
-    has_more = len(listing) > want
-    window = listing[offset:want]
+    # Fetch a full listing page even when a small window is asked for, so
+    # the weekly rotation below has somewhere to move. One AOTY page
+    # either way, so this costs nothing extra.
+    listing = _rec_safe(
+        lambda: aoty_module.top_albums_by_genre(slug, max(want + 1, _GENRE_PAGE_POOL)), []
+    )
+    # Start the genre somewhere different each week. Without this the
+    # drill-down is a fixed all-time ranking: the same album leads
+    # "Shoegaze" forever, which is the staleness the main page rotation
+    # was meant to solve — it just never reached this surface.
+    #
+    # Rotating the sequence rather than the client's offset keeps paging
+    # honest: "load more" still walks forward through this week's order
+    # instead of jumping around.
+    # Same taste ranking the main page applies, so drilling into a genre
+    # doesn't drop back to AOTY's generic chart order.
+    listing = _rank_by_taste(listing, orbit or {}, played or set())
+    # Start inside the best-ranked head, then page forward through the
+    # full ranked order — so "load more" still goes deeper rather than
+    # circling the same top slice.
+    base = _rotation_offset(min(len(listing), _GENRE_RANK_POOL),
+                            _GENRE_ROTATION_STRIDE)
+    sequence = listing[base:] + listing[:base]
+    has_more = want < len(sequence)
+    window = sequence[offset:want]
     resolved = _rec_safe(lambda: aoty_resolver.resolve_listing(window), []) or []
     albums = [
         it["tidal_album"]
@@ -12634,6 +12976,12 @@ def _genre_page(slug: str, name: str, offset: int, limit: int,
         "subtitle": f"Highest rated {name}",
         "slug": slug,
         "offset": offset,
+        # Where the next page starts, in listing positions. The client
+        # can't derive this from what it rendered: a window of twelve
+        # rarely renders twelve once saved albums and the per-artist cap
+        # have taken their cut, so paging by the rendered count re-served
+        # rows it had already consumed.
+        "next_offset": want,
         "has_more": has_more,
         "albums": _dedupe_cap_albums(albums, limit, exclude=owned),
     }
@@ -12675,7 +13023,14 @@ def recommendations_genre(slug: str, offset: int = 0, limit: int = 18) -> dict:
         (n for s_, n, _w in _taste_profile().get("genres", []) if s_ == slug),
         slug.partition("-")[2].replace("-", " ").title(),
     )
-    section = _genre_page(slug, name, offset, limit, _owned_album_ids())
+    profile = _taste_profile()
+    name = next(
+        (n for s_, n, _w in profile.get("genres", []) if s_ == slug), name
+    )
+    section = _genre_page(
+        slug, name, offset, limit, _owned_album_ids(),
+        profile.get("orbit") or {}, profile.get("artist_names") or set(),
+    )
     return {"enabled": True, "section": section}
 
 

--- a/tests/test_album_recommendations.py
+++ b/tests/test_album_recommendations.py
@@ -146,7 +146,7 @@ def test_favorited_albums_are_filtered_from_every_section(stub_auth, monkeypatch
     # runs its candidates through the shared tail exactly as the real
     # builders do, which is where the exclusion happens.
     def _fake_section(key, title, subtitle, listing, profile, taste_rank,
-                      deep=False, owned=None):
+                      deep=False, owned=None, rotate=False):
         return {
             "key": key, "title": title, "subtitle": subtitle,
             "albums": server._dedupe_cap_albums(
@@ -640,3 +640,369 @@ def test_owned_filter_is_optional():
 
     albums = [{"id": "1", "name": "A", "artists": [{"name": "X"}]}]
     assert len(server._dedupe_cap_albums(albums, 5)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Recency blending, tag specificity, and weekly rotation
+# ---------------------------------------------------------------------------
+
+
+def test_seed_artists_blend_recent_over_long_window(stub_auth, monkeypatch):
+    """A single six-month window left the page effectively frozen. Recent
+    listening has to outweigh the long window without erasing it."""
+    import server
+
+    windows = {
+        "1month": [{"name": "NewObsession", "playcount": 100}],
+        "6month": [{"name": "OldFavourite", "playcount": 1000},
+                   {"name": "NewObsession", "playcount": 50}],
+    }
+    monkeypatch.setattr(
+        server.lastfm, "get_top_artists", lambda p, limit: windows.get(p, [])
+    )
+    names = [e["name"] for e in server._seed_artists()]
+    # Raw play counts would rank OldFavourite far ahead; normalising each
+    # window against its own top artist is what lets the recent one lead.
+    assert names[0] == "NewObsession"
+    assert "OldFavourite" in names, "the long window is ballast, not discarded"
+
+
+def test_seed_artists_survive_a_missing_window(stub_auth, monkeypatch):
+    import server
+
+    monkeypatch.setattr(
+        server.lastfm, "get_top_artists",
+        lambda p, limit: [{"name": "Only", "playcount": 5}] if p == "6month" else [],
+    )
+    assert [e["name"] for e in server._seed_artists()] == ["Only"]
+
+
+def test_broad_tags_lose_to_specific_ones(stub_auth, monkeypatch):
+    """Tag strength and breadth rise together, so ranking on strength alone
+    just recovers whichever vague tag every artist carries. Discounting by
+    global reach is what surfaces the sub-genre."""
+    import server
+
+    monkeypatch.setattr(server.lastfm, "status", lambda: {"connected": True})
+    monkeypatch.setattr(
+        server.lastfm, "get_top_artists",
+        lambda p, limit: [{"name": "BoC", "playcount": 100}] if p == "1month" else [],
+    )
+    # "electronic" is tagged nearly as strongly as "idm" but applied to
+    # vastly more artists globally.
+    monkeypatch.setattr(
+        server.lastfm, "get_artist_top_tags",
+        lambda name, limit=8: [
+            {"name": "electronic", "count": 95},
+            {"name": "idm", "count": 90},
+        ],
+    )
+    monkeypatch.setattr(
+        server.lastfm, "get_chart_top_tags",
+        lambda limit=250: [
+            {"name": "electronic", "reach": 262672},
+            {"name": "idm", "reach": 39205},
+        ],
+    )
+    monkeypatch.setattr(server.lastfm, "get_chart_top_artists", lambda limit=500: [])
+    monkeypatch.setattr(
+        server, "_aoty_genre_slug_map",
+        lambda: {"electronic": ("6-electronic", "Electronic"),
+                 "idm": ("47-idm", "IDM")},
+    )
+    genres = [name for _slug, name, _w in server._taste_profile()["genres"]]
+    assert genres[0] == "IDM", f"broad tag won: {genres}"
+
+
+def test_rotation_advances_weekly_and_holds_within_a_week(monkeypatch):
+    import server
+
+    pool = [f"a{i}" for i in range(60)]
+    base = 1_000_000_000.0
+    monkeypatch.setattr(server.time, "time", lambda: base)
+    first = server._rotate(pool, 18)
+    assert server._rotate(pool, 18) == first, "must not shift between calls"
+
+    monkeypatch.setattr(server.time, "time", lambda: base + 7 * 86400)
+    later = server._rotate(pool, 18)
+    assert later != first, "row is frozen week to week"
+    carried = len(set(later) & set(first))
+    # Partial overlap: a full swap gives the row no continuity, none at all
+    # means nothing carries over.
+    assert 0 < carried < 18, f"expected partial turnover, carried {carried}"
+
+
+def test_rotation_wraps_so_the_tail_is_reachable(monkeypatch):
+    """Without wrapping, entries near the end of a pool would only surface
+    in the weeks the offset happened to land there — and the last few
+    never at all."""
+    import server
+
+    pool = [f"a{i}" for i in range(20)]
+    seen = set()
+    for week in range(12):
+        monkeypatch.setattr(
+            server.time, "time", lambda w=week: 1_000_000_000.0 + w * 7 * 86400
+        )
+        seen.update(server._rotate(pool, 6))
+    assert seen == set(pool), f"unreachable entries: {sorted(set(pool) - seen)}"
+
+
+def test_rotation_handles_pools_smaller_than_the_window(monkeypatch):
+    import server
+
+    monkeypatch.setattr(server.time, "time", lambda: 1_000_000_000.0)
+    assert server._rotate(["a", "b"], 18) == ["a", "b"]
+    assert server._rotate([], 18) == []
+
+
+def test_reach_discount_is_steep_enough_to_beat_tag_strength(stub_auth, monkeypatch):
+    """A logarithmic discount separated the broadest tag from an unlisted
+    one by only ~1.5x, which a broad tag's higher count simply cancelled —
+    so "rock" and "electronic" kept winning over the sub-genre. The
+    discount has to outweigh that gap, not merely exist.
+    """
+    import server
+
+    monkeypatch.setattr(server.lastfm, "status", lambda: {"connected": True})
+    monkeypatch.setattr(
+        server.lastfm, "get_top_artists",
+        lambda p, limit: [{"name": "A", "playcount": 10}] if p == "1month" else [],
+    )
+    # The broad tag is applied *more* strongly than the specific one, which
+    # is the realistic case and the one a weak discount gets wrong.
+    monkeypatch.setattr(
+        server.lastfm, "get_artist_top_tags",
+        # Both are defining tags for this artist, so the solo-tag rule
+        # keeps them and the reach discount is what decides the order.
+        lambda name, limit=12: [
+            {"name": "rock", "count": 100},
+            {"name": "dariacore", "count": 90},
+        ],
+    )
+    monkeypatch.setattr(
+        server.lastfm, "get_chart_top_tags",
+        lambda limit=250: [{"name": "rock", "reach": 403263}],
+    )
+    monkeypatch.setattr(server.lastfm, "get_chart_top_artists", lambda limit=500: [])
+    monkeypatch.setattr(
+        server, "_aoty_genre_slug_map",
+        lambda: {"rock": ("7-rock", "Rock"), "dariacore": ("999-dariacore", "Dariacore")},
+    )
+    names = [n for _s, n, _w in server._taste_profile()["genres"]]
+    assert names[0] == "Dariacore", f"broad tag still won: {names}"
+
+
+def test_profile_ranks_deeper_than_any_row_shows(stub_auth, monkeypatch):
+    """The profile is pure tag arithmetic with no fetches, so it ranks well
+    past what the rows use. The main page and the drill-down then take the
+    slice each can afford — keeping that budget decision out of the
+    inference."""
+    import server
+
+    assert server._TASTE_GENRE_MAX > server._GENRE_HUB_MAX > server._GENRE_BLEND_SEEDS
+
+
+def test_genre_page_reports_listing_offset_not_rendered_count(stub_auth, monkeypatch):
+    """Paging has to advance by listing positions consumed.
+
+    A window of N rarely renders N — saved albums and the per-artist cap
+    take their cut — so a client paging by what it rendered re-requests
+    rows the previous page already consumed, and "load more" crawls.
+    """
+    import server
+
+    listing = [{"artist": f"A{i}", "title": f"T{i}"} for i in range(40)]
+    monkeypatch.setattr(
+        server.aoty_module, "top_albums_by_genre", lambda slug, limit=60: listing[:limit]
+    )
+    # Every other entry resolves; the rest drop out, so rendered < window.
+    monkeypatch.setattr(
+        server.aoty_resolver, "resolve_listing",
+        lambda rows: [
+            {**r, "tidal_album": (
+                {"id": r["title"], "name": r["title"],
+                 "artists": [{"name": r["artist"]}], "available": True}
+                if int(r["title"][1:]) % 2 == 0 else None
+            )}
+            for r in rows
+        ],
+    )
+    monkeypatch.setattr(server, "_rotation_offset", lambda *a, **kw: 0)
+
+    page = server._genre_page("26-shoegaze", "Shoegaze", 0, 12)
+    assert len(page["albums"]) < 12, "fixture should render fewer than the window"
+    # The next page starts where this one stopped consuming, not where it
+    # stopped rendering.
+    assert page["next_offset"] == 12
+
+
+def test_genre_drilldown_rotates_between_weeks(stub_auth, monkeypatch):
+    """The drill-down was a fixed all-time ranking: the same album led a
+    genre forever, which is exactly the staleness the main page rotation
+    addressed but never reached this surface."""
+    import server
+
+    listing = [{"artist": f"A{i}", "title": f"T{i}"} for i in range(25)]
+    monkeypatch.setattr(
+        server.aoty_module, "top_albums_by_genre", lambda slug, limit=60: listing[:limit]
+    )
+    monkeypatch.setattr(
+        server.aoty_resolver, "resolve_listing",
+        lambda rows: [
+            {**r, "tidal_album": {"id": r["title"], "name": r["title"],
+                                  "artists": [{"name": r["artist"]}], "available": True}}
+            for r in rows
+        ],
+    )
+    base = 1_000_000_000.0
+    monkeypatch.setattr(server.time, "time", lambda: base)
+    week0 = [a["name"] for a in server._genre_page("26-x", "X", 0, 12)["albums"]]
+    monkeypatch.setattr(server.time, "time", lambda: base + 7 * 86400)
+    week1 = [a["name"] for a in server._genre_page("26-x", "X", 0, 12)["albums"]]
+    assert week0[0] != week1[0], "genre still leads with the same album every week"
+
+
+# ---------------------------------------------------------------------------
+# Taste ranking inside a genre
+# ---------------------------------------------------------------------------
+
+
+def _listing_row(artist, score, votes=1000):
+    return {"artist": artist, "title": f"{artist} LP", "score": score,
+            "rating_count": votes}
+
+
+def test_orbit_artists_outrank_strangers_at_similar_quality():
+    """Without this a genre row is the same chart for everyone who shares
+    the genre — the listener's own listening never enters into it."""
+    import server
+
+    rows = [_listing_row("Stranger", 88), _listing_row("InOrbit", 86)]
+    ranked = server._rank_by_taste(rows, {"inorbit": 1.0}, set())
+    assert ranked[0]["artist"] == "InOrbit"
+
+
+def test_thin_rating_counts_do_not_beat_well_rated_albums():
+    """AOTY lets a 95 from eleven people sit above an 88 from thousands.
+    That's noise outranking evidence, so scores shrink toward a prior
+    until the vote count earns them."""
+    import server
+
+    rows = [_listing_row("Obscure", 95, votes=11), _listing_row("Established", 88, votes=3000)]
+    ranked = server._rank_by_taste(rows, {}, set())
+    assert ranked[0]["artist"] == "Established"
+
+
+def test_already_played_artists_are_demoted():
+    """A row of albums by artists already in heavy rotation is a mirror,
+    not a recommendation."""
+    import server
+
+    rows = [_listing_row("Played", 90), _listing_row("Fresh", 88)]
+    orbit = {"played": 1.0, "fresh": 1.0}
+    ranked = server._rank_by_taste(rows, orbit, {"played"})
+    assert ranked[0]["artist"] == "Fresh"
+
+
+def test_seeds_are_not_boosted_into_their_own_orbit(stub_auth, monkeypatch):
+    """Adding the seeds to their own orbit put a listener's most-played
+    artist at the head of every genre row that artist appears in."""
+    import server
+
+    monkeypatch.setattr(
+        server.lastfm, "get_similar_artists", lambda name, limit=50: []
+    )
+    orbit = server._listening_orbit([{"name": "TopArtist", "score": 5.0}])
+    assert "topartist" not in orbit, "seed boosted itself into its own orbit"
+
+
+def test_orbit_is_normalised_so_weights_stay_meaningful():
+    """Affinities scale with how heavily seeds are played; without
+    normalising, the orbit term would swamp the others for a heavy
+    listener and vanish for a light one."""
+    import server
+
+    class _LF:
+        @staticmethod
+        def get_similar_artists(name, limit=50):
+            return [{"name": "Neighbour", "match": 0.9}]
+
+    import types
+    orig = server.lastfm
+    server.lastfm = types.SimpleNamespace(get_similar_artists=_LF.get_similar_artists)
+    try:
+        light = server._listening_orbit([{"name": "A", "score": 0.1}])
+        heavy = server._listening_orbit([{"name": "A", "score": 900.0}])
+    finally:
+        server.lastfm = orig
+    assert max(light.values()) == max(heavy.values()) == 1.0
+
+
+def test_ranking_survives_missing_scores():
+    """AOTY ships rows with no score during release week."""
+    import server
+
+    rows = [{"artist": "NoScore", "title": "X"}, _listing_row("Scored", 80)]
+    assert len(server._rank_by_taste(rows, {}, set())) == 2
+
+
+def test_one_artists_passing_tag_is_not_a_genre(stub_auth, monkeypatch):
+    """A tag carried by a single artist, and not even that artist's
+    defining one, was enough to put a genre on the page. Quadeca is
+    tagged "emo rap" at 59 out of 100 — a footnote next to their "art
+    pop" and "folktronica" at 100 — and that alone made emo rap a genre
+    for someone who doesn't listen to it. Worse, the niche bonus favours
+    exactly these rarely-used tags.
+    """
+    import server
+
+    monkeypatch.setattr(server.lastfm, "status", lambda: {"connected": True})
+    monkeypatch.setattr(
+        server.lastfm, "get_top_artists",
+        lambda p, limit: [{"name": "Quadeca", "playcount": 100}] if p == "1month" else [],
+    )
+    monkeypatch.setattr(
+        server.lastfm, "get_artist_top_tags",
+        lambda name, limit=12: [
+            {"name": "art pop", "count": 100},
+            {"name": "emo rap", "count": 59},
+        ],
+    )
+    monkeypatch.setattr(server.lastfm, "get_chart_top_tags", lambda limit=250: [])
+    monkeypatch.setattr(server.lastfm, "get_chart_top_artists", lambda limit=500: [])
+    monkeypatch.setattr(server.lastfm, "get_similar_artists", lambda n, limit=50: [])
+    monkeypatch.setattr(
+        server, "_aoty_genre_slug_map",
+        lambda: {"art pop": ("141-art-pop", "Art Pop"),
+                 "emo rap": ("306-emo-rap", "Emo Rap")},
+    )
+    names = [n for _s, n, _w in server._taste_profile()["genres"]]
+    assert "Art Pop" in names, "the artist's defining tag should survive"
+    assert "Emo Rap" not in names, f"a footnote tag became a genre: {names}"
+
+
+def test_a_solo_tag_survives_when_it_defines_the_artist(stub_auth, monkeypatch):
+    """The rule must not simply demand two artists — breadth and backer
+    count rise together, so that readmits "electronic" while dropping
+    genuinely specific genres like folktronica that rest on one artist."""
+    import server
+
+    monkeypatch.setattr(server.lastfm, "status", lambda: {"connected": True})
+    monkeypatch.setattr(
+        server.lastfm, "get_top_artists",
+        lambda p, limit: [{"name": "Quadeca", "playcount": 100}] if p == "1month" else [],
+    )
+    monkeypatch.setattr(
+        server.lastfm, "get_artist_top_tags",
+        lambda name, limit=12: [{"name": "folktronica", "count": 100}],
+    )
+    monkeypatch.setattr(server.lastfm, "get_chart_top_tags", lambda limit=250: [])
+    monkeypatch.setattr(server.lastfm, "get_chart_top_artists", lambda limit=500: [])
+    monkeypatch.setattr(server.lastfm, "get_similar_artists", lambda n, limit=50: [])
+    monkeypatch.setattr(
+        server, "_aoty_genre_slug_map",
+        lambda: {"folktronica": ("104-folktronica", "Folktronica")},
+    )
+    names = [n for _s, n, _w in server._taste_profile()["genres"]]
+    assert names == ["Folktronica"]

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -128,6 +128,9 @@ export type RecommendationSections = {
     /** Paging fields, present on drill-down rows that can load more. */
     slug?: string;
     offset?: number;
+    /** Listing position the next page starts at. Not derivable from the
+     *  rendered album count — filtering makes those diverge. */
+    next_offset?: number;
     has_more?: boolean;
   }[];
 };

--- a/web/src/components/RecShelf.tsx
+++ b/web/src/components/RecShelf.tsx
@@ -19,6 +19,8 @@ export type RecSection = {
   /** Paging state, on drill-down rows that can fetch further pages. */
   slug?: string;
   offset?: number;
+  /** Listing position the next page starts at, supplied by the backend. */
+  next_offset?: number;
   has_more?: boolean;
 };
 

--- a/web/src/pages/ForYouHubPage.tsx
+++ b/web/src/pages/ForYouHubPage.tsx
@@ -26,7 +26,10 @@ function ForYouHubPage({
   // stays owned by the fetch. Deriving the rendered rows from both means
   // no effect has to copy fetched data into state and re-sync it.
   const [extra, setExtra] = useState<
-    Record<string, { albums: RecSection["albums"]; has_more: boolean }>
+    Record<
+      string,
+      { albums: RecSection["albums"]; next_offset?: number; has_more: boolean }
+    >
   >({});
   const [busy, setBusy] = useState<string | null>(null);
 
@@ -38,6 +41,7 @@ function ForYouHubPage({
       return {
         ...s,
         albums: [...s.albums, ...more.albums],
+        next_offset: more.next_offset ?? s.next_offset,
         has_more: more.has_more,
       };
     });
@@ -46,9 +50,12 @@ function ForYouHubPage({
     if (!section.slug) return;
     setBusy(section.key);
     try {
+      // The backend tells us where the next page starts. Using the
+      // rendered count instead re-fetched rows already consumed, because
+      // filtering makes rendered and consumed counts diverge.
       const res = await api.recommendationGenrePage(
         section.slug,
-        section.albums.length,
+        section.next_offset ?? section.albums.length,
       );
       const page = res.section;
       if (!page) return;
@@ -63,6 +70,7 @@ function ForYouHubPage({
           ...prev,
           [section.key]: {
             albums: [...held, ...added],
+            next_offset: page.next_offset,
             has_more: page.has_more ?? false,
           },
         };


### PR DESCRIPTION
Follow-up to #319. The For You page shipped in v1.25.0 built rows that were
neither personal nor changing: a genre row was AOTY's chart for that genre,
identical for anyone who shared the genre, and it never moved.

## Taste now follows recent listening

Everything was inferred from a single six-month Last.fm window, so the same
handful of artists drove the page for months. The windows differ sharply — a
listener's one-month and six-month top artists overlapped by two of six here.
A one-month window at double weight now blends over a six-month one, each
normalised against its own top artist first, since play counts aren't
comparable across windows.

## Genres prefer the specific over the broad

Ranking by tag strength alone just recovers whichever broad label every
artist carries. Boards of Canada is tagged "electronic" at 84 as strongly as
"ambient" at 100, and "idm" is the tag that actually describes them.

Tags are discounted by how widely they're applied across Last.fm. A
logarithmic discount separates the broadest tag from an unlisted one by only
about 1.5x, which higher counts on broad tags cancel, so this takes a square
root instead. Broad tags in a real profile's top twelve:

| discount | broad genres |
| --- | --- |
| log10 | 4 |
| reach**0.25 | 3 |
| **reach**0.5** | **1** |
| reach**0.6 | 0, but also drops "ambient" where the listening supports it |

Result on a real profile: `Electronic` out, `Slowcore`, `Dariacore`,
`Experimental Hip Hop` in.

## One artist's footnote is not a genre

The niche bonus favours rarely-used tags, which surfaced a second fault: a
tag carried by a single artist, and not even that artist's defining one, was
enough to make a genre. Quadeca is "emo rap" at 59 beside "art pop" and
"folktronica" at 100, and emo rap reached the page of someone who doesn't
listen to it.

Requiring two artists per genre does **not** fix this — breadth and backer
count rise together, so it readmits "electronic" and "indie rock" while
dropping folktronica and dariacore, which are genuine. A solo tag now has to
be that artist's defining genre.

## Genre rows are ranked, not charted

Candidates are scored on three things: whether the artist sits in the
listener's orbit (top artists expanded one hop through Last.fm's
similar-artist graph, ~400 artists, covering about a fifth of a genre's
candidates), the album's rating shrunk toward a prior until the vote count
earns it, and a penalty for artists already in heavy rotation.

Seeds are deliberately not boosted into their own orbit — doing so put the
listener's most-played artist at the head of every genre it appeared in.

## Rows rotate weekly

Bucketed by week rather than randomised, so the page holds still across a
refresh and changes on a schedule. Rotation is bounded to the best-ranked
candidates: ranking and then rotating across the whole listing walked past
the best matches, dropping orbit hits from 8 of 13 to 2 of 13.

Measured over five simulated weeks: 8-10 of 18 new per week on the blended
row, 54 distinct albums across the span, without cycling between two states.

## Also

- Drill-down paging reports the listing position consumed instead of leaving
  the client to infer it from what rendered. Those diverge once saved albums
  and the per-artist cap take their cut, so pages overlapped by three albums.
- Genre inference ranks 20 genres; the main page uses six and the drill-down
  twelve, so the budget decision stays out of the inference.
- README documents every row's source, ranking and time scope, plus cache
  lifetimes. Figures checked against the constants rather than written from
  memory.

## Test plan

- `./scripts/preflight.sh` green: 1199 pytest, tsc, eslint, stylelint,
  htmlhint, prettier, 133 vitest. Both commits pass on their own.
- New tests pin each rule against the behaviour it replaced, and each was
  checked to fail against the previous behaviour: recency blending, the reach
  discount being steep enough to beat tag strength, solo tags needing to be
  defining, orbit ranking, vote-count shrinkage, played-artist demotion,
  rotation advancing weekly while holding within a week, and paging by
  listing position.
- Exercised against a live Tidal and Last.fm account throughout.

## Not covered

- A cold start is still unmeasured; every timing here had a warm cache.
- AOTY rate limiting was hit twice during development. Fetch budget is down
  to roughly 19 pages per cold build, but the page sits closer to that
  ceiling than is comfortable, and the failure is quiet — rows just come back
  short.
