### PR TITLE
Serve DLNA tracks with real Content-Length; don't tear the renderer down on desktop seek

### DIFF
--- a/app/audio/http_stream.py
+++ b/app/audio/http_stream.py
@@ -34,8 +34,10 @@ from __future__ import annotations
 
 import http.server
 import logging
+import os
 import socket
 import socketserver
+import tempfile
 import threading
 import time
 import urllib.parse
@@ -994,6 +996,131 @@ class FlacPassthroughEncoder:
             pass
 
 
+class TrackFileSource:
+    """Demux a finite fMP4 source into a complete FLAC temp file.
+
+    FlacPassthroughEncoder streams into a live RingBuffer and the stream
+    advertises a synthetic ~1TB Content-Length. Strict DLNA renderers
+    (UAPP) use that Content-Length as the track length, so when the real
+    FLAC ends they seek "ahead" for data that isn't there and hit
+    'unexpected end of stream' / avcodec -1094995529 at every track
+    boundary (perceived as a cut before the end).
+
+    This buffers the ENTIRE track to a temp file so the DLNA response
+    can advertise the REAL byte length. The renderer then knows the
+    exact end, treats it as expected, and never seeks past it.
+
+    `ready` fires once the whole track is on disk and `total_size` is
+    final. The HTTP serve loop waits on `ready` before answering, then
+    streams the file — Content-Length = total_size, Range supported.
+    `done_event`, when given, is set on completion so the UPnP session's
+    passthrough state machine advances exactly as with the live encoder.
+    """
+
+    def __init__(self, source, track_id: int = 0, *, tempdir=None, done_event=None) -> None:
+        self._source = source
+        self.track_id = track_id
+        self.total_size = 0
+        self.failed = False
+        self.ready = threading.Event()
+        self._done_event = done_event
+        self._tempdir = tempdir
+        self._path = None
+        self._thread = None
+        self._container_in = None
+
+    @property
+    def path(self) -> Optional[str]:
+        return self._path
+
+    def start(self) -> None:
+        self._thread = threading.Thread(
+            target=self._run, name="flac-track-filesource", daemon=True
+        )
+        self._thread.start()
+
+    def close(self) -> None:
+        if self._thread is not None:
+            self._thread.join(timeout=5.0)
+        try:
+            if self._container_in is not None:
+                self._container_in.close()
+        except Exception:
+            pass
+        if self._path and os.path.exists(self._path):
+            try:
+                os.unlink(self._path)
+            except OSError:
+                pass
+
+    def _run(self) -> None:
+        import av
+
+        try:
+            self._container_in = av.open(
+                self._source,
+                format="mp4",
+                options={"probesize": "131072", "analyzeduration": "200000"},
+            )
+            stream_in = next(
+                s for s in self._container_in.streams if s.type == "audio"
+            )
+            extradata = getattr(stream_in.codec_context, "extradata", None) or b""
+            raw_streaminfo = extradata[4:] if extradata[:1] == b"\x80" else extradata
+            if len(raw_streaminfo) < 18:
+                raw_streaminfo = b""
+
+            demux_iter = self._container_in.demux(stream_in)
+            first_packet = next(demux_iter)
+            raw_first = bytes(first_packet)
+            frame_bps = _parse_flac_frame_bps(raw_first) if raw_first else 16
+
+            bps = 16
+            if raw_streaminfo and len(raw_streaminfo) >= 18:
+                bps = (((raw_streaminfo[12] & 1) << 4) | (raw_streaminfo[13] >> 4)) + 1
+
+            header = _build_flac_stream_header(
+                sample_rate=stream_in.codec_context.sample_rate,
+                channels=getattr(stream_in.codec_context.layout, "nb_channels", 2) or 2,
+                bits_per_sample=bps if raw_streaminfo else frame_bps,
+                total_samples=0,
+                streaminfo_bytes=raw_streaminfo if raw_streaminfo else None,
+            )
+
+            tf = tempfile.NamedTemporaryFile(
+                prefix="tideway-track-", suffix=".flac",
+                dir=self._tempdir, delete=False,
+            )
+            self._path = tf.name
+            total = 0
+            with tf:
+                tf.write(header)
+                total += len(header)
+                if raw_first:
+                    tf.write(raw_first)
+                    total += len(raw_first)
+                for packet in demux_iter:
+                    raw = bytes(packet)
+                    if not raw:
+                        continue
+                    tf.write(raw)
+                    total += len(raw)
+            self.total_size = total
+        except Exception as exc:
+            self.failed = True
+            print(f"[upnp] track-filesource failed: {exc!r}", flush=True)
+        finally:
+            try:
+                if self._container_in is not None:
+                    self._container_in.close()
+            except Exception:
+                pass
+            self.ready.set()
+            if self._done_event is not None:
+                self._done_event.set()
+            print("[upnp] track-filesource complete", flush=True)
+
+
 class StreamHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
     """Dedicated HTTP server, bound to 0.0.0.0 on an ephemeral port,
     used solely for serving an audio stream to a LAN receiver.
@@ -1025,6 +1152,13 @@ class StreamHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
     # don't and shouldn't see the header. Set per session so the
     # shared handler only emits DLNA-specific headers on DLNA streams.
     dlna: bool = False
+
+    # When set, DLNA requests are served from a bounded per-track temp
+    # file (TrackFileSource) with the REAL Content-Length instead of
+    # the synthetic ~1TB the live RingBuffer path advertises. Set by
+    # the UPnP session on start_passthrough, cleared when passthrough
+    # stops (fallback PCM re-encode is served from the RingBuffer).
+    track_source: Optional["TrackFileSource"] = None
 
 
 class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
@@ -1134,6 +1268,69 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         self.send_header("Connection", "close")
         self.end_headers()
 
+    def _serve_track(self, server: "StreamHTTPServer", head: bool = False) -> None:
+        """Serve a fully-buffered track file with the REAL byte length.
+
+        The renderer's decoder uses the FLAC STREAMINFO (real
+        total_samples) but the HTTP Content-Length we used to advertise
+        was a synthetic ~1TB. That mismatch made strict renderers treat
+        the real track end as 'unexpected end of stream' and seek past
+        it. Here the Content-Length is the actual file size, so the
+        renderer knows the exact end and stops cleanly.
+
+        Always answers 206 (DLNA convention) with a Content-Range over
+        the real total, and honours a byte Range for seek.
+        """
+        src = server.track_source
+        if src is None:
+            self.send_error(503, "no track")
+            return
+        parsed = urllib.parse.urlsplit(self.path)
+        req_ts = int(urllib.parse.parse_qs(parsed.query).get("ts", [0])[0])
+        if req_ts and src.track_id and req_ts != src.track_id:
+            self.send_error(410, "stale track")
+            return
+        if not src.ready.wait(timeout=15.0):
+            self.send_error(503, "track not ready")
+            return
+        if src.failed or src.path is None:
+            self.send_error(502, "track failed")
+            return
+        total = src.total_size
+        range_hdr = self.headers.get("Range", "")
+        start = 0
+        if range_hdr.startswith("bytes="):
+            try:
+                start = int(range_hdr[6:].split("-")[0] or 0)
+            except ValueError:
+                start = 0
+        if start > total:
+            start = total
+        self.send_response(206)
+        self.send_header(
+            "Content-Range", f"bytes {start}-{max(total - 1, 0)}/{total}"
+        )
+        self.send_header("Content-Length", str(total - start))
+        self.send_header("Accept-Ranges", "bytes")
+        self.send_header("Content-Type", server.content_type)
+        self.send_header("transferMode.dlna.org", "Streaming")
+        if self.headers.get("getcontentFeatures.dlna.org"):
+            self.send_header("contentFeatures.dlna.org", DLNA_CONTENT_FEATURES)
+        self.send_header("Connection", "close")
+        self.end_headers()
+        if head:
+            return
+        try:
+            with open(src.path, "rb") as f:
+                f.seek(start)
+                while True:
+                    chunk = f.read(65536)
+                    if not chunk:
+                        break
+                    self.wfile.write(chunk)
+        except (BrokenPipeError, ConnectionResetError, socket.timeout):
+            pass
+
     def do_HEAD(self) -> None:  # noqa: N802 - stdlib API
         # Some receivers (and plenty of middleboxes) probe headers
         # with a HEAD before GET to check Content-Type and confirm
@@ -1141,22 +1338,39 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         # uses so they don't fall back or abort.
         self._log_connection("HEAD")
         server = self.server  # type: ignore[assignment]
-        if not isinstance(server, StreamHTTPServer) or server.buffer is None:
+        if not isinstance(server, StreamHTTPServer):
             self.send_error(503, "stream session not ready")
             return
         if self._request_path() != server.stream_path:
             self.send_error(404, "not found")
+            return
+        # Bounded per-track file: headers only, with the real length.
+        if server.dlna and server.track_source is not None:
+            self._serve_track(server, head=True)
+            return
+        if server.buffer is None:
+            self.send_error(503, "stream session not ready")
             return
         self._send_stream_headers(server)
 
     def do_GET(self) -> None:  # noqa: N802 - stdlib API
         self._log_connection("GET")
         server = self.server  # type: ignore[assignment]
-        if not isinstance(server, StreamHTTPServer) or server.buffer is None:
+        if not isinstance(server, StreamHTTPServer):
             self.send_error(503, "stream session not ready")
             return
         if self._request_path() != server.stream_path:
             self.send_error(404, "not found")
+            return
+        # Bounded per-track file: real Content-Length (the whole track
+        # is buffered to disk before we answer), so UAPP never seeks
+        # past the real end or hits the "unexpected end of stream"
+        # recovery that the synthetic ~1TB Content-Length caused.
+        if server.dlna and server.track_source is not None:
+            self._serve_track(server)
+            return
+        if server.buffer is None:
+            self.send_error(503, "stream session not ready")
             return
         buf = server.buffer
         # Parse ?ts= from the request to detect stale requests from

--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -1299,6 +1299,24 @@ class PCMPlayer:
             )
             with self._lock:
                 self._preload = pre
+            # Pre-buffer the next track's DLNA passthrough while this one
+            # plays, so the renderer's track-change can promote it without
+            # a demux pause (gapless). No-ops for local files and when
+            # no UPnP session is active.
+            if pre.source_urls is not None:
+                if (
+                    _upnp_manager is not None
+                    and _upnp_manager.is_active()
+                ):
+                    try:
+                        _upnp_manager.prepare_next_passthrough(
+                            pre.source_urls, prefetched_bytes
+                        )
+                    except Exception as exc:
+                        print(
+                            f"[player] upnp prepare_next failed: {exc!r}",
+                            flush=True,
+                        )
             return {
                 "ok": True,
                 "cached": True,

--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -1046,9 +1046,17 @@ class PCMPlayer:
             # over for the remainder of this track; passthrough
             # resumes automatically when the next track loads.
             # See issue #273 for context.
+            #
+            # BUT: while DLNA is serving a bounded per-track file the
+            # renderer is the playback clock. A desktop seek must NOT
+            # tear down the renderer's source — that drops it onto the
+            # ~1TB synthetic RingBuffer stream, which UAPP cannot parse
+            # (contentLength=1099511627776) and it stalls/fails. Here we
+            # just re-seek the local decoder; the renderer keeps playing
+            # this track and advances when it consumes it.
             if _upnp_manager is not None:
                 try:
-                    if _upnp_manager.is_active():
+                    if _upnp_manager.is_active() and not _upnp_manager.bounded_serving():
                         _upnp_manager.stop_passthrough()
                 except Exception as exc:
                     print(f"[player] upnp stop_passthrough on seek failed: {exc!r}", flush=True)

--- a/app/audio/upnp.py
+++ b/app/audio/upnp.py
@@ -446,6 +446,26 @@ class UpnpManager:
         actually taken."""
         return self._session is not None
 
+    def bounded_serving(self) -> bool:
+        """True while a bounded per-track DLNA file is being served to
+        the renderer (a `TrackFileSource`, not the live RingBuffer).
+
+        Used by the player's seek path: while DLNA is serving a bounded
+        file, the renderer is the playback clock, so a desktop seek must
+        NOT tear down the renderer's source (which would drop it onto
+        the ~1TB synthetic RingBuffer stream). Takes the session lock —
+        only called from non-realtime paths."""
+        with self._session_lock:
+            session = self._session
+        if session is None:
+            return False
+        http = getattr(session, "http_server", None)
+        return bool(
+            http is not None
+            and getattr(http, "dlna", False)
+            and getattr(http, "track_source", None) is not None
+        )
+
     # ---- listener bus ----------------------------------------------
 
     def set_local_silencer(

--- a/app/audio/upnp.py
+++ b/app/audio/upnp.py
@@ -318,6 +318,11 @@ class _SessionState:
     passthrough_active: bool = False
     _passthrough_source_urls: Optional[tuple[str, ...]] = None
     _passthrough_done_event: Optional[threading.Event] = None
+    # Bounded per-track preload: the NEXT track's buffered file, demuxed
+    # during the current track so the renderer's SetAVTransportURI switch
+    # can promote it instantly instead of pausing for a full demux.
+    next_track_source: Optional[TrackFileSource] = None
+    next_source_urls: Optional[tuple[str, ...]] = None
     # Serializes every read-modify-write of the passthrough fields above.
     # Touched from three threads — player pipeline (start/stop), realtime
     # audio callback (push_pcm), and last-track EOF (signal_source_done).
@@ -616,21 +621,49 @@ class UpnpManager:
         http_server = getattr(session, "http_server", None)
         track_source = None
         if http_server is not None and getattr(http_server, "dlna", False):
-            # Drop the previous track's buffered file (natural end ->
-            # next track does NOT go through stop_passthrough).
             prev = getattr(http_server, "track_source", None)
-            if prev is not None:
-                try:
-                    prev.close()
-                except Exception:
-                    pass
-            track_source = TrackFileSource(
-                source=reader,
-                track_id=_track_ts,
-                done_event=done_event,
-            )
-            http_server.track_source = track_source
-            track_source.start()
+            # Promote a preloaded next-track file if it matches this
+            # source (the renderer's track change then serves it
+            # immediately — gapless, no demux pause). Otherwise build a
+            # fresh bounded file (first track, or a skip to a track that
+            # wasn't preloaded).
+            with session.passthrough_lock:
+                pre_loaded = session.next_track_source
+                pre_urls = session.next_source_urls
+                session.next_track_source = None
+                session.next_source_urls = None
+            if pre_loaded is not None and pre_urls == _source_urls:
+                if prev is not None and prev is not pre_loaded:
+                    try:
+                        prev.close()
+                    except Exception:
+                        pass
+                pre_loaded.track_id = _track_ts
+                http_server.track_source = pre_loaded
+                track_source = pre_loaded
+            else:
+                if pre_loaded is not None:
+                    try:
+                        pre_loaded.close()
+                    except Exception:
+                        pass
+                if prev is not None:
+                    try:
+                        prev.close()
+                    except Exception:
+                        pass
+                # No done_event: the file is served to the renderer up to
+                # its real Content-Length, so the track change is driven
+                # by the player, not by a demux-complete signal (which
+                # for a bounded file happens seconds before the audio
+                # ends and would cut off the tail).
+                track_source = TrackFileSource(
+                    source=reader,
+                    track_id=_track_ts,
+                    done_event=None,
+                )
+                http_server.track_source = track_source
+                track_source.start()
         else:
             session.passthrough_encoder = FlacPassthroughEncoder(
                 source=reader,
@@ -654,6 +687,60 @@ class UpnpManager:
             "[upnp] passthrough ON -- bitperfect FLAC passthrough enabled",
             flush=True,
         )
+
+    def prepare_next_passthrough(
+        self, source_urls, prefetched=None
+    ) -> None:
+        """Demux the NEXT track's FLAC to a buffered temp file while the
+        current one plays, so the renderer's track change can promote it
+        instantly — gapless with no demux pause.
+
+        Called by the player when it preloads the following track (it
+        already knows that track's source URLs via the PCM preload). If a
+        different source was preloaded previously, it is replaced. A stale
+        preload that never gets promoted is closed on the next
+        start_passthrough / disconnect.
+        """
+        with self._session_lock:
+            session = self._session
+        if session is None:
+            return
+        http_server = getattr(session, "http_server", None)
+        if http_server is None or not getattr(http_server, "dlna", False):
+            return
+        if not session.passthrough_active:
+            return
+        if not isinstance(source_urls, (list, tuple)):
+            return
+        _src = tuple(source_urls)
+        with session.passthrough_lock:
+            if (
+                session.next_track_source is not None
+                and session.next_source_urls == _src
+            ):
+                return
+            old = session.next_track_source
+            session.next_track_source = None
+            session.next_source_urls = None
+        if old is not None:
+            try:
+                old.close()
+            except Exception:
+                pass
+        try:
+            from app.audio.segment_reader import SegmentReader
+            reader = SegmentReader(list(_src), prefetched=prefetched or {})
+            ts = TrackFileSource(source=reader)
+        except Exception as exc:
+            print(
+                f"[upnp] prepare_next_passthrough failed: {exc!r}",
+                flush=True,
+            )
+            return
+        with session.passthrough_lock:
+            session.next_track_source = ts
+            session.next_source_urls = _src
+        ts.start()
 
     # ---- track-change notification ----------------------------------
 

--- a/app/audio/upnp.py
+++ b/app/audio/upnp.py
@@ -68,6 +68,7 @@ from app.audio.http_stream import (
     FlacStreamEncoder,
     RingBuffer,
     StreamHTTPServer,
+    TrackFileSource,
     primary_lan_ip,
     start_stream_http_server,
 )
@@ -603,6 +604,34 @@ class UpnpManager:
             session.passthrough_active = True
             session.buffer.flush()
             session.buffer.set_track_id(_track_ts)
+            session.passthrough_encoder = None
+
+        # Bounded per-track file: demux the whole track to a temp file so
+        # the DLNA response can advertise the REAL byte length. The live
+        # RingBuffer encoder (FlacPassthroughEncoder) plus a synthetic
+        # ~1TB Content-Length made strict renderers (UAPP) seek past the
+        # real track end -> 'unexpected end of stream' -> avcodec
+        # -1094995529 (a cut before the end). Buffering per track lets us
+        # serve the actual size instead.
+        http_server = getattr(session, "http_server", None)
+        track_source = None
+        if http_server is not None and getattr(http_server, "dlna", False):
+            # Drop the previous track's buffered file (natural end ->
+            # next track does NOT go through stop_passthrough).
+            prev = getattr(http_server, "track_source", None)
+            if prev is not None:
+                try:
+                    prev.close()
+                except Exception:
+                    pass
+            track_source = TrackFileSource(
+                source=reader,
+                track_id=_track_ts,
+                done_event=done_event,
+            )
+            http_server.track_source = track_source
+            track_source.start()
+        else:
             session.passthrough_encoder = FlacPassthroughEncoder(
                 source=reader,
                 buffer=session.buffer,
@@ -718,6 +747,17 @@ class UpnpManager:
         if encoder is not None:
             try:
                 encoder.close()
+            except Exception:
+                pass
+        # Clear any bounded per-track file so subsequent requests fall
+        # back to the live RingBuffer (PCM re-encode) path, and delete
+        # its temp file.
+        http_server = getattr(session, "http_server", None)
+        track_source = getattr(http_server, "track_source", None) if http_server else None
+        if track_source is not None:
+            http_server.track_source = None
+            try:
+                track_source.close()
             except Exception:
                 pass
         print("[upnp] passthrough OFF", flush=True)
@@ -852,6 +892,12 @@ class UpnpManager:
             except Exception:
                 pass
             try:
+                ts = getattr(session.http_server, "track_source", None)
+                if ts is not None:
+                    ts.close()
+            except Exception:
+                pass
+            try:
                 session.buffer.close()
             except Exception:
                 pass
@@ -930,6 +976,12 @@ class UpnpManager:
                 session.http_server.server_close()
         except Exception as exc:
             log.debug("http server shutdown failed: %r", exc)
+        try:
+            ts = getattr(session.http_server, "track_source", None)
+            if ts is not None:
+                ts.close()
+        except Exception as exc:
+            log.debug("track-source close failed: %r", exc)
         # Tell the device to stop pulling. Best-effort: if the
         # device has already disconnected we'll get a transport
         # error and that's fine.

--- a/tests/test_http_stream.py
+++ b/tests/test_http_stream.py
@@ -763,3 +763,119 @@ class TestDlnaHttpCompliance:
             server.shutdown()
             server.server_close()
             buffer.close()
+
+
+# ---------------------------------------------------------------------
+# Bounded per-track file serve (real Content-Length)
+# ---------------------------------------------------------------------
+
+
+class TestBoundedTrackServe:
+    """A strict DLNA renderer uses the HTTP Content-Length as the track
+    length. The live RingBuffer path advertised a synthetic ~1TB, so a
+    renderer (UAPP) hit 'unexpected end of stream' and sought past the
+    real end at every track boundary. The bounded path serves a fully
+    buffered track with the REAL byte length so the end is expected."""
+
+    def _server(self, track_id: int):
+        import os
+        import tempfile
+        from types import SimpleNamespace
+
+        buffer = RingBuffer()
+        buffer.write(b"\x00" * 256)
+        buffer.data_ready.set()
+        server = start_stream_http_server(
+            buffer,
+            stream_path="/dlna/stream",
+            content_type="audio/flac",
+            dlna=True,
+        )
+        path = tempfile.NamedTemporaryFile(
+            prefix="tideway-test-", suffix=".flac", delete=False
+        ).name
+        body = b"\xff\xf8FLAC" + b"x" * 1000
+        with open(path, "wb") as f:
+            f.write(body)
+        ready = threading.Event()
+        ready.set()
+        server.track_source = SimpleNamespace(
+            ready=ready,
+            total_size=len(body),
+            path=path,
+            track_id=track_id,
+            failed=False,
+        )
+        return server, buffer, path, len(body)
+
+    def _get_full(self, server, raw_request: bytes) -> bytes:
+        import socket as _socket
+
+        port = server.server_address[1]
+        sock = _socket.create_connection(("127.0.0.1", port), timeout=3.0)
+        try:
+            sock.sendall(raw_request)
+            chunks = []
+            while True:
+                data = sock.recv(4096)
+                if not data:
+                    break
+                chunks.append(data)
+            return b"".join(chunks)
+        finally:
+            sock.close()
+
+    def test_serves_real_content_length_without_range(self):
+        import os
+
+        server, buffer, path, total = self._server(12345)
+        try:
+            raw = self._get_full(
+                server,
+                b"GET /dlna/stream?ts=12345 HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            )
+            assert raw.startswith(b"HTTP/1.1 206"), raw[:60]
+            assert f"Content-Length: {total}".encode() in raw, raw[:200]
+            assert b"Content-Range: bytes 0-" in raw
+            assert b"\xff\xf8FLAC" in raw
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()
+            os.unlink(path)
+
+    def test_serves_byte_range(self):
+        import os
+
+        server, buffer, path, total = self._server(1)
+        try:
+            raw = self._get_full(
+                server,
+                b"GET /dlna/stream?ts=1 HTTP/1.1\r\nHost: localhost\r\nRange: bytes=10-\r\n\r\n",
+            )
+            assert raw.startswith(b"HTTP/1.1 206"), raw[:60]
+            assert (
+                f"Content-Range: bytes 10-{total - 1}/{total}".encode() in raw
+            ), raw[:200]
+            assert len(raw.split(b"\r\n\r\n", 1)[1]) == total - 10
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()
+            os.unlink(path)
+
+    def test_stale_ts_rejected(self):
+        import os
+
+        server, buffer, path, _ = self._server(999)
+        try:
+            raw = self._get_full(
+                server,
+                b"GET /dlna/stream?ts=111 HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            )
+            assert raw.startswith(b"HTTP/1.1 410"), raw[:60]
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()
+            os.unlink(path)

--- a/tests/test_upnp_session.py
+++ b/tests/test_upnp_session.py
@@ -501,6 +501,38 @@ def _attach_session(mgr: UpnpManager) -> _SessionState:
     return sess
 
 
+class TestBoundedServing:
+    def test_no_session_is_false(self):
+        assert UpnpManager().bounded_serving() is False
+
+    def test_dlna_track_source_serving_is_true(self):
+        mgr = UpnpManager()
+        sess = _attach_session(mgr)
+        http = MagicMock()
+        http.dlna = True
+        http.track_source = object()
+        sess.http_server = http
+        assert mgr.bounded_serving() is True
+
+    def test_no_track_source_is_false(self):
+        mgr = UpnpManager()
+        sess = _attach_session(mgr)
+        http = MagicMock()
+        http.dlna = True
+        http.track_source = None
+        sess.http_server = http
+        assert mgr.bounded_serving() is False
+
+    def test_non_dlna_server_is_false(self):
+        mgr = UpnpManager()
+        sess = _attach_session(mgr)
+        http = MagicMock()
+        http.dlna = False
+        http.track_source = object()
+        sess.http_server = http
+        assert mgr.bounded_serving() is False
+
+
 class TestPushPcmNoSession:
     def test_no_session_returns_cheaply(self):
         """Audio callback hits push_pcm on every frame even when


### PR DESCRIPTION
## Summary

Two fixes for the DLNA FLAC passthrough path.

**Real Content-Length (no early cut).** The passthrough stream advertised a synthetic ~1TB `Content-Length` while the FLAC kept the real `total_samples`. UAPP treats the advertised length as the track length, so at a real track end it seeks "ahead" for data that doesn't exist and hits `avcodec_send_packet error: -1094995529` — a cut before the end.

`TrackFileSource` now demuxes the whole track to a temp file, and `_serve_track` advertises the real byte length. `prepare_next_passthrough` demuxes the NEXT track to its own temp file while the current plays, and `start_passthrough` promotes it at the boundary — gapless with no re-demux pause. The live RingBuffer (Cast / PCM re-encode) path is unchanged.

**Desktop seek no longer tears down the renderer.** While a bounded per-track file is being served the renderer is the playback clock. A desktop seek used to call `stop_passthrough`, which cleared `track_source` and dropped the renderer onto the ~1TB synthetic RingBuffer stream (`contentLength=1099511627776`) it cannot parse — UAPP sat with `currentDecoder was nullptr!`. Now `seek()` only re-seeks the local decoder when `bounded_serving()` is true, leaving the renderer's source untouched so it finishes the track and advances on its own.

## Test plan

- `pytest tests/test_http_stream.py tests/test_upnp_session.py tests/test_prefetch_jitter.py tests/test_resolve_source_parallel.py tests/test_pcm_stream_eof.py`.
- On device: play an album in UAPP and let it run through several tracks — each track should play to its full length (no `avcodec -1094995529`, no cut). A desktop seek back should no longer make the renderer fall back to the ~1TB stream or stall; the renderer keeps playing the current track.

Note: perfect gap-free gapless across tracks is still open — UAPP confirms playback position only via its own clock and buffers (`networkBufferSizeSeconds=15`), so an exact zero-gap cut is not achievable over this passthrough. This PR guarantees each track plays to its real end (no premature cut) and removes the seek-triggered stall.