### PR TITLE
Stop capping the artist page's Videos row at 50

### DIFF
--- a/server.py
+++ b/server.py
@@ -8744,7 +8744,13 @@ def artist_detail(artist_id: int) -> dict:
         f_videos = pool.submit(
             _safe_t,
             "videos",
-            lambda: [video_to_dict(v) for v in artist.get_videos(limit=50) or []],
+            # No limit: Tidal returns the artist's whole video list in
+            # one response and charges nothing for the extra (59 vs 50
+            # for Drake, same ~160ms). The old cap of 50 silently cut
+            # the tail off any artist with more.
+            lambda: [
+                video_to_dict(v) for v in artist.get_videos(limit=None) or []
+            ],
             [],
         )
         f_credits = pool.submit(


### PR DESCRIPTION
## Summary

Reported by a user: "not all the artist videos are shown". `get_videos` asked for `limit=50` and Drake has 59, so the tail was silently cut. `limit=None` returns the whole list for the same ~160ms, so there's nothing to trade.

The drill-down at `/artist/:id/all/videos` reads this straight off the main artist payload, so it picks up the longer list with no frontend change.

| Artist | Before | After |
|---|---|---|
| Drake | 50 | **59** |
| Radiohead | 18 | 18 |
| Phoebe Bridgers | 3 | 3 |

## Dropped from this PR

This originally also raised "Popular" from 10 top tracks to 100, answering the same user's request. That's been removed. Three reasons, all found after the fact:

- The artist page's "Show more" under Popular expands **inline**, not into a drill-down, so 100 tracks would push the entire discography below the fold.
- A 100-item list under a heading called "Popular" isn't popular, it's the catalogue ordered by play count.
- `useSpotifyTrackPlaycountBatch(artist.top_tracks)` enriches **every** top track on every artist page load. 10 → 100 would have made that a 10x larger Spotify request on the critical path, for tracks nobody scrolls to. The original PR claimed the change cost "about 20ms", which was the Tidal call in isolation and ignored this entirely.

If it's ever revisited, the binding constraints are the inline expand and that batch, not the Tidal call.

## Test plan

- `./scripts/preflight.sh` green.
- Verified through the running endpoint on three artists, table above.
- No test asserted the old cap.

Note: `GET /api/artist/{id}/videos` still defaults to `limit=50`. It's declared in `client.ts` but never called from any page, so I left the dead path alone.