### PR TITLE
Handle the mouse's side buttons natively on GTK

### DIFF
--- a/desktop.py
+++ b/desktop.py
@@ -502,6 +502,89 @@ def _enable_webview_media_prefs() -> None:
     BrowserView.__init__ = patched_init
 
 
+# X11/GDK button numbers for the mouse's dedicated side buttons, and the
+# history move each one means. GDK numbers buttons from 1, so these are
+# the 8th and 9th physical buttons — the same pair X11 reports for the
+# thumb rest on essentially every mouse that has them.
+_GDK_BUTTON_BACK = 8
+_GDK_BUTTON_FORWARD = 9
+_GDK_HISTORY_BUTTONS = {
+    _GDK_BUTTON_BACK: "back",
+    _GDK_BUTTON_FORWARD: "forward",
+}
+
+
+def gdk_history_move(button: int) -> Optional[str]:
+    """Which history move a GDK button number means, if any.
+
+    Split out from the signal handler so the mapping is testable
+    without a GTK main loop.
+    """
+    return _GDK_HISTORY_BUTTONS.get(button)
+
+
+def _wire_gtk_mouse_nav() -> None:
+    """Route the mouse's Back/Forward side buttons to history on the GTK
+    backend (#316).
+
+    These buttons cannot be handled in the web layer on Linux. WebKitGTK
+    does not deliver the 4th and 5th buttons to the DOM at all, which
+    MDN states plainly: "On Linux (GTK), the 4th button and the 5th
+    button are not supported." So the app's `mouseup` listener — which
+    does work on WebView2 and WKWebView — never fires there, and the
+    buttons instead did whatever GTK did with them, which is what the
+    reporter saw as unpredictable behaviour over the sidebar.
+
+    GDK does deliver them, as buttons 8 and 9 on `button-press-event`,
+    so the handler belongs at that layer. Returning True marks the event
+    handled so WebKitGTK does not also act on it.
+
+    pywebview only connects that signal itself for frameless windows
+    with easy_drag, and Tideway sets easy_drag=False, so the signal is
+    free. We hook the BrowserView constructor because the widget does
+    not exist before then — the same approach _enable_webview_media_prefs
+    already uses for Cocoa.
+    """
+    if not sys.platform.startswith("linux"):
+        return
+    try:
+        from webview.platforms.gtk import BrowserView
+    except Exception:
+        # No GTK backend in this environment (Qt, or the AppImage's
+        # no-backend fallback). Nothing to wire up.
+        return
+
+    original_init = BrowserView.__init__
+
+    def patched_init(self, window):  # type: ignore[no-untyped-def]
+        original_init(self, window)
+
+        def on_button_press(_widget, event):  # type: ignore[no-untyped-def]
+            move = gdk_history_move(getattr(event, "button", 0))
+            if move is None:
+                return False
+            # WebKit's own back/forward list, which is what the router's
+            # pushState entries land in, so moving through it delivers
+            # the popstate React Router navigates on. Preferred over
+            # evaluating `history.back()`: pywebview's evaluate_js blocks
+            # on a semaphore that only the GTK main loop can release, and
+            # this handler runs on that loop, so calling it here would
+            # deadlock the way the geometry read used to.
+            if move == "back":
+                if self.webview.can_go_back():
+                    self.webview.go_back()
+            elif self.webview.can_go_forward():
+                self.webview.go_forward()
+            # Consume it either way: at the ends of the history there is
+            # nothing to do, but letting it through would hand the button
+            # back to whatever GTK did with it before.
+            return True
+
+        self.webview.connect("button-press-event", on_button_press)
+
+    BrowserView.__init__ = patched_init
+
+
 def _guard_cocoa_window_move() -> None:
     """Stop a macOS 26 (Tahoe) startup crash in pywebview's Cocoa
     backend (issue #215).
@@ -612,6 +695,7 @@ def main(argv: Optional[list[str]] = None) -> int:
         import webview  # pywebview
         _enable_webview_media_prefs()
         _guard_cocoa_window_move()
+        _wire_gtk_mouse_nav()
     except ImportError:
         print(
             "[desktop] pywebview not installed; falling back to default browser. "

--- a/desktop.py
+++ b/desktop.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import argparse
 import io
+import logging
 import os
 import sys
 import threading
@@ -560,8 +561,21 @@ def _wire_gtk_mouse_nav() -> None:
         original_init(self, window)
 
         def on_button_press(_widget, event):  # type: ignore[no-untyped-def]
-            move = gdk_history_move(getattr(event, "button", 0))
+            button = getattr(event, "button", 0)
+            move = gdk_history_move(button)
             if move is None:
+                # 8 and 9 are what X11 reports for the thumb buttons, but
+                # that is convention rather than something GDK's docs
+                # promise, and this could not be tried on a real GTK
+                # widget before shipping. Naming any other extra button
+                # we see means a report says which number to map instead
+                # of costing another round trip, the way #309's silent
+                # paths did.
+                if button > 3:
+                    logging.getLogger("tideway.audio").info(
+                        f"[desktop] unmapped mouse button {button} "
+                        "(expected 8=back, 9=forward)"
+                    )
                 return False
             # WebKit's own back/forward list, which is what the router's
             # pushState entries land in, so moving through it delivers

--- a/tests/test_mouse_nav_buttons.py
+++ b/tests/test_mouse_nav_buttons.py
@@ -128,6 +128,34 @@ def test_ordinary_clicks_pass_through(monkeypatch):
     assert handled is False
 
 
+def test_an_unmapped_extra_button_is_named_in_the_log(monkeypatch, caplog):
+    """The 8/9 numbering is X11 convention, not something GDK's docs
+    promise, and it could not be tried on a real widget before shipping.
+    If a mouse reports something else, the log has to say which number so
+    it takes one report rather than a round trip."""
+    webview = _wired_webview(monkeypatch)
+    handler = webview.connected["button-press-event"]
+
+    with caplog.at_level("INFO", logger="tideway.audio"):
+        handler(None, types.SimpleNamespace(button=6))
+
+    assert "unmapped mouse button 6" in caplog.text
+    assert webview.moves == []
+
+
+def test_normal_buttons_do_not_log(monkeypatch, caplog):
+    """Left/middle/right clicks are constant traffic; logging them would
+    bury the signal above."""
+    webview = _wired_webview(monkeypatch)
+    handler = webview.connected["button-press-event"]
+
+    with caplog.at_level("INFO", logger="tideway.audio"):
+        for button in (1, 2, 3):
+            handler(None, types.SimpleNamespace(button=button))
+
+    assert caplog.text == ""
+
+
 @pytest.mark.parametrize("button", [8, 9])
 def test_ends_of_history_are_a_no_op(monkeypatch, button):
     """Pressing Back on the first page must not navigate, but must still

--- a/tests/test_mouse_nav_buttons.py
+++ b/tests/test_mouse_nav_buttons.py
@@ -128,7 +128,36 @@ def test_ordinary_clicks_pass_through(monkeypatch):
     assert handled is False
 
 
-def test_an_unmapped_extra_button_is_named_in_the_log(monkeypatch, caplog):
+@pytest.fixture
+def audio_log():
+    """Capture what reaches the logger that writes audio.log.
+
+    Attached straight to that logger rather than going through caplog:
+    app.audio.player sets propagate=False on it, so once anything has
+    imported that module the records never reach caplog's root handler
+    and the assertion passes against an empty string.
+    """
+    import logging
+
+    records = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            records.append(record.getMessage())
+
+    logger = logging.getLogger("tideway.audio")
+    handler = _Capture()
+    logger.addHandler(handler)
+    previous = logger.level
+    logger.setLevel(logging.INFO)
+    try:
+        yield records
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous)
+
+
+def test_an_unmapped_extra_button_is_named_in_the_log(monkeypatch, audio_log):
     """The 8/9 numbering is X11 convention, not something GDK's docs
     promise, and it could not be tried on a real widget before shipping.
     If a mouse reports something else, the log has to say which number so
@@ -136,24 +165,22 @@ def test_an_unmapped_extra_button_is_named_in_the_log(monkeypatch, caplog):
     webview = _wired_webview(monkeypatch)
     handler = webview.connected["button-press-event"]
 
-    with caplog.at_level("INFO", logger="tideway.audio"):
-        handler(None, types.SimpleNamespace(button=6))
+    handler(None, types.SimpleNamespace(button=6))
 
-    assert "unmapped mouse button 6" in caplog.text
+    assert any("unmapped mouse button 6" in m for m in audio_log)
     assert webview.moves == []
 
 
-def test_normal_buttons_do_not_log(monkeypatch, caplog):
+def test_normal_buttons_do_not_log(monkeypatch, audio_log):
     """Left/middle/right clicks are constant traffic; logging them would
     bury the signal above."""
     webview = _wired_webview(monkeypatch)
     handler = webview.connected["button-press-event"]
 
-    with caplog.at_level("INFO", logger="tideway.audio"):
-        for button in (1, 2, 3):
-            handler(None, types.SimpleNamespace(button=button))
+    for button in (1, 2, 3):
+        handler(None, types.SimpleNamespace(button=button))
 
-    assert caplog.text == ""
+    assert audio_log == []
 
 
 @pytest.mark.parametrize("button", [8, 9])

--- a/tests/test_mouse_nav_buttons.py
+++ b/tests/test_mouse_nav_buttons.py
@@ -1,0 +1,157 @@
+"""The mouse's Back/Forward side buttons need a native handler on GTK (#316).
+
+WebKitGTK does not deliver the 4th and 5th mouse buttons to the DOM —
+MDN: "On Linux (GTK), the 4th button and the 5th button are not
+supported." So the frontend's `mouseup` listener, which is fine on
+WebView2 and WKWebView, can never fire on Linux. GDK does report them,
+as buttons 8 and 9 on `button-press-event`, so that is where the Linux
+handler has to live.
+
+These cover the mapping and the wiring. They do not cover GTK itself:
+there is no GTK backend on the machine this is developed on, so the
+signal actually firing is verified against a stand-in BrowserView rather
+than a real widget.
+"""
+import sys
+import types
+
+import pytest
+
+import desktop
+
+
+# ----------------------------------------------------------------------
+# Button mapping
+# ----------------------------------------------------------------------
+
+
+def test_side_buttons_map_to_history_moves():
+    assert desktop.gdk_history_move(8) == "back"
+    assert desktop.gdk_history_move(9) == "forward"
+
+
+@pytest.mark.parametrize("button", [0, 1, 2, 3, 4, 5, 6, 7, 10])
+def test_other_buttons_are_left_alone(button):
+    """Left/middle/right and the scroll-tilt buttons (6 and 7 on X11)
+    must fall through, or normal clicking breaks."""
+    assert desktop.gdk_history_move(button) is None
+
+
+# ----------------------------------------------------------------------
+# Wiring
+# ----------------------------------------------------------------------
+
+
+class _FakeWebView:
+    def __init__(self, can_back=True, can_forward=True):
+        self.connected = {}
+        self.moves = []
+        self._can_back = can_back
+        self._can_forward = can_forward
+
+    def connect(self, signal, handler):
+        self.connected[signal] = handler
+
+    def can_go_back(self):
+        return self._can_back
+
+    def can_go_forward(self):
+        return self._can_forward
+
+    def go_back(self):
+        self.moves.append("back")
+
+    def go_forward(self):
+        self.moves.append("forward")
+
+
+def _install_fake_gtk_backend(monkeypatch):
+    """Stand in for webview.platforms.gtk, which does not import on a
+    machine with no GTK."""
+    inits = []
+
+    class BrowserView:
+        def __init__(self, window):
+            self.window = window
+            self.webview = _FakeWebView()
+            inits.append(self)
+
+    module = types.ModuleType("webview.platforms.gtk")
+    module.BrowserView = BrowserView
+    monkeypatch.setitem(sys.modules, "webview.platforms.gtk", module)
+    return BrowserView
+
+
+def test_does_nothing_off_linux(monkeypatch):
+    """The Cocoa and WebView2 backends deliver these buttons to the DOM,
+    where the frontend hook already handles them."""
+    monkeypatch.setattr(sys, "platform", "darwin")
+    BrowserView = _install_fake_gtk_backend(monkeypatch)
+    original = BrowserView.__init__
+
+    desktop._wire_gtk_mouse_nav()
+
+    assert BrowserView.__init__ is original
+
+
+def _wired_webview(monkeypatch):
+    monkeypatch.setattr(sys, "platform", "linux")
+    BrowserView = _install_fake_gtk_backend(monkeypatch)
+    desktop._wire_gtk_mouse_nav()
+    return BrowserView(window=object()).webview
+
+
+def test_connects_the_gdk_button_signal(monkeypatch):
+    webview = _wired_webview(monkeypatch)
+    assert "button-press-event" in webview.connected
+
+
+@pytest.mark.parametrize("button,move", [(8, "back"), (9, "forward")])
+def test_side_buttons_drive_history(monkeypatch, button, move):
+    webview = _wired_webview(monkeypatch)
+    handler = webview.connected["button-press-event"]
+
+    handled = handler(None, types.SimpleNamespace(button=button))
+
+    assert webview.moves == [move]
+    # True marks the event consumed, so WebKitGTK doesn't also act on it.
+    assert handled is True
+
+
+def test_ordinary_clicks_pass_through(monkeypatch):
+    webview = _wired_webview(monkeypatch)
+    handler = webview.connected["button-press-event"]
+
+    handled = handler(None, types.SimpleNamespace(button=1))
+
+    assert webview.moves == []
+    assert handled is False
+
+
+@pytest.mark.parametrize("button", [8, 9])
+def test_ends_of_history_are_a_no_op(monkeypatch, button):
+    """Pressing Back on the first page must not navigate, but must still
+    be consumed rather than falling back to GTK's own handling."""
+    webview = _wired_webview(monkeypatch)
+    webview._can_back = False
+    webview._can_forward = False
+    handler = webview.connected["button-press-event"]
+
+    handled = handler(None, types.SimpleNamespace(button=button))
+
+    assert webview.moves == []
+    assert handled is True
+
+
+def test_the_original_constructor_still_runs(monkeypatch):
+    """The patch wraps pywebview's __init__ rather than replacing it, so
+    the window is still built."""
+    monkeypatch.setattr(sys, "platform", "linux")
+    BrowserView = _install_fake_gtk_backend(monkeypatch)
+    desktop._wire_gtk_mouse_nav()
+
+    sentinel = object()
+    view = BrowserView(window=sentinel)
+
+    assert view.window is sentinel
+    assert view.webview is not None

--- a/web/src/hooks/useMouseNavButtons.ts
+++ b/web/src/hooks/useMouseNavButtons.ts
@@ -2,15 +2,20 @@ import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
 
 /**
- * Wire the mouse's dedicated Back (X1 / button 3) and Forward (X2 /
- * button 4) side buttons to router navigation (#316).
+ * Wire the mouse's dedicated Back (X1, button 3) and Forward (X2, button
+ * 4) side buttons to router navigation (#316).
  *
  * The packaged webview doesn't map these to history the way a normal
  * browser does, so they did nothing inside Tideway even though they work
- * everywhere else. We listen on `mouseup` — the event that reliably
- * reports the X buttons across the webviews we ship (WebView2 / WebKit),
- * where `auxclick` coverage for them is patchier — and call the router.
- * `navigate(1)` past the end of history is a harmless no-op.
+ * everywhere else. We listen on `mouseup`, which reports the X buttons
+ * more reliably than `auxclick` on the webviews we ship, and call the
+ * router. `navigate(1)` past the end of history is a harmless no-op.
+ *
+ * This covers WebView2 and WKWebView only. WebKitGTK does not deliver
+ * these buttons to the DOM at all — per MDN, "On Linux (GTK), the 4th
+ * button and the 5th button are not supported" — so no web-layer
+ * listener can see them and Linux is handled natively in desktop.py,
+ * where GDK does report them as buttons 8 and 9.
  */
 export function useMouseNavButtons(): void {
   const navigate = useNavigate();


### PR DESCRIPTION
Addresses the reopened part of #316.

## Summary

The web-layer listener shipped for this issue cannot work on Linux. WebKitGTK does not deliver the 4th and 5th mouse buttons to the DOM at all. MDN states it outright:

> On Linux (GTK), the 4th button and the 5th button are not supported.

So the `mouseup` handler never fired there, and the buttons kept doing whatever GTK did with them. That is what the reporter saw: unpredictable behaviour over the sidebar, nothing at all over the content pane. No amount of work in the web layer fixes this.

GDK does report them, as buttons 8 and 9 on `button-press-event`, so the handler belongs at that layer. pywebview only connects that signal for frameless windows with `easy_drag`, and Tideway sets `easy_drag=False`, so the signal is free. The `BrowserView` constructor is hooked the same way `_enable_webview_media_prefs` already hooks Cocoa, because the widget does not exist before then.

## One design note

Navigation goes through WebKit's own back/forward list rather than evaluating `history.back()`. The router's pushState entries are in that list, so it delivers the popstate React Router moves on, and it sidesteps a deadlock: pywebview's `evaluate_js` blocks on a semaphore that only the GTK main loop can release, and this handler runs on that loop. That is the same trap the window geometry read fell into, which is documented in `desktop.py`.

The frontend hook stays for WebView2 and WKWebView, where these buttons do reach the DOM. Its comment claimed WebKit coverage generally, which is the wrong belief that produced the broken fix, so it now names the engines it actually covers.

## Test plan

18 tests covering the button mapping, that ordinary and scroll-tilt buttons fall through, the signal wiring, event consumption, the ends of the history, and that the wrapped constructor still runs. Full backend suite green at 1199.

## Not covered, and this one matters

**Not verified on GTK.** There is no GTK backend on the machine this was written on, so the tests drive a stand-in `BrowserView` rather than a real widget. The mapping and wiring are covered, but that GDK delivers buttons 8 and 9 to this signal on the reporter's setup is reasoned from the platform docs, not observed.

This needs a Linux user to confirm before it ships. I would rather ask the reporter to test a build than tell them it is fixed twice in a row.