### PR TITLE
Answer a no-Range DLNA GET with 200, not 206 (Rygel 716)

### DIFF
--- a/app/audio/http_stream.py
+++ b/app/audio/http_stream.py
@@ -1092,10 +1092,17 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         Takes the isinstance-validated server so it never reaches
         through the unnarrowed self.server for the session config.
 
-        DLNA: always 206 + Content-Length + Content-Range, never
-        chunked. Strict renderers (UAPP) do a plain GET without a
-        Range header and still need Content-Length for SEEK_END during
-        decoder-init. Chunked → contentLength=-1 → seek fails.
+        DLNA: a finite Content-Length (never chunked), so strict
+        renderers (UAPP) that do a plain GET still get a length for
+        SEEK_END during decoder-init — chunked → contentLength=-1 →
+        seek fails. A 206 + Content-Range is sent only when the request
+        actually carried a Range header; a request with no Range gets a
+        plain 200. RFC 7233 forbids a 206 for a request that didn't ask
+        for a range, and Rygel's GStreamer souphttpsrc (KEF LS50 II and
+        other Rygel renderers) enforces it — the unsolicited 206 made it
+        reject the resource with UPnP 716 "Resource not found," so DLNA
+        connected but never played (#332). UAPP is unaffected: its plain
+        GET now gets 200 + the same Content-Length instead of 206.
 
         Cast: plain 200 + chunked transfer, unchanged.
         """
@@ -1105,20 +1112,29 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         self._range_start = 0
         if server.dlna:
             range_hdr = self.headers.get("Range", "")
+            has_range = range_hdr.startswith("bytes=")
             start = 0
-            if range_hdr.startswith("bytes="):
+            if has_range:
                 try:
                     start = int(range_hdr[6:].split("-")[0] or 0)
                 except ValueError:
                     start = 0
             self._range_start = start
-            self.send_response(206)
-            self.send_header(
-                "Content-Range",
-                f"bytes {start}-{_STREAM_SYNTHETIC_TOTAL - 1}/{_STREAM_SYNTHETIC_TOTAL}",
-            )
-            self.send_header("Content-Length", str(_STREAM_SYNTHETIC_TOTAL - start))
             self._chunked = False
+            if has_range:
+                self.send_response(206)
+                self.send_header(
+                    "Content-Range",
+                    f"bytes {start}-{_STREAM_SYNTHETIC_TOTAL - 1}/{_STREAM_SYNTHETIC_TOTAL}",
+                )
+                self.send_header(
+                    "Content-Length", str(_STREAM_SYNTHETIC_TOTAL - start)
+                )
+            else:
+                self.send_response(200)
+                self.send_header(
+                    "Content-Length", str(_STREAM_SYNTHETIC_TOTAL)
+                )
             self.send_header("Accept-Ranges", "bytes")
         else:
             self.send_response(200)

--- a/tests/test_http_stream.py
+++ b/tests/test_http_stream.py
@@ -539,7 +539,9 @@ class TestDlnaHttpCompliance:
     def test_query_params_do_not_404(self):
         """Hisense pulls `/dlna/stream?mediaPlayerId=1&playMode=2`.
         The handler must match on the path alone, not the raw target,
-        or the stream 404s and the device stays silent."""
+        or the stream 404s and the device stays silent. This request
+        carries no Range header, so a compliant server answers 200
+        (see test_no_range_request_is_200)."""
         server, buffer = self._seeded_server()
         try:
             data = self._request(
@@ -547,8 +549,58 @@ class TestDlnaHttpCompliance:
                 b"GET /dlna/stream?mediaPlayerId=1&playMode=2 HTTP/1.1\r\n"
                 b"Host: localhost\r\n\r\n",
             )
+            assert data.startswith(b"HTTP/1.1 200"), (
+                f"query-param URL should serve, not 404, got: {data!r}"
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()
+
+    def test_no_range_request_is_200(self):
+        """A DLNA GET without a Range header must get a plain 200 with a
+        Content-Length, not a 206 (#332). RFC 7233 forbids a 206 for a
+        request that didn't ask for a range, and Rygel's GStreamer
+        souphttpsrc (KEF LS50 II and other Rygel renderers) rejects the
+        unsolicited 206 with UPnP 716 "Resource not found." The finite
+        Content-Length is what UAPP needs for SEEK_END, and it's present
+        either way."""
+        server, buffer = self._seeded_server()
+        try:
+            data = self._request(
+                server,
+                b"GET /dlna/stream HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            )
+            assert data.startswith(b"HTTP/1.1 200"), (
+                f"no-Range GET should be 200, got: {data!r}"
+            )
+            assert b"Content-Length:" in data, (
+                f"200 still needs a Content-Length for SEEK_END, got: {data!r}"
+            )
+            assert b"206" not in data.split(b"\r\n", 1)[0], (
+                f"status line must not be 206, got: {data!r}"
+            )
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()
+
+    def test_range_request_is_206_with_content_range(self):
+        """A GET that *does* carry a Range header still gets 206 +
+        Content-Range — renderers that probe with a range rely on it."""
+        server, buffer = self._seeded_server()
+        try:
+            data = self._request(
+                server,
+                b"GET /dlna/stream HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"Range: bytes=0-\r\n\r\n",
+            )
             assert data.startswith(b"HTTP/1.1 206"), (
-                f"query-param URL should serve 206, got: {data!r}"
+                f"Range GET should be 206, got: {data!r}"
+            )
+            assert b"Content-Range: bytes 0-" in data, (
+                f"206 must carry a Content-Range, got: {data!r}"
             )
         finally:
             server.shutdown()
@@ -679,25 +731,6 @@ class TestDlnaHttpCompliance:
                 f"expected a Content-Range header, got: {data!r}"
             )
             assert b"Accept-Ranges: bytes" in data
-        finally:
-            server.shutdown()
-            server.server_close()
-            buffer.close()
-
-    def test_no_range_header_gets_206(self):
-        """A DLNA GET without a Range header still gets 206 + Content-Length
-        + Content-Range. Strict renderers (UAPP) need Content-Length on their
-        initial plain GET for SEEK_END during decoder-init."""
-        server, buffer = self._seeded_server()
-        try:
-            data = self._request(
-                server,
-                b"GET /dlna/stream HTTP/1.1\r\nHost: localhost\r\n\r\n",
-            )
-            assert data.startswith(b"HTTP/1.1 206"), (
-                f"non-Range DLNA GET should get 206, got: {data!r}"
-            )
-            assert b"Content-Range" in data
         finally:
             server.shutdown()
             server.server_close()


### PR DESCRIPTION
Candidate fix for #332 — **needs verification on real hardware before merge** (I have no Rygel device).

## Diagnosis
The DLNA stream server (`app/audio/http_stream.py`) replied **206 Partial Content to every request**, including a plain GET with no `Range` header. RFC 7233 forbids a 206 for a request that didn't ask for a range, and Rygel's GStreamer `souphttpsrc` — the renderer in the KEF LS50 Wireless II (`Rygel/0.42.5`) and other Rygel devices — enforces it: it rejects the unsolicited 206 with **UPnP 716 "Resource not found,"** so DLNA connects but never plays.

This lines up with the report that **Chromecast works on the same speaker** — Cast uses the plain-`200` path (`dlna=False`), so it never hits the non-compliant 206.

## Fix
- **No Range header** → `200 OK` + full synthetic `Content-Length` (compliant).
- **Range header present** → `206` + `Content-Range` (unchanged).

The #239 UAPP requirement was the **Content-Length for SEEK_END** during decoder-init — that is still carried on the 200, so UAPP's plain initial GET is unaffected; only the status line changes from 206 → 200.

## Verification needed
- ✅ Unit tests updated + added (`test_no_range_request_is_200`, `test_range_request_is_206_with_content_range`); `pytest tests/test_http_stream.py` = 37 passed.
- ⚠️ **Please test on the KEF (does it now play over DLNA?)** and, if possible, **re-check UAPP** (does the 200 still SEEK_END correctly?) before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)