### PR TITLE
Honour a pause pressed while a track is still loading

### DIFF
--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -281,6 +281,13 @@ class PCMPlayer:
         self._samples_emitted = 0
 
         self._paused = False
+        # Bumped by pause() every time the user actually asks for a
+        # pause. play_track() samples it either side of the load so a
+        # pause pressed while a track is still resolving isn't lost:
+        # both _load_locked and play() clear _paused as part of normal
+        # startup, so without a record of the request there is nothing
+        # left to tell "user paused mid-load" from "fresh load".
+        self._pause_requests = 0
         self._seeking = False
         # Set while _swap_pipeline_to() is rewriting the pipeline refs
         # from another thread. The audio callback is lock-free, so
@@ -956,10 +963,24 @@ class PCMPlayer:
         """Combined load + play. The pipeline lock keeps load +
         play atomic relative to other state changes, so a
         concurrent stop / seek can't land in between the two
-        phases."""
+        phases.
+
+        A pause arriving mid-load is honoured rather than discarded.
+        pause() accepts input in the "loading" state and takes only
+        `_lock`, so it runs freely while the resolve holds
+        `_pipeline_lock` — and a cold resolve is bounded at
+        `_RESOLVE_TIMEOUT_S`, which is a long time to be leaning on a
+        button. Both _load_locked and play() clear `_paused` on the
+        way up, so the request has to be carried across the load as a
+        counter. When it moved, we stop at "loaded but not playing" —
+        the same state a load()-without-play caller lands in — and the
+        next play() starts the stream."""
         with self._pipeline_lock:
+            pause_requests_before = self._pause_requests
             snap = self.load(track_id, quality=quality)
             if snap.state == "error":
+                return snap
+            if self._pause_requests != pause_requests_before:
                 return snap
             return self.play()
 
@@ -986,6 +1007,7 @@ class PCMPlayer:
         with self._lock:
             if self._state not in ("playing", "loading"):
                 return self.snapshot()
+            self._pause_requests += 1
             self._paused = True
             self._transition("paused")
         self._emit()

--- a/tests/test_pause_during_load.py
+++ b/tests/test_pause_during_load.py
@@ -1,0 +1,107 @@
+"""A pause pressed while a track is still loading must survive the load.
+
+`pause()` accepts input in the "loading" state and takes only `_lock`,
+while a resolve holds `_pipeline_lock` — so the two genuinely overlap,
+and a cold resolve is bounded by `_RESOLVE_TIMEOUT_S` (45 s), which is
+a long time for a user to be looking at a play button that hasn't
+started yet.
+
+The problem is that the pause leaves no trace. `_load_locked` sets
+`_paused = False` as part of opening the new stream, and `play()` sets
+it again on the way to "playing", so by the time `play_track()` reaches
+its `play()` call there is nothing left to distinguish "the user paused
+during this load" from "a fresh load that should start". The pause was
+silently discarded and the track started anyway — the button did
+nothing, which is the shape of the "pause feels dead" reports.
+
+These tests drive `play_track()` against a stand-in `load` that
+reproduces the real one's observable contract: transition to "loading",
+open a stream, clear `_paused`, land in "paused". The internals of the
+real load are covered elsewhere; what matters here is what
+`play_track()` does either side of it.
+"""
+from __future__ import annotations
+
+from app.audio.player import PCMPlayer
+
+
+class _FakeStream:
+    """Stands in for the sounddevice OutputStream. Only the two
+    attributes `play()` touches."""
+
+    def __init__(self) -> None:
+        self.active = False
+        self.started = False
+
+    def start(self) -> None:
+        self.started = True
+        self.active = True
+
+
+def _player() -> PCMPlayer:
+    """A no-network player; `session_getter` is never invoked here."""
+    return PCMPlayer(lambda: None)
+
+
+def _install_fake_load(p: PCMPlayer, stream: _FakeStream, during_load=None):
+    """Replace `load` with one that mirrors `_load_locked`'s visible
+    effects. `during_load` runs at the point the real resolve would be
+    in flight — the window in which a pause can land."""
+
+    def fake_load(track_id: str, quality=None):
+        with p._lock:
+            p._transition("loading", track_id=track_id)
+        if during_load is not None:
+            during_load()
+        with p._lock:
+            p._stream = stream
+            # Both of these are what the real _load_locked does, and
+            # both are why the pause needs carrying separately.
+            p._paused = False
+            p._transition("paused")
+        return p.snapshot()
+
+    p.load = fake_load  # type: ignore[method-assign]
+
+
+def test_pause_during_load_leaves_playback_stopped():
+    p = _player()
+    stream = _FakeStream()
+    _install_fake_load(p, stream, during_load=lambda: p.pause())
+
+    snap = p.play_track("t1")
+
+    assert stream.started is False, "pause during load was discarded"
+    assert snap.state == "paused"
+
+
+def test_load_without_pause_starts_playback():
+    """The fix must not turn every load into a no-op."""
+    p = _player()
+    stream = _FakeStream()
+    _install_fake_load(p, stream)
+
+    snap = p.play_track("t1")
+
+    assert stream.started is True
+    assert snap.state == "playing"
+
+
+def test_pause_before_play_track_does_not_block_the_next_track():
+    """Only a pause that lands *during* this load counts. Pausing, then
+    picking a new track, has to start that track — otherwise the first
+    click after any pause would do nothing."""
+    p = _player()
+    # Get into a genuinely paused, playing-capable state first.
+    first = _FakeStream()
+    _install_fake_load(p, first)
+    p.play_track("t1")
+    p.pause()
+    assert p.snapshot().state == "paused"
+
+    second = _FakeStream()
+    _install_fake_load(p, second)
+    snap = p.play_track("t2")
+
+    assert second.started is True
+    assert snap.state == "playing"


### PR DESCRIPTION
## Summary

Pressing pause while a track is still loading did nothing — the track started playing anyway. This is one of the "pause feels dead" reports, and it isn't a contention problem; it's a lost state transition.

`pause()` accepts input in the `"loading"` state and takes only `_lock`, while a resolve holds `_pipeline_lock`. The two overlap freely, so the pause is *accepted* — the UI even flips to paused. But it leaves no trace for `play_track()` to act on:

- `_load_locked` sets `_paused = False` as part of opening the new stream
- `play()` sets `_paused = False` again on the way to `"playing"`

By the time `play_track()` reaches its `play()` call, nothing distinguishes "the user paused during this load" from "a fresh load that should start". The pause is discarded and playback begins.

The window is not small. A cold resolve is bounded by `_RESOLVE_TIMEOUT_S` at **45 seconds**, and that's exactly when a user is most likely to press pause — the track is taking a long time to start.

The fix carries the request across the load as a counter. `play_track()` samples `_pause_requests` either side of `load()`; if it moved, it stops at "loaded but not playing" — the same state a `load()`-without-`play()` caller already lands in (the restore-on-quit path, the album-end flow) — and the next `play()` starts the stream. No new state, no change to `pause()`'s own semantics.

Deliberately scoped to a pause arriving *during this particular load*. Pausing and then picking a different track still plays that track; the third test pins that down so the fix can't regress into "the first click after any pause does nothing."

## Test plan

`tests/test_pause_during_load.py`, three cases:

1. **pause during load leaves playback stopped** — fails on `main` with "pause during load was discarded", passes here. Verified by stashing the `player.py` change and re-running.
2. **load without pause starts playback** — guards against over-fixing into a no-op.
3. **pause before `play_track` does not block the next track** — guards the scoping above.

The tests drive `play_track()` against a stand-in `load` reproducing the real one's observable contract (transition to `loading`, open a stream, clear `_paused`, land in `paused`), following the offline `PCMPlayer(lambda: None)` pattern already used by `test_player_seq_bump_cadence.py`. No network, no sounddevice.

Full backend suite: **1276 passed, 9 skipped, 1 failed**. The failure is `test_desktop_event_loop.py::test_uvloop_is_importable_so_auto_would_have_picked_it`, which is pre-existing and environmental — `uvloop` has no Windows wheel. It fails the same way on `main`.

Backend-only change; no web files touched, so `tsc` / `lint` / `vitest` results are unchanged from `main` and were not re-run locally. CI covers them.

## Note

This came out of investigating the download-contention theory. Worth saying plainly: **this bug is independent of load.** It reproduces whenever a resolve is slow enough for a user to react, contention or not. The remaining contention questions — the UI lag and "Fetch is aborted" reports — are still open and need a runtime measurement, not a code reading.
