### PR TITLE
Reject ring writes after source_done

### DIFF
--- a/app/audio/http_stream.py
+++ b/app/audio/http_stream.py
@@ -277,6 +277,17 @@ class RingBuffer:
         """
         deadline = time.monotonic() + block_timeout
         with self._cv:
+            # A stream that has been marked finished accepts no more
+            # bytes. The re-encode fallback (FlacStreamEncoder via
+            # push_pcm) must not append a second FLAC stream — fresh
+            # header + PCM — after the passthrough's source ran out:
+            # the renderer is still reading the first stream and
+            # decodes the boundary as garbage (UAPP avcodec
+            # -1094995529). The next stream starts through flush(),
+            # which clears _source_done, so this only ever drops
+            # bytes that belong to an already-ended stream.
+            if self._source_done:
+                return True
             # Fill head cache under the lock so write() and flush()
             # don't race on _head (flush clears it under the lock).
             if len(self._head) < self._head_max:

--- a/tests/test_http_stream.py
+++ b/tests/test_http_stream.py
@@ -126,6 +126,34 @@ class TestRingBuffer:
         # returns "" — first read drains).
         assert out == b"alive"
 
+    def test_write_after_source_done_is_silent_drop(self):
+        """A stream that has been marked finished must not accept a
+        second encoder's output. The DLNA re-encode fallback picks
+        up on the realtime thread after the passthrough source runs
+        out; appending its fresh FLAC header onto the ended stream
+        corrupts the renderer's decoder (-1094995529). The bytes
+        are dropped and the next stream starts via flush()."""
+        buf = RingBuffer(max_bytes=1024)
+        buf.write(b"first-stream")
+        buf.source_done()
+        buf.write(b"second-stream-append")
+        out = buf.read(100, timeout=0.05)
+        assert out == b"first-stream"
+        assert buf.is_source_done is True
+
+    def test_flush_clears_source_done_for_next_stream(self):
+        """flush() resets the ended-stream state so the next track's
+        stream can write again — that's the start_passthrough path
+        on every track change."""
+        buf = RingBuffer(max_bytes=1024)
+        buf.write(b"first-stream")
+        buf.source_done()
+        buf.flush()
+        buf.write(b"next-stream")
+        out = buf.read(100, timeout=0.05)
+        assert out == b"next-stream"
+        assert buf.is_source_done is False
+
     def test_attach_supersedes_prior_generation(self):
         """A second attach() bumps the generation so the first
         consumer sees is_superseded — the single-active-consumer


### PR DESCRIPTION
## Summary

At the natural end of a DLNA passthrough track, the passthrough source runs out (`demux complete`) but the muted local player keeps playing — its decode lags the passthrough when segment downloads are throttled. The re-encode fallback (`FlacStreamEncoder` via `push_pcm`) then appended a **second FLAC stream** (fresh header + PCM) into the same `RingBuffer` the renderer was still reading. UAPP decoded the boundary between the real stream and the appended header as garbage and hard-failed with avcodec `-1094995529 Invalid data found` — no recovery for minutes.

A ring that has been marked `source_done` now accepts no more bytes (`write()` returns without appending). A new stream always starts through `start_passthrough`'s `flush()`, which clears `_source_done`, so this only drops bytes that belonged to an already-ended stream. The renderer drains the remaining real data and gets a clean end-of-stream (`end=source_done`) instead of a corrupted one — and UAPP's existing end-of-track handling recovers normally within milliseconds.

Cast never signals `source_done` on its buffer, so the fallback path there is unaffected.

## Behavior change

The re-encode fallback can no longer take over **mid-stream** on an existing renderer connection. That includes the mid-track passthrough-failure case: instead of appending a fresh header onto the live stream (which always corrupted the renderer's decoder), the connection now drains and ends with a clean `source_done`, and playback resumes on the next track's stream. This is degraded but honest — never a silent fallback that masks a corrupted stream.

The fallback still works from byte 0 for a fresh stream (non-FLAC source, or passthrough that never started): those never set `source_done` before the first write.

## Test plan

- New unit tests: write-after-`source_done` is a silent drop; `flush()` clears `_source_done` for the next stream (tests/test_http_stream.py).
- Full suite: `pytest tests/` → 1197 passed, 3 skipped.
- Manual DLNA session against UAPP (192.168.17.33), ~40 min / 10 tracks:
  - Server: 0 `RING DROP`, 0 `ENCODER REBUILD` (previously a 2-minute cascade at every no-preload track end), 13 connections ended `end=source_done`.
  - Renderer: 11/11 `setAVTransportURI` transitions received; 0 `Failure in decoding` / `av_read_frame failed` / `avcodec_receive_frame`; only benign `avcodec_send_packet` EOF packets, each retried once and recovered <1s with the next track's URI.

## Follow-up (out of scope)

A slow segment-download episode can lag the local decode behind the passthrough for a while; with this fix that only means a short pause between tracks, never a corrupted stream.