### PR TITLE
Show an artist's whole discography, and their playlists

### DIFF
--- a/app/tidal_client.py
+++ b/app/tidal_client.py
@@ -1514,6 +1514,11 @@ class TidalClient:
         return _sort_by_date_added(items)
 
     def get_artist_albums(self, artist) -> list:
+        # No `limit`, which is tidalapi's "everything": Tidal returns
+        # the artist's whole album list in one response (168 for Taylor
+        # Swift, measured) rather than a first page. Don't add a cap
+        # here — a number chosen to look generous is what truncated the
+        # EPs shelf for prolific artists.
         try:
             return list(artist.get_albums())
         except Exception:

--- a/server.py
+++ b/server.py
@@ -8708,16 +8708,25 @@ def artist_detail(artist_id: int) -> dict:
             lambda: list(tidal.get_artist_albums(artist)) or [],
             [],
         )
+        # `limit=None` is tidalapi's "everything", and Tidal answers
+        # these in a single response: 234 EPs and singles for Taylor
+        # Swift, 1000 compilation credits for Drake, ~200-350ms each.
+        # The previous `limit=40` was an arbitrary cap and was the
+        # whole reason prolific artists showed a fraction of their
+        # catalogue. Don't reintroduce a number here, and don't page
+        # by offset either — Tidal's paged view of these endpoints is
+        # not a partition of the unlimited one, so walking it both
+        # costs more round trips and drops releases at the seams.
         f_eps = pool.submit(
             _safe_t,
             "eps",
-            lambda: list(artist.get_ep_singles(limit=40)) or [],
+            lambda: list(artist.get_ep_singles(limit=None)) or [],
             [],
         )
         f_compilations = pool.submit(
             _safe_t,
             "comps",
-            lambda: list(artist.get_other(limit=40)) or [],
+            lambda: list(artist.get_other(limit=None)) or [],
             [],
         )
         # Credits and videos used to be separate endpoints the
@@ -8977,18 +8986,30 @@ def artist_extras(artist_id: int) -> dict:
 
     raw_appears: list = []
     raw_comps: list = []
+    # Playlists an artist appears on ("This Is …", genre sets, radio
+    # spin-offs) exist only as modules on Tidal's curated page — there
+    # is no artists/{id}/playlists endpoint in the API or in tidalapi.
+    # The loop below already walks those modules for albums; the
+    # Playlist items in them used to be dropped on the floor, which is
+    # why the artist page had no playlists at all.
+    raw_playlists: list = []
     if page is not None:
         try:
             from tidalapi.album import Album as _TidalAlbum
+            from tidalapi.playlist import Playlist as _TidalPlaylist
 
             for cat in getattr(page, "categories", []) or []:
                 t = (getattr(cat, "title", "") or "").strip().lower()
                 is_app = "appear" in t or "featured" in t
                 is_comp = "compilation" in t
-                if not is_app and not is_comp:
-                    continue
                 for item in getattr(cat, "items", []) or []:
-                    if isinstance(item, _TidalAlbum):
+                    # Playlists are collected from every module, not
+                    # just the appears-on/compilation ones, because
+                    # Tidal spreads them across several differently
+                    # titled shelves and the titles are localized.
+                    if isinstance(item, _TidalPlaylist):
+                        raw_playlists.append(item)
+                    elif isinstance(item, _TidalAlbum) and (is_app or is_comp):
                         (raw_comps if is_comp else raw_appears).append(item)
         except Exception:
             pass
@@ -8997,7 +9018,8 @@ def artist_extras(artist_id: int) -> dict:
         seen: set = set()
         out: list = []
         for a in items:
-            aid = getattr(a, "id", None)
+            # Playlists are keyed by uuid rather than id in tidalapi.
+            aid = getattr(a, "id", None) or getattr(a, "uuid", None)
             if aid is None or aid in seen:
                 continue
             seen.add(aid)
@@ -9007,6 +9029,7 @@ def artist_extras(artist_id: int) -> dict:
     result = {
         "appears_on": [album_to_dict(a) for a in _byid(raw_appears)],
         "compilations": [album_to_dict(a) for a in _byid(raw_comps)],
+        "playlists": [playlist_to_dict(p) for p in _byid(raw_playlists)],
         "artist_mix_id": mix_id,
     }
     with _artist_extras_cache_lock:

--- a/web/src/api/types.ts
+++ b/web/src/api/types.ts
@@ -212,6 +212,11 @@ export interface AlbumDetail extends Album {
 export interface ArtistExtras {
   appears_on: Album[];
   compilations: Album[];
+  /** Playlists featuring the artist. Only Tidal's curated artist page
+   *  carries these — there is no artists/{id}/playlists endpoint —
+   *  which is why they arrive with the deferred extras rather than in
+   *  the main artist payload. */
+  playlists: Playlist[];
   artist_mix_id: string | null;
 }
 

--- a/web/src/pages/ArtistDetail.tsx
+++ b/web/src/pages/ArtistDetail.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { Heart, Music, Video as VideoIcon } from "lucide-react";
 import { api } from "@/api/client";
-import type { Album, Artist, Track, Video } from "@/api/types";
+import type { Album, Artist, Playlist, Track, Video } from "@/api/types";
 import type { OnDownload } from "@/api/download";
 import { useApi } from "@/hooks/useApi";
 import { queryKeys } from "@/api/queryKeys";
@@ -80,6 +80,7 @@ export function ArtistDetail({ onDownload }: { onDownload: OnDownload }) {
       ? extras.appears_on
       : artist.appears_on;
   const artistMixId = extras?.artist_mix_id ?? artist.artist_mix_id;
+  const playlists = extras?.playlists ?? [];
 
   // "Download full discography" needs a single merged list of everything
   // the artist has released (albums + EPs + singles + their own
@@ -179,6 +180,12 @@ export function ArtistDetail({ onDownload }: { onDownload: OnDownload }) {
         title="Appears on"
         items={appearsOn}
         viewMoreTo={`/artist/${id}/all/appears-on`}
+        onDownload={onDownload}
+      />
+      <MediaRow
+        title="Playlists"
+        items={playlists}
+        viewMoreTo={`/artist/${id}/all/playlists`}
         onDownload={onDownload}
       />
       <MediaRow
@@ -296,7 +303,7 @@ function LikedSummaryCard({
  * "View more" link that lands on the dedicated section page. Matches
  * the one-row + view-more convention used on Home, Album, Stats.
  */
-function MediaRow<T extends Album | Artist>({
+function MediaRow<T extends Album | Artist | Playlist>({
   title,
   items,
   viewMoreTo,

--- a/web/src/pages/ArtistSection.tsx
+++ b/web/src/pages/ArtistSection.tsx
@@ -2,7 +2,14 @@ import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 import { List, Video as VideoIcon } from "lucide-react";
 import { api } from "@/api/client";
-import type { Album, Artist, Track, Video } from "@/api/types";
+import type {
+  Album,
+  Artist,
+  ArtistExtras,
+  Playlist,
+  Track,
+  Video,
+} from "@/api/types";
 import type { OnDownload } from "@/api/download";
 import { useApi } from "@/hooks/useApi";
 import { queryKeys } from "@/api/queryKeys";
@@ -103,6 +110,7 @@ export type ArtistSectionKey =
   | "eps"
   | "compilations"
   | "appears-on"
+  | "playlists"
   | "similar"
   | "videos"
   | "liked";
@@ -129,6 +137,7 @@ const SECTIONS: Record<ArtistSectionKey, SectionMeta> = {
     kind: "media",
   },
   "appears-on": { title: "Appears on", field: "appears_on", kind: "media" },
+  playlists: { title: "Playlists", field: "playlists", kind: "media" },
   similar: { title: "Fans also like", field: "similar", kind: "media" },
   videos: { title: "Videos", field: "videos", kind: "videos" },
   // Liked content isn't in the artist payload — comes from the
@@ -148,6 +157,7 @@ interface ArtistData {
   ep_singles: Album[];
   compilations: Album[];
   appears_on: Album[];
+  playlists: Playlist[];
   similar: Artist[];
   videos: Video[];
 }
@@ -170,6 +180,17 @@ export function ArtistSection({ onDownload }: { onDownload: OnDownload }) {
     error,
   } = useApi(() => api.artist(id), [id], {
     cacheKey: queryKeys.artist(id),
+  });
+  // Three of these sections don't live in the main artist payload at
+  // all. Compilations and playlists come only from Tidal's curated
+  // artist page, and the full Appears-on set does too, so they were
+  // split off into /extras to keep the artist page's first paint
+  // fast. Same cache key as ArtistDetail, so arriving through its
+  // "View more" link is a hit rather than a second fetch — but
+  // without fetching them here, the compilations drill-down rendered
+  // an empty grid no matter what the artist page had just shown.
+  const { data: extras } = useApi(() => api.artistExtras(id), [id], {
+    cacheKey: `artist-extras:${id}`,
   });
   const meta = SECTIONS[section as ArtistSectionKey];
   // Liked source: pull from the user's library filtered to this
@@ -231,16 +252,48 @@ export function ArtistSection({ onDownload }: { onDownload: OnDownload }) {
       ) : (
         <SectionBody
           kind={meta.kind}
-          items={
-            ((artist as unknown as ArtistData)[
-              meta.field as keyof ArtistData
-            ] ?? []) as Track[] | Album[] | Artist[] | Video[]
-          }
+          items={sectionItems(
+            artist as unknown as ArtistData,
+            extras,
+            meta.field,
+          )}
           onDownload={onDownload}
         />
       )}
     </div>
   );
+}
+
+type SectionItems = Track[] | Album[] | Artist[] | Video[] | Playlist[];
+
+/**
+ * Pick a section's items, preferring the deferred extras where they
+ * are the real source.
+ *
+ * The main artist payload still carries `compilations` and
+ * `appears_on` keys for compatibility, but compilations is always
+ * empty there and appears_on holds only the thin get_other() set. An
+ * `undefined` extras means the fetch hasn't landed yet, so the
+ * payload's value is the right thing to show in the meantime; an
+ * empty array from extras is an answer and replaces it.
+ */
+function sectionItems(
+  artist: ArtistData,
+  extras: ArtistExtras | null | undefined,
+  field: keyof ArtistData | null,
+): SectionItems {
+  if (!field) return [];
+  const fromPayload = (artist[field] ?? []) as SectionItems;
+  if (!extras) return fromPayload;
+  if (field === "compilations") return extras.compilations;
+  if (field === "playlists") return extras.playlists;
+  if (field === "appears_on") {
+    // The curated page's set is richer when it has one, but it can
+    // come back empty for a lesser-known artist whose page has no
+    // Appears On module. Falling back keeps that case populated.
+    return extras.appears_on.length ? extras.appears_on : fromPayload;
+  }
+  return fromPayload;
 }
 
 /**
@@ -300,7 +353,7 @@ function SectionBody({
   onDownload,
 }: {
   kind: SectionMeta["kind"];
-  items: Track[] | Album[] | Artist[] | Video[];
+  items: SectionItems;
   onDownload: OnDownload;
 }) {
   if (items.length === 0) {
@@ -319,13 +372,13 @@ function SectionBody({
   if (kind === "videos") {
     return <VideosGrid videos={items as Video[]} />;
   }
-  // The "media" kind covers both album lists (albums, EPs,
-  // compilations, appears-on) and artist lists ("similar"). Only
-  // the album lists get the view toggle + sort — sorting artists
-  // by release date is nonsense, and they're rare enough on this
-  // page (only one section, "Fans also like") that the simpler
-  // tile-only render is fine.
-  const firstItemKind = (items as (Album | Artist)[])[0]?.kind ?? "album";
+  // The "media" kind covers album lists (albums, EPs, compilations,
+  // appears-on), artist lists ("similar"), and playlists. Only the
+  // album lists get the view toggle + sort — release-date order means
+  // nothing for an artist or a playlist — so everything else falls
+  // through to the plain tile grid.
+  const firstItemKind =
+    (items as (Album | Artist | Playlist)[])[0]?.kind ?? "album";
   if (firstItemKind === "album") {
     return (
       <AlbumSectionBody albums={items as Album[]} onDownload={onDownload} />
@@ -333,7 +386,7 @@ function SectionBody({
   }
   return (
     <Grid>
-      {(items as Artist[]).map((item) => (
+      {(items as (Artist | Playlist)[]).map((item) => (
         <MediaCard key={item.id} item={item} onDownload={onDownload} />
       ))}
     </Grid>


### PR DESCRIPTION
## Summary

Reported by a user: artists are missing albums, Singles & EPs, and playlists.

The EPs & Singles and Appears On shelves were fetched with a hardcoded `limit=40` and the result treated as the complete list. Against Tidal that meant Taylor Swift's EPs and singles showed as 15 unique releases out of a possible 234, and Drake's as 22 out of 105.

Passing no limit is tidalapi's "everything", and Tidal answers these in a single response: 234 EPs and singles for Taylor Swift, 1000 compilation credits for Drake, 200-350ms each. A cold artist page lands in ~360-440ms with all three shelves complete.

Offset paging was the obvious alternative and is the wrong one, so there's a comment saying so. Tidal's paged view of these endpoints is not a partition of its unlimited view: walking `get_albums` in pages of 50 returns 166 of Taylor Swift's 168 albums, dropping two specific ids deterministically at a page seam, while costing four round trips instead of one. `get_artist_albums` is left exactly as it was for the same reason — it already passed no limit and was never the truncated shelf.

Artist playlists had never been implemented. There is no `artists/{id}/playlists` endpoint in the API or in tidalapi, and the only source is Tidal's own curated artist page. The extras endpoint already walks that page's modules for albums and was dropping the Playlist items on the floor, so collecting them costs nothing extra. Around a hundred per major artist.

The Compilations drill-down was broken in the same family of bug and is fixed here too. It read from the main artist payload, where `compilations` is always empty because the curated page is deferred, so clicking View more on a populated row landed on an empty grid. The section page now overlays the extras the artist page overlays.

## Test plan

- Measured against live Tidal, before and after, for Taylor Swift, Drake and Radiohead. EPs & Singles for Taylor Swift goes from 15 unique to 92 after the full dedupe and explicit-collapse pipeline.
- Cold artist pages verified through the running app: 429ms (Radiohead) to 642ms (Drake), every shelf populated, playlists row and its drill-down rendering.
- Compilations drill-down confirmed populated where it was previously an empty grid.
- `./scripts/preflight.sh` green.

## Note for review

An earlier draft of this branch added an offset paginator. It was wrong — it cost 4-5x the round trips and lost two albums — and it is not in this diff. The measurements above are against a single unlimited call.