### PR TITLE
Stop committing the flatpak manifest to PR branches

### DIFF
--- a/.github/flatpak-node-generator-requirements.txt
+++ b/.github/flatpak-node-generator-requirements.txt
@@ -1,0 +1,19 @@
+# Pinned installer for flatpak-node-generator, shared by
+# update-flatpak-node-sources.yml and flatpak-build-check.yml so the
+# manifest a PR is *built* from and the manifest that gets *committed*
+# can never come from different versions of the tool.
+#
+# Installed from git, not PyPI. The only PyPI release (0.1.1) predates
+# lockfile-v2 support for bundled dependencies: its
+# _process_packages_v2 raises NotImplementedError for any entry with no
+# "resolved" URL, and npm records bundleDependencies exactly that way -
+# they ship inside the parent package's tarball, so there is no
+# separate download to mirror. Tailwind's @tailwindcss/oxide-wasm32-wasi
+# bundles six such packages. Upstream resolves them to a local source
+# and emits no download entry, which is the right answer.
+#
+# Pinned to a commit rather than tracking master so that regenerating
+# node-sources.json stays reproducible.
+aiohttp>=3.8
+aiofiles
+flatpak-node-generator @ git+https://github.com/flatpak/flatpak-builder-tools.git@737c0085912f9f7dabf9341d4608e2a77a51a73a#subdirectory=node

--- a/.github/workflows/flatpak-build-check.yml
+++ b/.github/workflows/flatpak-build-check.yml
@@ -16,6 +16,7 @@ on:
     paths:
       - "flatpak/**"
       - ".github/workflows/flatpak-build-check.yml"
+      - ".github/flatpak-node-generator-requirements.txt"
       - ".github/workflows/release.yml"
       - "requirements.txt"
       - "web/package-lock.json"
@@ -25,6 +26,7 @@ on:
     paths:
       - "flatpak/**"
       - ".github/workflows/flatpak-build-check.yml"
+      - ".github/flatpak-node-generator-requirements.txt"
       - ".github/workflows/release.yml"
       - "requirements.txt"
       - "web/package-lock.json"
@@ -34,6 +36,35 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v7
+
+      - name: Set up Python
+        uses: actions/setup-python@v7
+        with:
+          python-version: "3.11"
+
+      - name: Regenerate node-sources.json for this build
+        # Regenerated into the working tree and never committed.
+        #
+        # A PR that bumps web/package-lock.json arrives with the
+        # manifest that was committed for the PREVIOUS lockfile, and
+        # building the new lockfile against the old mirror fails with
+        # "npm error code ENOTCACHED ... cache mode is only-if-cached
+        # but no cached response is available". Regenerating here makes
+        # the build test the lockfile actually under review.
+        #
+        # update-flatpak-node-sources.yml owns committing the file, and
+        # only does so on main and deploy/** - committing to a PR
+        # branch is what made Dependabot refuse to rebase its own PRs.
+        # This step is the other half of that split: PRs get a truthful
+        # build, integration branches get the committed artifact.
+        run: |
+          pip install --quiet -r .github/flatpak-node-generator-requirements.txt
+          flatpak-node-generator \
+            --electron-node-headers \
+            npm \
+            web/package-lock.json \
+            -o flatpak/node-sources.json
+          git --no-pager diff --stat -- flatpak/node-sources.json
 
       - name: Install flatpak + flatpak-builder + elfutils
         # elfutils provides eu-strip, which flatpak-builder shells

--- a/.github/workflows/update-flatpak-node-sources.yml
+++ b/.github/workflows/update-flatpak-node-sources.yml
@@ -1,23 +1,38 @@
 name: Update flatpak node-sources.json
 
-# Runs whenever web/package-lock.json changes — either from a
-# dependabot PR or a manual npm install. Regenerates
-# flatpak/node-sources.json with flatpak-node-generator and commits
-# the result back to the same branch. Without this, bumping any web
-# dependency also requires a manual Linux step to keep the Flatpak
-# offline mirror in sync, which is easy to forget and causes the
-# Flatpak build to fail with ENOTCACHED.
+# Regenerates flatpak/node-sources.json and commits it, on the
+# branches that actually ship: main and the deploy branches. Without
+# it, bumping any web dependency also requires a manual Linux step to
+# keep the Flatpak offline mirror in sync, which is easy to forget and
+# causes the Flatpak build to fail with ENOTCACHED.
 #
-# The job is a no-op when node-sources.json doesn't change (e.g. a
-# lockfile bump that only touches non-npm-cached metadata). The
-# commit step is skipped when there's nothing new to record.
+# Deliberately NOT run on pull-request branches. It used to run on
+# every branch, and committing to a PR branch cost more than it was
+# worth: Dependabot refuses to rebase a PR that anything other than
+# itself has touched ("Looks like this PR has been edited by someone
+# other than Dependabot"), so every dependency PR became permanently
+# un-rebaseable and had to be recreated by hand once main moved. The
+# bot commit also re-tripped the workflow-approval gate, leaving the
+# corrected runs unstarted while `gh pr checks` reported "no checks".
+#
+# PRs still get an honest build: flatpak-build-check.yml regenerates
+# the manifest into its own working tree and builds from that, without
+# committing. deploy/** is included here so a release branch's
+# committed manifest matches the lockfiles merged into it - the
+# release build reads the committed file, not a regenerated one.
+#
+# The job is a no-op when node-sources.json doesn't change. The commit
+# step is skipped when there's nothing new to record.
+
 on:
   push:
     branches:
-      - "**"
+      - main
+      - "deploy/**"
     paths:
       - "web/package-lock.json"
       - ".github/workflows/update-flatpak-node-sources.yml"
+      - ".github/flatpak-node-generator-requirements.txt"
   workflow_dispatch:
 
 jobs:
@@ -40,24 +55,11 @@ jobs:
           python-version: "3.11"
 
       - name: Install flatpak-node-generator
-        # Installed from git, not PyPI. The only PyPI release (0.1.1)
-        # predates lockfile-v2 support for bundled dependencies: its
-        # _process_packages_v2 raises NotImplementedError for any entry
-        # with no "resolved" URL, and npm records bundleDependencies
-        # exactly that way - they ship inside the parent package's
-        # tarball, so there is no separate download to mirror. Tailwind's
-        # @tailwindcss/oxide-wasm32-wasi bundles six @emnapi / @napi-rs
-        # packages, which is why every lockfile bump since Tailwind 4
-        # landed has failed here. Upstream resolves those to a local
-        # source and emits no download entry, which is the right answer.
-        #
-        # Pinned to a commit rather than tracking master so that
-        # regenerating node-sources.json stays reproducible.
+        # Pin and rationale live in the shared requirements file so
+        # this job and flatpak-build-check.yml can never install
+        # different versions of the generator.
         run: |
-          pip install --quiet \
-            "aiohttp>=3.8" \
-            "aiofiles" \
-            "flatpak-node-generator @ git+https://github.com/flatpak/flatpak-builder-tools.git@737c0085912f9f7dabf9341d4608e2a77a51a73a#subdirectory=node"
+          pip install --quiet -r .github/flatpak-node-generator-requirements.txt
 
       - name: Regenerate node-sources.json
         # Linux-only. The generator builds the setup_sdk_node_headers.sh


### PR DESCRIPTION
## Summary

Regenerating `flatpak/node-sources.json` on every branch and committing the result costs more than it's worth. Today it cost three manual PR recreations and four rounds of clicking approval gates.

Two distinct failures, both from the same bot commit:

**1. Dependabot can't rebase its own PRs.** Committing to a dependency branch makes Dependabot treat the PR as externally edited:

> Looks like this PR has been edited by someone other than Dependabot. That means Dependabot can't rebase it - sorry!

So once `main` moves, every web dependency PR is permanently stuck — `rebase` is refused and only `recreate` works. #365, #366 and #369 all hit this today and had to be recreated by hand.

**2. The approval gate fires twice.** The bot commit spawns a fresh set of runs that park at `action_required`. `gh pr checks` renders that as "no checks reported", which reads as *nothing ran* rather than *something is waiting*. That's what made the original triage report all nine dependency PRs as failing when five were green.

### The split

Committing the manifest now happens **only on `main` and `deploy/**`** — the branches that actually ship it. PR branches stay pristine, so Dependabot can rebase again and the gate fires once.

PRs still get an honest build. `flatpak-build-check.yml` regenerates the manifest into its own working tree and builds from that, without committing. This isn't optional: without it a lockfile bump builds the new lockfile against the previously committed mirror and dies with

```
npm error code ENOTCACHED
npm error request to https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz failed:
cache mode is 'only-if-cached' but no cached response is available.
```

which is precisely what all four web PRs did this morning before their regenerate commit landed. Regeneration runs *before* the cache restore, so the flatpak-builder cache key covers the manifest actually built rather than the stale one.

### Why `deploy/**` is in there

The release build reads the committed file rather than regenerating. Without `deploy/**`, a deploy branch would carry whatever manifest `main` had when it was cut, while the PR merges into it moved the lockfile underneath — and the release's flatpak build would fail the same `ENOTCACHED` way, *after* tagging. That's the worst possible time to discover it, so the deploy branch keeps its committed manifest current.

### One pin, one place

The generator spec moves to `.github/flatpak-node-generator-requirements.txt`, shared by both workflows. The manifest a PR is built from and the manifest that gets committed can no longer come from different versions of the tool — which would be an unusually annoying bug to track down.

## Test plan

This PR touches `flatpak-build-check.yml`, which is in its own `paths` filter, so **it verifies itself**: the build check runs here and exercises the new regenerate-in-place step on a branch whose lockfile is unchanged, so the regenerated manifest should come out byte-identical to the committed one and the build should pass.

Both workflow files parse (`yaml.safe_load`), and step ordering is confirmed — regenerate lands between checkout and the cache restore.

What this PR **cannot** prove on its own is the interesting case: a PR that actually changes `web/package-lock.json` and would previously have hit `ENOTCACHED`. The next dependency bump is the real test. Worth watching #368 or #370 once their peer conflicts are sorted, since those still have live lockfile changes.
