### PR TITLE
Move track-load side effect out of the setState updater

### DIFF
--- a/web/src/hooks/usePlayer.ts
+++ b/web/src/hooks/usePlayer.ts
@@ -959,24 +959,28 @@ export function usePlayer() {
                 ? null
                 : s.source,
         };
-        void (async () => {
-          try {
-            // Single round-trip for load+play — saves ~20-40ms of
-            // await gap between the two HTTP calls and lets the
-            // backend start priming the decoder immediately after
-            // set_media, which is where the audible delay lives.
-            await api.player.playTrack(track.id, qualityRef.current);
-          } catch (err) {
-            setState((cur) => ({
-              ...cur,
-              playing: false,
-              loading: false,
-              error: err instanceof Error ? err.message : String(err),
-            }));
-          }
-        })();
         return next;
       });
+      // Kick off load+play as a side effect OUTSIDE the setState updater.
+      // StrictMode double-invokes updaters in dev, so having this inside
+      // fired two play_track loads (two full teardown+rebuilds) per
+      // action. The updater above is now pure; `track` was bounds-checked
+      // against the queue at the top of playAtIndex.
+      void (async () => {
+        try {
+          // Single round-trip for load+play — saves ~20-40ms of await
+          // gap between two HTTP calls and lets the backend start priming
+          // the decoder immediately after set_media, where the delay lives.
+          await api.player.playTrack(track.id, qualityRef.current);
+        } catch (err) {
+          setState((cur) => ({
+            ...cur,
+            playing: false,
+            loading: false,
+            error: err instanceof Error ? err.message : String(err),
+          }));
+        }
+      })();
     },
     [],
   );
@@ -1017,20 +1021,22 @@ export function usePlayer() {
                 ? null
                 : s.source,
         };
-        void (async () => {
-          try {
-            await api.player.load(track.id, qualityRef.current);
-          } catch (err) {
-            setState((cur) => ({
-              ...cur,
-              playing: false,
-              loading: false,
-              error: err instanceof Error ? err.message : String(err),
-            }));
-          }
-        })();
         return next;
       });
+      // Load (paused) as a side effect OUTSIDE the updater — same
+      // StrictMode dev double-invoke fix as playAtIndex.
+      void (async () => {
+        try {
+          await api.player.load(track.id, qualityRef.current);
+        } catch (err) {
+          setState((cur) => ({
+            ...cur,
+            playing: false,
+            loading: false,
+            error: err instanceof Error ? err.message : String(err),
+          }));
+        }
+      })();
     },
     [],
   );


### PR DESCRIPTION
## Summary

Debug-build-only issue with double-invocation of next/prev/play, described in #329. This is a really small issue, but it kept biting me while trying to debug some DLNA issues, so I thought it worth a small change to smooth development work.

In `usePlayer.tss`, `playAtIndex` and `loadAtIndexPaused` kicked off the load (playTrack / load) from inside their setState updater. React StrictMode double- invokes updaters in development, so every next/prev/select fired the load twice — two full backend teardown+rebuild loads per action, doubling perceived track-change latency in dev. It's also a side-effect-in-updater anti-pattern regardless; updaters must be pure.

Move the load side effect out of the updater so it runs once, after the optimistic state is queued. The track is already bounds-checked at the top of each function, so the effect is safe to fire there.

## Test plan

Repeat the steps described in the linked issue: Only one backend API invocation.

## Related issues

Closes #329

## Pre-PR checklist

- [x] Branch name follows `fix/<slug>` / `feature/<slug>` / `chore/<slug>`
- [x] `pytest tests/` passes locally
- [x] `cd web && npx tsc -b --noEmit` passes locally
- [x] `cd web && npm run lint:all` passes locally (no NEW errors; the existing baseline of 50-ish warnings is fine)
- [x] `cd web && npm test` passes locally
- [x] Commit messages are imperative, under 70 chars, with no AI attribution