### PR TITLE
Never overwrite a stored refresh token with nothing

### DIFF
--- a/app/tidal_client.py
+++ b/app/tidal_client.py
@@ -41,6 +41,25 @@ def _tlog(msg: str) -> None:
 
 SESSION_FILE = user_data_dir() / "tidal_session.json"
 
+
+def _stored_refresh_token() -> Optional[str]:
+    """The refresh token currently on disk, if any.
+
+    Read at save time so an in-memory session that has lost its refresh
+    token cannot overwrite a good one. Returns None when the file is
+    missing or unreadable, which puts the caller back where it already
+    was rather than inventing a credential.
+    """
+    try:
+        with open(SESSION_FILE) as f:
+            return json.load(f).get("refresh_token") or None
+    except FileNotFoundError:
+        return None
+    except (OSError, ValueError):
+        # Unreadable or malformed. Nothing to preserve, and the caller
+        # is about to replace the file anyway.
+        return None
+
 # Connection-level failures from either HTTP transport. Loading a
 # persisted session over a dead network has to be told apart from
 # Tidal rejecting the credentials — see load_session.
@@ -505,6 +524,9 @@ class TidalClient:
         # yet. Read by the server's auth check (offline ≠ signed out)
         # and cleared by the watchdog's retry once the network is back.
         self._session_load_deferred = False
+        # One-shot latch so the watchdog's "this session can never be
+        # renewed" warning is logged once rather than every tick.
+        self._warned_no_refresh_token = False
         # Serializes the deferred-load retry across the watchdog tick
         # and connectivity-triggered retries, which can land together.
         self._deferred_retry_lock = threading.Lock()
@@ -947,6 +969,23 @@ class TidalClient:
                 expiry = getattr(self.session, "expiry_time", None)
                 refresh_token = getattr(self.session, "refresh_token", None)
                 if not expiry or not refresh_token:
+                    # A signed-in session with no refresh token can never
+                    # be renewed, so this loop will skip it every tick
+                    # until the access token expires and the user is
+                    # silently signed out. Say so once, rather than once
+                    # a minute, so the log explains the logout that is
+                    # coming instead of only recording the aftermath.
+                    if (
+                        refresh_token is None
+                        and expiry is not None
+                        and not self._warned_no_refresh_token
+                    ):
+                        self._warned_no_refresh_token = True
+                        _tlog(
+                            "refresh watchdog: session has no refresh token, "
+                            f"so it cannot be renewed and ends at {expiry} "
+                            "(UTC) — a re-login will be required"
+                        )
                     continue
                 now = (
                     datetime.now(expiry.tzinfo)
@@ -1087,10 +1126,40 @@ class TidalClient:
         every other user can read them.
         """
         expiry = self.session.expiry_time
+        refresh_token = self.session.refresh_token
+        if not refresh_token:
+            # Never write away a refresh token we still hold on disk.
+            #
+            # It is the only credential that can renew a session, and an
+            # absent value on the session object means "unchanged", not
+            # "revoked": Tidal omits the field unless it rotates, and
+            # tidalapi drops it when it does. `_token_refresh_capturing`
+            # already applies that rule at the HTTP layer; persistence
+            # has to apply it too or one save undoes the other.
+            #
+            # Writing the None instead disables renewal permanently. The
+            # watchdog skips a session with no refresh token, so the
+            # access token just expires and the user is signed out with
+            # nothing in the log to explain it. That is how #309
+            # reproduced here: a session file written with a null refresh
+            # token and a four hour access token, signed out on the dot
+            # when it expired.
+            refresh_token = _stored_refresh_token()
+            if refresh_token:
+                _tlog(
+                    "save_session: session had no refresh token, kept the "
+                    "stored one"
+                )
+            else:
+                _tlog(
+                    "save_session: no refresh token to store — this session "
+                    "cannot be renewed and will end when the access token "
+                    "expires"
+                )
         data = {
             "token_type": self.session.token_type,
             "access_token": self.session.access_token,
-            "refresh_token": self.session.refresh_token,
+            "refresh_token": refresh_token,
             "expiry_time": expiry.isoformat() if expiry else None,
             # Track PKCE sessions separately — their client_id/secret
             # need to be re-swapped to the hi-res-entitled pair after

--- a/tests/test_refresh_token_preserved.py
+++ b/tests/test_refresh_token_preserved.py
@@ -1,0 +1,237 @@
+"""Saving a session must never throw away the refresh token (#309).
+
+The refresh token is the only credential that can renew a session, and
+an absent value on the session object means "unchanged", not "revoked":
+Tidal omits the field unless it rotates, and tidalapi drops it when it
+does. `_token_refresh_capturing` already applies that rule at the HTTP
+layer. `save_session` did not, so one save could undo the other and
+write a null over a perfectly good token.
+
+The result is a session that cannot be renewed. The watchdog skips a
+session with no refresh token, so the access token simply expires and
+the user is signed out with nothing in the log. This was found on a real
+install: a session file written with a null refresh token and a four
+hour access token, signed out on the dot when it expired, and no
+`[tidal]` line anywhere near the event.
+"""
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from app import tidal_client
+
+
+@pytest.fixture
+def session_file(tmp_path, monkeypatch):
+    f = tmp_path / "tidal_session.json"
+    monkeypatch.setattr(tidal_client, "SESSION_FILE", f)
+    return f
+
+
+@pytest.fixture
+def tidal(monkeypatch):
+    import server
+
+    return server.tidal
+
+
+def _write(f, refresh_token):
+    f.write_text(
+        json.dumps(
+            {
+                "token_type": "Bearer",
+                "access_token": "A1",
+                "refresh_token": refresh_token,
+                "expiry_time": datetime.now(timezone.utc)
+                .replace(tzinfo=None)
+                .isoformat(),
+                "is_pkce": False,
+            }
+        )
+    )
+
+
+def _set_session(monkeypatch, tidal, **attrs):
+    for name, value in attrs.items():
+        monkeypatch.setattr(tidal.session, name, value, raising=False)
+
+
+# ----------------------------------------------------------------------
+# save_session
+# ----------------------------------------------------------------------
+
+
+def test_a_session_without_a_refresh_token_keeps_the_stored_one(
+    session_file, tidal, monkeypatch
+):
+    """The bug. Saving a session whose refresh token went missing used to
+    persist the None and permanently disable renewal."""
+    _write(session_file, "GOOD")
+    _set_session(
+        monkeypatch,
+        tidal,
+        token_type="Bearer",
+        access_token="A2",
+        refresh_token=None,
+        expiry_time=datetime.now(timezone.utc).replace(tzinfo=None),
+    )
+
+    tidal.save_session()
+
+    assert json.loads(session_file.read_text())["refresh_token"] == "GOOD"
+
+
+def test_an_empty_string_is_treated_as_missing(session_file, tidal, monkeypatch):
+    _write(session_file, "GOOD")
+    _set_session(
+        monkeypatch,
+        tidal,
+        token_type="Bearer",
+        access_token="A2",
+        refresh_token="",
+        expiry_time=datetime.now(timezone.utc).replace(tzinfo=None),
+    )
+
+    tidal.save_session()
+
+    assert json.loads(session_file.read_text())["refresh_token"] == "GOOD"
+
+
+def test_a_rotated_refresh_token_still_replaces_the_stored_one(
+    session_file, tidal, monkeypatch
+):
+    """The guard must not pin the old token in place — rotation has to
+    keep working, or Tidal invalidates us a few days later."""
+    _write(session_file, "OLD")
+    _set_session(
+        monkeypatch,
+        tidal,
+        token_type="Bearer",
+        access_token="A2",
+        refresh_token="NEW",
+        expiry_time=datetime.now(timezone.utc).replace(tzinfo=None),
+    )
+
+    tidal.save_session()
+
+    assert json.loads(session_file.read_text())["refresh_token"] == "NEW"
+
+
+def test_first_save_with_no_file_writes_what_it_has(
+    session_file, tidal, monkeypatch
+):
+    """A fresh login has nothing on disk to preserve."""
+    assert not session_file.exists()
+    _set_session(
+        monkeypatch,
+        tidal,
+        token_type="Bearer",
+        access_token="A1",
+        refresh_token="R1",
+        expiry_time=datetime.now(timezone.utc).replace(tzinfo=None),
+    )
+
+    tidal.save_session()
+
+    assert json.loads(session_file.read_text())["refresh_token"] == "R1"
+
+
+def test_a_malformed_file_does_not_break_saving(session_file, tidal, monkeypatch):
+    session_file.write_text("{ not json")
+    _set_session(
+        monkeypatch,
+        tidal,
+        token_type="Bearer",
+        access_token="A1",
+        refresh_token=None,
+        expiry_time=datetime.now(timezone.utc).replace(tzinfo=None),
+    )
+
+    tidal.save_session()
+
+    assert json.loads(session_file.read_text())["refresh_token"] is None
+
+
+# ----------------------------------------------------------------------
+# The watchdog's silence
+# ----------------------------------------------------------------------
+
+
+class _FakeSession:
+    def __init__(self, expiry, refresh_token):
+        self.expiry_time = expiry
+        self.refresh_token = refresh_token
+
+
+def _run_watchdog_ticks(client, ticks=3):
+    seen = {"n": 0}
+    real_wait = client._refresh_stop.wait
+
+    def _counting_wait(timeout=None):
+        seen["n"] += 1
+        if seen["n"] > ticks:
+            return True
+        return real_wait(0)
+
+    client._refresh_stop.wait = _counting_wait
+    client._refresh_watchdog()
+
+
+def _unrenewable_client():
+    import threading
+
+    from app.tidal_client import TidalClient
+
+    c = object.__new__(TidalClient)
+    c.session = _FakeSession(
+        datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(hours=4),
+        None,
+    )
+    c._refresh_stop = threading.Event()
+    c._session_load_deferred = False
+    c._warned_no_refresh_token = False
+    c._REFRESH_CHECK_INTERVAL_SEC = 0
+    return c
+
+
+def test_the_watchdog_says_a_session_can_never_be_renewed(audio_lines):
+    """Without this the loop skips such a session every tick in silence,
+    which is why the real logout left no trace at all."""
+    _run_watchdog_ticks(_unrenewable_client())
+
+    assert any("no refresh token" in line for line in audio_lines)
+
+
+def test_the_warning_is_not_repeated_every_tick(audio_lines):
+    """The loop runs once a minute; repeating this would bury the log."""
+    _run_watchdog_ticks(_unrenewable_client(), ticks=5)
+
+    assert sum("no refresh token" in line for line in audio_lines) == 1
+
+
+@pytest.fixture
+def audio_lines():
+    """What reaches the logger behind audio.log.
+
+    Attached to that logger directly: app.audio.player sets
+    propagate=False on it, so caplog's root handler never sees these.
+    """
+    import logging
+
+    lines = []
+
+    class _Capture(logging.Handler):
+        def emit(self, record):
+            lines.append(record.getMessage())
+
+    logger = logging.getLogger("tideway.audio")
+    handler = _Capture()
+    logger.addHandler(handler)
+    previous = logger.level
+    logger.setLevel(logging.INFO)
+    try:
+        yield lines
+    finally:
+        logger.removeHandler(handler)
+        logger.setLevel(previous)


### PR DESCRIPTION
A second, independent cause of #309, found on a real install while testing the timezone fix in #323.

## What happened

My own session file, written hours before any testing started:

```
refresh_token : null
access_token  : <set>
expiry_time   : 2026-08-11 02:49:07   (4 hours after the file was written)
```

Signed out on the dot when that access token expired, with no `[tidal]` line anywhere near the event.

## Why a null there is fatal

The watchdog's first check is:

```python
if not expiry or not refresh_token:
    continue
```

With no refresh token it skips silently, every tick, forever. Nothing retries, the access token runs out its remaining life, and the user is signed out with nothing to look at. The missing token is checked **before** the clock, so this beats the timezone bug to it — on that session, the fix in #323 would never have been reached.

## How it gets to null

`save_session()` wrote `self.session.refresh_token` unconditionally. But an absent value there means "unchanged", not "revoked": Tidal omits the field unless it rotates, and tidalapi drops it when it does. `_token_refresh_capturing` already applies exactly that rule at the HTTP layer, with the comment *"when absent the existing token stays valid, so keep it."* Persistence didn't, so one save could undo the other.

Both login paths call `save_session()` right after `check_login()` passes, and `check_login()` only proves the *access* token works. That is enough to persist a session that is already unrenewable.

## Why preserving it is safe

`logout()` unlinks the file and builds a fresh `Session` rather than saving, so no path legitimately clears the token. Nothing depends on being able to write a null.

## Test plan

7 tests. Four fail against the previous code:

- a session with no refresh token keeps the stored one
- an empty string counts as missing
- the watchdog says once that a session can never be renewed
- and says it once, not every tick

Three pass both ways on purpose, because they guard against over-correcting: rotation must still replace the stored token, a first save with no file must write what it has, and a malformed file must not break saving. Pinning the old token in place would get us invalidated by Tidal a few days later, which is the failure `_refresh_once` already documents.

Full backend suite green at 1188.

## Not covered

Why the session lost its refresh token upstream in the first place. This stops the loss being written to disk and makes it visible in the log, which is what turns the next occurrence into something diagnosable. If it recurs, the new lines say which path produced it.