### PR TITLE
Compare token expiry in UTC, the frame it is written in

### DIFF
--- a/app/tidal_client.py
+++ b/app/tidal_client.py
@@ -39,6 +39,42 @@ def _tlog(msg: str) -> None:
         # stderr line already carried the signal.
         pass
 
+
+def _now_matching(expiry: datetime) -> datetime:
+    """The current time in the same frame as `expiry`.
+
+    Token expiry is stored as *naive UTC*: tidalapi builds it with
+    `datetime.utcnow()` (session.py) and `_token_refresh_capturing`
+    matches that convention deliberately. Comparing such a value
+    against `datetime.now()` compares UTC against local time, so the
+    remaining lifetime comes out wrong by the machine's UTC offset in
+    whichever direction that offset points:
+
+      - West of UTC the remaining time is *overstated*. The refresh
+        watchdog only acts inside a 5 minute window, so an offset of
+        several hours means it never fires at all: the token dies
+        while the countdown still reads hours, and `load_session`'s
+        `expiry <= now` test misses for the same reason, so the launch
+        refresh is skipped too. The user is silently signed out with
+        no log line explaining it.
+      - East of UTC it is *understated*, so refreshes fire an offset
+        early and every launch takes the refresh path, rotating the
+        refresh token far more often than necessary.
+
+    Only machines sitting exactly on UTC behave correctly, which is
+    why this survived: the tests built their fixture expiry with
+    `datetime.now()` too, so they agreed with the reader and never
+    exercised the frame the writer actually uses (#309).
+
+    An aware `expiry` is handled for its own sake, so this stays
+    correct if tidalapi ever moves off naive datetimes.
+    """
+    tz = getattr(expiry, "tzinfo", None)
+    if tz is not None:
+        return datetime.now(tz)
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
 SESSION_FILE = user_data_dir() / "tidal_session.json"
 
 # Connection-level failures from either HTTP transport. Loading a
@@ -539,6 +575,7 @@ class TidalClient:
 
     def load_session(self) -> bool:
         if not SESSION_FILE.exists():
+            _tlog(f"load_session: no session file at {SESSION_FILE}")
             return False
         try:
             with open(SESSION_FILE) as f:
@@ -550,6 +587,7 @@ class TidalClient:
             )
             refresh_token = data.get("refresh_token")
             is_pkce = bool(data.get("is_pkce", False))
+            refreshed_on_launch = False
             # For PKCE sessions, swap the client_id to the hi-res-entitled
             # one BEFORE any Tidal call. Otherwise the /sessions call
             # inside load_oauth_session (and the proactive refresh below)
@@ -565,8 +603,7 @@ class TidalClient:
             # 401s propagating to the caller (e.g. download endpoints).
             # If the stored expiry is in the past, skip trying the stale
             # token and refresh up front.
-            now = datetime.now(expiry.tzinfo) if expiry and expiry.tzinfo else datetime.now()
-            if expiry and refresh_token and expiry <= now:
+            if expiry and refresh_token and expiry <= _now_matching(expiry):
                 # The stored access token is already expired, so this refresh
                 # is what keeps a relaunch (app was closed past the token
                 # lifetime) from bouncing the user to the login screen. It
@@ -580,6 +617,7 @@ class TidalClient:
                 try:
                     if self._token_refresh_capturing(refresh_token):
                         self.save_session()
+                        refreshed_on_launch = True
                         _tlog("load_session: expired token refreshed on launch")
                 except tidalapi.exceptions.AuthenticationError as exc:
                     _tlog(
@@ -609,7 +647,18 @@ class TidalClient:
             # — including a False, which is a genuine rejection and not
             # something a retry would fix.
             self._session_load_deferred = False
-            return self.session.check_login()
+            ok = self.session.check_login()
+            if not ok:
+                # The one logout that leaves no other trace: Tidal
+                # rejects the stored session even though we either
+                # refreshed it just now or judged it unexpired. Silence
+                # here is what made #309 undiagnosable from a user's log.
+                _tlog(
+                    "load_session: Tidal rejected the stored session "
+                    f"(stored expiry={expiry}, "
+                    f"refreshed on launch={refreshed_on_launch})"
+                )
+            return ok
         except _NETWORK_ERRORS:
             # No route to Tidal. load_oauth_session never populated
             # session.user / session_id, which makes check_login()
@@ -631,7 +680,13 @@ class TidalClient:
             # the abuse case), so this is reachable on a normal start.
             self._session_load_deferred = bool(refresh_token)
             return False
-        except Exception:
+        except Exception as exc:
+            # Anything left is a malformed or unreadable session file
+            # (bad JSON, missing key, unparseable expiry). Treating that
+            # as "not signed in" is right, but doing it silently means a
+            # user who suddenly has to log in again finds nothing in the
+            # log to explain why.
+            _tlog(f"load_session: could not restore session: {exc!r}")
             return False
 
     def _token_refresh_capturing(self, refresh_token: str) -> bool:
@@ -948,12 +1003,7 @@ class TidalClient:
                 refresh_token = getattr(self.session, "refresh_token", None)
                 if not expiry or not refresh_token:
                     continue
-                now = (
-                    datetime.now(expiry.tzinfo)
-                    if getattr(expiry, "tzinfo", None)
-                    else datetime.now()
-                )
-                seconds_left = (expiry - now).total_seconds()
+                seconds_left = (expiry - _now_matching(expiry)).total_seconds()
                 if seconds_left > self._REFRESH_WINDOW_SEC:
                     continue
                 _tlog(

--- a/tests/test_login_persistence.py
+++ b/tests/test_login_persistence.py
@@ -14,7 +14,7 @@ them apart. These pin the corrected behavior:
   - success            -> refreshed and validated
 """
 import json
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import pytest
 import tidalapi
@@ -25,9 +25,17 @@ from app.tidal_client import TransientRefreshError
 
 @pytest.fixture
 def expired_session(tmp_path, monkeypatch):
-    """Point SESSION_FILE at a file whose access token expired 2h ago."""
+    """Point SESSION_FILE at a file whose access token expired 2h ago.
+
+    Naive UTC, because that is the frame the app actually writes
+    (tidalapi's `datetime.utcnow()`). This used to use `datetime.now()`,
+    which agreed with the reader's own wrong frame and so hid #309 —
+    off-UTC machines never took the branch these tests exercise.
+    """
     f = tmp_path / "tidal_session.json"
-    expiry = (datetime.now() - timedelta(hours=2)).isoformat()
+    expiry = (
+        datetime.now(timezone.utc).replace(tzinfo=None) - timedelta(hours=2)
+    ).isoformat()
     f.write_text(json.dumps({
         "token_type": "Bearer",
         "access_token": "stale",

--- a/tests/test_token_expiry_timezone.py
+++ b/tests/test_token_expiry_timezone.py
@@ -1,0 +1,211 @@
+"""Token expiry must be compared in the frame it was written in (#309).
+
+`expiry_time` is stored as *naive UTC* — tidalapi builds it with
+`datetime.utcnow()` and `_token_refresh_capturing` matches that on
+purpose. The readers used to compare it against `datetime.now()`, which
+is naive *local* time, so the remaining lifetime was off by the machine's
+UTC offset:
+
+  - West of UTC it was overstated. The watchdog only acts inside a five
+    minute window, so an offset of hours meant it never fired: the token
+    died while the countdown still read hours, and load_session's
+    `expiry <= now` test missed for the same reason, skipping the launch
+    refresh. The user was signed out with nothing in the log.
+  - East of UTC it was understated, so refreshes fired an offset early
+    and every launch took the refresh path, rotating the refresh token
+    far more often than needed.
+
+Only a machine sitting exactly on UTC behaved correctly, which is how
+this survived: the fixtures built their expiry with `datetime.now()`
+too, agreeing with the reader and never exercising the writer's frame.
+
+These tests force a fixed local timezone so they assert the same thing
+no matter where they run. Both zones are DST-free (Phoenix is always
+UTC-7, Tokyo always UTC+9) so the arithmetic can't drift with the season.
+"""
+import json
+import os
+import time
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app import tidal_client
+from app.tidal_client import TidalClient, _now_matching
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(time, "tzset"), reason="TZ override requires time.tzset (POSIX)"
+)
+
+WEST = "America/Phoenix"  # UTC-7 year round
+EAST = "Asia/Tokyo"  # UTC+9 year round
+
+
+@pytest.fixture
+def local_tz():
+    """Force the process's local timezone, restoring it afterwards.
+
+    TZ is restored here rather than through monkeypatch because the
+    matching `time.tzset()` has to run *after* the env var goes back,
+    and monkeypatch's undo happens after this fixture's teardown.
+    """
+    saved = os.environ.get("TZ")
+
+    def _set(name: str) -> None:
+        os.environ["TZ"] = name
+        time.tzset()
+
+    yield _set
+
+    if saved is None:
+        os.environ.pop("TZ", None)
+    else:
+        os.environ["TZ"] = saved
+    time.tzset()
+
+
+def _utc_naive() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
+
+
+# ----------------------------------------------------------------------
+# The frame helper
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("zone", [WEST, EAST])
+def test_now_matching_tracks_utc_not_the_local_clock(local_tz, zone):
+    local_tz(zone)
+    naive_expiry = _utc_naive()
+
+    now = _now_matching(naive_expiry)
+
+    assert abs((now - _utc_naive()).total_seconds()) < 5
+    # And is emphatically not the local wall clock, which is what the
+    # bug compared against.
+    assert abs((now - datetime.now()).total_seconds()) > 3600
+
+
+def test_now_matching_honours_an_aware_expiry(local_tz):
+    local_tz(WEST)
+    aware = datetime.now(timezone.utc)
+
+    now = _now_matching(aware)
+
+    assert now.tzinfo is not None
+    assert abs((now - aware).total_seconds()) < 5
+
+
+# ----------------------------------------------------------------------
+# The refresh watchdog
+# ----------------------------------------------------------------------
+
+
+class _FakeSession:
+    def __init__(self, expiry, refresh_token="R1"):
+        self.expiry_time = expiry
+        self.refresh_token = refresh_token
+
+
+def _watchdog_client(expiry):
+    """A client with just enough wired up to run one watchdog tick.
+
+    Built without __init__ on purpose: the real constructor opens a
+    tidalapi session and starts the watchdog thread, neither of which
+    this test wants. The loop body under test only touches the
+    attributes set here.
+    """
+    import threading
+
+    c = object.__new__(TidalClient)
+    c.session = _FakeSession(expiry)
+    c._refresh_stop = threading.Event()
+    c._session_load_deferred = False
+    c._REFRESH_CHECK_INTERVAL_SEC = 0.01
+    return c
+
+
+def _run_one_tick(client):
+    """Run the watchdog until it either refreshes once or ticks twice."""
+    refreshes = []
+    ticks = {"n": 0}
+
+    def _force_refresh():
+        refreshes.append(True)
+        client._refresh_stop.set()
+
+    real_wait = client._refresh_stop.wait
+
+    def _counting_wait(timeout=None):
+        ticks["n"] += 1
+        if ticks["n"] > 2:
+            # No refresh is coming; end the loop so the test can assert.
+            return True
+        return real_wait(timeout)
+
+    client.force_refresh = _force_refresh
+    client._refresh_stop.wait = _counting_wait
+    client._refresh_watchdog()
+    return bool(refreshes)
+
+
+def test_watchdog_refreshes_a_nearly_expired_token_west_of_utc(local_tz):
+    """The silent-logout case. With a UTC-7 local clock the old code read
+    a token expiring in 60s as having ~7 hours left and never refreshed
+    it, so it died and the next call bounced the user to login."""
+    local_tz(WEST)
+    client = _watchdog_client(_utc_naive() + timedelta(seconds=60))
+
+    assert _run_one_tick(client) is True
+
+
+def test_watchdog_leaves_a_healthy_token_alone_east_of_utc(local_tz):
+    """The churn case. With a UTC+9 local clock the old code read a token
+    with three hours left as long expired and refreshed it immediately,
+    rotating the refresh token on every tick."""
+    local_tz(EAST)
+    client = _watchdog_client(_utc_naive() + timedelta(hours=3))
+
+    assert _run_one_tick(client) is False
+
+
+# ----------------------------------------------------------------------
+# Relaunch
+# ----------------------------------------------------------------------
+
+
+def test_launch_refresh_fires_for_an_expired_token_west_of_utc(
+    local_tz, tmp_path, monkeypatch
+):
+    """A token that really expired two hours ago looked five hours in the
+    *future* to a UTC-7 local clock, so load_session skipped the launch
+    refresh and handed Tidal a dead token instead."""
+    local_tz(WEST)
+    import server
+
+    f = tmp_path / "tidal_session.json"
+    f.write_text(
+        json.dumps(
+            {
+                "token_type": "Bearer",
+                "access_token": "stale",
+                "refresh_token": "R1",
+                "expiry_time": (_utc_naive() - timedelta(hours=2)).isoformat(),
+                "is_pkce": False,
+            }
+        )
+    )
+    monkeypatch.setattr(tidal_client, "SESSION_FILE", f)
+
+    t = server.tidal
+    monkeypatch.setattr(t, "_session_load_deferred", False)
+    monkeypatch.setattr(t, "save_session", lambda: None)
+    refreshed = []
+    monkeypatch.setattr(
+        t, "_token_refresh_capturing", lambda rt: refreshed.append(rt) or True
+    )
+    monkeypatch.setattr(t.session, "load_oauth_session", lambda *a, **k: None)
+    monkeypatch.setattr(t.session, "check_login", lambda: True)
+
+    assert t.load_session() is True
+    assert refreshed == ["R1"], "launch refresh never ran for an expired token"


### PR DESCRIPTION
Fixes the root cause behind #309.

## Summary

`expiry_time` is stored as **naive UTC**: tidalapi builds it with `datetime.utcnow()` and `_token_refresh_capturing` matches that deliberately. Both readers compared it against `datetime.now()`, which is naive **local** time. The remaining lifetime was therefore wrong by the machine's UTC offset, and only a machine sitting exactly on UTC behaved correctly.

The two directions produce the two different reports on the issue:

- **West of UTC the remaining time is overstated.** The watchdog only acts inside a five minute window, so an offset of several hours means it never fires: the token expires while the countdown still reads hours. `load_session`'s `expiry <= now` test misses for the same reason and skips the launch refresh. The user is signed out with nothing in the log, matching the macOS report.
- **East of UTC it is understated**, so refreshes fire an offset early and every launch takes the refresh path. That matches the reporter's own logs, where a token with a four hour lifetime was refreshed every two hours from a UTC+2 machine.

Both call sites now go through one helper that encodes the frame, so there is a single place to be right.

## Why the tests missed it

The fixture built its expiry with `datetime.now()` as well, agreeing with the reader's wrong frame instead of the writer's, so it never exercised the mismatch. It now uses naive UTC.

## Test plan

- New `tests/test_token_expiry_timezone.py` forces a DST-free local zone either side of UTC (Phoenix at -7, Tokyo at +9) so the assertions hold wherever they run.
- Verified the new tests fail against the previous code: 5 new failures plus 1 in the existing suite once its fixture uses the real frame. The watchdog case fails as "never refreshed a token expiring in 60s", the relaunch case as "launch refresh never ran for an expired token".
- Full backend suite green.

## Also included

The paths through `load_session` that returned False in silence now log, including the bare `except Exception`. A user whose session stops persisting had no line to send us, which is why this took three rounds on the issue to pin down. One of those lines shows up in the failing-test output above.

## Not covered

Whether this fully closes the reporter's own case. Their UTC+2 machine takes the launch refresh path, which already logged, so the churn explanation fits them better than the silent one. If it recurs, the new lines say which path they hit.