### PR TITLE
Group peer-linked npm packages so they bump together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,10 @@
 # Dependabot keeps the project's dependencies fresh by opening
 # weekly PRs against `main` when a newer version is available. PRs
 # come in at the configured cadence rather than per-commit so the
-# review queue stays manageable. Major-version bumps land in their
-# own PRs (the `groups:` block batches patch + minor only).
+# review queue stays manageable. Major-version bumps land in their own
+# PRs so they get a proper review — except for packages that peer-
+# depend on each other, which have to move together or the PR cannot
+# install at all. See the `react` and `stylelint` groups below.
 
 version: 2
 updates:
@@ -20,7 +22,43 @@ updates:
       - frontend
     commit-message:
       prefix: "deps(web)"
+    ignore:
+      # React 19 is a migration, not a bump: breaking changes across a
+      # codebase with Radix throughout, ~115 existing hooks warnings,
+      # and an audio player full of timing-sensitive effects. Dependabot
+      # proposed it as "bump react and @types/react" (#368) while
+      # leaving react-dom on 18, which npm refused outright.
+      #
+      # Deferred rather than declined. Drop these four entries when the
+      # migration is actually being planned and the group below will
+      # produce one coherent PR moving all four together.
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "@types/react-dom"
+        update-types: ["version-update:semver-major"]
     groups:
+      # Peer-linked packages, listed before the catch-all because a
+      # dependency joins the first group it matches. No `update-types`
+      # filter, so majors group too — that is the whole point.
+      #
+      # These declare peer ranges on each other, so a PR that moves one
+      # without the others cannot be installed. Both failed exactly
+      # that way: #368 (react 19 without react-dom) and #370 (stylelint
+      # 17 against stylelint-config-standard@36, which peers on ^16).
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+          - "@types/react-dom"
+      stylelint:
+        patterns:
+          - "stylelint"
+          - "stylelint-config-*"
       # Group patch + minor bumps so a slow week doesn't spawn 12
       # near-identical PRs. Major bumps stay separate so they get a
       # proper review.


### PR DESCRIPTION
## Summary

Two of this week's dependency PRs couldn't be installed at all, for the same reason: dependabot moved one half of a peer-linked pair.

- **#368** bumped `react` to 19 and left `react-dom` on 18 → `npm error Conflicting peer dependency: @types/react@18.3.31`
- **#370** bumped `stylelint` to 17 against `stylelint-config-standard@36.0.1`, which declares `peer stylelint@^16.1.0`

Neither was fixable by rerunning, and dependabot would never propose the companion bump on its own.

### Grouping

Two new groups move these as units. Neither carries an `update-types` filter, so **majors group too** — which is the point, since it's exactly the major bumps that break peer ranges.

Order matters: a dependency joins the first group it matches, and `web-minor-and-patch` has no `patterns` so it matches everything. The specific groups therefore have to come first.

### Deferring React 19

React 19 is a migration, not a bump. Radix UI throughout, ~115 existing hooks warnings, and an audio player full of timing-sensitive effects — that's a planned branch with its own testing, not something to review inside a weekly dependency PR. Left as-is it gets re-proposed every Monday and rots.

The four `ignore` entries are **a deferral, not a decision**, and the comment says so. Delete them when someone is actually planning the migration, and the new `react` group will produce one coherent PR with all four packages moving together — which is strictly better than what #368 was.

## Test plan

Config only; no code paths. YAML parses, and I verified the parsed structure directly:

- group order: `react`, `stylelint`, `web-minor-and-patch` — specific before catch-all
- `react` patterns: `react`, `react-dom`, `@types/react`, `@types/react-dom`
- `stylelint` patterns: `stylelint`, `stylelint-config-*`
- ignores scoped to `version-update:semver-major` only, so React **patch and minor** updates still flow

The real proof is next Monday's run. Worth a look then to confirm the groups form as intended rather than splitting.

## Related

#376 does the stylelint 17 bump properly and supersedes #370. #368 can't be salvaged and should be closed — I've left that to you.
