### PR TITLE
Teach stylelint and prettier the Tailwind 4 syntax

### DIFF
--- a/web/.stylelintrc.json
+++ b/web/.stylelintrc.json
@@ -10,10 +10,22 @@
           "layer",
           "variants",
           "responsive",
-          "screen"
+          "screen",
+          "theme",
+          "plugin",
+          "custom-variant",
+          "variant",
+          "utility",
+          "config",
+          "source",
+          "reference"
         ]
       }
     ],
+    "import-notation": "string",
+    "media-query-no-invalid": null,
+    "at-rule-empty-line-before": null,
+    "custom-property-empty-line-before": null,
     "selector-pseudo-class-no-unknown": [
       true,
       {

--- a/web/README.md
+++ b/web/README.md
@@ -18,11 +18,11 @@ export default tseslint.config({
   languageOptions: {
     // other options...
     parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
+      project: ["./tsconfig.node.json", "./tsconfig.app.json"],
       tsconfigRootDir: import.meta.dirname,
     },
   },
-})
+});
 ```
 
 - Replace `tseslint.configs.recommended` to `tseslint.configs.recommendedTypeChecked` or `tseslint.configs.strictTypeChecked`
@@ -31,11 +31,11 @@ export default tseslint.config({
 
 ```js
 // eslint.config.js
-import react from 'eslint-plugin-react'
+import react from "eslint-plugin-react";
 
 export default tseslint.config({
   // Set the react version
-  settings: { react: { version: '18.3' } },
+  settings: { react: { version: "18.3" } },
   plugins: {
     // Add the react plugin
     react,
@@ -44,7 +44,7 @@ export default tseslint.config({
     // other rules...
     // Enable its recommended rules
     ...react.configs.recommended.rules,
-    ...react.configs['jsx-runtime'].rules,
+    ...react.configs["jsx-runtime"].rules,
   },
-})
+});
 ```

--- a/web/postcss.config.js
+++ b/web/postcss.config.js
@@ -1,5 +1,5 @@
 export default {
   plugins: {
-    '@tailwindcss/postcss': {},
+    "@tailwindcss/postcss": {},
   },
 };

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -1,4 +1,4 @@
-@import 'tailwindcss';
+@import "tailwindcss";
 
 @plugin 'tailwindcss-animate';
 


### PR DESCRIPTION
Repairs the frontend lint job on `main`, which went red after the Tailwind 4 migration: v4's CSS-first at-rules (`@theme`, `@plugin`, `@custom-variant`, `@utility`), the string-form `@import "tailwindcss"`, and a `(width >= --theme(...))` media query weren't recognised by the stylelint config, and `index.css`/`postcss.config.js` were left un-prettier'd by the codemod. (The tailwind PR was merged on tsc/eslint/build/vitest green without the full `lint:all`.)

- Adds the v4 at-rules to `at-rule-no-unknown` ignores
- `import-notation: "string"` for the v4 import
- Disables `media-query-no-invalid` + the empty-line-before rules that fight v4's generated CSS
- Prettier-formats `index.css`, `postcss.config.js`, `README.md`

Verified: `stylelint` clean, `prettier --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)