### PR TITLE
Write a DATE tag on single-track downloads

### DIFF
--- a/app/downloader.py
+++ b/app/downloader.py
@@ -1142,6 +1142,54 @@ class Downloader:
                 raise _Cancelled()
             time.sleep(min(1.0, remaining))
 
+    def _album_with_details(self, album_obj):
+        """Return an album object carrying the fields tagging needs,
+        fetching the full one if what we have is the thin blob.
+
+        tidalapi populates `track.album` thinly: `release_date` and
+        `available_release_date` both come back None. An album download
+        resolves the real album once and passes it down, so its tracks
+        get a DATE tag; a single-track download had only the thin blob
+        and wrote no date at all, landing the file in the user's
+        library with a blank Year column while the same track pulled
+        as part of its album looked right (issue #357).
+
+        Guarded on the date being absent, so the album path — which
+        already has everything — pays nothing, and only a single-track
+        download spends the extra `session.album(id)` call.
+        """
+        if album_obj is None:
+            return None
+        for attr in ("release_date", "tidal_release_date"):
+            try:
+                if getattr(album_obj, attr, None):
+                    return album_obj
+            except Exception:
+                # tidalapi models raise from property getters when a
+                # field is absent from the payload rather than
+                # returning None; that means "not set", so keep looking.
+                continue
+        album_id = getattr(album_obj, "id", None)
+        if album_id is None:
+            return album_obj
+        try:
+            full = self.tidal.session.album(album_id)
+        except Exception as exc:
+            # Tag with the thin object rather than failing a download
+            # that already has its audio on disk — a missing DATE is
+            # worse than it was, not fatal. A 429 still has to reach
+            # the shared backoff or the sibling workers keep hammering
+            # a bucket that just told us to stop.
+            if _looks_like_rate_limit(exc):
+                self._note_rate_limit(exc, 0)
+            print(
+                f"[downloader] album detail fetch failed "
+                f"album_id={album_id}: {exc!r}",
+                flush=True,
+            )
+            return album_obj
+        return full or album_obj
+
     def _note_rate_limit(self, exc: Exception, attempt: int) -> None:
         """Record a 429 so every worker backs off.
 
@@ -1545,7 +1593,9 @@ class Downloader:
                 write_lrc_sidecar,
             )
             tag_error: Optional[str] = None
-            resolved_album = album_obj or getattr(track, "album", None)
+            resolved_album = self._album_with_details(
+                album_obj or getattr(track, "album", None)
+            )
             try:
                 cover = fetch_cover_art(
                     resolved_album,

--- a/app/metadata.py
+++ b/app/metadata.py
@@ -353,10 +353,10 @@ def _tag_flac(
     audio = FLAC(str(path))
     audio["title"] = track.name
     audio["artist"] = _artist_names(track)
-    audio["album"] = _safe(getattr(track, "album", None), "name") or ""
+    audio["album"] = _album_attr(track, album_obj, "name") or ""
     audio["albumartist"] = _album_artist_name(track, album_obj)
     audio["tracknumber"] = str(getattr(track, "track_num", 0))
-    num_tracks = _safe(getattr(track, "album", None), "num_tracks")
+    num_tracks = _album_attr(track, album_obj, "num_tracks")
     if num_tracks:
         audio["totaltracks"] = str(num_tracks)
     release_date = _release_date_str(track, album_obj)
@@ -399,9 +399,9 @@ def _tag_m4a(
     audio = MP4(str(path))
     audio["\xa9nam"] = track.name
     audio["\xa9ART"] = _artist_names(track)
-    audio["\xa9alb"] = _safe(getattr(track, "album", None), "name") or ""
+    audio["\xa9alb"] = _album_attr(track, album_obj, "name") or ""
     audio["aART"] = _album_artist_name(track, album_obj)
-    num_tracks = _safe(getattr(track, "album", None), "num_tracks") or 0
+    num_tracks = _album_attr(track, album_obj, "num_tracks") or 0
     audio["trkn"] = [(getattr(track, "track_num", 0), num_tracks)]
     release_date = _release_date_str(track, album_obj)
     if release_date:
@@ -541,3 +541,23 @@ def _safe(obj, attr: str):
         return getattr(obj, attr)
     except Exception:
         return None
+
+
+def _album_attr(track, album_obj, attr: str):
+    """Read an album-level attribute, preferring the album the
+    downloader resolved over the per-track `track.album` blob.
+
+    Same preference order `_release_date_str` and `_album_artist_name`
+    already use, and for the same reason: tidalapi populates
+    `track.album` thinly, so fields it leaves unset are present on a
+    real album fetch. Reading `track.album` directly - which the album
+    name and track count used to do - silently degraded those tags
+    whenever the thin object was all we had.
+    """
+    for source in (album_obj, getattr(track, "album", None)):
+        if source is None:
+            continue
+        value = _safe(source, attr)
+        if value:
+            return value
+    return None

--- a/tests/test_single_track_date_tag.py
+++ b/tests/test_single_track_date_tag.py
@@ -1,0 +1,181 @@
+"""Single-track downloads write a DATE tag (issue #357).
+
+Downloading a track on its own wrote no `DATE`, while the same track
+pulled as part of its album did. The cause is that tidalapi populates
+`track.album` thinly — `release_date` and `available_release_date` are
+both None on it — and the single-track path had nothing else to hand
+to the tagger. An album download resolves the real album once and
+passes it down, which is why only one of the two paths looked right.
+
+Users notice because Mp3Tag, foobar2000 and Picard all derive their
+"Year" column from Vorbis DATE, so a single-track download lands in
+the library with a blank year next to album downloads that have one.
+
+`Downloader._album_with_details` closes the gap by fetching the full
+album when what it has carries no date. These tests pin that it fires
+on the thin object, stays out of the way on the album path, and never
+turns a failed lookup into a failed download.
+"""
+from __future__ import annotations
+
+import datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from app.downloader import Downloader
+from app.metadata import _album_attr, tag_file
+
+
+def _thin_album():
+    """Shaped like tidalapi's `track.album`: a name and a track count,
+    no dates."""
+    return SimpleNamespace(
+        id=77, name="Pablo Honey", num_tracks=12, release_date=None
+    )
+
+
+def _full_album():
+    """What `session.album(id)` returns."""
+    return SimpleNamespace(
+        id=77,
+        name="Pablo Honey",
+        num_tracks=12,
+        release_date=datetime.date(1993, 4, 20),
+        artist=SimpleNamespace(name="Radiohead"),
+    )
+
+
+class _Session:
+    def __init__(self, result):
+        self._result = result
+        self.calls: list = []
+
+    def album(self, album_id):
+        self.calls.append(album_id)
+        if isinstance(self._result, Exception):
+            raise self._result
+        return self._result
+
+
+def _downloader(session):
+    """Only the attributes `_album_with_details` touches. Building a
+    real Downloader would drag in settings, callbacks and worker
+    threads for a method that needs a session and a backoff hook."""
+    return SimpleNamespace(
+        tidal=SimpleNamespace(session=session),
+        _note_rate_limit=lambda exc, attempt: None,
+    )
+
+
+def test_thin_album_is_resolved_to_the_full_one():
+    session = _Session(_full_album())
+    got = Downloader._album_with_details(_downloader(session), _thin_album())
+
+    assert session.calls == [77], "should have fetched the full album"
+    assert got.release_date == datetime.date(1993, 4, 20)
+
+
+def test_album_path_does_not_pay_for_the_extra_fetch():
+    """An album download already holds the resolved object. It must not
+    spend a request per track re-fetching what it has."""
+    session = _Session(_full_album())
+    got = Downloader._album_with_details(_downloader(session), _full_album())
+
+    assert session.calls == [], "album path made a redundant request"
+    assert got.release_date == datetime.date(1993, 4, 20)
+
+
+def test_failed_lookup_degrades_instead_of_failing_the_download():
+    """The audio is already on disk by this point. A missing DATE is
+    worse than before; a raised exception would be a lost download."""
+    session = _Session(RuntimeError("tidal is having a day"))
+    thin = _thin_album()
+    got = Downloader._album_with_details(_downloader(session), thin)
+
+    assert got is thin
+
+
+def test_rate_limit_on_lookup_reaches_the_shared_backoff():
+    """A 429 here has to be recorded, or sibling workers keep hammering
+    a bucket that just said stop."""
+    noted: list = []
+    dl = _downloader(_Session(RuntimeError("429 Too Many Requests")))
+    dl._note_rate_limit = lambda exc, attempt: noted.append(exc)
+
+    Downloader._album_with_details(dl, _thin_album())
+
+    assert len(noted) == 1
+
+
+def test_missing_album_id_is_left_alone():
+    session = _Session(_full_album())
+    thin = SimpleNamespace(name="Pablo Honey", release_date=None)
+    got = Downloader._album_with_details(_downloader(session), thin)
+
+    assert session.calls == []
+    assert got is thin
+
+
+# --- the second half of #357: tags read straight off the thin blob ---
+
+
+def test_album_attr_prefers_the_resolved_album():
+    """`num_tracks` and the album name were read from `track.album`
+    directly, ignoring the resolved album the other tags prefer."""
+    track = SimpleNamespace(
+        album=SimpleNamespace(name="Pablo Honey (Promo)", num_tracks=None)
+    )
+    full = SimpleNamespace(name="Pablo Honey", num_tracks=12)
+
+    assert _album_attr(track, full, "name") == "Pablo Honey"
+    assert _album_attr(track, full, "num_tracks") == 12
+
+
+def test_album_attr_falls_back_to_the_track_blob():
+    track = SimpleNamespace(album=SimpleNamespace(name="Pablo Honey", num_tracks=12))
+
+    assert _album_attr(track, None, "name") == "Pablo Honey"
+    assert _album_attr(track, None, "num_tracks") == 12
+
+
+def _make_flac(path: Path) -> None:
+    """A few ms of real silence so mutagen has a STREAMINFO block.
+    Same approach as tests/test_metadata_year_tag.py."""
+    import av
+
+    with av.open(str(path), "w", format="flac") as container:
+        stream = container.add_stream("flac", rate=44100)
+        frame = av.AudioFrame.from_ndarray(
+            np.zeros((2, 1024), dtype=np.int16), format="s16p", layout="stereo"
+        )
+        frame.sample_rate = 44100
+        for packet in stream.encode(frame):
+            container.mux(packet)
+        for packet in stream.encode(None):
+            container.mux(packet)
+
+
+def test_resolved_album_reaches_the_file(tmp_path):
+    """End to end through the production tagger: with the resolved
+    album in hand the file carries both the date and the track count."""
+    from mutagen.flac import FLAC
+
+    path = tmp_path / "Creep.flac"
+    _make_flac(path)
+    track = SimpleNamespace(
+        id=3135556,
+        name="Creep",
+        track_num=2,
+        artists=[SimpleNamespace(name="Radiohead")],
+        album=_thin_album(),
+    )
+
+    tag_file(path, track, None, album_obj=_full_album())
+
+    audio = FLAC(str(path))
+    assert audio["date"] == ["1993-04-20"]
+    assert audio["totaltracks"] == ["12"]
+    assert audio["album"] == ["Pablo Honey"]


### PR DESCRIPTION
## Summary

Downloading a track on its own wrote no `DATE` tag. The same track pulled as part of its album wrote one. Verified against `Radiohead - Creep`, where `date` came back empty on the single-track path while every other tag was correct.

tidalapi populates `track.album` thinly — `release_date` and `available_release_date` are both `None` on it — so `_release_date_str` returned `''` and the field was skipped. An album download resolves the real album once and passes it down as `album_obj`, which is why only one of the two paths ever looked right.

It's user-visible because Mp3Tag, foobar2000 and Picard all derive their **Year** column from Vorbis `DATE`. Single-track downloads land in the library with a blank year sitting next to album downloads that have one — easy to miss unless you compare the two. Same field #196 was about, missed on the other path.

### The fix

`Downloader._album_with_details` fetches the full album when the one in hand carries no date. Guarded on the date being absent, so an album download — which already holds everything — spends nothing, and only the single-track path makes the extra `session.album(id)` call.

A failed lookup keeps the thin object and tags with what it has. By that point the audio is already on disk, so a missing `DATE` is a degradation; raising would cost the whole download. A 429 still reaches the shared backoff, matching what the lyrics fetch beside it does — otherwise sibling workers keep hammering a bucket that just said stop.

### The second half of the same report

The issue flagged that `num_tracks` was read from the same thin object and asked whether other tags degrade the same way. They do — `album` and `num_tracks` both read `track.album` directly, ignoring the resolved album that `_release_date_str` and `_album_artist_name` already prefer. So those two degraded even on the album path, where the good data was sitting right there unused. `_album_attr` gives all four the same preference order.

## Test plan

`tests/test_single_track_date_tag.py`, 8 cases:

- thin album is resolved to the full one, and the fetched date lands
- **album path makes no request** — pins that this can't become a per-track fetch on album downloads
- failed lookup returns the thin object rather than raising
- a 429 reaches `_note_rate_limit`
- an album with no `id` is left alone
- `_album_attr` prefers the resolved album, and falls back to the track blob when there isn't one
- end-to-end through the production `tag_file` against a real FLAC: `date`, `totaltracks` and `album` all present

The FLAC is built with PyAV the same way `tests/test_metadata_year_tag.py` does it, so mutagen has a real STREAMINFO block rather than a touched file.

Full suite: **1284 passed, 9 skipped, 1 failed** — the failure is the pre-existing `uvloop`-has-no-Windows-wheel test, which fails identically on `main`.

## Note

The extra fetch is one request per single-track download, only when the date is missing. If that ever shows up in rate-limit reports the next step would be caching resolved albums for the life of a queue run, the way cover art already is — but I'd rather not add a cache before there's evidence it's needed.
