### PR TITLE
Save lyrics alongside downloaded tracks

### DIFF
--- a/app/downloader.py
+++ b/app/downloader.py
@@ -1426,7 +1426,12 @@ class Downloader:
             # retry would hit skip_existing on the already-complete
             # audio file and silently decline to re-download, leaving
             # the user with an untagged track and a stuck FAILED row.
-            from app.metadata import fetch_cover_art, tag_file
+            from app.metadata import (
+                fetch_cover_art,
+                fetch_lyrics,
+                tag_file,
+                write_lrc_sidecar,
+            )
             tag_error: Optional[str] = None
             resolved_album = album_obj or getattr(track, "album", None)
             try:
@@ -1437,11 +1442,59 @@ class Downloader:
             except Exception as exc:
                 cover = None
                 tag_error = f"cover fetch failed: {exc}"
+            # fetch_lyrics swallows only "this track has none", which
+            # most of the catalogue is, so a miss is silent and the
+            # file is simply tagged without a lyric field. Anything
+            # else it raises, and that has to be handled rather than
+            # ignored: this is an extra Tidal request per track and a
+            # 429 here must reach the shared backoff, or the sibling
+            # workers keep hammering a bucket that just told us to
+            # stop. Recording it on the item matters too, because the
+            # audio is already in place and skip-existing will decline
+            # to redo the file, so a silently dropped lyric never gets
+            # a second attempt.
+            lyrics = None
+            if getattr(s, "download_lyrics", True):
+                try:
+                    lyrics = fetch_lyrics(track)
+                except Exception as exc:
+                    if _looks_like_rate_limit(exc):
+                        self._note_rate_limit(exc, 0)
+                    if not tag_error:
+                        tag_error = f"lyrics fetch failed: {exc}"
+                    print(
+                        f"[downloader] lyrics fetch failed "
+                        f"id={item.item_id[:8]} track_id="
+                        f"{getattr(track, 'id', '?')}: {exc!r}",
+                        file=_sys.stderr,
+                        flush=True,
+                    )
             try:
-                tag_file(out_path, track, cover, album_obj=resolved_album)
+                tag_file(
+                    out_path,
+                    track,
+                    cover,
+                    album_obj=resolved_album,
+                    lyrics=lyrics,
+                )
             except Exception as exc:
                 if not tag_error:
                     tag_error = f"tagging failed: {exc}"
+
+            # Timed lyrics can't live in a tag, so they go beside the
+            # track as the .lrc every synced-lyric player looks for.
+            try:
+                write_lrc_sidecar(out_path, lyrics)
+            except OSError as exc:
+                # A read-only destination or a full disk. The audio is
+                # already safely in place; say so and move on rather
+                # than failing a download over its sidecar.
+                print(
+                    f"[downloader] .lrc write failed id={item.item_id[:8]}: "
+                    f"{exc}",
+                    file=_sys.stderr,
+                    flush=True,
+                )
 
             # Drop a cover.jpg next to the track when the track lives
             # in a per-album (or per-playlist) subfolder. Most music
@@ -1801,6 +1854,13 @@ def _looks_like_rate_limit(exc: Exception) -> bool:
     sometimes re-raises with the code in the message string."""
     resp = getattr(exc, "response", None)
     if resp is not None and getattr(resp, "status_code", None) == 429:
+        return True
+    # tidalapi's own TooManyRequests carries no response, and callers
+    # of it sometimes rewrite the message to something friendlier
+    # (Track.lyrics() replaces it with "Lyrics unavailable"), so the
+    # string check below can't see it. The class is the only signal
+    # left.
+    if type(exc).__name__ == "TooManyRequests":
         return True
     msg = str(exc)
     return "429" in msg or "Too Many Requests" in msg

--- a/app/metadata.py
+++ b/app/metadata.py
@@ -3,6 +3,7 @@ import shutil
 import tempfile
 import threading
 from collections import OrderedDict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
@@ -51,6 +52,7 @@ def tag_file(
     track,
     cover_data: Optional[bytes] = None,
     album_obj=None,
+    lyrics: Optional["Lyrics"] = None,
 ):
     """Tag a downloaded audio file atomically.
 
@@ -71,9 +73,9 @@ def tag_file(
     try:
         shutil.copy2(file_path, tmp_path)
         if ext == ".flac":
-            _tag_flac(tmp_path, track, cover_data, album_obj)
+            _tag_flac(tmp_path, track, cover_data, album_obj, lyrics)
         else:
-            _tag_m4a(tmp_path, track, cover_data, album_obj)
+            _tag_m4a(tmp_path, track, cover_data, album_obj, lyrics)
         os.replace(tmp_path, file_path)
     except Exception:
         try:
@@ -256,7 +258,96 @@ def fetch_cover_art(
     return data
 
 
-def _tag_flac(path: Path, track, cover_data: Optional[bytes], album_obj=None):
+# ---------------------------------------------------------------------------
+# Lyrics
+#
+# Tidal returns two independent things under one call: `text`, the
+# plain unsynced lyric, and `subtitles`, the same words carrying
+# [mm:ss.xx] cues. They travel to different places on disk. The plain
+# text is embedded in the file's own tags, which every tagger and
+# player can read but which has no notion of timing. The timed version
+# goes out as a sidecar .lrc, because that is the only format the
+# players that do synced display actually look for.
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Lyrics:
+    """What Tidal has for one track. Either field may be empty."""
+
+    text: str = ""
+    subtitles: str = ""
+
+    def __bool__(self) -> bool:
+        return bool(self.text or self.subtitles)
+
+
+def _is_missing_lyrics(exc: BaseException) -> bool:
+    """True for Tidal's ordinary "this track has no lyrics" answer.
+
+    Most of the catalogue has none and Tidal says so with a 404. Our
+    HTTP layer hands that back as the transport's own HTTPError with
+    the response attached, because curl_cffi replaces tidalapi's
+    request session and the raw error surfaces before tidalapi can map
+    it; the class-name check covers the path where tidalapi does the
+    mapping itself.
+    """
+    resp = getattr(exc, "response", None)
+    if getattr(resp, "status_code", None) == 404:
+        return True
+    return type(exc).__name__ in ("MetadataNotAvailable", "ObjectNotFound")
+
+
+def fetch_lyrics(track) -> Optional[Lyrics]:
+    """Read a track's lyrics off Tidal, or None if it has none.
+
+    Only the no-lyrics answer is swallowed. Everything else — a 429,
+    an expired token, a dropped connection — is raised, because those
+    are indistinguishable from "no lyrics" at this level and the
+    caller has to be able to tell them apart: a rate limit needs to
+    reach the downloader's shared backoff, and a genuine failure needs
+    to be visible rather than shipping a file that quietly has no
+    lyrics in it.
+    """
+    try:
+        raw = track.lyrics()
+    except Exception as exc:
+        if _is_missing_lyrics(exc):
+            return None
+        raise
+    if raw is None:
+        return None
+    lyrics = Lyrics(
+        text=(getattr(raw, "text", "") or "").strip(),
+        subtitles=(getattr(raw, "subtitles", "") or "").strip(),
+    )
+    return lyrics or None
+
+
+def write_lrc_sidecar(audio_path: Path, lyrics: Optional[Lyrics]) -> Optional[Path]:
+    """Write `<track>.lrc` beside the audio file for timed lyrics.
+
+    Returns the path written, or None when there was nothing timed to
+    write. An existing .lrc is left alone: the user may have fetched
+    or hand-corrected a better one, and clobbering it on a re-download
+    would be the kind of silent data loss that is hard to notice.
+    """
+    if lyrics is None or not lyrics.subtitles:
+        return None
+    lrc_path = audio_path.with_suffix(".lrc")
+    if lrc_path.exists():
+        return None
+    lrc_path.write_text(lyrics.subtitles + "\n", encoding="utf-8")
+    return lrc_path
+
+
+def _tag_flac(
+    path: Path,
+    track,
+    cover_data: Optional[bytes],
+    album_obj=None,
+    lyrics: Optional["Lyrics"] = None,
+):
     from mutagen.flac import FLAC, Picture
 
     audio = FLAC(str(path))
@@ -278,6 +369,14 @@ def _tag_flac(path: Path, track, cover_data: Optional[bytes], album_obj=None):
     if track_id is not None:
         audio[TIDAL_ID_TAG.lower()] = str(track_id)
 
+    if lyrics is not None and lyrics.text:
+        # Two fields for one string because Vorbis never settled on
+        # one. foobar2000 and MusicBrainz Picard read UNSYNCEDLYRICS;
+        # VLC, Kodi, and most Android players read LYRICS. Writing
+        # both is what taggers themselves do.
+        audio["lyrics"] = lyrics.text
+        audio["unsyncedlyrics"] = lyrics.text
+
     if cover_data:
         pic = Picture()
         pic.data = cover_data
@@ -288,7 +387,13 @@ def _tag_flac(path: Path, track, cover_data: Optional[bytes], album_obj=None):
     audio.save()
 
 
-def _tag_m4a(path: Path, track, cover_data: Optional[bytes], album_obj=None):
+def _tag_m4a(
+    path: Path,
+    track,
+    cover_data: Optional[bytes],
+    album_obj=None,
+    lyrics: Optional["Lyrics"] = None,
+):
     from mutagen.mp4 import MP4, MP4Cover
 
     audio = MP4(str(path))
@@ -307,6 +412,10 @@ def _tag_m4a(path: Path, track, cover_data: Optional[bytes], album_obj=None):
     track_id = getattr(track, "id", None)
     if track_id is not None:
         audio[M4A_TIDAL_ID_KEY] = [str(track_id).encode("utf-8")]
+
+    if lyrics is not None and lyrics.text:
+        # MP4 has exactly one lyrics atom, and it is unsynced text.
+        audio["\xa9lyr"] = lyrics.text
 
     if cover_data:
         audio["covr"] = [MP4Cover(cover_data, imageformat=MP4Cover.FORMAT_JPEG)]

--- a/app/settings.py
+++ b/app/settings.py
@@ -125,6 +125,13 @@ class Settings:
     # origin master would. The download path falls back to a smaller
     # size when an album doesn't publish the chosen one.
     cover_art_resolution: str = "1280"
+    # Write the track's lyrics when downloading it: the plain text into
+    # the file's own tags, and a sidecar .lrc alongside it when Tidal
+    # has a time-coded version. On by default — a downloaded library
+    # that silently drops lyrics the streaming view shows is the
+    # surprise, not the other way round. Costs one small JSON request
+    # per track, which is why it can be turned off.
+    download_lyrics: bool = True
     skip_existing: bool = True
     # How many downloads may run in parallel. Gated by the Downloader's
     # semaphore so changing this doesn't require a process restart.

--- a/server.py
+++ b/server.py
@@ -10805,6 +10805,7 @@ class SettingsPayload(BaseModel):
     create_playlist_folders: Optional[bool] = None
     downconvert_hires_downloads: Optional[bool] = None
     cover_art_resolution: Optional[str] = None
+    download_lyrics: Optional[bool] = None
     window_x: Optional[int] = None
     window_y: Optional[int] = None
     window_width: Optional[int] = None

--- a/tests/test_download_lyrics.py
+++ b/tests/test_download_lyrics.py
@@ -1,0 +1,280 @@
+"""Tests for saving lyrics alongside a downloaded track.
+
+Reported as "lyrics are not downloaded along with the songs": the
+player had lyrics all along, via `GET /api/track/{id}/lyrics`, but the
+download path never asked for them, so a downloaded library lost
+something the streaming view was showing.
+
+Tidal hands back two independent things under one call. `text` is the
+plain lyric and goes into the file's own tags, where every tagger can
+read it but nothing can time it. `subtitles` is the same words with
+[mm:ss.xx] cues, and goes out as a sidecar .lrc because that is the
+only thing players with scrolling lyrics look for.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from app.metadata import Lyrics, fetch_lyrics, write_lrc_sidecar
+
+
+class _RawLyrics:
+    """Shaped like tidalapi's Lyrics object."""
+
+    def __init__(self, text=None, subtitles=None) -> None:
+        self.text = text
+        self.subtitles = subtitles
+
+
+class _Track:
+    def __init__(self, raw) -> None:
+        self._raw = raw
+
+    def lyrics(self):
+        if isinstance(self._raw, Exception):
+            raise self._raw
+        return self._raw
+
+
+class _HttpError(Exception):
+    """Shaped like the curl_cffi HTTPError our HTTP layer actually
+    raises: the status lives on an attached response, not in the
+    message. tidalapi's own ObjectNotFound mapping never runs because
+    curl_cffi replaces its request session."""
+
+    def __init__(self, status: int) -> None:
+        super().__init__(f"HTTP Error {status}: ")
+        self.response = type("_R", (), {"status_code": status})()
+
+
+class _MetadataNotAvailable(Exception):
+    """Stands in for tidalapi.exceptions.MetadataNotAvailable, which
+    is what Track.lyrics() raises when the mapping does run."""
+
+
+_LRC = "[00:12.34]First line\n[00:15.00]Second line"
+
+
+# ---------------------------------------------------------------------------
+# fetch_lyrics
+# ---------------------------------------------------------------------------
+
+
+def test_reads_both_forms() -> None:
+    got = fetch_lyrics(_Track(_RawLyrics(text="Plain words", subtitles=_LRC)))
+    assert got == Lyrics(text="Plain words", subtitles=_LRC)
+
+
+def test_reads_plain_text_when_there_are_no_cues() -> None:
+    got = fetch_lyrics(_Track(_RawLyrics(text="Plain words")))
+    assert got is not None
+    assert got.text == "Plain words"
+    assert got.subtitles == ""
+
+
+def test_a_track_with_no_lyrics_is_not_an_error() -> None:
+    """Most of the catalogue has none. Tidal answers 404, and that has
+    to stay an ordinary outcome or every instrumental would surface as
+    a tagging warning."""
+    assert fetch_lyrics(_Track(_HttpError(404))) is None
+
+
+def test_tidalapis_own_no_lyrics_error_is_also_ordinary() -> None:
+    _MetadataNotAvailable.__name__ = "MetadataNotAvailable"
+    assert fetch_lyrics(_Track(_MetadataNotAvailable("no lyrics"))) is None
+
+
+def test_a_rate_limit_is_raised_not_swallowed() -> None:
+    """A 429 has to reach the downloader so it can feed the shared
+    backoff. Collapsing it to None would look identical to an
+    instrumental and leave sibling workers hammering."""
+    with pytest.raises(Exception) as caught:
+        fetch_lyrics(_Track(_HttpError(429)))
+    assert caught.value.response.status_code == 429
+
+
+def test_a_transport_failure_is_raised_not_swallowed() -> None:
+    """The audio file is already written and skip-existing will
+    decline to redo it, so a dropped connection that silently yields
+    no lyrics would never get a second attempt."""
+    with pytest.raises(ConnectionError):
+        fetch_lyrics(_Track(ConnectionError("connection reset")))
+
+
+def test_an_auth_failure_is_raised_not_swallowed() -> None:
+    with pytest.raises(Exception) as caught:
+        fetch_lyrics(_Track(_HttpError(401)))
+    assert caught.value.response.status_code == 401
+
+
+def test_empty_strings_count_as_no_lyrics() -> None:
+    assert fetch_lyrics(_Track(_RawLyrics(text="", subtitles=""))) is None
+    assert fetch_lyrics(_Track(_RawLyrics(text="   "))) is None
+
+
+def test_a_null_response_is_no_lyrics() -> None:
+    assert fetch_lyrics(_Track(None)) is None
+
+
+def test_surrounding_whitespace_is_stripped() -> None:
+    got = fetch_lyrics(_Track(_RawLyrics(text="\n Words \n")))
+    assert got is not None and got.text == "Words"
+
+
+# ---------------------------------------------------------------------------
+# write_lrc_sidecar
+# ---------------------------------------------------------------------------
+
+
+def test_timed_lyrics_land_in_a_matching_lrc(tmp_path: Path) -> None:
+    audio = tmp_path / "01 - Song.flac"
+    audio.touch()
+
+    written = write_lrc_sidecar(audio, Lyrics(text="Plain", subtitles=_LRC))
+
+    assert written == tmp_path / "01 - Song.lrc"
+    assert written.read_text(encoding="utf-8") == _LRC + "\n"
+
+
+def test_no_sidecar_without_cues(tmp_path: Path) -> None:
+    """Plain text alone belongs in the tags. A .lrc with no timestamps
+    is not something a synced-lyrics player can use."""
+    audio = tmp_path / "Song.flac"
+    audio.touch()
+
+    assert write_lrc_sidecar(audio, Lyrics(text="Plain")) is None
+    assert list(tmp_path.glob("*.lrc")) == []
+
+
+def test_no_sidecar_when_the_track_has_no_lyrics(tmp_path: Path) -> None:
+    audio = tmp_path / "Song.flac"
+    audio.touch()
+
+    assert write_lrc_sidecar(audio, None) is None
+    assert list(tmp_path.glob("*.lrc")) == []
+
+
+def test_an_existing_lrc_is_left_alone(tmp_path: Path) -> None:
+    """The user may have fetched or hand-corrected a better one.
+    Silently overwriting it on a re-download is data loss they would
+    have no reason to look for."""
+    audio = tmp_path / "Song.flac"
+    audio.touch()
+    existing = tmp_path / "Song.lrc"
+    existing.write_text("[00:01.00]Mine, corrected", encoding="utf-8")
+
+    assert write_lrc_sidecar(audio, Lyrics(subtitles=_LRC)) is None
+    assert existing.read_text(encoding="utf-8") == "[00:01.00]Mine, corrected"
+
+
+def test_sidecar_replaces_the_audio_extension(tmp_path: Path) -> None:
+    """Players pair `Song.lrc` with `Song.m4a`, not `Song.m4a.lrc`."""
+    audio = tmp_path / "Song.m4a"
+    audio.touch()
+
+    written = write_lrc_sidecar(audio, Lyrics(subtitles=_LRC))
+    assert written is not None and written.name == "Song.lrc"
+
+
+def test_a_dotted_track_name_keeps_its_stem(tmp_path: Path) -> None:
+    audio = tmp_path / "Mr. Brightside.flac"
+    audio.touch()
+
+    written = write_lrc_sidecar(audio, Lyrics(subtitles=_LRC))
+    assert written is not None and written.name == "Mr. Brightside.lrc"
+
+
+# ---------------------------------------------------------------------------
+# Tag writing
+# ---------------------------------------------------------------------------
+
+
+class _Album:
+    id = 1
+    name = "An Album"
+    num_tracks = 10
+    artist = type("_A", (), {"name": "An Artist"})()
+    artists = [artist]
+    release_date = None
+    available_release_date = None
+
+
+class _TaggableTrack:
+    id = 42
+    name = "A Song"
+    track_num = 1
+    album = _Album()
+    artist = _Album.artist
+    artists = [_Album.artist]
+
+
+def _flac_fixture(tmp_path: Path) -> Path:
+    """A real, minimal FLAC. mutagen refuses to open anything else, so
+    there's no way to test tag writing without one.
+
+    Built with PyAV rather than a shelled-out ffmpeg: PyAV is already a
+    hard dependency (it's the decoder the player runs on) and its
+    wheels bundle libav, so this works on a checkout with nothing but
+    `pip install -r requirements.txt`.
+    """
+    pytest.importorskip("mutagen")
+    av = pytest.importorskip("av")
+
+    src = tmp_path / "silence.flac"
+    with av.open(str(src), mode="w", format="flac") as container:
+        stream = container.add_stream("flac", rate=44100)
+        stream.layout = "stereo"
+        frame = av.AudioFrame(format="s16", layout="stereo", samples=4410)
+        for plane in frame.planes:
+            plane.update(bytes(plane.buffer_size))
+        frame.rate = 44100
+        frame.pts = 0
+        for packet in stream.encode(frame):
+            container.mux(packet)
+        for packet in stream.encode(None):
+            container.mux(packet)
+    return src
+
+
+def test_flac_gets_both_vorbis_lyric_fields(tmp_path: Path) -> None:
+    """Vorbis never settled on one field name. foobar2000 and Picard
+    read UNSYNCEDLYRICS, VLC and Kodi read LYRICS, so both get written
+    or half the user's players show nothing."""
+    from mutagen.flac import FLAC
+
+    from app.metadata import tag_file
+
+    path = _flac_fixture(tmp_path)
+    tag_file(path, _TaggableTrack(), None, lyrics=Lyrics(text="Plain words"))
+
+    tags = FLAC(str(path))
+    assert tags["lyrics"] == ["Plain words"]
+    assert tags["unsyncedlyrics"] == ["Plain words"]
+
+
+def test_flac_without_lyrics_gets_no_lyric_field(tmp_path: Path) -> None:
+    from mutagen.flac import FLAC
+
+    from app.metadata import tag_file
+
+    path = _flac_fixture(tmp_path)
+    tag_file(path, _TaggableTrack(), None, lyrics=None)
+
+    tags = FLAC(str(path))
+    assert "lyrics" not in tags
+    assert "unsyncedlyrics" not in tags
+
+
+def test_timed_only_lyrics_do_not_become_a_tag(tmp_path: Path) -> None:
+    """A tag holds no timing, so writing the raw LRC into one would
+    show the user a wall of [00:12.34] markers."""
+    from mutagen.flac import FLAC
+
+    from app.metadata import tag_file
+
+    path = _flac_fixture(tmp_path)
+    tag_file(path, _TaggableTrack(), None, lyrics=Lyrics(subtitles=_LRC))
+
+    assert "lyrics" not in FLAC(str(path))

--- a/tests/test_download_rate_limiter.py
+++ b/tests/test_download_rate_limiter.py
@@ -281,3 +281,20 @@ def test_bulk_cooldown_passes_through_after_long_idle(monkeypatch):
     downloader._wait_for_bulk_cooldown()
 
     assert slept == []
+
+
+def test_tidalapi_too_many_requests_is_detected_without_a_response():
+    """tidalapi's own TooManyRequests carries no `.response`, and
+    Track.lyrics() rewrites its message to "Lyrics unavailable" before
+    re-raising, so neither the status check nor the string check can
+    see it. Without the class check a lyrics 429 would slip past the
+    shared backoff and sibling workers would keep hammering."""
+    from app.downloader import _looks_like_rate_limit
+
+    class TooManyRequests(Exception):
+        pass
+
+    exc = TooManyRequests("Lyrics unavailable")
+    assert "429" not in str(exc)
+    assert getattr(exc, "response", None) is None
+    assert _looks_like_rate_limit(exc)

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -468,6 +468,10 @@ export interface Settings {
    *  as cover.jpg. "640" / "1280" / "origin" (3000x3000 master).
    *  Default "1280". */
   cover_art_resolution: "640" | "1280" | "origin";
+  /** Write lyrics when downloading a track: plain text into the file's
+   *  tags, plus a sidecar .lrc when Tidal has a time-coded version.
+   *  On by default. */
+  download_lyrics: boolean;
   /** Desktop window geometry, persisted on close. -1 = not set yet
    *  (first run uses the platform default). */
   window_x: number;

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -402,6 +402,12 @@ export function SettingsPage({ onLogout }: { onLogout: () => void }) {
                 hint="For old iPods (Rockbox) and other legacy players that can't decode 24-bit or high-sample-rate FLAC in real time. Only hi-res sources are touched; CD-quality and lossy downloads stay bit-exact. Resampling is high quality with TPDF dither."
               />
               <Toggle
+                checked={settings.download_lyrics ?? true}
+                onChange={(v) => patch({ download_lyrics: v })}
+                label="Save lyrics with downloads"
+                hint="Writes the lyrics into the track's own tags, and drops a matching .lrc file beside it when Tidal has a time-coded version, which is what players with scrolling lyrics read. Tracks Tidal has no lyrics for are downloaded as usual. Costs one small request per track."
+              />
+              <Toggle
                 checked={settings.skip_existing}
                 onChange={(v) => patch({ skip_existing: v })}
                 label="Skip downloads that already exist on disk"


### PR DESCRIPTION
## Summary

Reported by a user: lyrics aren't downloaded with the songs. The player has had them since the full-screen view shipped, but the download path never asked for them, so a track pulled to disk lost something the streaming view was showing a second earlier.

Tidal returns two independent things from one call and they belong in different places:

- The plain text goes into the file's own tags, where every tagger and player can read it but nothing can time it. Both `LYRICS` and `UNSYNCEDLYRICS` on FLAC, since Vorbis never settled on one name and reading only one of them is how half a user's players end up showing nothing, and the single `©lyr` atom on MP4.
- The time-coded version goes out as a sidecar `.lrc`, which is what players with scrolling lyrics actually look for. An `.lrc` already on disk is never overwritten, in case the user corrected it.

`fetch_lyrics` swallows only the no-lyrics answer, which most of the catalogue is. Everything else it raises, because a 429 has to reach the downloader's shared backoff or sibling workers keep hammering a bucket that just told us to stop — and because the audio file is already in place by then, so skip-existing declines to redo it and a silently dropped lyric never gets a second attempt. A real failure is recorded on the item instead, the same way a cover or tag warning is.

`_looks_like_rate_limit` also learned to recognise tidalapi's own `TooManyRequests`, which carries no response and whose message `Track.lyrics()` rewrites to "Lyrics unavailable" before re-raising — neither the status check nor the string check could see it.

On by default, with a Downloads toggle for anyone who would rather not spend the extra request per track. New setting is mirrored in `SettingsPayload`, `web/src/api/types.ts`, and the Settings UI.

## Test plan

- `tests/test_download_lyrics.py`, 19 tests: both forms fetched, the no-lyrics 404 staying an ordinary outcome, 429/401/transport failures raising rather than collapsing to None, sidecar naming and skip-if-exists, and the Vorbis/MP4 tag fields written into a real FLAC built with PyAV.
- `tests/test_download_rate_limiter.py` gains a case for the response-less `TooManyRequests`.
- Verified against live Tidal: an instrumental returns None, "Creep" returns 44 lines plus `[00:19.92]`-style cues, and the sidecar writes correctly. Multi-line lyrics round-trip through both FLAC and M4A tags.
- Settings round-trip checked through `PUT /api/settings` (the documented Pydantic-mirror foot-gun).
- `./scripts/preflight.sh` green.