### PR TITLE
Add the contributed Papirus icon (#317)

### DIFF
--- a/contrib/papirus/README.md
+++ b/contrib/papirus/README.md
@@ -1,0 +1,24 @@
+# Papirus icon
+
+A [Papirus](https://github.com/PapirusDevelopmentTeam/papirus-icon-theme)-style
+Tideway icon, contributed by [@C-O-D](https://github.com/J-M-PUNK/tideway/issues/317)
+(#317). It follows the Papirus circular base with Tideway's equalizer mark in
+the app's cyan, so it sits consistently alongside other Papirus app icons.
+
+## Using it
+
+The desktop entry ships `Icon=com.tidaldownloader.Tideway`, so the file here is
+named to match. Drop it into your Papirus theme's app-icon directory and refresh
+the icon cache, for example:
+
+```sh
+sudo cp com.tidaldownloader.Tideway.svg \
+  /usr/share/icons/Papirus/48x48/apps/
+sudo gtk-update-icon-cache /usr/share/icons/Papirus
+```
+
+Papirus resolves an SVG placed in any one size bucket across every size, so a
+single copy is enough. To keep it after Papirus updates, drop it in a personal
+theme dir (`~/.local/share/icons/…`) instead.
+
+Thanks to @C-O-D for the contribution.

--- a/contrib/papirus/com.tidaldownloader.Tideway.svg
+++ b/contrib/papirus/com.tidaldownloader.Tideway.svg
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" version="1.1">
+  <circle style="opacity:0.2" cx="12" cy="12.55" r="11"/>
+  <circle style="fill:#3f3f3f" cx="12" cy="12" r="11"/>
+  <path style="opacity:0.1;fill:#ffffff" d="M 12 1 C 5.925 1 1 5.925 1 12 C 1.002 12.107 1.006 12.214 1.012 12.321 C 1.137 6.34 6.018 1.555 12 1.55 C 17.947 1.554 22.816 6.284 22.988 12.229 C 22.993 12.153 22.997 12.076 23 12 C 23 5.925 18.075 1 12 1 Z"/>
+  <rect x="5" width="2" height="6" style="stroke-width: 1; opacity: 0.2;" rx="1" ry="1" y="9.5"/>
+  <rect x="9" y="6.5" width="2" height="12" style="stroke-width: 1; opacity: 0.2;" rx="1" ry="1"/>
+  <rect x="13" y="8" width="2" height="9" style="stroke-width: 1; opacity: 0.2;" rx="1" ry="1"/>
+  <rect x="17" y="10.5" width="2" height="4.5" style="stroke-width: 1; opacity: 0.2;" rx="1" ry="1"/>
+  <rect x="5" width="2" height="6" style="fill: rgb(22, 187, 242); stroke-width: 1;" rx="1" ry="1" y="9"/>
+  <rect x="9" y="6" width="2" height="12" style="stroke-width: 1; fill: rgb(22, 187, 242);" rx="1" ry="1"/>
+  <rect x="13" y="7.5" width="2" height="9" style="stroke-width: 1; fill: rgb(22, 187, 242);" rx="1" ry="1"/>
+  <rect x="17" y="10" width="2" height="4.5" style="stroke-width: 1; fill: rgb(22, 187, 242);" rx="1" ry="1"/>
+  <path d="M 6 9 C 6.552 9 7 9.448 7 10 L 7 10.5 C 7 9.948 6.552 9.5 6 9.5 C 5.448 9.5 5 9.948 5 10.5 L 5 10 C 5 9.448 5.448 9 6 9 Z" style="stroke-width: 1; fill: rgb(255, 255, 255); opacity: 0.2;"/>
+  <path d="M 10 6 C 10.552 6 11 6.448 11 7 L 11 7.5 C 11 6.948 10.552 6.5 10 6.5 C 9.448 6.5 9 6.948 9 7.5 L 9 7 C 9 6.448 9.448 6 10 6 Z" style="stroke-width: 1; fill: rgb(255, 255, 255); opacity: 0.2;"/>
+  <path d="M 14 7.5 C 14.552 7.5 15 7.948 15 8.5 L 15 9 C 15 8.448 14.552 8 14 8 C 13.448 8 13 8.448 13 9 L 13 8.5 C 13 7.948 13.448 7.5 14 7.5 Z" style="stroke-width: 1; fill: rgb(255, 255, 255); opacity: 0.2;"/>
+  <path d="M 18 10 C 18.552 10 19 10.448 19 11 L 19 11.5 C 19 10.948 18.552 10.5 18 10.5 C 17.448 10.5 17 10.948 17 11.5 L 17 11 C 17 10.448 17.448 10 18 10 Z" style="stroke-width: 1; fill: rgb(255, 255, 255); opacity: 0.2;"/>
+</svg>


### PR DESCRIPTION
Adds the Papirus-theme Tideway icon [@C-O-D](https://github.com/C-O-D) contributed in #317.

- Lives in `contrib/papirus/`, named `com.tidaldownloader.Tideway.svg` to match the desktop entry's `Icon=` so Papirus users can drop it straight into their theme.
- Short README with install steps + attribution.
- SVG verified: plain vector paths, no scripts / event handlers / external references.

Closes #317.

🤖 Generated with [Claude Code](https://claude.com/claude-code)