### PR TITLE
Serve Rygel/GStreamer renderers a chunked stream, not a bare 206

### DIFF
--- a/app/audio/http_stream.py
+++ b/app/audio/http_stream.py
@@ -72,6 +72,31 @@ DLNA_CONTENT_FEATURES = (
 # technique squeeze2upnp uses for renderers that reject an open range.
 _STREAM_SYNTHETIC_TOTAL = 1 << 40
 
+# Renderers whose HTTP client rejects a 206 sent to a request that
+# carried no Range header. Per RFC 9110 15.3.7 a 206 answers a *range*
+# request; a strict renderer treats an unsolicited 206 as malformed. A
+# Rygel/GStreamer renderer (e.g. KEF LS50 Wireless II firmware) rejects
+# our open-ended 206 + synthetic Content-Length with UPnP 716 at
+# SetAVTransportURI -> connected but silent. Observed User-Agents from
+# one such device: the SetAVTransportURI-time probe is a HEAD as
+# "Rygel/0.42.5 DLNADOC/1.50 UPnP/1.0"; the stream pull is a GET as
+# "GStreamer souphttpsrc 1.22.12 libsoup/2.74.3". Match either token
+# (and souphttpsrc) case-insensitively. These renderers play a plain
+# 200 + chunked stream (the same shape Cast uses) end-to-end. UAPP
+# (OkHttp) and TV firmwares don't carry these tokens, so their
+# 206 + Content-Length response -- which they need for SEEK_END during
+# decoder init (#234/#239) -- is unchanged.
+_CHUNKED_ON_BARE_GET_UA_TOKENS = ("rygel", "gstreamer", "souphttpsrc")
+
+
+def _renderer_rejects_bare_206(user_agent: str) -> bool:
+    """True if the renderer's User-Agent marks it as one that rejects a
+    206 response to a request without a Range header (Rygel/GStreamer).
+    """
+    ua = (user_agent or "").lower()
+    return any(token in ua for token in _CHUNKED_ON_BARE_GET_UA_TOKENS)
+
+
 # Upper bound on how long attach() waits for the outgoing consumer to
 # serve its first chunk before superseding it. Returns the instant that
 # chunk is served, so this cap only bites when the encoder hasn't
@@ -1081,10 +1106,18 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         Takes the isinstance-validated server so it never reaches
         through the unnarrowed self.server for the session config.
 
-        DLNA: always 206 + Content-Length + Content-Range, never
+        DLNA default: 206 + Content-Length + Content-Range, never
         chunked. Strict renderers (UAPP) do a plain GET without a
         Range header and still need Content-Length for SEEK_END during
         decoder-init. Chunked → contentLength=-1 → seek fails.
+
+        DLNA Rygel/GStreamer quirk: those renderers reject a 206 sent
+        to a request without a Range header (UPnP 716 at
+        SetAVTransportURI → connected but silent). When the User-Agent
+        marks such a renderer and no Range was sent, answer 200 +
+        chunked instead (see _renderer_rejects_bare_206). An explicit
+        Range still gets a conformant 206 from the offset for every
+        renderer.
 
         Cast: plain 200 + chunked transfer, unchanged.
         """
@@ -1094,21 +1127,33 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         self._range_start = 0
         if server.dlna:
             range_hdr = self.headers.get("Range", "")
+            has_range = range_hdr.startswith("bytes=")
             start = 0
-            if range_hdr.startswith("bytes="):
+            if has_range:
                 try:
                     start = int(range_hdr[6:].split("-")[0] or 0)
                 except ValueError:
                     start = 0
             self._range_start = start
-            self.send_response(206)
-            self.send_header(
-                "Content-Range",
-                f"bytes {start}-{_STREAM_SYNTHETIC_TOTAL - 1}/{_STREAM_SYNTHETIC_TOTAL}",
-            )
-            self.send_header("Content-Length", str(_STREAM_SYNTHETIC_TOTAL - start))
-            self._chunked = False
-            self.send_header("Accept-Ranges", "bytes")
+            if not has_range and _renderer_rejects_bare_206(
+                self.headers.get("User-Agent", "")
+            ):
+                # Rygel/GStreamer plain GET: 200 + chunked, the only
+                # shape this renderer class plays end-to-end.
+                self.send_response(200)
+                self.send_header("Transfer-Encoding", "chunked")
+                self._chunked = True
+            else:
+                # Default (UAPP/TVs) or any explicit Range: 206 with a
+                # Content-Length the renderer can seek against.
+                self.send_response(206)
+                self.send_header(
+                    "Content-Range",
+                    f"bytes {start}-{_STREAM_SYNTHETIC_TOTAL - 1}/{_STREAM_SYNTHETIC_TOTAL}",
+                )
+                self.send_header("Content-Length", str(_STREAM_SYNTHETIC_TOTAL - start))
+                self._chunked = False
+                self.send_header("Accept-Ranges", "bytes")
         else:
             self.send_response(200)
             self.send_header("Transfer-Encoding", "chunked")

--- a/tests/test_http_stream.py
+++ b/tests/test_http_stream.py
@@ -24,6 +24,7 @@ from app.audio.http_stream import (
     RingBuffer,
     _StreamRequestHandler,
     _build_flac_stream_header,
+    _renderer_rejects_bare_206,
     primary_lan_ip,
     start_stream_http_server,
 )
@@ -735,3 +736,137 @@ class TestDlnaHttpCompliance:
             server.shutdown()
             server.server_close()
             buffer.close()
+
+    # -- Renderer-profile matrix -------------------------------------
+    # A Rygel/GStreamer renderer (e.g. KEF LS50 Wireless II) rejects a
+    # 206 sent to a request with no Range header (UPnP 716 at
+    # SetAVTransportURI -> connected but silent). For those User-Agents
+    # a no-Range request must get 200 + chunked instead. UAPP/TVs and
+    # explicit Range requests are unchanged (206 + Content-Length).
+    # Observed UAs: the SetAVTransportURI-time probe is a Rygel HEAD;
+    # the stream pull is a GStreamer souphttpsrc GET.
+    _RYGEL_UA = b"Rygel/0.42.5 DLNADOC/1.50 UPnP/1.0"
+    _GSTREAMER_UA = b"GStreamer souphttpsrc 1.22.12 libsoup/2.74.3"
+
+    def test_rygel_head_probe_no_range_gets_200_chunked(self):
+        """Rygel HEAD-probes the URL while processing
+        SetAVTransportURI. A 206 to that no-Range probe is what it
+        rejects with 716, so it must see a 200 + chunked instead."""
+        server, buffer = self._seeded_server()
+        try:
+            data = self._request(
+                server,
+                b"HEAD /dlna/stream HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"User-Agent: " + self._RYGEL_UA + b"\r\n\r\n",
+            )
+            assert data.startswith(b"HTTP/1.1 200"), (
+                f"Rygel no-Range probe should get 200, got: {data!r}"
+            )
+            assert b"Transfer-Encoding: chunked" in data, (
+                f"expected chunked framing, got: {data!r}"
+            )
+            assert b"HTTP/1.1 206" not in data
+            assert b"Content-Range" not in data
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()
+
+    def test_gstreamer_plain_get_no_range_gets_200_chunked(self):
+        """The stream pull is a GStreamer souphttpsrc GET. A plain GET
+        (no Range) must get 200 + chunked -- the only shape this
+        renderer class plays end-to-end."""
+        server, buffer = self._seeded_server()
+        try:
+            data = self._request(
+                server,
+                b"GET /dlna/stream HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"User-Agent: " + self._GSTREAMER_UA + b"\r\n\r\n",
+            )
+            assert data.startswith(b"HTTP/1.1 200"), (
+                f"GStreamer plain GET should get 200, got: {data!r}"
+            )
+            assert b"Transfer-Encoding: chunked" in data
+            assert b"Content-Range" not in data
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()
+
+    def test_rygel_class_range_request_still_gets_206(self):
+        """An explicit Range is a conformant range request: every
+        renderer, Rygel included, gets a 206 from the offset. The quirk
+        only diverts the no-Range case."""
+        server, buffer = self._seeded_server()
+        try:
+            data = self._request(
+                server,
+                b"GET /dlna/stream HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"User-Agent: " + self._GSTREAMER_UA + b"\r\n"
+                b"Range: bytes=0-\r\n\r\n",
+            )
+            assert data.startswith(b"HTTP/1.1 206"), (
+                f"Range request should get 206 even from Rygel, got: {data!r}"
+            )
+            assert b"Content-Range: bytes 0-" in data
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()
+
+    def test_uapp_style_no_range_stays_206_with_content_length(self):
+        """A non-Rygel renderer (UAPP is OkHttp) sending a plain GET is
+        unchanged: 206 + Content-Length, which it needs for SEEK_END
+        during decoder-init. Guards against regressing #234/#239."""
+        server, buffer = self._seeded_server()
+        try:
+            data = self._request(
+                server,
+                b"GET /dlna/stream HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"User-Agent: okhttp/4.9.3\r\n\r\n",
+            )
+            assert data.startswith(b"HTTP/1.1 206"), (
+                f"non-Rygel plain GET should stay 206, got: {data!r}"
+            )
+            assert b"Content-Length: " in data
+            assert b"Transfer-Encoding: chunked" not in data
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()
+
+    def test_rygel_ua_on_cast_session_unaffected(self):
+        """The quirk is DLNA-scoped. A Cast session (dlna=False) that
+        happens to carry a Rygel-class UA must still get a plain 200 +
+        chunked with no DLNA/range headers."""
+        server, buffer = self._seeded_server(dlna=False)
+        try:
+            data = self._request(
+                server,
+                b"GET /dlna/stream HTTP/1.1\r\n"
+                b"Host: localhost\r\n"
+                b"User-Agent: " + self._GSTREAMER_UA + b"\r\n\r\n",
+            )
+            assert data.startswith(b"HTTP/1.1 200")
+            assert b"Content-Range" not in data
+            assert b"contentFeatures.dlna.org" not in data
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()
+
+    def test_renderer_rejects_bare_206_token_match(self):
+        """Pin the User-Agent tokens the quirk keys on."""
+        assert _renderer_rejects_bare_206("Rygel/0.42.5 DLNADOC/1.50 UPnP/1.0")
+        assert _renderer_rejects_bare_206(
+            "GStreamer souphttpsrc 1.22.12 libsoup/2.74.3"
+        )
+        assert _renderer_rejects_bare_206("rygel/1.0")  # case-insensitive
+        # UAPP (OkHttp), Hisense, empty, and unknown UAs are unaffected.
+        assert not _renderer_rejects_bare_206("okhttp/4.9.3")
+        assert not _renderer_rejects_bare_206("")
+        assert not _renderer_rejects_bare_206("Some Random TV Firmware/2.0")


### PR DESCRIPTION
## Summary
Devices using Rygel-based firmware don't accept audio over DLNA with the same sequence of requests that UAPP does. Forcing us to use UA detection to tweak the response and headers to make both systems happy.

## Details
The DLNA stream answers every request with 206 + a synthetic Content-Length, including plain GETs with no Range. Per RFC 9110 15.3.7 a 206 answers a range request, so a strict renderer rejects the unsolicited 206: a Rygel/GStreamer renderer (KEF LS50 Wireless II firmware) returns UPnP 716 at SetAVTransportURI and stays silent while the UI shows "connected".

No single response plays on every renderer -- UAPP and some TVs need the Content-Length for SEEK_END during decoder init (#234 / #239), while Rygel needs a plain 200 and wedges on 206 or 200+Content-Length. So key the response on the renderer, the same device-profile approach MiniDLNA/Serviio/UMS use: when the User-Agent marks a Rygel/GStreamer client and the request carried no Range, answer 200 + chunked (the shape Cast already uses); everything else -- UAPP, TVs, and any explicit Range request -- is unchanged.

## Test plan
- Connect over DLNA to any Rygel-based firmware (the KEF LS50 series recently updated to use it).
- You actually get audio (or not if the bug isn't fixed).
- Do the same with UAPP hardware
  (I haven't been able to test it locally yet, but the change is limited by UA to affect only these devices)

## Related issues
Closes #332

## Pre-PR checklist
- [x] Branch name follows `fix/<slug>` / `feature/<slug>` / `chore/<slug>`
- [x] `pytest tests/` passes locally
- [x] `cd web && npx tsc -b --noEmit` passes locally
- [x] `cd web && npm run lint:all` passes locally (no NEW errors; the existing baseline of 50-ish warnings is fine)
- [x] `cd web && npm test` passes locally
- [x] Commit messages are imperative, under 70 chars, with no AI attribution
- [x] If this PR adds a `Settings` field, the matching `SettingsPayload` (server.py) and `Settings` interface (web/src/api/types.ts) entries are also added (see CONTRIBUTING.md)
