### PR TITLE
Feature/dlna connect observability

### DIFF
--- a/app/audio/http_stream.py
+++ b/app/audio/http_stream.py
@@ -1075,7 +1075,7 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
             flush=True,
         )
 
-    def _send_stream_headers(self, server: "StreamHTTPServer") -> None:
+    def _send_stream_headers(self, server: "StreamHTTPServer", method: str) -> None:
         """Send the response line + headers shared by HEAD and GET.
 
         Takes the isinstance-validated server so it never reaches
@@ -1087,13 +1087,21 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         decoder-init. Chunked → contentLength=-1 → seek fails.
 
         Cast: plain 200 + chunked transfer, unchanged.
+
+        Logs the response shape (status + body framing + whether the
+        request carried a Range) right after the headers go out. Paired
+        with the request line from _log_connection, a connect report
+        then shows both what the renderer asked for and what we
+        answered — e.g. a 206 sent to a request with range=none is the
+        RFC 9110 §15.3.7 violation that strict renderers (Rygel) reject
+        with UPnP 716, visible in the log without a packet capture.
         """
         # Body offset the do_GET loop starts serving from. DLNA
         # parse of Range: bytes=N- updates this to N so the body
         # actually starts at N (not 0). Cast path leaves it at 0.
         self._range_start = 0
+        range_hdr = self.headers.get("Range", "")
         if server.dlna:
-            range_hdr = self.headers.get("Range", "")
             start = 0
             if range_hdr.startswith("bytes="):
                 try:
@@ -1101,7 +1109,8 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
                 except ValueError:
                     start = 0
             self._range_start = start
-            self.send_response(206)
+            status = 206
+            self.send_response(status)
             self.send_header(
                 "Content-Range",
                 f"bytes {start}-{_STREAM_SYNTHETIC_TOTAL - 1}/{_STREAM_SYNTHETIC_TOTAL}",
@@ -1109,10 +1118,13 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
             self.send_header("Content-Length", str(_STREAM_SYNTHETIC_TOTAL - start))
             self._chunked = False
             self.send_header("Accept-Ranges", "bytes")
+            body_desc = f"content-length:{_STREAM_SYNTHETIC_TOTAL - start}"
         else:
-            self.send_response(200)
+            status = 200
+            self.send_response(status)
             self.send_header("Transfer-Encoding", "chunked")
             self._chunked = True
+            body_desc = "chunked"
         self.send_header("Content-Type", server.content_type)
         if server.dlna:
             self.send_header("transferMode.dlna.org", "Streaming")
@@ -1122,6 +1134,12 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
                 )
         self.send_header("Connection", "close")
         self.end_headers()
+        print(
+            f"[http_stream] ANSWERED {method} {status} "
+            f"type={server.content_type} body={body_desc} "
+            f"range={range_hdr or 'none'} to {self.client_address[0]}",
+            flush=True,
+        )
 
     def do_HEAD(self) -> None:  # noqa: N802 - stdlib API
         # Some receivers (and plenty of middleboxes) probe headers
@@ -1136,7 +1154,7 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         if self._request_path() != server.stream_path:
             self.send_error(404, "not found")
             return
-        self._send_stream_headers(server)
+        self._send_stream_headers(server, "HEAD")
 
     def do_GET(self) -> None:  # noqa: N802 - stdlib API
         self._log_connection("GET")
@@ -1171,7 +1189,7 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         if not buf.data_ready.wait(timeout=10.0):
             self.send_error(503, "stream data not ready")
             return
-        self._send_stream_headers(server)
+        self._send_stream_headers(server, "GET")
         # Set a socket write timeout so that _write_chunk doesn't
         # block for minutes when the receiver stops reading the
         # socket (UAPP pauses reading for ~3.5 min after each seek).

--- a/app/audio/openhome.py
+++ b/app/audio/openhome.py
@@ -311,6 +311,14 @@ class OpenHomeSOAPError(RuntimeError):
     Failed, etc.). `description` is the human-readable string the
     device sent. `action` and `service_type` are echoed for log
     clarity when many calls are in flight.
+
+    `request_envelope` and `response_body` carry the raw SOAP request
+    we sent and the raw fault body the device returned. A bare UPnP
+    code rarely explains a device-specific rejection (e.g. a KEF
+    returning 716 on SetAVTransportURI); the request shows the exact
+    CurrentURI + DIDL the device refused, and the response often
+    carries a more specific errorDescription. Kept off `__str__` (which
+    stays a concise one-liner) so callers choose when to dump them.
     """
 
     def __init__(
@@ -320,11 +328,15 @@ class OpenHomeSOAPError(RuntimeError):
         *,
         action: str = "",
         service_type: str = "",
+        request_envelope: str = "",
+        response_body: str = "",
     ) -> None:
         self.code = code
         self.description = description
         self.action = action
         self.service_type = service_type
+        self.request_envelope = request_envelope
+        self.response_body = response_body
         super().__init__(
             f"UPnP {code} {description!r}"
             f"{f' on {service_type}#{action}' if service_type else ''}"
@@ -389,11 +401,18 @@ def invoke(
     fault = _parse_soap_fault(body)
     if fault is not None:
         code, description = fault
+        # Attach the request we sent + the raw fault body to the error.
+        # The numeric UPnP code alone rarely explains a device-specific
+        # rejection; the caller that treats this fault as significant
+        # (e.g. the DLNA connect path) logs the detail. Truncate the
+        # body so an oversized fault page can't bloat the exception.
         raise OpenHomeSOAPError(
             code,
             description,
             action=action_name,
             service_type=service.service_type,
+            request_envelope=envelope,
+            response_body=body[:2000],
         )
     if resp.status_code >= 400:
         raise RuntimeError(

--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -648,7 +648,7 @@ class PCMPlayer:
                                 prefetched=None,
                                 metadata=self._current_track_meta,
                             )
-                        except (ValueError, RuntimeError, OSError) as exc:
+                        except Exception as exc:  # noqa: BLE001 - passthrough is optional
                             print(
                                 f"[player] upnp start_passthrough failed "
                                 f"(Path 0): {exc!r}",
@@ -853,7 +853,7 @@ class PCMPlayer:
                             prefetched=prefetched_bytes,
                             metadata=self._current_track_meta,
                         )
-                except (ValueError, RuntimeError, OSError) as exc:
+                except Exception as exc:  # noqa: BLE001 - passthrough is optional
                     print(
                         f"[player] upnp start_passthrough failed "
                         f"(Path B): {exc!r}",
@@ -1349,7 +1349,7 @@ class PCMPlayer:
                         prefetched=prefetched_bytes,
                         metadata=self._current_track_meta,
                     )
-            except (ValueError, RuntimeError, OSError) as exc:
+            except Exception as exc:  # noqa: BLE001 - passthrough is optional
                 print(
                     f"[player] upnp start_passthrough failed: {exc!r}",
                     flush=True,
@@ -3263,7 +3263,7 @@ class PCMPlayer:
                     prefetched=None,
                     metadata=self._current_track_meta,
                 )
-            except (ValueError, RuntimeError, OSError) as exc:
+            except Exception as exc:  # noqa: BLE001 - passthrough is optional
                 print(
                     f"[player] upnp start_passthrough failed "
                     f"(adopt_preload): {exc!r}",
@@ -3995,7 +3995,7 @@ class PCMPlayer:
                             prefetched=None,
                             metadata=self._current_track_meta,
                         )
-                    except (ValueError, RuntimeError, OSError) as exc:
+                    except Exception as exc:  # noqa: BLE001 - passthrough is optional
                         print(
                             f"[player] upnp start_passthrough failed "
                             f"(bridge): {exc!r}",

--- a/app/audio/upnp.py
+++ b/app/audio/upnp.py
@@ -73,6 +73,7 @@ from app.audio.http_stream import (
 )
 from app.audio.openhome import (
     OpenHomeDevice,
+    OpenHomeSOAPError,
     TrackMetadata,
     build_didl_lite,
     fetch_device,
@@ -518,7 +519,7 @@ class UpnpManager:
     # ---- passthrough -----------------------------------------------
 
     def start_passthrough(
-        self, source, prefetched=None, metadata=None
+        self, source, prefetched=None, metadata=None,
     ) -> None:
         """Start bit-perfect FLAC passthrough for the current track.
 
@@ -611,20 +612,26 @@ class UpnpManager:
             )
             session.passthrough_encoder.start()
 
-        # Notify the renderer of the new track. Falls back to the
-        # metadata provider callback if no metadata dict was passed.
+        # Resolve metadata for the renderer notify below, falling back
+        # to the metadata provider callback if no dict was passed.
         if metadata is None and self._metadata_provider is not None:
             try:
                 metadata = self._metadata_provider()
             except Exception as exc:
                 print(f"[upnp] metadata provider raised: {exc!r}", flush=True)
-        if metadata:
-            self._notify_track_change(metadata, session, track_ts=_track_ts)
-
+        # Passthrough (the encoder -> ring-buffer pipeline) is on as
+        # soon as the encoder starts; the device notify below is a
+        # separate step, so log it here before the notify can raise.
         print(
             "[upnp] passthrough ON -- bitperfect FLAC passthrough enabled",
             flush=True,
         )
+        # Notify the renderer. _notify_track_change raises on failure;
+        # the caller decides how bad that is. connect() (initial notify)
+        # lets it propagate and tears the session down; mid-session
+        # callers in player.py catch and keep the existing stream going.
+        if metadata:
+            self._notify_track_change(metadata, session, track_ts=_track_ts)
 
     # ---- track-change notification ----------------------------------
 
@@ -634,6 +641,15 @@ class UpnpManager:
         """Send SetAVTransportURI + Play to the renderer so it updates
         its now-playing display and initiates a fresh HTTP GET for the
         new track's FLAC stream.
+
+        Raises on failure (an OpenHomeSOAPError if the device rejected
+        the action, or the underlying transport error otherwise). The
+        caller owns the policy, because whether a failed notify is fatal
+        depends on the context, not the exception: connect() treats a
+        rejected initial notify as fatal and tears the session down (a
+        Rygel renderer returning UPnP 716 must not report a false
+        "connected"); a mid-session track change treats it as
+        best-effort and keeps the existing stream flowing.
 
         Without this, the renderer keeps showing the previous track's
         name and its decoder may not re-parse the new STREAMINFO header
@@ -681,10 +697,20 @@ class UpnpManager:
                 flush=True,
             )
         except Exception as exc:
+            # Surface the SOAP fault detail the device sent (the request
+            # it refused + its raw fault body), which the numeric UPnP
+            # code alone doesn't explain, then let the caller decide.
+            detail = ""
+            if isinstance(exc, OpenHomeSOAPError) and exc.request_envelope:
+                detail = (
+                    f"\n  request: {exc.request_envelope}"
+                    f"\n  response: {exc.response_body}"
+                )
             print(
-                f"[upnp] track change notification failed: {exc!r}",
+                f"[upnp] track change notification failed: {exc!r}{detail}",
                 flush=True,
             )
+            raise
 
     def signal_source_done(self) -> None:
         """Signal that the current track's source has reached EOF.
@@ -824,37 +850,38 @@ class UpnpManager:
         # If a track is already loaded, start passthrough before play()
         # so the FLAC header is in the ring buffer when the renderer's
         # first GET arrives. Reduces the race to zero in the common case.
-        _notified = False
+        # A source-provider failure only costs us the header pre-roll;
+        # fall back to the placeholder SetAVTransportURI below rather
+        # than failing the connect over it.
+        urls = None
         if self._source_provider is not None:
             try:
-                urls = self._source_provider()
-                if urls and isinstance(urls, list):
-                    self.start_passthrough(urls)
-                    _notified = True
+                _u = self._source_provider()
+                if _u and isinstance(_u, list):
+                    urls = _u
             except (ValueError, RuntimeError, OSError) as exc:
                 log.debug("upnp: source provider raised: %r", exc)
 
         try:
-            if not _notified:
+            if urls is not None:
+                # Passthrough path: the initial SetAVTransportURI + Play
+                # happens inside start_passthrough -> _notify_track_change,
+                # which raises on failure. A rejected URI (e.g. a Rygel
+                # renderer returning UPnP 716) therefore propagates here
+                # and tears down, instead of a false "connected" with no
+                # audio.
+                self.start_passthrough(urls)
+            else:
                 av.set_av_transport_uri(session.stream_url, didl)
                 av.play()
                 session.media_loaded = True
         except Exception as exc:
-            # Undo the early session registration
-            with self._session_lock:
-                self._session = None
-            # Tear down the HTTP server we just stood up; otherwise
-            # we leak a port until the manager's process exits.
-            try:
-                if session.http_server is not None:
-                    session.http_server.shutdown()
-                    session.http_server.server_close()
-            except Exception:
-                pass
-            try:
-                session.buffer.close()
-            except Exception:
-                pass
+            # Full teardown: disconnect() stops the passthrough encoder
+            # start_passthrough may have started, closes the buffer and
+            # HTTP server, Stops the device, and un-silences local
+            # audio. Then surface the failure so the UI shows an error
+            # rather than a dead "connected" session.
+            self.disconnect()
             raise RuntimeError(
                 f"AVTransport handshake to {device.name} failed: {exc}"
             ) from exc

--- a/tests/test_openhome_soap.py
+++ b/tests/test_openhome_soap.py
@@ -346,6 +346,19 @@ class TestInvoke:
         assert exc.value.action == "Insert"
         assert "Playlist:1" in exc.value.service_type
 
+    def test_fault_error_carries_request_and_response(self, monkeypatch):
+        """On a fault, the error carries the SOAP request we sent and
+        the raw fault body, so a caller (the DLNA connect path) can log
+        exactly what the device refused instead of a bare UPnP code."""
+        _mock_post(monkeypatch, body=FAULT_RESPONSE_402, status_code=500)
+        svc = _service()
+        with pytest.raises(OpenHomeSOAPError) as exc:
+            invoke(svc, "Insert", {"AfterId": "abc"})
+        # The request envelope we POSTed (contains the action name).
+        assert "Insert" in exc.value.request_envelope
+        # The raw fault body the device returned.
+        assert "402" in exc.value.response_body
+
     def test_fault_response_with_200_status_still_raises(self, monkeypatch):
         """A few OpenHome firmwares answer with HTTP 200 even on
         UPnP faults. The body shape is what matters; status code

--- a/tests/test_upnp_session.py
+++ b/tests/test_upnp_session.py
@@ -24,7 +24,11 @@ import numpy as np
 import pytest
 import requests
 
-from app.audio.openhome import OpenHomeDevice, OpenHomeService
+from app.audio.openhome import (
+    OpenHomeDevice,
+    OpenHomeService,
+    OpenHomeSOAPError,
+)
 from app.audio.upnp import (
     UpnpDevice,
     UpnpManager,
@@ -423,6 +427,91 @@ class TestConnect:
         assert mock_http_server.shutdown.called
         assert mock_http_server.server_close.called
         # No session should be left dangling.
+        assert mgr._session is None
+
+    def test_notify_track_change_raises_on_fault(self):
+        """_notify_track_change has one contract: it raises on failure,
+        and the caller owns the policy (connect() = fatal, mid-session
+        = best-effort). The raised OpenHomeSOAPError carries the SOAP
+        request + raw fault body so the caller can log what the device
+        actually refused."""
+        mgr = UpnpManager()
+        session = MagicMock()
+        session.stream_url = "http://192.168.1.10:54321/dlna/stream"
+        session.av.set_av_transport_uri.side_effect = OpenHomeSOAPError(
+            716,
+            "Resource not found",
+            action="SetAVTransportURI",
+            service_type="urn:schemas-upnp-org:service:AVTransport:2",
+            request_envelope="<s:Envelope>...CurrentURI...</s:Envelope>",
+            response_body="<UPnPError><errorCode>716</errorCode></UPnPError>",
+        )
+        meta = {"title": "T", "artist": "A", "album": "Al", "duration_s": 1}
+
+        with pytest.raises(OpenHomeSOAPError) as excinfo:
+            mgr._notify_track_change(meta, session)
+        # Play is never attempted once SetAVTransportURI failed.
+        session.av.play.assert_not_called()
+        # The fault detail rides along for the caller to log.
+        assert "CurrentURI" in excinfo.value.request_envelope
+        assert "716" in excinfo.value.response_body
+
+    def test_connect_passthrough_reject_tears_down(
+        self, mock_soap, mock_http_server, monkeypatch,
+    ):
+        """When a track is already loaded, connect() goes through the
+        passthrough path and the initial SetAVTransportURI happens
+        inside start_passthrough. If the device rejects it (716), that
+        failure must propagate: connect tears the session down and
+        raises, instead of the old swallowed-fault false 'connected'
+        with no audio."""
+        mgr = UpnpManager()
+        device = _device_record()
+        mgr._devices = {device.id: device}
+        monkeypatch.setattr(
+            "app.audio.upnp.fetch_device",
+            lambda location, **_kw: _openhome_device(),
+        )
+
+        # A loaded track drives the passthrough path. Stub the encoder
+        # + segment reader so no real network/thread work happens; we
+        # only care about the SOAP handshake outcome.
+        class _StubEncoder:
+            def __init__(self, *a, **k):
+                pass
+
+            def start(self):
+                pass
+
+            def close(self):
+                pass
+
+        class _StubReader:
+            def __init__(self, *a, **k):
+                pass
+
+        monkeypatch.setattr(
+            "app.audio.upnp.FlacPassthroughEncoder", _StubEncoder
+        )
+        monkeypatch.setattr(
+            "app.audio.segment_reader.SegmentReader", _StubReader
+        )
+        mgr.set_source_provider(lambda: ["http://192.168.1.9/seg0"])
+        mgr.set_metadata_provider(lambda: {"title": "T", "artist": "A"})
+
+        # Every SOAP call raises -> the passthrough SetAVTransportURI
+        # fails like a 716-rejecting renderer.
+        def _raising_post(*args, **kwargs):
+            raise RuntimeError("simulated 716 rejection")
+
+        monkeypatch.setattr(requests, "post", _raising_post)
+
+        with pytest.raises(RuntimeError):
+            mgr.connect(device.id)
+
+        # Torn down, not left as a phantom 'connected' session.
+        assert mock_http_server.shutdown.called
+        assert mock_http_server.server_close.called
         assert mgr._session is None
 
 


### PR DESCRIPTION
## Summary
Adds log o11y for better debugging of DLNA errors.
Fixes an issue where the exception structure can cause a DLNA error to wedge playback.

## Related issues
Refs #332

## Pre-PR checklist
- [x] Branch name follows `fix/<slug>` / `feature/<slug>` / `chore/<slug>`
- [x] `pytest tests/` passes locally
- [x] `cd web && npx tsc -b --noEmit` passes locally
- [x] `cd web && npm run lint:all` passes locally (no NEW errors; the existing baseline of 50-ish warnings is fine)
- [x] `cd web && npm test` passes locally
- [x] Commit messages are imperative, under 70 chars, with no AI attribution
