### PR TITLE
Give the python flatpak manifest the same regen split as node

### DIFF
--- a/.github/workflows/flatpak-build-check.yml
+++ b/.github/workflows/flatpak-build-check.yml
@@ -17,6 +17,7 @@ on:
       - "flatpak/**"
       - ".github/workflows/flatpak-build-check.yml"
       - ".github/flatpak-node-generator-requirements.txt"
+      - "scripts/regen-flatpak-python-sources.sh"
       - ".github/workflows/release.yml"
       - "requirements.txt"
       - "web/package-lock.json"
@@ -27,6 +28,7 @@ on:
       - "flatpak/**"
       - ".github/workflows/flatpak-build-check.yml"
       - ".github/flatpak-node-generator-requirements.txt"
+      - "scripts/regen-flatpak-python-sources.sh"
       - ".github/workflows/release.yml"
       - "requirements.txt"
       - "web/package-lock.json"
@@ -90,6 +92,18 @@ jobs:
             org.gnome.Platform//49 \
             org.gnome.Sdk//49 \
             org.freedesktop.Sdk.Extension.node20//25.08
+
+      - name: Regenerate python3-requirements.json for this build
+        # Regenerated into the working tree and never committed, the
+        # same split as node-sources.json above.
+        #
+        # A stale python manifest fails more quietly than a stale node
+        # one: the flatpak build installs from the manifest, not from
+        # requirements.txt, so a PR that bumps a Python dependency
+        # would build and PASS while shipping the previous version.
+        # Regenerating here makes the check test the requirements.txt
+        # actually under review.
+        run: bash scripts/regen-flatpak-python-sources.sh
 
       - name: Restore flatpak-builder cache
         # Same key as release.yml so a release rebuild after this

--- a/.github/workflows/update-flatpak-python-sources.yml
+++ b/.github/workflows/update-flatpak-python-sources.yml
@@ -27,9 +27,12 @@ name: Update flatpak python3-requirements.json
 on:
   push:
     branches:
-      - "**"
+      - main
+      - "deploy/**"
     paths:
       - "requirements.txt"
+      - ".github/workflows/update-flatpak-python-sources.yml"
+      - "scripts/regen-flatpak-python-sources.sh"
   workflow_dispatch:
 
 jobs:
@@ -67,51 +70,11 @@ jobs:
             org.gnome.Platform//49 \
             org.gnome.Sdk//49
 
-      - name: Fetch flatpak-pip-generator
-        # The pip generator ships as a standalone script in
-        # flatpak-builder-tools (not a PyPI console script like
-        # flatpak-node-generator). Pull it from the upstream repo and
-        # install its one runtime dependency. The historical
-        # `pip/flatpak-pip-generator` path is now a git symlink to the
-        # .py file, and raw.githubusercontent serves a symlink as its
-        # one-line target text — fetch the real file.
-        run: |
-          curl -fsSL -o flatpak-pip-generator \
-            https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/pip/flatpak-pip-generator.py
-          head -1 flatpak-pip-generator | grep -q python || {
-            echo "downloaded file is not the generator script:"; head -3 flatpak-pip-generator; exit 1; }
-          # Matches the script's PEP 723 inline metadata block.
-          python3 -m pip install --quiet "requirements-parser<1.0.0,>=0.11.0" "packaging>=23.0"
-
       - name: Regenerate python3-requirements.json
-        # --requirements-file mirrors docs/linux-flatpak.md ("generated
-        # offline+hashed from requirements.txt"). Platform markers in
-        # requirements.txt are resolved for the Linux/GNOME target, so
-        # the darwin-only pyobjc drops out and the linux-only dbus-next
-        # is included automatically.
-        #
-        # --prefer-wheels takes a per-package list upstream now (it
-        # used to be a boolean): these are the native-extension
-        # packages that have no PEP-517 build backend inside the
-        # sandbox, so their sdists can't build and the prebuilt
-        # manylinux wheel is required. The list is every package that
-        # ships as a platform wheel in the current source set; when a
-        # new native dep joins requirements.txt, add it here (the
-        # build-check failing on a missing build backend is the
-        # symptom). Pure-Python packages build fine from sdists and
-        # don't need listing.
-        # --ignore-pkg drops build-only tools from the runtime set:
-        # pyinstaller freezes the macOS/Windows bundles and has no
-        # place inside the Flatpak (docs/linux-flatpak.md: "there is
-        # no freeze step in this path"); its module also fails to pip
-        # install in the sandbox, which is how its inclusion surfaces.
-        run: |
-          python3 flatpak-pip-generator \
-            --runtime="org.gnome.Sdk//49" \
-            --prefer-wheels="aiohttp,av,cffi,curl-cffi,httptools,numpy,orjson,pillow,pydantic-core,pyyaml,rapidfuzz,scipy,uvloop,watchfiles,zeroconf" \
-            --ignore-pkg=pyinstaller \
-            --requirements-file=requirements.txt \
-            --output=flatpak/python3-requirements
+        # Invocation lives in the script so this job and
+        # flatpak-build-check.yml cannot drift apart. The generator is
+        # pinned to a commit there too.
+        run: bash scripts/regen-flatpak-python-sources.sh
 
       - name: Commit if changed
         run: |

--- a/scripts/regen-flatpak-python-sources.sh
+++ b/scripts/regen-flatpak-python-sources.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# Regenerate flatpak/python3-requirements.json from requirements.txt.
+#
+# Shared by update-flatpak-python-sources.yml (which commits the result
+# on main and deploy/**) and flatpak-build-check.yml (which regenerates
+# into its working tree so a PR builds against its own requirements.txt
+# without committing anything to the branch). The generator invocation
+# below is long enough that keeping two copies of it in YAML would
+# drift; this file is the single source of truth for both.
+#
+# Requires: the GNOME 49 Sdk installed as a flatpak, python3, and pip.
+set -euo pipefail
+
+# Pinned to a commit rather than tracking master so the generated file
+# is reproducible — an upstream change must be adopted deliberately
+# rather than silently altering what gets committed to main. Same
+# commit the node generator is pinned to in
+# .github/flatpak-node-generator-requirements.txt; bump them together.
+GENERATOR_REF="737c0085912f9f7dabf9341d4608e2a77a51a73a"
+
+# The historical `pip/flatpak-pip-generator` path is a git symlink to
+# the .py file, and raw.githubusercontent serves a symlink as its
+# one-line target text — fetch the real file.
+curl -fsSL -o flatpak-pip-generator \
+  "https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/${GENERATOR_REF}/pip/flatpak-pip-generator.py"
+head -1 flatpak-pip-generator | grep -q python || {
+  echo "downloaded file is not the generator script:" >&2
+  head -3 flatpak-pip-generator >&2
+  exit 1
+}
+
+# Matches the script's PEP 723 inline metadata block.
+python3 -m pip install --quiet "requirements-parser<1.0.0,>=0.11.0" "packaging>=23.0"
+
+# --runtime resolves wheels by running pip inside the Sdk, so the Python
+# ABI matches the manifest's pinned org.gnome.Platform//49.
+#
+# --requirements-file mirrors docs/linux-flatpak.md ("generated
+# offline+hashed from requirements.txt"). Platform markers are resolved
+# for the Linux/GNOME target, so darwin-only pyobjc drops out and
+# linux-only dbus-next is included automatically.
+#
+# --prefer-wheels takes a per-package list upstream now (it used to be a
+# boolean): these are the native-extension packages with no PEP-517
+# build backend inside the sandbox, so their sdists can't build and the
+# prebuilt manylinux wheel is required. When a new native dep joins
+# requirements.txt, add it here — the build-check failing on a missing
+# build backend is the symptom. Pure-Python packages build fine from
+# sdists and don't need listing.
+#
+# --ignore-pkg drops build-only tools from the runtime set: pyinstaller
+# freezes the macOS/Windows bundles and has no place inside the Flatpak
+# (docs/linux-flatpak.md: "there is no freeze step in this path"); its
+# module also fails to pip install in the sandbox, which is how its
+# inclusion surfaces.
+python3 flatpak-pip-generator \
+  --runtime="org.gnome.Sdk//49" \
+  --prefer-wheels="aiohttp,av,cffi,curl-cffi,httptools,numpy,orjson,pillow,pydantic-core,pyyaml,rapidfuzz,scipy,uvloop,watchfiles,zeroconf" \
+  --ignore-pkg=pyinstaller \
+  --requirements-file=requirements.txt \
+  --output=flatpak/python3-requirements


### PR DESCRIPTION
## Summary

#375 fixed one of **two** identical workflows. `update-flatpak-python-sources.yml` still ran on `branches: ["**"]` and committed `flatpak/python3-requirements.json` to whichever branch triggered it — so pip PRs kept hitting the exact problem npm PRs no longer have.

#381 conflicted that way minutes after #375 landed, and needed `recreate` rather than `rebase` for the same reason the web PRs did:

> Looks like this PR has been edited by someone other than Dependabot.

This applies the same split. Committing happens on `main` and `deploy/**`; `flatpak-build-check.yml` regenerates into its own working tree so a PR builds against its own `requirements.txt` without touching the branch.

### The stale-manifest case is worse here than for node

This part argues for regenerating in the check regardless of Dependabot.

A stale **node** mirror fails loudly — `ENOTCACHED`, which is how we found the original bug. A stale **python** manifest doesn't fail at all. The flatpak build installs from `python3-requirements.json`, not from `requirements.txt`, so a PR bumping a Python dependency would build **green while shipping the previous version**. A check that passes while testing the wrong thing is worse than one that breaks.

### Shared script

The invocation moves to `scripts/regen-flatpak-python-sources.sh`. Unlike the node one — four short flags — this is a fifteen-package `--prefer-wheels` list plus `--ignore-pkg` and `--runtime`, and two copies in YAML would drift. Both workflows call the script; all the existing explanatory comments moved with it.

### Generator pin

It was fetched from `master`, unpinned:

```
https://raw.githubusercontent.com/flatpak/flatpak-builder-tools/master/pip/flatpak-pip-generator.py
```

So an upstream commit could silently change what gets committed to `main` — the same reproducibility hole #371 closed for the node generator. Pinned to the same `flatpak-builder-tools` commit (`737c008`), verified present at that ref (HTTP 200), with a comment in each place saying to bump them together.

## Test plan

This PR touches `flatpak-build-check.yml` and the new script, both in the check's `paths` filter, so **it verifies itself**: the build check runs here and exercises the new step. `requirements.txt` is unchanged on this branch, so the regenerated manifest should come out identical to the committed one and the build should pass — same shape as #375's self-verification, which then held up on #376 where the lockfile really did change.

Also verified locally:

- `bash -n` on the script — syntax clean
- both workflows parse via `yaml.safe_load`
- step ordering — python regeneration lands after the GNOME 49 Sdk install it depends on, and before the cache restore, so the flatpak-builder cache key covers the manifest actually built
- script stored mode `100755`, matching the other `scripts/*.sh`
- **stored blob has 0 CR bytes** — a CRLF shell script would die on the Linux runner, and this repo has no `.gitattributes` to enforce it

## Related

#381 still needs its recreate to finish; it was the last PR to hit this. After this lands, neither ecosystem commits to PR branches.
