### PR TITLE
Install flatpak-node-generator from git, not stale PyPI 0.1.1

### DIFF
--- a/.github/workflows/update-flatpak-node-sources.yml
+++ b/.github/workflows/update-flatpak-node-sources.yml
@@ -17,6 +17,7 @@ on:
       - "**"
     paths:
       - "web/package-lock.json"
+      - ".github/workflows/update-flatpak-node-sources.yml"
   workflow_dispatch:
 
 jobs:
@@ -39,16 +40,30 @@ jobs:
           python-version: "3.11"
 
       - name: Install flatpak-node-generator
-        # flatpak-builder-tools ships flatpak-node-generator as a
-        # standalone script. pip-installing from the upstream repo
-        # gives us the same tool the Flatpak maintainers use.
+        # Installed from git, not PyPI. The only PyPI release (0.1.1)
+        # predates lockfile-v2 support for bundled dependencies: its
+        # _process_packages_v2 raises NotImplementedError for any entry
+        # with no "resolved" URL, and npm records bundleDependencies
+        # exactly that way - they ship inside the parent package's
+        # tarball, so there is no separate download to mirror. Tailwind's
+        # @tailwindcss/oxide-wasm32-wasi bundles six @emnapi / @napi-rs
+        # packages, which is why every lockfile bump since Tailwind 4
+        # landed has failed here. Upstream resolves those to a local
+        # source and emits no download entry, which is the right answer.
+        #
+        # Pinned to a commit rather than tracking master so that
+        # regenerating node-sources.json stays reproducible.
         run: |
           pip install --quiet \
             "aiohttp>=3.8" \
             "aiofiles" \
-            "flatpak-node-generator"
+            "flatpak-node-generator @ git+https://github.com/flatpak/flatpak-builder-tools.git@737c0085912f9f7dabf9341d4608e2a77a51a73a#subdirectory=node"
 
       - name: Regenerate node-sources.json
+        # Linux-only. The generator builds the setup_sdk_node_headers.sh
+        # commands with the host's path separator, so generating this
+        # file anywhere but Linux writes backslash paths that break
+        # inside the Flatpak build.
         run: |
           flatpak-node-generator \
             --electron-node-headers \

--- a/flatpak/node-sources.json
+++ b/flatpak/node-sources.json
@@ -5617,26 +5617,12 @@
     },
     {
         "type": "script",
-        "commands": [],
-        "dest-filename": "patch.sh",
-        "dest": "flatpak-node"
-    },
-    {
-        "type": "script",
-        "commands": [
-            "$FLATPAK_BUILDER_BUILDDIR/flatpak-node/patch.sh"
-        ],
-        "dest-filename": "patch-all.sh",
-        "dest": "flatpak-node"
-    },
-    {
-        "type": "script",
         "commands": [
             "version=$(node --version | sed \"s/^v//\")",
             "nodedir=$(dirname \"$(dirname \"$(which node)\")\")",
             "mkdir -p \"flatpak-node/cache/node-gyp/$version\"",
             "ln -s \"$nodedir/include\" \"flatpak-node/cache/node-gyp/$version/include\"",
-            "echo 9 > \"flatpak-node/cache/node-gyp/$version/installVersion\""
+            "echo 11 > \"flatpak-node/cache/node-gyp/$version/installVersion\""
         ],
         "dest-filename": "setup_sdk_node_headers.sh",
         "dest": "flatpak-node"
@@ -5644,7 +5630,6 @@
     {
         "type": "shell",
         "commands": [
-            "FLATPAK_BUILDER_BUILDDIR=$PWD flatpak-node/patch-all.sh",
             "bash flatpak-node/setup_sdk_node_headers.sh"
         ]
     }


### PR DESCRIPTION
## Summary

The `regenerate` job has failed on every lockfile bump since Tailwind 4 landed in 1.27.0:

```
NotImplementedError: Don't know how to handle package
node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core
```

`flatpak/node-sources.json` has therefore been frozen for a week. The committed file still builds — v1.30.0's Flatpak was fine — but it can't be regenerated, so it drifts further from the lockfile with every dependency bump, and the four open web dependency PRs (#367, #368, #369, #370) can't go green.

**The cause is our tool, not Tailwind's package.** The workflow installs `flatpak-node-generator` from PyPI, whose only release is `0.1.1`. Its lockfile-v2 reader classifies each entry as a symlink, a local path, or a `resolved` URL, and raises `NotImplementedError` on anything else. npm records `bundleDependencies` with neither `resolved` nor `integrity` — they ship inside the parent package's tarball, so there is no separate download to mirror — and `oxide-wasm32-wasi` bundles six of them (`@emnapi/*`, `@napi-rs/wasm-runtime`, `@tybys/wasm-util`, `tslib`). The v1 reader has skipped `bundled` entries for years; v2 never got the equivalent.

Upstream has since replaced that `raise` with a local-source fallback, so bundled entries resolve to no download entry at all — which is the correct result. This pins the install to that upstream commit instead of the stale release. No local patch, no lockfile preprocessing.

## Test plan

Ran the pinned build locally against both lockfiles before pinning:

- **main's lockfile** — reproduces the committed `node-sources.json` exactly: all 432 `file` and 432 `inline` cache entries identical, nothing generated that isn't already committed. The only delta is two dropped no-op scripts (`patch.sh`, whose `commands` is `[]`, and `patch-all.sh`, which only invokes it). Neither is referenced by the manifest, which uses only the cache dirs.
- **`web-minor-and-patch` branch's lockfile** (the one that crashes today) — exits 0, emits 866 sources, and produces zero entries for any of the six bundled packages.

In CI this PR proves itself: adding this workflow to its own `paths` filter — the same way `flatpak-build-check.yml` watches its own filename — means pushing it runs `regenerate`, which commits the refreshed `node-sources.json` to the branch, which in turn triggers `Flatpak build check` on the result.

Two things to look at in that regenerated diff:

- `setup_sdk_node_headers.sh` changes `installVersion` from **9 to 11**. That's a real behavior change riding along with the upgrade, not part of the crash fix. CI builds on Node 20, where 11 is the right value, and the Flatpak build check is what confirms it.
- The generator writes those shell commands using the host's path separator, so this file can only be generated on Linux. The job runs on `ubuntu-22.04`, so that holds — there's now a comment on the step saying why it has to.

After this lands, #367–#370 need a rerun to pick up the fixed workflow. The `frontend` failures on #368 (react) and #370 (stylelint 17) are unrelated and stay broken.
