### PR TITLE
Show recent searches in the search bar, not just on the Search page

### DIFF
--- a/web/src/components/NavBar.tsx
+++ b/web/src/components/NavBar.tsx
@@ -150,10 +150,12 @@ function NavBarSearch({ className }: { className?: string }) {
     }
   };
 
-  // Dropdown is "open" only when both: the input has focus AND there's
-  // something to search for. Empty + focused renders nothing — no
-  // gratuitous "Start typing" panel, that's the placeholder's job.
-  const dropdownOpen = focused && value.trim().length > 0;
+  // Open whenever the input has focus. An empty box is no longer a
+  // dead end: SearchSuggestions shows recent searches there, which is
+  // where people look for their history. It renders no panel at all
+  // when there is nothing to offer, so a first-run empty box still
+  // gets the placeholder rather than a gratuitous popover.
+  const dropdownOpen = focused;
 
   const closeDropdown = () => {
     setFocused(false);

--- a/web/src/components/SearchSuggestions.tsx
+++ b/web/src/components/SearchSuggestions.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { ArrowRight, Loader2, Music } from "lucide-react";
+import { ArrowRight, Clock, Loader2, Music } from "lucide-react";
 import { api } from "@/api/client";
 import type {
   Album,
@@ -9,6 +9,7 @@ import type {
   SearchResponse,
   Track,
 } from "@/api/types";
+import { useSearchHistory } from "@/hooks/useSearchHistory";
 import { cn, imageProxy } from "@/lib/utils";
 
 /**
@@ -16,6 +17,11 @@ import { cn, imageProxy } from "@/lib/utils";
  * input. Reuses /api/search at a smaller limit and renders a compact
  * preview: top hit + a couple of rows from each kind, plus a
  * "Show all results" footer that lands on the full Search page.
+ *
+ * With the input empty it shows recent searches instead. That is
+ * where people look for their history — clicking the search bar —
+ * and 1.29.0 shipped it only on the Search page's empty state, which
+ * a user has to already be on to see.
  *
  * Click target depends on row kind: track → album page (no per-track
  * page exists), album / playlist → detail page, artist → profile.
@@ -31,7 +37,8 @@ type ContentRow =
   | { kind: "artist"; item: Artist }
   | { kind: "playlist"; item: Playlist };
 
-type Row = ContentRow | { kind: "see-all" };
+type Row =
+  ContentRow | { kind: "see-all" } | { kind: "history"; query: string };
 
 export function SearchSuggestions({
   query,
@@ -47,6 +54,7 @@ export function SearchSuggestions({
   /** Fired on Escape so the parent can clear focus / close. */
   onCloseRequested: () => void;
 }) {
+  const { history } = useSearchHistory();
   const [results, setResults] = useState<SearchResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [selected, setSelected] = useState(0);
@@ -95,6 +103,12 @@ export function SearchSuggestions({
   // 2 of each remaining kind. Keep the dropdown short — the full
   // Search page is one Enter / click away.
   const rows = useMemo<Row[]>(() => {
+    // Empty input: offer what the user searched for before. Recents
+    // and results are never both on screen, so they share the row
+    // list and get the same keyboard handling for free.
+    if (query.trim().length === 0) {
+      return history.map((q) => ({ kind: "history", query: q }) as Row);
+    }
     if (!results) return [];
     const out: Row[] = [];
     const topHitId = results.top_hit
@@ -127,7 +141,7 @@ export function SearchSuggestions({
     take("playlist", results.playlists, 1);
     if (out.length > 0) out.push({ kind: "see-all" });
     return out;
-  }, [results]);
+  }, [results, query, history]);
 
   // Reset selection whenever the row set changes so we don't point at
   // a stale index after a query refresh.
@@ -139,6 +153,10 @@ export function SearchSuggestions({
     onActivate();
     if (row.kind === "see-all") {
       navigate(`/search?q=${encodeURIComponent(query.trim())}`);
+      return;
+    }
+    if (row.kind === "history") {
+      navigate(`/search?q=${encodeURIComponent(row.query)}`);
       return;
     }
     const { kind, item } = row;
@@ -201,6 +219,10 @@ export function SearchSuggestions({
   }, [selected]);
 
   if (!open) return null;
+  const isHistoryView = query.trim().length === 0;
+  // An empty box with nothing searched yet has nothing to say. Render
+  // no panel at all rather than an empty popover under the input.
+  if (isHistoryView && rows.length === 0) return null;
 
   const showEmpty = !loading && query.trim().length >= 2 && rows.length === 0;
   const tooShort = query.trim().length > 0 && query.trim().length < 2;
@@ -217,6 +239,11 @@ export function SearchSuggestions({
         ref={listRef}
         className="max-h-[60vh] overflow-y-auto scrollbar-thin"
       >
+        {isHistoryView && (
+          <div className="px-4 pb-1 pt-2.5 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+            Recent searches
+          </div>
+        )}
         {loading && rows.length === 0 && (
           <div className="flex items-center gap-2 px-4 py-3 text-sm text-muted-foreground">
             <Loader2 className="h-4 w-4 animate-spin" /> Searching…
@@ -249,6 +276,7 @@ export function SearchSuggestions({
 
 function rowKey(row: Row): string {
   if (row.kind === "see-all") return "see-all";
+  if (row.kind === "history") return `history:${row.query}`;
   return `${row.kind}:${row.item.id}`;
 }
 
@@ -279,6 +307,24 @@ function SuggestionRow({
       >
         <span>Show all results</span>
         <ArrowRight className="h-4 w-4" />
+      </button>
+    );
+  }
+
+  if (row.kind === "history") {
+    return (
+      <button
+        data-row-index={index}
+        type="button"
+        onMouseMove={onMouseMove}
+        onClick={onClick}
+        className={cn(
+          "flex w-full items-center gap-3 px-4 py-2.5 text-left text-sm transition-colors",
+          active ? "bg-accent" : "hover:bg-accent/60",
+        )}
+      >
+        <Clock className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="truncate">{row.query}</span>
       </button>
     );
   }

--- a/web/src/hooks/useSearchHistory.test.tsx
+++ b/web/src/hooks/useSearchHistory.test.tsx
@@ -4,6 +4,7 @@ import { createRoot, type Root } from "react-dom/client";
 import {
   MAX_HISTORY,
   addToHistory,
+  resetSearchHistoryCache,
   useSearchHistory,
 } from "./useSearchHistory";
 
@@ -95,7 +96,12 @@ describe("useSearchHistory", () => {
     act(() => root.render(<Probe />));
   }
 
-  beforeEach(() => localStorage.clear());
+  beforeEach(() => {
+    localStorage.clear();
+    // The store is module-level, so each case has to start from a
+    // clean read of the (now empty) store.
+    resetSearchHistoryCache();
+  });
 
   afterEach(() => {
     act(() => root.unmount());
@@ -159,6 +165,33 @@ describe("useSearchHistory", () => {
     } finally {
       Object.defineProperty(window, "localStorage", real);
     }
+  });
+
+  it("keeps two mounted readers in sync", () => {
+    // The search bar's dropdown is mounted for the whole session
+    // while the Search page comes and goes. With per-hook state, a
+    // query recorded on the page would never reach the dropdown and
+    // the bar would keep offering a stale list.
+    const second = document.createElement("div");
+    document.body.appendChild(second);
+    const secondRoot = createRoot(second);
+    let other!: ReturnType<typeof useSearchHistory>;
+    function OtherProbe() {
+      other = useSearchHistory();
+      return null;
+    }
+
+    mount();
+    act(() => secondRoot.render(<OtherProbe />));
+
+    act(() => latest.record("daft punk"));
+    expect(other.history).toEqual(["daft punk"]);
+
+    act(() => other.clear());
+    expect(latest.history).toEqual([]);
+
+    act(() => secondRoot.unmount());
+    second.remove();
   });
 
   it("never writes on mount", () => {

--- a/web/src/hooks/useSearchHistory.ts
+++ b/web/src/hooks/useSearchHistory.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
 /**
  * Recent search queries, persisted per install.
@@ -88,52 +88,61 @@ export function addToHistory(entries: string[], raw: string): string[] {
   return [query, ...deduped].slice(0, MAX_HISTORY);
 }
 
-export function useSearchHistory() {
-  // Read in the initializer, not an effect: installStorageShim runs
-  // before the first render, so storage is already usable here, and
-  // seeding state directly avoids a second render pass on every mount
-  // of the search page.
-  const [history, setHistory] = useState<string[]>(read);
+// One shared store rather than per-hook state. Two surfaces read this
+// now — the Search page and the search bar's dropdown — and the
+// dropdown is mounted the whole time the app is. With independent
+// useState copies, a query recorded on the Search page would not
+// reach the already-mounted dropdown until a remount, so the bar
+// would keep offering a stale list.
+//
+// `cache` is read from storage once, lazily. useSyncExternalStore
+// requires getSnapshot to return a stable reference for unchanged
+// state, so re-reading storage on every call would loop forever.
+let cache: string[] | null = null;
+const subscribers = new Set<() => void>();
 
-  // Persisting happens here rather than inside the state updaters,
-  // because an updater has to be pure: React may run one
-  // speculatively and discard the result, which would leave
-  // localStorage holding a list that never became state. StrictMode
-  // also double-invokes them in development.
-  //
-  // The mount pass is skipped deliberately. `history` starts as
-  // whatever read() returned, and read() falls back to [] when
-  // storage is unreadable — writing that back immediately would turn
-  // a transient read failure into permanent data loss.
-  const loaded = useRef(false);
-  useEffect(() => {
-    if (!loaded.current) {
-      loaded.current = true;
-      return;
-    }
-    write(history);
-  }, [history]);
+function getSnapshot(): string[] {
+  if (cache === null) cache = read();
+  return cache;
+}
+
+function subscribe(onChange: () => void): () => void {
+  subscribers.add(onChange);
+  return () => {
+    subscribers.delete(onChange);
+  };
+}
+
+/** Commit a new list: persist it, then wake every mounted reader.
+ *  Only ever called from an event handler or an effect, never from a
+ *  render or a state updater. */
+function commit(next: string[]): void {
+  if (sameOrder(next, getSnapshot())) return;
+  cache = next;
+  write(next);
+  for (const notify of subscribers) notify();
+}
+
+/** Drop the in-memory copy so the next read comes from storage again.
+ *  Exists for tests, which need each case to start from a known
+ *  store; nothing in the app calls it. */
+export function resetSearchHistoryCache(): void {
+  cache = null;
+}
+
+export function useSearchHistory() {
+  const history = useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
 
   const record = useCallback((query: string) => {
-    // Returning `prev` unchanged when nothing moved keeps React from
-    // re-rendering and keeps the persist effect from firing. The
-    // search page calls this again on every re-fetch of the same
-    // query, so the no-op case is the common one.
-    setHistory((prev) => {
-      const next = addToHistory(prev, query);
-      return sameOrder(next, prev) ? prev : next;
-    });
+    commit(addToHistory(getSnapshot(), query));
   }, []);
 
   const remove = useCallback((query: string) => {
-    setHistory((prev) => {
-      const next = prev.filter((e) => e !== query);
-      return sameOrder(next, prev) ? prev : next;
-    });
+    commit(getSnapshot().filter((e) => e !== query));
   }, []);
 
   const clear = useCallback(() => {
-    setHistory((prev) => (prev.length === 0 ? prev : []));
+    commit([]);
   }, []);
 
   return { history, record, remove, clear };


### PR DESCRIPTION
## Summary

A user reported that search "doesn't save the search history; it doesn't show the search history when I press the search bar". They're on 1.29.0, which shipped history — but only on the Search page's empty state, which you have to already be on to see. They clicked the search bar, which is where every other app puts it, and got nothing. Fair.

The NavBar dropdown now shows recents when the input is empty. Recents and results are never on screen together, so they share the existing row list and inherit its keyboard handling, click targets and styling rather than growing a parallel path. An empty box with no history renders **no panel at all**, so a fresh install still gets the placeholder rather than an empty popover under the input.

## The part that needed care

`useSearchHistory` had to become a shared store. Two surfaces read it now, and the dropdown is mounted for the entire session while the Search page comes and goes. With per-hook `useState`, a query recorded on the Search page would never have reached the already-mounted dropdown, so the bar would have kept offering a stale list until a remount.

It's now `useSyncExternalStore` over a module-level cache. That also drops the persist-on-change effect the old shape needed, since writes happen in `commit()` rather than anywhere near a render. `resetSearchHistoryCache()` is exported for tests, which need each case to start from a known store; nothing in the app calls it.

## Test plan

`./scripts/preflight.sh` green. `useSearchHistory.test.tsx` is up to 19 cases, including a new one that mounts two independent readers and asserts a record on one reaches the other — the exact failure the refactor exists to prevent.

Verified in the running app:

- Empty history, click the bar → no panel, just the focused input
- Search "boards of canada", clear the box, click the bar → **"RECENT SEARCHES" with the entry, without a reload**, which is what proves the store propagated across components
- Click a recent → navigates to `/search?q=…` and refills the input
- Arrow down + Enter → same, with the row correctly highlighted

One note: the browser automation's synthetic Return didn't reach the window keydown listener, so I confirmed keyboard activation with a dispatched `KeyboardEvent` instead. The row selection state was verified separately from the DOM (`data-row-index="0"` carrying `bg-accent`).