### PR TITLE
Give search tabs the whole result set, not sixteen rows

### DIFF
--- a/app/search_ranking.py
+++ b/app/search_ranking.py
@@ -14,6 +14,14 @@ among results of the same class the artists you actually listen to
 and the more popular ones float up — which is what makes an
 ambiguous query feel like it read your mind.
 
+For a track or an album the class is taken against the credited
+artist as well as against the title, whichever matches better. An
+artist name is a perfectly ordinary thing to type into a search box,
+and without this a nobody's album literally titled "Radiohead"
+scores EXACT while OK Computer scores nothing at all. Popularity
+then separates them, which is the correct outcome and the one Tidal
+itself returns before we touch the order.
+
 The taste signal is the set of artists you listen to (Tidal
 favourites + Last.fm top artists). Building it hits the network, so
 it is cached and refreshed on a background thread; the search
@@ -100,15 +108,22 @@ def score(
 ) -> float:
     """Score one candidate. `name` is the entity's own name (artist
     name, track/album title); `artist_names` are the names of the
-    artists credited on it (so a track by an artist you listen to
-    gets the taste lift even when the title itself doesn't)."""
+    artists credited on it.
+
+    The class is the better of the title's match and the credited
+    artist's, because a query is as likely to be an artist as a
+    title. Artist rescoring passes no `artist_names` — the name is
+    already the artist — so this only affects tracks and albums.
+    """
     name_norm = normalize(name)
-    base = _match_class(query_norm, name_norm)
+    artist_norms = [normalize(a) for a in artist_names]
+    base = max(
+        [_match_class(query_norm, name_norm)]
+        + [_match_class(query_norm, a) for a in artist_norms if a]
+    )
     total = base + _popularity_component(popularity)
     if taste:
-        if name_norm in taste or any(
-            normalize(a) in taste for a in artist_names
-        ):
+        if name_norm in taste or any(a in taste for a in artist_norms):
             total += _TASTE_BONUS
     return total
 

--- a/server.py
+++ b/server.py
@@ -7701,17 +7701,25 @@ async def player_events(request: Request):
 # ---------------------------------------------------------------------------
 
 
+# Tidal's own ceiling on a search: `limit` is per type and the API
+# stops serving past 300 of anything, so this is as much as the
+# endpoint can ever return and there is nothing past it to paginate
+# to. Measured on a warm session, asking for the ceiling instead of a
+# handful costs about 120ms on a ~300ms request.
+MAX_SEARCH_RESULTS = 300
+
+
 @app.get("/api/search")
 def search(q: str, limit: int = 25) -> dict:
     _require_auth()
     if not q.strip():
         return {"top_hit": None, "tracks": [], "albums": [], "artists": [], "playlists": []}
-    display = max(1, min(limit, 100))
+    display = max(1, min(limit, MAX_SEARCH_RESULTS))
     # Ask Tidal for a wider pool than we'll show. Its ranking is
     # popularity-skewed, so a good exact match for a short query can
     # sit past position 25; rescoring can't surface what was never
     # fetched. One call, just a bigger page — no extra round-trips.
-    pool = min(100, max(display, 50))
+    pool = min(MAX_SEARCH_RESULTS, max(display, 50))
     try:
         results = tidal.search(q, limit=pool)
     except Exception as exc:

--- a/tests/test_search_ranking.py
+++ b/tests/test_search_ranking.py
@@ -18,12 +18,30 @@ def _artist(name, pop=0):
     return SimpleNamespace(name=name, popularity=pop)
 
 
+def _album(title, by, pop=0):
+    return SimpleNamespace(name=title, popularity=pop, by=by)
+
+
 def _rank(query, items, taste=frozenset()):
     out = sr.rerank(
         query,
         items,
         get_name=lambda a: a.name,
         get_popularity=lambda a: a.popularity,
+        taste=taste,
+    )
+    return [a.name for a in out]
+
+
+def _rank_albums(query, items, taste=frozenset()):
+    """Rerank the way /api/search does for albums and tracks: the
+    credited artist is passed alongside the title."""
+    out = sr.rerank(
+        query,
+        items,
+        get_name=lambda a: a.name,
+        get_popularity=lambda a: a.popularity,
+        get_artist_names=lambda a: [a.by],
         taste=taste,
     )
     return [a.name for a in out]
@@ -148,3 +166,69 @@ def test_get_taste_survives_build_failure():
     # Failure leaves an empty set rather than crashing the caller.
     assert sr.get_taste(boom) == frozenset()
     sr._reset_taste_for_tests()
+
+
+# --- artist-shaped queries against titled entities -------------------------
+#
+# An artist name is an ordinary thing to type into a search box, and
+# scoring a track or album on its title alone gets it backwards:
+# searching "radiohead" put six unrelated albums literally titled
+# "Radiohead" above OK Computer, because the title scored EXACT and
+# the real record scored nothing at all. The class is now the better
+# of the title's match and the credited artist's.
+
+
+def test_an_album_by_the_searched_artist_beats_one_merely_named_for_them():
+    items = [
+        _album("Radiohead", by="Anchor + Bell", pop=2),
+        _album("radiohead", by="Nightly", pop=5),
+        _album("OK Computer", by="Radiohead", pop=87),
+        _album("In Rainbows", by="Radiohead", pop=89),
+    ]
+    ranked = _rank_albums("radiohead", items)
+    assert ranked[:2] == ["In Rainbows", "OK Computer"]
+
+
+def test_a_title_query_still_puts_the_title_first():
+    """The artist signal must not drown the case it was already
+    getting right."""
+    items = [
+        _album("Kid A", by="Radiohead", pop=87),
+        _album("In Rainbows", by="Radiohead", pop=89),
+    ]
+    assert _rank_albums("kid a", items)[0] == "Kid A"
+
+
+def test_the_artist_signal_respects_the_class_hierarchy():
+    """A credited artist matching at a weaker class can't overtake a
+    stronger title match, however popular the artist."""
+    items = [
+        # Artist is a substring match only.
+        _album("Something Else", by="Radiohead Tribute Band", pop=99),
+        # Title is an exact match.
+        _album("Radiohead", by="Nobody", pop=1),
+    ]
+    assert _rank_albums("radiohead", items)[0] == "Radiohead"
+
+
+def test_popularity_still_orders_a_title_and_artist_tie():
+    items = [
+        _album("Drake", by="Someone Else", pop=10),
+        _album("Views", by="Drake", pop=95),
+    ]
+    assert _rank_albums("drake", items)[0] == "Views"
+
+
+def test_artists_are_unaffected_by_the_artist_signal():
+    """Artist rescoring passes no credited names — the name already is
+    the artist — so its behavior is unchanged."""
+    items = [_artist("Earth, Wind & Fire", pop=92), _artist("ear", pop=3)]
+    assert _rank("ear", items)[0] == "ear"
+
+
+def test_a_missing_artist_credit_falls_back_to_the_title():
+    items = [
+        _album("Creep", by="", pop=50),
+        _album("Something", by="", pop=90),
+    ]
+    assert _rank_albums("creep", items)[0] == "Creep"

--- a/web/src/api/queryKeys.ts
+++ b/web/src/api/queryKeys.ts
@@ -22,7 +22,12 @@ export const queryKeys = {
   pagePath: (path: string) => `page:path:${path}`,
   popularArtists: "page:popular:artists",
   popularTracks: "page:popular:tracks",
-  search: (query: string) => `search:${query.toLowerCase()}`,
+  // The limit is part of the key: the All tab asks for one row's
+  // worth and a dedicated tab asks for everything Tidal will give, so
+  // two different result sets exist for the same query and must not
+  // share a cache entry.
+  search: (query: string, limit: number) =>
+    `search:${query.toLowerCase()}:${limit}`,
   libraryAlbums: "library:albums",
   libraryArtists: "library:artists",
   libraryPlaylists: "library:playlists",

--- a/web/src/pages/Search.tsx
+++ b/web/src/pages/Search.tsx
@@ -23,6 +23,17 @@ import {
 type Filter = "all" | "tracks" | "albums" | "artists" | "playlists";
 const FILTERS: Filter[] = ["all", "tracks", "albums", "artists", "playlists"];
 
+/** What the All tab asks for. Its per-type sections are one viewport
+ *  row plus a "View more" link, so a handful past the widest
+ *  breakpoint is all it can show — and this request fires on every
+ *  pause while the user is still typing. */
+const LANDING_LIMIT = 16;
+
+/** What a dedicated tab asks for. Tidal's search stops serving past
+ *  300 of any one type, so this is everything there is; the tab is a
+ *  full list and has no reason to show less. */
+const FULL_LIMIT = 300;
+
 function asFilter(v: string | null): Filter {
   return FILTERS.includes(v as Filter) ? (v as Filter) : "all";
 }
@@ -83,11 +94,17 @@ export function Search({ onDownload }: { onDownload: OnDownload }) {
     return () => window.clearTimeout(t);
   }, [trimmedQ]);
 
+  // The All tab is the landing view and re-runs as the user types, so
+  // it stays cheap. A dedicated tab is a deliberate drill-down into
+  // one kind, reached by an explicit navigation, and asks for the
+  // whole result set — that tab showing sixteen albums and no way to
+  // see the rest is the bug being fixed here.
+  const limit = filter === "all" ? LANDING_LIMIT : FULL_LIMIT;
   const { data: results, loading: fetchLoading } = useApi(
-    () => api.search(debouncedQ, 16),
-    [debouncedQ],
+    () => api.search(debouncedQ, limit),
+    [debouncedQ, limit],
     {
-      cacheKey: debouncedQ ? queryKeys.search(debouncedQ) : undefined,
+      cacheKey: debouncedQ ? queryKeys.search(debouncedQ, limit) : undefined,
       skip: !debouncedQ,
     },
   );
@@ -166,7 +183,16 @@ export function Search({ onDownload }: { onDownload: OnDownload }) {
         </div>
       )}
 
-      {results && hasAny && (
+      {/* Kept mounted while a fetch is in flight, not just when there
+          are results. Switching tabs changes the requested limit,
+          which is a different useApi cache key, which is a cold load
+          that clears `data` — so gating this on `results` made the
+          control the user just clicked vanish for the length of the
+          fetch, leaving the browser's back button as the only way
+          out. `loading` covers that window; once it clears, a query
+          that genuinely matched nothing drops the tabs and shows the
+          empty state instead. */}
+      {!!debouncedQ && (loading || hasAny) && (
         <div className="mb-6 flex flex-wrap items-center justify-between gap-3">
           <Tabs value={filter} onValueChange={(v) => onTabChange(v as Filter)}>
             <TabsList>


### PR DESCRIPTION
## Summary

Reported by a user: searching an artist doesn't show all their albums, tracks and playlists.

The Search page asked for sixteen of each kind and every tab reused that one response, so clicking through to Albums showed the same sixteen the landing row had already shown and there was no way to reach the rest. Tidal's search stops serving past 300 of any one type, so that is what a dedicated tab asks for now: 163 albums for "radiohead" instead of 16. The All tab keeps its small request — it re-runs on every pause while the user is still typing, its sections are one viewport row each, and the full set measures ~400ms against ~100ms warm.

The tab bar is now kept mounted while a fetch is in flight rather than only when there are results. Switching tabs changes the requested limit, which is a different `useApi` cache key, which is a cold load that clears `data` — so gating the tab bar on `results` made the control the user just clicked vanish for the length of the fetch, leaving the browser's back button as the only way out.

## Scope note, please read

Widening the pool exposed a ranking bug that the small pool had been hiding, and it is fixed here rather than shipped as a regression. **This is scope beyond the reported bug and is the part worth a careful look.**

The reranker scored an album or track on its title alone, which is backwards when the query is an artist name: six unrelated albums literally titled "Radiohead" scored EXACT and pushed OK Computer, which scored nothing, off the top. The lexical class is now the better of the title's match and the credited artist's, with popularity separating the tie — which restores the order Tidal returns before we touch it. Artist rescoring passes no credited names and is unchanged.

## Test plan

- `tests/test_search_ranking.py` gains 6 cases: an album by the searched artist beating one merely named for them, a title query still putting the title first, the class hierarchy still dominating, popularity ordering a tie, artists being unaffected, and a missing artist credit falling back to the title.
- Verified live: "radiohead" now leads with In Rainbows / OK Computer / Kid A instead of junk; "in rainbows" and "ok computer" still put the real album first.
- Tab-switch flicker verified with a real click and a 25ms sampler across the fetch window: the tab bar was present in all 13 samples, 107 albums landed.
- `./scripts/preflight.sh` green.