### PR TITLE
Guarantee readable lyrics contrast on light album covers

### DIFF
--- a/web/src/components/FullScreenPlayer.tsx
+++ b/web/src/components/FullScreenPlayer.tsx
@@ -31,7 +31,12 @@ import {
 import { Button } from "@/components/ui/button";
 import { HeartButton } from "@/components/HeartButton";
 import { DownloadButton } from "@/components/DownloadButton";
-import { cn, formatDuration, imageProxy } from "@/lib/utils";
+import {
+  cn,
+  darkenForLightText,
+  formatDuration,
+  imageProxy,
+} from "@/lib/utils";
 
 // Right-pane tab in the full-screen player. Matches the affordance
 // the official Tidal desktop client surfaces in the same view —
@@ -104,8 +109,14 @@ export function FullScreenPlayer({
   // killing the "the room is the album cover" mood. Falls back to
   // the old neutral gradient if the dominant-color extraction is
   // still pending or failed.
-  const bg = dominant
-    ? `linear-gradient(180deg, ${dominant} 0%, ${dominant} 70%, color-mix(in srgb, ${dominant} 70%, black) 100%)`
+  //
+  // The whole view lays near-white `text-foreground` over this tone, so
+  // a light-covered album (e.g. Glass Animals — "Life Itself") used to
+  // paint white-on-white lyrics (#327). Darken the base just enough to
+  // guarantee readable contrast; a color that's already dark is kept.
+  const base = dominant ? darkenForLightText(dominant) : null;
+  const bg = base
+    ? `linear-gradient(180deg, ${base} 0%, ${base} 70%, color-mix(in srgb, ${base} 70%, black) 100%)`
     : "linear-gradient(180deg, hsl(0 0% 20%), hsl(0 0% 5%))";
 
   return (

--- a/web/src/lib/utils.test.ts
+++ b/web/src/lib/utils.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { darkenForLightText } from "./utils";
+
+// WCAG contrast of an `rgb(r, g, b)` string against white, mirroring the
+// math the helper targets — so the test asserts the actual readability
+// guarantee, not an implementation detail.
+function contrastWithWhite(color: string): number {
+  const m = color.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i)!;
+  const lin = (v: number) => {
+    const c = Number(v) / 255;
+    return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+  };
+  const L =
+    0.2126 * lin(Number(m[1])) +
+    0.7152 * lin(Number(m[2])) +
+    0.0722 * lin(Number(m[3]));
+  return 1.05 / (L + 0.05);
+}
+
+describe("darkenForLightText", () => {
+  it("darkens a light color until near-white text is readable", () => {
+    const src = "rgb(240, 240, 240)"; // ~1.1:1 against white — unreadable
+    expect(contrastWithWhite(src)).toBeLessThan(2);
+    const out = darkenForLightText(src);
+    expect(contrastWithWhite(out)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("leaves an already-dark color unchanged", () => {
+    const src = "rgb(20, 30, 40)"; // already high contrast with white
+    expect(contrastWithWhite(src)).toBeGreaterThanOrEqual(4.5);
+    expect(darkenForLightText(src)).toBe(src);
+  });
+
+  it("preserves hue when darkening (channel ordering kept)", () => {
+    // A warm light color: red > green > blue. Darkening scales all
+    // channels together, so the ordering must survive.
+    const out = darkenForLightText("rgb(250, 200, 120)");
+    const m = out.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i)!;
+    const [r, g, b] = [Number(m[1]), Number(m[2]), Number(m[3])];
+    expect(r).toBeGreaterThan(g);
+    expect(g).toBeGreaterThan(b);
+    expect(contrastWithWhite(out)).toBeGreaterThanOrEqual(4.5);
+  });
+
+  it("passes an unparseable value through untouched", () => {
+    expect(darkenForLightText("transparent")).toBe("transparent");
+  });
+});

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -19,3 +19,56 @@ export function imageProxy(url: string | null | undefined): string | undefined {
   if (!url) return undefined;
   return `/api/image?url=${encodeURIComponent(url)}`;
 }
+
+// WCAG relative luminance of a single sRGB channel value (0–255).
+function srgbChannelToLinear(value: number): number {
+  const c = value / 255;
+  return c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4);
+}
+
+function relativeLuminance(r: number, g: number, b: number): number {
+  return (
+    0.2126 * srgbChannelToLinear(r) +
+    0.7152 * srgbChannelToLinear(g) +
+    0.0722 * srgbChannelToLinear(b)
+  );
+}
+
+/**
+ * Darken an `rgb(...)` color just enough that near-white text stays
+ * readable on top of it (#327). The Now Playing / lyrics view paints a
+ * cover-derived color as the backdrop and lays `text-foreground`
+ * (near-white) over it, so a light album cover produced white-on-white.
+ * This blends the color toward black until its contrast ratio against
+ * white reaches `minContrast` (WCAG AA for normal text by default),
+ * scaling all channels together so the hue survives — the backdrop just
+ * gets deeper. Colors already dark enough come back unchanged, and an
+ * unparseable value is passed through untouched.
+ */
+export function darkenForLightText(color: string, minContrast = 4.5): string {
+  const m = color.match(/rgba?\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)/i);
+  if (!m) return color;
+  const r0 = Number(m[1]);
+  const g0 = Number(m[2]);
+  const b0 = Number(m[3]);
+  // Contrast against white (luminance 1.0): (1 + 0.05) / (L + 0.05).
+  const contrastAt = (f: number) =>
+    1.05 / (relativeLuminance(r0 * f, g0 * f, b0 * f) + 0.05);
+  if (contrastAt(1) >= minContrast) {
+    return `rgb(${r0}, ${g0}, ${b0})`;
+  }
+  // Contrast rises monotonically as the scale factor shrinks toward
+  // black, so binary-search the largest factor that still clears the
+  // bar — the least darkening that keeps the text legible.
+  let lo = 0;
+  let hi = 1;
+  for (let i = 0; i < 16; i++) {
+    const mid = (lo + hi) / 2;
+    if (contrastAt(mid) >= minContrast) lo = mid;
+    else hi = mid;
+  }
+  // Floor rather than round: the search converges on the boundary, so
+  // rounding a channel *up* could dip contrast back under the bar.
+  // Flooring only ever darkens, keeping the guarantee intact.
+  return `rgb(${Math.floor(r0 * lo)}, ${Math.floor(g0 * lo)}, ${Math.floor(b0 * lo)})`;
+}


### PR DESCRIPTION
Fixes #327.

## Problem
The full-screen Now Playing / lyrics view paints the cover's dominant color as its backdrop and lays near-white `text-foreground` over it. A light album cover (report's example: Glass Animals — "Life Itself") rendered white text on a near-white wash — unreadable.

## Fix
New `darkenForLightText(color)` helper (in `lib/utils`) blends an `rgb()` color toward black until its contrast against white clears **WCAG AA 4.5:1**, scaling all channels together so the hue survives — a warm cover stays a warm, darker tone (keeps the "the room is the album cover" mood). Colors already dark enough are returned untouched, so dark covers are unaffected. Applied to the full-screen player's background base.

Real-value examples:
- `rgb(235,225,210)` → `rgb(123,118,110)` (4.5:1)
- `rgb(200,210,230)` → `rgb(113,118,130)` (4.5:1, still blue-tinted)
- `rgb(40,55,70)` → unchanged (already 12:1)

## Verification
- Unit tests: contrast guarantee, no-op on dark colors, hue preservation, unparseable pass-through (4 tests)
- Full suite 145 passing, tsc / eslint / build clean

## Note
The contrast math is unit-tested, but I couldn't do an in-app visual of the actual lyrics view here (needs a live playback session). A quick eyeball on a light-covered track is worth it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)