### PR TITLE
Apply macOS window chrome tint on the main thread

### DIFF
--- a/app/window_chrome.py
+++ b/app/window_chrome.py
@@ -120,6 +120,44 @@ def get_theme() -> str:
 
 
 # ---------------------------------------------------------------------------
+# Main-thread marshaling
+#
+# AppKit is strict: mutating NSWindow / NSView state (setAppearance_,
+# setStyleMask_, setBackgroundColor_, …) off the main thread trips an
+# assertion that SIGTRAPs the whole process ("Must only be used from
+# the main thread"). set_theme() is driven by the sync
+# /api/_internal/window-theme FastAPI handler, which Starlette runs on
+# an anyio worker thread — so the apply path has to hop back onto the
+# main run loop before it touches any Cocoa object. desktop.py already
+# uses the same AppHelper.callAfter idiom to marshal window.show() from
+# its login poller.
+# ---------------------------------------------------------------------------
+def _on_main_thread() -> bool:
+    """True on the AppKit main thread, or on any non-macOS platform
+    where the constraint doesn't apply. Fails safe to True so a
+    Foundation import problem degrades to the old direct-call behavior
+    rather than silently dropping the apply."""
+    if sys.platform != "darwin":
+        return True
+    try:
+        from Foundation import NSThread  # type: ignore
+
+        return bool(NSThread.isMainThread())
+    except Exception:
+        return True
+
+
+def _dispatch_to_main(fn) -> None:
+    """Schedule fn() on the main run loop. Async (waitUntilDone=NO):
+    the theme endpoint doesn't need the apply to have finished before
+    it responds, and not blocking the worker thread rules out any
+    worker↔main deadlock."""
+    from PyObjCTools import AppHelper  # type: ignore
+
+    AppHelper.callAfter(fn)
+
+
+# ---------------------------------------------------------------------------
 # macOS
 # ---------------------------------------------------------------------------
 
@@ -158,6 +196,14 @@ def reapply_macos_chrome() -> None:
 
 
 def _apply_macos(nswindow: object, theme: str) -> None:
+    # Every Cocoa call below must run on the main thread. When we're on
+    # a worker thread (the theme endpoint runs on anyio's pool),
+    # re-enter through the main run loop instead of touching AppKit
+    # here. Checked before the AppKit import so the hop happens even for
+    # callers that arrive off-thread.
+    if not _on_main_thread():
+        _dispatch_to_main(lambda: _apply_macos(nswindow, theme))
+        return
     try:
         import AppKit  # type: ignore
     except Exception:

--- a/tests/test_window_chrome.py
+++ b/tests/test_window_chrome.py
@@ -66,6 +66,66 @@ def test_resolve_color_falls_back_to_dark_for_unknown():
     assert window_chrome._resolve_color("vaporwave") == (5, 5, 5)
 
 
+# ---------------------------------------------------------------------------
+# Main-thread marshaling
+#
+# Regression guard for the v1.25.2 SIGTRAP: the /api/_internal/window-
+# theme endpoint is a sync FastAPI handler, so Starlette runs it on an
+# anyio worker thread. _apply_macos() touching NSWindow state from
+# there trips AppKit's "Must only be used from the main thread"
+# assertion and crashes the process. _apply_macos must hop onto the
+# main run loop instead. The check lives before the AppKit import, so
+# monkeypatching the two seams exercises it on any platform.
+# ---------------------------------------------------------------------------
+
+
+def test_apply_macos_marshals_when_off_main_thread(monkeypatch):
+    """Off the main thread, _apply_macos must defer to the main run
+    loop and must NOT touch any Cocoa object inline (the crash path)."""
+    dispatched = []
+    monkeypatch.setattr(window_chrome, "_on_main_thread", lambda: False)
+    monkeypatch.setattr(
+        window_chrome, "_dispatch_to_main", lambda fn: dispatched.append(fn)
+    )
+
+    # A bare object() would explode if the body ran (it has no
+    # styleMask()/setAppearance_), so "doesn't raise" also proves the
+    # AppKit work was skipped.
+    window_chrome._apply_macos(object(), "dark")
+
+    assert len(dispatched) == 1, (
+        "off-main-thread apply must be marshaled to the main run loop, "
+        "not executed inline"
+    )
+    assert callable(dispatched[0])
+
+
+def test_apply_macos_does_not_redispatch_on_main_thread(monkeypatch):
+    """On the main thread the apply proceeds inline (no marshaling).
+    Off darwin the AppKit import then fails and it returns cleanly;
+    the point of this test is that _dispatch_to_main is never called,
+    so we don't ping-pong callables onto the run loop forever."""
+    dispatched = []
+    monkeypatch.setattr(window_chrome, "_on_main_thread", lambda: True)
+    monkeypatch.setattr(
+        window_chrome, "_dispatch_to_main", lambda fn: dispatched.append(fn)
+    )
+
+    window_chrome._apply_macos(object(), "dark")
+
+    assert dispatched == [], "main-thread apply must not re-marshal"
+
+
+def test_on_main_thread_true_off_platform():
+    """On non-macOS the concept doesn't apply, so the guard must report
+    True and let the (no-op) apply proceed without importing Foundation."""
+    import sys
+
+    if sys.platform == "darwin":
+        return
+    assert window_chrome._on_main_thread() is True
+
+
 def test_register_macos_nswindow_no_op_off_platform():
     """Calling the macOS register from a non-darwin process must
     not append to the tracking list. The cross-platform set_theme


### PR DESCRIPTION
## Summary
AFAICT, this happens reliably when I build and run the full native app bundle on MacOS. I'm not yet certain why it's not happening in the actual release, but I can reproduce it reliably on a local build.

The packaged macOS app crashes with `EXC_BREAKPOINT` (SIGTRAP) — `Must only be used from the main thread` — on every window-chrome retint (e.g. flipping the theme).

`/api/_internal/window-theme` is a sync FastAPI handler, so Starlette dispatches it on an anyio worker thread. From there `set_theme()` → `_apply_macos()` mutates `NSWindow` state (`setAppearance_`, `setStyleMask_`,  setBackgroundColor_`), which trips AppKit's main-thread assertion and kills the process. The crash stack shows the
worker thread (`context_run` → `partial_call` → `thread_run`) calling `setAppearance:` through pyobjc.

The fix marshals the apply onto the main run loop via `AppHelper.callAfter` when it's invoked off-thread — the same idiom `desktop.py` already uses to hop `window.show()` onto the main thread. The main-thread check sits *before* the AppKit import behind two small seams (`_on_main_thread` / `_dispatch_to_main`) so it stays unit-testable off-darwin. Main-thread callers are unchanged. No PyInstaller spec change is needed — `PyObjCTools.AppHelper` is already bundled via `desktop.py`.

## Test plan
- `pytest tests/test_window_chrome.py` — 14 passed, including 3 new regression tests pinning the off-thread → main-thread marshaling contract (off-thread defers and touches no Cocoa; main-thread does not re-dispatch; guard reports True off-platform).
- Rebuilt the macOS `.app` and flipped the theme repeatedly: titlebar retints smoothly, no crash. DLNA playback verified in the same build.
