### PR TITLE
Show recent searches on the empty search page

### DIFF
--- a/web/src/hooks/useSearchHistory.test.tsx
+++ b/web/src/hooks/useSearchHistory.test.tsx
@@ -1,0 +1,214 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import {
+  MAX_HISTORY,
+  addToHistory,
+  useSearchHistory,
+} from "./useSearchHistory";
+
+// React nags when act() is used without this flag on the global.
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+/**
+ * The list transform carries all the behavior worth pinning: what
+ * counts as a duplicate, which entries the typing stems are allowed to
+ * eat, and where the cap bites. It's pure, so it tests without a DOM.
+ */
+describe("addToHistory", () => {
+  it("puts the newest query first", () => {
+    expect(addToHistory(["b"], "a")).toEqual(["a", "b"]);
+  });
+
+  it("trims whitespace off the stored entry", () => {
+    expect(addToHistory([], "  daft punk  ")).toEqual(["daft punk"]);
+  });
+
+  it("ignores an empty or whitespace-only query", () => {
+    expect(addToHistory(["a"], "")).toEqual(["a"]);
+    expect(addToHistory(["a"], "   ")).toEqual(["a"]);
+  });
+
+  it("moves a repeated query back to the top instead of duplicating", () => {
+    expect(addToHistory(["a", "b", "c"], "c")).toEqual(["c", "a", "b"]);
+  });
+
+  it("treats a differently-cased repeat as the same query", () => {
+    expect(addToHistory(["Daft Punk"], "daft punk")).toEqual(["daft punk"]);
+  });
+
+  it("swallows the stems a query was typed through", () => {
+    // What the debounce actually produces when someone pauses twice on
+    // the way to a full query.
+    let h: string[] = [];
+    h = addToHistory(h, "daft");
+    h = addToHistory(h, "daft pu");
+    h = addToHistory(h, "daft punk");
+    expect(h).toEqual(["daft punk"]);
+  });
+
+  it("leaves an older unrelated prefix alone", () => {
+    // "radiohead" was a real search from a while back, not a stem of
+    // today's query, so it survives — stems are only ever consecutive.
+    const h = addToHistory(["nirvana", "radiohead"], "radiohead in rainbows");
+    expect(h).toEqual(["radiohead in rainbows", "nirvana", "radiohead"]);
+  });
+
+  it("does not treat an unrelated query as a stem", () => {
+    expect(addToHistory(["daft punk"], "justice")).toEqual([
+      "justice",
+      "daft punk",
+    ]);
+  });
+
+  it("caps the list", () => {
+    const full = Array.from({ length: MAX_HISTORY }, (_, i) => `q${i}`);
+    const next = addToHistory(full, "newest");
+    expect(next).toHaveLength(MAX_HISTORY);
+    expect(next[0]).toBe("newest");
+    expect(next).not.toContain(`q${MAX_HISTORY - 1}`);
+  });
+});
+
+/**
+ * The hook's own job is persistence: read what the last session left
+ * behind, write every change straight back.
+ */
+describe("useSearchHistory", () => {
+  const KEY = "tideway:search-history";
+
+  let container: HTMLDivElement;
+  let root: Root;
+  let latest: ReturnType<typeof useSearchHistory>;
+
+  function Probe() {
+    latest = useSearchHistory();
+    return null;
+  }
+
+  function mount() {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => root.render(<Probe />));
+  }
+
+  beforeEach(() => localStorage.clear());
+
+  afterEach(() => {
+    act(() => root.unmount());
+    container.remove();
+    localStorage.clear();
+  });
+
+  it("loads what the previous session stored", () => {
+    localStorage.setItem(KEY, JSON.stringify(["daft punk", "justice"]));
+    mount();
+    expect(latest.history).toEqual(["daft punk", "justice"]);
+  });
+
+  it("persists a recorded query", () => {
+    mount();
+    act(() => latest.record("boards of canada"));
+    expect(latest.history).toEqual(["boards of canada"]);
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual([
+      "boards of canada",
+    ]);
+  });
+
+  it("persists a removal", () => {
+    localStorage.setItem(KEY, JSON.stringify(["a", "b"]));
+    mount();
+    act(() => latest.remove("a"));
+    expect(latest.history).toEqual(["b"]);
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual(["b"]);
+  });
+
+  it("persists a clear", () => {
+    localStorage.setItem(KEY, JSON.stringify(["a", "b"]));
+    mount();
+    act(() => latest.clear());
+    expect(latest.history).toEqual([]);
+    expect(JSON.parse(localStorage.getItem(KEY)!)).toEqual([]);
+  });
+
+  it("survives storage disappearing mid-session without throwing", () => {
+    // installStorageShim only substitutes a working Storage at boot.
+    // Its own header documents the WebKitGTK web process crashing and
+    // reloading into a context with no storage binding — after that
+    // getItem throws, and read() runs during render, so anything that
+    // escapes takes the ErrorBoundary and blanks the whole app.
+    const real = Object.getOwnPropertyDescriptor(
+      window,
+      "localStorage",
+    ) as PropertyDescriptor;
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get() {
+        throw new DOMException(
+          "localStorage is not available",
+          "SecurityError",
+        );
+      },
+    });
+    try {
+      expect(() => mount()).not.toThrow();
+      expect(latest.history).toEqual([]);
+    } finally {
+      Object.defineProperty(window, "localStorage", real);
+    }
+  });
+
+  it("never writes on mount", () => {
+    // The persist effect skips its first pass on purpose. `history`
+    // is seeded from read(), and read() falls back to [] whenever
+    // storage is unreadable — so a mount that persisted would turn
+    // one transient read failure into permanent data loss.
+    localStorage.setItem(KEY, JSON.stringify(["daft punk", "justice"]));
+    const real = window.localStorage;
+    const descriptor = Object.getOwnPropertyDescriptor(
+      window,
+      "localStorage",
+    ) as PropertyDescriptor;
+    let writes = 0;
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      get: () => ({
+        getItem: (k: string) => real.getItem(k),
+        setItem: (k: string, v: string) => {
+          writes++;
+          real.setItem(k, v);
+        },
+        removeItem: (k: string) => real.removeItem(k),
+      }),
+    });
+    try {
+      mount();
+    } finally {
+      Object.defineProperty(window, "localStorage", descriptor);
+    }
+
+    expect(latest.history).toEqual(["daft punk", "justice"]);
+    expect(writes).toBe(0);
+  });
+
+  it("starts empty when the stored value is corrupt", () => {
+    localStorage.setItem(KEY, "{not json");
+    mount();
+    expect(latest.history).toEqual([]);
+  });
+
+  it("starts empty when the stored value is the wrong shape", () => {
+    localStorage.setItem(KEY, JSON.stringify({ queries: ["a"] }));
+    mount();
+    expect(latest.history).toEqual([]);
+  });
+
+  it("drops non-string entries from a hand-edited file", () => {
+    localStorage.setItem(KEY, JSON.stringify(["a", 7, null, "  ", "b"]));
+    mount();
+    expect(latest.history).toEqual(["a", "b"]);
+  });
+});

--- a/web/src/hooks/useSearchHistory.ts
+++ b/web/src/hooks/useSearchHistory.ts
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * Recent search queries, persisted per install.
+ *
+ * The search box updates results as you type, so there is no submit
+ * event to hang "the user searched for this" off. What we record
+ * instead is every debounced query that came back with results, then
+ * collapse the typing stems on the way in: while the newest entry is a
+ * strict prefix of the query being recorded, it gets dropped. Typing
+ * "daft punk" with a pause after "daft" leaves one entry, not two,
+ * and an unrelated older "daft" from last week is untouched because
+ * stems are only ever consecutive.
+ *
+ * Storage is localStorage, which the shim in installStorageShim.ts
+ * guarantees exists even when WebKitGTK takes the real one away. In
+ * that degraded state history lives for the session and no longer.
+ */
+const STORAGE_KEY = "tideway:search-history";
+
+/** Enough to cover "what was I just looking at" without turning the
+ *  empty-search page into a wall of text. */
+export const MAX_HISTORY = 10;
+
+function read(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .filter((v): v is string => typeof v === "string")
+      .map((v) => v.trim())
+      .filter(Boolean)
+      .slice(0, MAX_HISTORY);
+  } catch {
+    // Never rethrow: this runs during render, so anything that
+    // escapes takes the ErrorBoundary and blanks the app. Corrupt
+    // JSON is one case. The other is storage itself going away —
+    // installStorageShim only substitutes a working Storage at boot,
+    // and the WebKitGTK web process it was written for can crash and
+    // reload mid-session into a context with no storage binding, at
+    // which point getItem throws. Losing the history is an acceptable
+    // outcome there; losing the whole UI is not. Same shape as
+    // ArtistSection's loadAlbumView.
+    return [];
+  }
+}
+
+function write(entries: string[]): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+  } catch {
+    // Ten short strings can't fill a quota on their own, but they
+    // share the origin with the Last.fm playcount cache, which holds
+    // thousands of entries. If that has filled the bucket — or
+    // storage has gone away entirely, as read() describes — losing
+    // search history is the correct thing to lose, never the search.
+  }
+}
+
+/** Same entries in the same order. Used to bail out of a no-op
+ *  update so React skips the re-render and the persist effect. */
+function sameOrder(a: string[], b: string[]): boolean {
+  return a.length === b.length && a.every((v, i) => v === b[i]);
+}
+
+/** Pure list transform, exported so the collapse rules can be tested
+ *  without mounting a component. */
+export function addToHistory(entries: string[], raw: string): string[] {
+  const query = raw.trim();
+  if (!query) return entries;
+
+  const next = [...entries];
+  const lower = query.toLowerCase();
+
+  // Drop the stems this query was typed through. They sit at the head
+  // of the list because they were recorded moments ago.
+  while (next.length > 0) {
+    const head = next[0].toLowerCase();
+    if (head !== lower && lower.startsWith(head)) next.shift();
+    else break;
+  }
+
+  // Case-insensitive dedupe: searching "Daft Punk" again moves the
+  // existing entry to the top rather than adding a second spelling.
+  const deduped = next.filter((e) => e.toLowerCase() !== lower);
+  return [query, ...deduped].slice(0, MAX_HISTORY);
+}
+
+export function useSearchHistory() {
+  // Read in the initializer, not an effect: installStorageShim runs
+  // before the first render, so storage is already usable here, and
+  // seeding state directly avoids a second render pass on every mount
+  // of the search page.
+  const [history, setHistory] = useState<string[]>(read);
+
+  // Persisting happens here rather than inside the state updaters,
+  // because an updater has to be pure: React may run one
+  // speculatively and discard the result, which would leave
+  // localStorage holding a list that never became state. StrictMode
+  // also double-invokes them in development.
+  //
+  // The mount pass is skipped deliberately. `history` starts as
+  // whatever read() returned, and read() falls back to [] when
+  // storage is unreadable — writing that back immediately would turn
+  // a transient read failure into permanent data loss.
+  const loaded = useRef(false);
+  useEffect(() => {
+    if (!loaded.current) {
+      loaded.current = true;
+      return;
+    }
+    write(history);
+  }, [history]);
+
+  const record = useCallback((query: string) => {
+    // Returning `prev` unchanged when nothing moved keeps React from
+    // re-rendering and keeps the persist effect from firing. The
+    // search page calls this again on every re-fetch of the same
+    // query, so the no-op case is the common one.
+    setHistory((prev) => {
+      const next = addToHistory(prev, query);
+      return sameOrder(next, prev) ? prev : next;
+    });
+  }, []);
+
+  const remove = useCallback((query: string) => {
+    setHistory((prev) => {
+      const next = prev.filter((e) => e !== query);
+      return sameOrder(next, prev) ? prev : next;
+    });
+  }, []);
+
+  const clear = useCallback(() => {
+    setHistory((prev) => (prev.length === 0 ? prev : []));
+  }, []);
+
+  return { history, record, remove, clear };
+}

--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useState } from "react";
-import { useSearchParams } from "react-router-dom";
-import { Loader2, Music, Search as SearchIcon } from "lucide-react";
+import { Link, useSearchParams } from "react-router-dom";
+import { Clock, Loader2, Music, Search as SearchIcon, X } from "lucide-react";
 import { api } from "@/api/client";
 import { queryKeys } from "@/api/queryKeys";
 import { useApi } from "@/hooks/useApi";
+import { useSearchHistory } from "@/hooks/useSearchHistory";
 import type { Album, Artist, Playlist, TopHit } from "@/api/types";
 import type { OnDownload } from "@/api/download";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -97,6 +98,23 @@ export function Search({ onDownload }: { onDownload: OnDownload }) {
   // reads as "the app didn't notice my input".
   const loading = fetchLoading || (!!trimmedQ && trimmedQ !== debouncedQ);
 
+  // Recent searches. There is no submit event to hook — the page
+  // searches as you type — so a query earns its place in the history
+  // by coming back with something. A typo that matched nothing is not
+  // worth offering back to the user, and the hook folds the prefixes
+  // that settled through the debounce into the final query.
+  const { history, record, remove, clear } = useSearchHistory();
+  useEffect(() => {
+    if (!debouncedQ || !results) return;
+    const matched =
+      results.tracks.length > 0 ||
+      results.albums.length > 0 ||
+      results.artists.length > 0 ||
+      results.playlists.length > 0 ||
+      !!results.top_hit;
+    if (matched) record(debouncedQ);
+  }, [debouncedQ, results, record]);
+
   const onTabChange = (next: Filter) => {
     const p = new URLSearchParams(params);
     if (next === "all") p.delete("tab");
@@ -183,13 +201,17 @@ export function Search({ onDownload }: { onDownload: OnDownload }) {
         </div>
       )}
 
-      {!results && !q && (
-        <EmptyState
-          icon={SearchIcon}
-          title="Search Tidal"
-          description="Start typing in the search bar at the top to find tracks, albums, artists, or playlists."
-        />
-      )}
+      {!results &&
+        !q &&
+        (history.length > 0 ? (
+          <RecentSearches entries={history} onRemove={remove} onClear={clear} />
+        ) : (
+          <EmptyState
+            icon={SearchIcon}
+            title="Search Tidal"
+            description="Start typing in the search bar at the top to find tracks, albums, artists, or playlists."
+          />
+        ))}
 
       {results && !hasAny && (
         <EmptyState
@@ -297,6 +319,57 @@ export function Search({ onDownload }: { onDownload: OnDownload }) {
           </Grid>
         </>
       )}
+    </div>
+  );
+}
+
+/**
+ * The empty-search landing: queries the user ran before, newest first.
+ * Clicking one re-runs it by navigating to the same URL the search bar
+ * would produce, which also refills the input via its params effect.
+ */
+function RecentSearches({
+  entries,
+  onRemove,
+  onClear,
+}: {
+  entries: string[];
+  onRemove: (query: string) => void;
+  onClear: () => void;
+}) {
+  return (
+    <div className="max-w-2xl">
+      <div className="mb-4 flex items-baseline justify-between gap-4">
+        <h2 className="text-2xl font-bold tracking-tight">Recent searches</h2>
+        <button
+          type="button"
+          onClick={onClear}
+          className="text-sm font-medium text-muted-foreground hover:text-foreground"
+        >
+          Clear all
+        </button>
+      </div>
+      <ul>
+        {entries.map((entry) => (
+          <li key={entry} className="group flex items-center gap-2">
+            <Link
+              to={`/search?q=${encodeURIComponent(entry)}`}
+              className="flex min-w-0 flex-1 items-center gap-3 rounded-md px-2 py-2 hover:bg-accent"
+            >
+              <Clock className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="truncate">{entry}</span>
+            </Link>
+            <button
+              type="button"
+              onClick={() => onRemove(entry)}
+              aria-label={`Remove "${entry}" from recent searches`}
+              className="shrink-0 rounded-md p-2 text-muted-foreground opacity-0 transition-opacity hover:text-foreground focus-visible:opacity-100 group-hover:opacity-100"
+            >
+              <X className="h-4 w-4" />
+            </button>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

Requested by a user: the search index has no history. Clearing the box dropped you on a static "Start typing" panel, and a query you ran a minute ago was only recoverable by typing it again.

The awkward part is that there is no submit event to record against, because results update as you type. So a query earns a place in the history by coming back with matches, and the prefixes that settled through the 300ms debounce on the way there are folded into the final query: while the newest entry is a strict prefix of the one being recorded, it gets dropped. Typing "radiohead" with a pause after "radio" leaves one entry. An older unrelated "radio" from last week survives, since stems are only ever consecutive.

Ten entries in localStorage, with per-row removal and a clear-all.

Persisting happens in an effect rather than inside the state updaters, because an updater has to be pure — React may run one speculatively and discard the result, which would leave localStorage holding a list that never became state. The effect skips its mount pass on purpose: `history` is seeded from `read()`, and `read()` falls back to `[]` when storage is unreadable, so a mount that persisted would turn one transient read failure into permanent data loss.

`read()` never rethrows. It runs during render, and the WebKitGTK case that `installStorageShim` documents (web process crashes and reloads mid-session into a context with no storage binding) would otherwise take the ErrorBoundary and blank the whole app.

## Test plan

- `web/src/hooks/useSearchHistory.test.tsx`, 18 tests: the collapse rules as a pure transform, plus persistence, corrupt/wrong-shape stored values, storage disappearing mid-session, and the never-write-on-mount guard.
- Verified live in the app: searching "radio" then typing "head" leaves a single `radiohead` entry, and per-row removal persists.
- `./scripts/preflight.sh` green.