### PR TITLE
Bump fastapi, sse-starlette, async-upnp-client, numpy floors

### DIFF
--- a/flatpak/python3-requirements.json
+++ b/flatpak/python3-requirements.json
@@ -250,7 +250,7 @@
             "name": "python3-fastapi",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"fastapi>=0.139.2\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"fastapi>=0.140.5\" --no-build-isolation"
             ],
             "sources": [
                 {
@@ -428,7 +428,7 @@
             "name": "python3-sse-starlette",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"sse-starlette>=3.4.4\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"sse-starlette>=3.4.6\" --no-build-isolation"
             ],
             "sources": [
                 {
@@ -546,7 +546,7 @@
             "name": "python3-numpy",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"numpy>=1.26.0\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"numpy>=2.5.1\" --no-build-isolation"
             ],
             "sources": [
                 {
@@ -807,7 +807,7 @@
             "name": "python3-async-upnp-client",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"async-upnp-client>=0.47.0\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"async-upnp-client>=0.48.0\" --no-build-isolation"
             ],
             "sources": [
                 {

--- a/requirements.txt
+++ b/requirements.txt
@@ -29,9 +29,9 @@ orjson>=3.11.9
 # together).
 curl-cffi>=0.15.0,<0.16
 pillow>=12.3.0
-fastapi>=0.139.2
+fastapi>=0.140.5
 uvicorn[standard]>=0.52.0
-sse-starlette>=3.4.4
+sse-starlette>=3.4.6
 # Packaged desktop app — pywebview wraps the web UI in a native window.
 # On Windows it requires WebView2 (preinstalled on Win11, auto-installs
 # on Win10 via the Evergreen bootstrapper). On macOS it uses WKWebView,
@@ -44,7 +44,7 @@ pywebview>=6.2.1
 # bit-perfect output.
 av>=18.0.0
 sounddevice>=0.5.5
-numpy>=1.26.0
+numpy>=2.5.1
 # scipy powers the PCM engine's 10-band parametric EQ. Biquad IIR
 # filtering in a Python loop can't keep up with the audio callback
 # at 48k; scipy.signal.sosfilt drops into C and comfortably runs
@@ -104,7 +104,7 @@ dbus-next>=0.2.3; sys_platform == "linux"
 # the Linn / Naim side of the streamer market. Optional: if the
 # wheel fails to install, app/audio/upnp.py silently disables the
 # UPnP output path and the rest of the app keeps working.
-async-upnp-client>=0.47.0
+async-upnp-client>=0.48.0
 # Chromecast sender. Used by app/audio/cast.py for device discovery
 # (mDNS via zeroconf) and the Cast Application Framework control
 # channel. We hand the Cast device an HTTP URL serving Tideway's


### PR DESCRIPTION
Consolidates four Dependabot dependency-floor bumps that Dependabot declined to auto-rebase once the tree moved under them:
- fastapi 0.139→**0.140.5** (#298)
- sse-starlette 3.4.4→**3.4.6** (#300)
- async-upnp-client 0.47→**0.48** (#299)
- numpy 1.26→**2.5.1** (#279)

They all raise the floor in the same `requirements.txt`, so bundling avoids the serial rebase-conflict churn of separate PRs on one file. `flatpak/python3-requirements.json` is regenerated on push by the flatpak-sources workflow.

## Verification
Full `pytest` passes against the installed targets (fastapi 0.141, sse-starlette 3.4.8, async-upnp 0.48, numpy 2.5.2). numpy 2.x is the only real risk — the DSP/audio code touches none of numpy 2.0's removed APIs.

Closes #298, #299, #300, #279.

🤖 Generated with [Claude Code](https://claude.com/claude-code)