### PR TITLE
Correct CLAUDE.md and settings.py on cross-device pause

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,3 +217,31 @@ reserved for noise that's only ever read off a captured log file.
 If you need a high-signal line (mint failure, takeover received,
 state change), use the print pattern. If you need debug detail
 (per-frame trace, periodic heartbeat), use the logger.
+
+## Cross-device pause
+
+Tideway pauses local playback when another device on the same Tidal
+account starts playing. Both halves are built and on by default.
+
+- **Receive**: `app/tidal_realtime.py` — a WebSocket client for
+  Tidal's realtime bus ("Pushkin"). Started from lifespan startup at
+  `server.py`, stopped on teardown. Its module docstring is the
+  protocol reference (token mint, frame types, reconnect/backoff,
+  self-event filtering); don't restate that here, and update it there
+  if the wire format shifts.
+- **Send**: `app/play_reporter.py` posts our own playback events, which
+  is what makes Tideway show up in Recently Played and pause other
+  devices.
+- **Setting**: `pause_on_other_device`, default on.
+- **Diagnostics**: `/api/realtime/status` returns phase, last error,
+  reconnect count and events received. Loopback-only. Ask for it first
+  when someone reports cross-device pause not firing — it says whether
+  the listener ever connected.
+
+Two things to know before touching it. The listener task lives in the
+FastAPI asyncio loop, so the pause callback fires from that loop rather
+than a worker thread — `PCMPlayer` methods take `_lock` internally, so
+calling in directly is correct and a thread hop would be wrong. And the
+protocol was reverse-engineered from Tidal's web client; it is not a
+published API and can break without notice, which is what the
+diagnostic endpoint is for.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,20 +217,3 @@ reserved for noise that's only ever read off a captured log file.
 If you need a high-signal line (mint failure, takeover received,
 state change), use the print pattern. If you need debug detail
 (per-frame trace, periodic heartbeat), use the logger.
-
-## Cross-device pause — not implemented
-
-This section previously claimed Tideway has an always-on realtime
-listener at `app/tidal_realtime.py` that pauses local playback when
-another device on the same Tidal account starts playing. **That was
-aspirational documentation; the module never existed.** No
-`tidal_realtime.py`, no `_under_pytest()` helper, no
-`/api/realtime/status` endpoint, no WebSocket client to Tidal's
-realtime bus.
-
-Building it for real means: a WebSocket client to Tidal's realtime
-endpoint, auth via the existing tidalapi session, reverse-engineering
-of the state-change message format, and wiring "another device
-started" to `PCMPlayer.pause()`. Comparable in scope to the Tidal
-Connect receiver work — undocumented protocol, ongoing maintenance.
-Out of scope until explicitly planned.

--- a/app/settings.py
+++ b/app/settings.py
@@ -317,11 +317,7 @@ class Settings:
     # cross-device handoff. Default on; users who explicitly want
     # multi-device-fighting playback can flip it off. Wired to
     # `app/tidal_realtime.py`'s on_other_device_started callback,
-    # which the desktop launcher binds to PCMPlayer.pause(). The
-    # listener itself is opt-in at the protocol level too: if the
-    # realtime bus protocol hasn't been captured yet (Phase 1 of
-    # the cross-device-pause feature), the listener stays disabled
-    # regardless of this setting.
+    # which the desktop launcher binds to PCMPlayer.pause().
     pause_on_other_device: bool = True
     # Spotify Developer app client_id, used by the Spotify → Tidal
     # playlist importer. Users register their own app at


### PR DESCRIPTION
## Summary

`CLAUDE.md` carried a section asserting that cross-device pause was unbuilt and that `app/tidal_realtime.py` "never existed — aspirational documentation."

It exists. `117bff5f` (2026-05-19) built it. The module is 501 lines, imported at [server.py:65](server.py:65), started at [server.py:1156](server.py:1156), stopped at [server.py:1237](server.py:1237), queried at [server.py:7130](server.py:7130), and referenced by name from [app/settings.py](app/settings.py). The section also listed the remaining work — WebSocket client, tidalapi auth, state-change message format, wiring "another device started" to `PCMPlayer.pause()`. All of it shipped.

Two commits:

**1. Remove the stale section.** A wrong "not implemented" note is worse than no note: anyone reading `CLAUDE.md` before touching playback would conclude the receive half still needs building and go build a second one.

**2. Replace it with an accurate one, and fix the same fiction in `app/settings.py`.** Removal alone left `CLAUDE.md` silent on a feature that's live and on by default, which invites the same wrong conclusion by omission. The new section covers where both halves live, the `pause_on_other_device` setting, the `/api/realtime/status` diagnostic, and the two non-obvious constraints: the pause callback fires on the FastAPI asyncio loop rather than a worker thread (so calling into `PCMPlayer` directly is correct and a thread hop would be wrong), and the protocol is reverse-engineered from Tidal's web client and can break without notice.

It points at the module's own docstring for the wire format rather than restating it. Two copies of a reverse-engineered protocol is how the first stale section came about.

`app/settings.py` had the same problem: `pause_on_other_device`'s comment claimed the listener "stays disabled regardless of this setting" until the realtime bus protocol was captured in a future "Phase 1." It was captured on 2026-05-20 — `is_protocol_known` has returned a hardcoded `True` ever since, documented in the property as "Always True now." That paragraph is gone.

## Test plan

Documentation and one comment block; no behaviour changes. `pytest -k "settings or realtime"` → **40 passed, 1 skipped**. All claims above verified against the current tree on `main`.
