### PR TITLE
Record the scroll offset before the route swap clamps it

### DIFF
--- a/web/src/hooks/useScrollRestoration.test.tsx
+++ b/web/src/hooks/useScrollRestoration.test.tsx
@@ -17,25 +17,65 @@ vi.mock("react-router-dom", () => ({
 
 import { useScrollRestoration } from "./useScrollRestoration";
 
-// A stand-in scroll container — the hook only touches these members, so
-// we skip jsdom's layout-less DOM entirely and control everything.
+// Every live observer, so a test can simulate the container's content
+// growing after mount the way an async page does.
+let observers: Array<() => void> = [];
+
+class FakeResizeObserver {
+  constructor(private cb: () => void) {
+    observers.push(() => this.cb());
+  }
+  observe() {}
+  disconnect() {
+    observers = observers.filter((f) => f !== this.cb);
+  }
+}
+
+class FakeMutationObserver {
+  observe() {}
+  disconnect() {}
+}
+
+/**
+ * A stand-in scroll container. The hook only touches these members, so we
+ * skip jsdom's layout-less DOM entirely and control everything.
+ *
+ * It clamps `scrollTop` to what the content can actually scroll, because
+ * that clamp is the behaviour the hook has to survive.
+ */
 function makeEl() {
   let top = 0;
   const listeners: Record<string, Array<() => void>> = {};
-  return {
+  const el = {
+    scrollHeight: 1000,
+    clientHeight: 500,
+    children: [] as Element[],
     fire(type: string) {
       (listeners[type] || []).forEach((f) => f());
+    },
+    get maxTop() {
+      return Math.max(0, el.scrollHeight - el.clientHeight);
     },
     get scrollTop() {
       return top;
     },
+    // Both user and programmatic scrolls emit a scroll event.
     set scrollTop(v: number) {
-      top = v;
+      top = Math.max(0, Math.min(v, el.maxTop));
+      el.fire("scroll");
     },
-    scrollHeight: 1000,
-    clientHeight: 500,
     scrollTo(opts: { top?: number }) {
-      top = opts?.top ?? 0;
+      el.scrollTop = opts?.top ?? 0;
+    },
+    /**
+     * Content is replaced by something shorter, as when React swaps in
+     * the next route during its render phase. The browser clamps
+     * scrollTop right away but dispatches the scroll event later, after
+     * the commit, so no event fires here.
+     */
+    shrinkTo(scrollHeight: number) {
+      el.scrollHeight = scrollHeight;
+      top = Math.min(top, el.maxTop);
     },
     addEventListener(t: string, f: () => void) {
       (listeners[t] = listeners[t] || []).push(f);
@@ -44,6 +84,14 @@ function makeEl() {
       listeners[t] = (listeners[t] || []).filter((x) => x !== f);
     },
   };
+  return el;
+}
+
+function growContent(el: ReturnType<typeof makeEl>, scrollHeight: number) {
+  el.scrollHeight = scrollHeight;
+  act(() => {
+    observers.forEach((fire) => fire());
+  });
 }
 
 let container: HTMLDivElement;
@@ -57,13 +105,9 @@ function Harness({ elRef }: { elRef: RefObject<HTMLElement | null> }) {
 beforeEach(() => {
   navType = "PUSH";
   locKey = "a";
-  // Run rAF synchronously so the throttled save + restore apply run inline.
-  vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) => {
-    cb(0);
-    return 1;
-  });
-  vi.stubGlobal("cancelAnimationFrame", () => {});
-  vi.stubGlobal("performance", { now: () => 0 });
+  observers = [];
+  vi.stubGlobal("ResizeObserver", FakeResizeObserver);
+  vi.stubGlobal("MutationObserver", FakeMutationObserver);
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
@@ -84,8 +128,10 @@ it("resets to top on forward nav and restores on back nav", () => {
   render();
   expect(el.scrollTop).toBe(0);
 
-  // 2. Scroll down (captured for "a" when we navigate away).
-  el.scrollTop = 300;
+  // 2. Scroll down (recorded for "a" when we navigate away).
+  act(() => {
+    el.scrollTop = 300;
+  });
 
   // 3. Navigate forward to "b" -> resets to top.
   navType = "PUSH";
@@ -102,10 +148,106 @@ it("resets to top on forward nav and restores on back nav", () => {
 
 it("restores to top when the entry has no saved position", () => {
   const el = makeEl();
-  el.scrollTop = 400;
   const ref = { current: el as unknown as HTMLElement };
   navType = "POP";
   locKey = "never-scrolled";
   act(() => root.render(<Harness elRef={ref} />));
   expect(el.scrollTop).toBe(0);
+});
+
+it("records where the user was, not where the route swap clamped them", () => {
+  // The reopened-issue case. React renders the next route before any
+  // layout effect runs, so the container is already short and the
+  // browser has clamped scrollTop by the time we record it. Reading
+  // scrollTop on the way out recorded ~140 for a list left at 8000.
+  const el = makeEl();
+  el.scrollHeight = 12345;
+  const ref = { current: el as unknown as HTMLElement };
+  const render = () => act(() => root.render(<Harness elRef={ref} />));
+
+  render();
+  act(() => {
+    el.scrollTop = 8000;
+  });
+  expect(el.scrollTop).toBe(8000);
+
+  // The outgoing list is replaced by the next route's skeleton, which
+  // leaves only 320px of scrollable content to clamp into.
+  act(() => el.shrinkTo(820));
+  expect(el.scrollTop).toBe(320);
+
+  navType = "PUSH";
+  locKey = "b";
+  render();
+
+  // Back to "a": the list has to load again, so it starts short.
+  navType = "POP";
+  locKey = "a";
+  el.scrollHeight = 500;
+  render();
+  growContent(el, 12345);
+
+  expect(el.scrollTop).toBe(8000);
+});
+
+it("reaches a deep offset when the page's content arrives late", () => {
+  const el = makeEl();
+  el.scrollHeight = 4000;
+  const ref = { current: el as unknown as HTMLElement };
+  const render = () => act(() => root.render(<Harness elRef={ref} />));
+
+  render();
+  act(() => {
+    el.scrollTop = 2000;
+  });
+
+  navType = "PUSH";
+  locKey = "b";
+  render();
+
+  // Back to "a", but the list is empty so far: nothing to scroll.
+  navType = "POP";
+  locKey = "a";
+  el.scrollHeight = 500;
+  render();
+  expect(el.scrollTop).toBe(0);
+
+  // Data lands in stages, well beyond any fixed grace window.
+  growContent(el, 1200);
+  expect(el.scrollTop).toBe(700);
+
+  growContent(el, 3000);
+  expect(el.scrollTop).toBe(2000);
+});
+
+it("stops restoring once the user scrolls for themselves", () => {
+  const el = makeEl();
+  el.scrollHeight = 4000;
+  const ref = { current: el as unknown as HTMLElement };
+  const render = () => act(() => root.render(<Harness elRef={ref} />));
+
+  render();
+  act(() => {
+    el.scrollTop = 2000;
+  });
+
+  navType = "PUSH";
+  locKey = "b";
+  render();
+
+  navType = "POP";
+  locKey = "a";
+  el.scrollHeight = 500;
+  render();
+
+  // The user gives up waiting and scrolls somewhere themselves.
+  act(() => el.fire("wheel"));
+  growContent(el, 3000);
+  act(() => {
+    el.scrollTop = 120;
+  });
+
+  // Late content must not yank them back to the old offset.
+  growContent(el, 6000);
+  expect(el.scrollTop).toBe(120);
 });

--- a/web/src/hooks/useScrollRestoration.ts
+++ b/web/src/hooks/useScrollRestoration.ts
@@ -1,61 +1,149 @@
-import { useLayoutEffect, useRef, type RefObject } from "react";
+import { useEffect, useLayoutEffect, useRef, type RefObject } from "react";
 import { useLocation, useNavigationType } from "react-router-dom";
+
+// Keys that scroll the container. A plain keydown listener would also
+// fire while the user types into a search box, which would abandon a
+// restore that was still in progress.
+const SCROLL_KEYS = new Set([
+  "PageUp",
+  "PageDown",
+  "Home",
+  "End",
+  "ArrowUp",
+  "ArrowDown",
+  " ",
+]);
 
 /**
  * Per-history-entry scroll restoration for the app's custom scroll
  * container (#315).
  *
  * The routed view scrolls inside an `overflow-y-auto` <main>, not the
- * window, so the browser never restores scroll on its own. Previously we
- * hard-reset to the top on every navigation — so scrolling deep into
+ * window, so the browser never restores scroll on its own. Originally we
+ * hard-reset to the top on every navigation, so scrolling deep into
  * Artists/Albums/Feed, opening an item, and coming back always dumped you
  * at the top.
  *
- * Behaviour now:
+ * Behaviour:
  *   - PUSH / REPLACE (following a link) → start at the top.
  *   - POP (back / forward) → restore where you were.
  *
- * Everything lives in one layout effect. Its setup restores/resets for the
- * entry being entered; its cleanup snapshots the current offset for the
- * entry being left. Ordering matters: on navigation React runs the
- * outgoing entry's cleanup *before* the incoming entry's setup, so we
- * capture the real scroll position before the shared container is reset —
- * a two-effect version raced and saved a zeroed value. Positions are keyed
- * on `location.key` (unique per history entry) and re-applied as async page
- * content grows, so a list that streams in after mount still lands where it
- * was instead of clamping short.
+ * Restoring lives in one layout effect. Its setup restores or resets for
+ * the entry being entered; its cleanup records the offset for the entry
+ * being left, keyed on `location.key`, which is unique per history entry.
+ *
+ * Two things make this harder than it looks, and the first is what
+ * reopened the issue.
+ *
+ * Recording the offset cannot just read `scrollTop` on the way out. By
+ * the time any layout effect runs, React has already swapped the outgoing
+ * route's content out during the render phase. The container is suddenly
+ * far shorter, often just a Suspense skeleton, and the browser has
+ * clamped `scrollTop` down to fit it. Reading it at cleanup returns that
+ * clamped remnant instead of where the user actually was: leaving a
+ * library list at 8000px recorded about 140px, so coming back landed near
+ * the top. Scroll events are dispatched asynchronously, after the commit,
+ * so the offset tracked by the listener below has not yet been overwritten
+ * by the clamp and still holds the real position.
+ *
+ * Applying the offset cannot happen in a single frame either, because a
+ * page's content arrives after mount and `scrollTop` clamps to whatever
+ * the container can currently scroll. So we re-apply as the content grows,
+ * watching the children with a ResizeObserver, since the container's own
+ * box does not change when its content does but `scrollHeight` does. That
+ * is event-driven with no deadline, which matters twice over: this was a
+ * rAF loop bounded by a 1000ms grace window, and any list slower than a
+ * second to come back from Tidal landed short, while an unbounded rAF loop
+ * would be the idle spin that #308 was about. When content stops growing,
+ * the observer stops firing.
+ *
+ * Restoring stops as soon as the offset is reachable, or as soon as the
+ * user scrolls for themselves, so late-arriving content cannot yank them
+ * back to a position they had already chosen to leave.
  */
 export function useScrollRestoration(ref: RefObject<HTMLElement | null>): void {
   const location = useLocation();
   const navType = useNavigationType();
   const positions = useRef<Map<string, number>>(new Map());
+  // The live scroll offset. See above on why reading scrollTop at
+  // navigation time is already too late.
+  const lastTop = useRef(0);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const onScroll = () => {
+      lastTop.current = el.scrollTop;
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, [ref]);
 
   useLayoutEffect(() => {
     const el = ref.current;
     if (!el) return;
     const key = location.key;
-    let raf = 0;
-
     const target = navType === "POP" ? (positions.current.get(key) ?? 0) : 0;
+
     if (target <= 0) {
       el.scrollTo({ top: 0 });
-    } else {
-      // Async pages grow after mount, so the target may be unreachable on
-      // the first frame. Nudge toward it each frame until the content is
-      // tall enough to hold it, or a short grace window elapses.
-      const startedAt = performance.now();
-      const apply = () => {
-        const maxTop = Math.max(0, el.scrollHeight - el.clientHeight);
-        el.scrollTop = Math.min(target, maxTop);
-        if (maxTop >= target || performance.now() - startedAt > 1000) return;
-        raf = requestAnimationFrame(apply);
-      };
-      raf = requestAnimationFrame(apply);
+      lastTop.current = 0;
+      return () => positions.current.set(key, lastTop.current);
     }
 
+    let settled = false;
+    const settle = () => {
+      if (settled) return;
+      settled = true;
+      resize.disconnect();
+      children.disconnect();
+      el.removeEventListener("wheel", onTakeover);
+      el.removeEventListener("touchstart", onTakeover);
+      window.removeEventListener("keydown", onKeyTakeover);
+    };
+
+    const apply = () => {
+      if (settled) return;
+      const maxTop = Math.max(0, el.scrollHeight - el.clientHeight);
+      el.scrollTop = Math.min(target, maxTop);
+      // Once the container can hold the offset there is nothing left to
+      // wait for; further growth below the fold is not our business.
+      if (maxTop >= target) {
+        lastTop.current = target;
+        settle();
+      }
+    };
+
+    const onTakeover = () => settle();
+    const onKeyTakeover = (e: KeyboardEvent) => {
+      if (SCROLL_KEYS.has(e.key)) settle();
+    };
+
+    const resize = new ResizeObserver(apply);
+    const observeChildren = () => {
+      for (const child of Array.from(el.children)) resize.observe(child);
+    };
+    // Banners mount and unmount, so the set of children is not fixed.
+    const children = new MutationObserver(() => {
+      observeChildren();
+      apply();
+    });
+
+    observeChildren();
+    children.observe(el, { childList: true });
+    el.addEventListener("wheel", onTakeover, { passive: true });
+    el.addEventListener("touchstart", onTakeover, { passive: true });
+    window.addEventListener("keydown", onKeyTakeover);
+    apply();
+
     return () => {
-      if (raf) cancelAnimationFrame(raf);
-      positions.current.set(key, el.scrollTop);
+      const reached = settled;
+      settle();
+      // Leaving before the content ever grew enough to hold the offset
+      // means the tracked value is a partial position we were clamped
+      // to. Keep aiming at the original target so a later return still
+      // lands in the right place.
+      positions.current.set(key, reached ? lastTop.current : target);
     };
   }, [ref, location.key, navType]);
 }


### PR DESCRIPTION
Fixes the reopened part of #315.

## Summary

Restoring a saved offset worked. **Recording one did not.**

React renders the incoming route during its render phase, before any layout effect runs. By the time the cleanup read `scrollTop`, the container had already been replaced by the next page's Suspense skeleton and the browser had clamped `scrollTop` to fit it. Leaving a library list at 8000px recorded about 140px, so going back landed just below the top. That is the reporter's description exactly: "you scroll to somewhere just a little deeper".

I reproduced it in the running app before changing anything: a list left at 8000 came back at 139.5, with `clientHeight` 681, meaning the container was 820px tall when the offset was recorded. That is the album page's skeleton.

The fix tracks the offset with a scroll listener and records that instead. Scroll events are dispatched after the commit, so the tracked value has not yet been overwritten by the clamp. This is the approach React Router's own `ScrollRestoration` takes.

## Second problem

Applying the offset had a real limit worth removing. It was a rAF loop bounded by a 1000ms grace window, so any list slower than a second to come back from Tidal landed short no matter what was recorded. A `ResizeObserver` on the container's children is the honest signal for "content grew": event driven, no deadline, and nothing to spin on once growth stops, which an unbounded rAF loop could not claim after #308.

Restoring now stops when the offset becomes reachable or when the user scrolls for themselves, so late content cannot yank them back to a position they had already left. Navigating away mid-restore keeps the original target rather than the partial offset it was clamped to.

## Test plan

- The old tests never exercised any of this: their fake container never clamped `scrollTop`, and their rAF stub ran synchronously, so the target was always reachable on the first frame. The fake now clamps the way a real container does and models the shrink-then-clamp of a route swap.
- Verified the new test fails against both the old code and against a version that fixed only the restore side, which records 320 instead of 8000.
- 141 frontend tests, typecheck, and lint all green.

## Not covered

End-to-end verification in the running app. The Browser pane reports `visibilityState: "hidden"`, which freezes the rendering loop: rAF callbacks never run and scroll events are never dispatched, so neither the listener nor the ResizeObserver can be exercised there. The original bug reproduced fine because reading `scrollTop` is a synchronous layout read. What I did confirm in the live app is the mechanism the fix depends on: the container's children include the route wrapper the content grows inside, and both observers exist. The behaviour itself is covered by the unit tests.