### PR TITLE
Record threadpool saturation so the lag reports can be settled

### DIFF
--- a/server.py
+++ b/server.py
@@ -1297,6 +1297,116 @@ app.add_middleware(
     allow_credentials=True,
 )
 
+# --- concurrency diagnostics ---------------------------------------
+#
+# Nearly every endpoint in this file is a sync `def`, which Starlette
+# runs on anyio's worker threadpool rather than the event loop. That
+# pool defaults to 40 threads and nothing here raises it, so a 41st
+# concurrent request waits for a thread instead of being served.
+#
+# Measured on a synthetic app with the same shape (sync endpoints,
+# default limiter): a latency-sensitive endpoint answers in 1-2 ms with
+# 39 slow requests in flight, 273 ms at 45, 951 ms at 60 and 1951 ms at
+# 100. It is a cliff, not a slope — nothing at all until the pool is
+# full, then queue-depth times however long the blocking calls take.
+#
+# What was never established is whether Tideway reaches 40 in normal
+# use. That matters because it is the leading explanation for four
+# separate reports — UI lag, "Fetch is aborted", covers not rendering,
+# and pause feeling unresponsive — and nobody has confirmed or killed
+# it. Rather than manufacture load to find out, this records what real
+# sessions actually do, so a user who hits the lag can read the answer
+# off /api/diagnostics/concurrency afterwards.
+#
+# Deliberately cheap: two integer updates under a lock held for a few
+# microseconds, on a path that is already doing network I/O. Nothing
+# here allocates per request beyond one dict entry that is removed in a
+# finally block.
+_conc_lock = threading.Lock()
+# Requests currently accepted but not yet returned, keyed by a counter.
+# Value is (path, started_monotonic). Bounded by concurrency, so tens
+# of entries at worst.
+_conc_active: dict = {}
+_conc_next_id = 0
+_conc_stats = {
+    "requests": 0,
+    "peak_in_flight": 0,
+    "peak_at": None,
+    "peak_paths": [],
+    # Requests that began while the pool was already full. Non-zero
+    # here is the whole question answered: it means real usage queues.
+    "started_while_saturated": 0,
+    "peak_threads_borrowed": 0,
+    # Sampled in the middleware, which runs on the event loop. anyio's
+    # limiter is loop-bound state and raises when read from a worker
+    # thread, so a sync endpoint cannot read it directly — and the
+    # diagnostic endpoint has to stay sync because the auth guard in
+    # front of it blocks (it waits on session-ready and can fall
+    # through to a network check_login).
+    "thread_pool_size": 0,
+    "threads_borrowed": 0,
+}
+
+
+def _thread_pool_size() -> int:
+    """Total tokens on anyio's default thread limiter — the number of
+    sync endpoints that can run at once. Read live rather than
+    hardcoded to 40 so raising it doesn't silently invalidate this."""
+    try:
+        import anyio.to_thread
+
+        return int(anyio.to_thread.current_default_thread_limiter().total_tokens)
+    except Exception:
+        # Only reachable if anyio changes this API; the diagnostic
+        # degrades to "unknown ceiling" rather than breaking requests.
+        return 0
+
+
+def _threads_borrowed() -> int:
+    try:
+        import anyio.to_thread
+
+        return int(anyio.to_thread.current_default_thread_limiter().borrowed_tokens)
+    except Exception:
+        return 0
+
+
+@app.middleware("http")
+async def _track_concurrency(request: Request, call_next):
+    global _conc_next_id
+    path = request.url.path
+    pool = _thread_pool_size()
+    with _conc_lock:
+        _conc_next_id += 1
+        rid = _conc_next_id
+        _conc_active[rid] = (path, time.monotonic())
+        in_flight = len(_conc_active)
+        _conc_stats["requests"] += 1
+        if pool and in_flight > pool:
+            _conc_stats["started_while_saturated"] += 1
+        if in_flight > _conc_stats["peak_in_flight"]:
+            _conc_stats["peak_in_flight"] = in_flight
+            _conc_stats["peak_at"] = datetime.now(timezone.utc).isoformat()
+            # Snapshot what was actually in flight at the high-water
+            # mark. Without it a peak of 60 says nothing about which
+            # part of the app produced it.
+            _conc_stats["peak_paths"] = sorted(
+                p for p, _ in _conc_active.values()
+            )
+    borrowed = _threads_borrowed()
+    # Plain assignments; a lost update here costs one sample and is not
+    # worth taking the lock again for.
+    _conc_stats["thread_pool_size"] = pool
+    _conc_stats["threads_borrowed"] = borrowed
+    if borrowed > _conc_stats["peak_threads_borrowed"]:
+        _conc_stats["peak_threads_borrowed"] = borrowed
+    try:
+        return await call_next(request)
+    finally:
+        with _conc_lock:
+            _conc_active.pop(rid, None)
+
+
 # Per-domain routers extracted from the all-in-one server.py — see
 # `app/routers/__init__.py` for the playbook + which domains have
 # moved. New extractions add their `include_router` call here.
@@ -7113,6 +7223,54 @@ def _autoeq_on_device_change(device_id: str) -> None:
     except Exception:
         log = logging.getLogger("autoeq.resolver")
         log.exception("autoeq device-change resolver failed")
+
+
+@app.get("/api/diagnostics/concurrency")
+def concurrency_diagnostics() -> dict:
+    """What this process has actually done to the request threadpool.
+
+    227 of this file's 230 endpoints are sync `def`, so each one holds
+    an anyio worker thread for its whole duration, blocking Tidal I/O
+    included. The pool defaults to 40. Past that, requests queue.
+
+    Read this after a session where the UI felt slow. The number that
+    answers the question is `started_while_saturated`: zero means real
+    usage never fills the pool and threadpool contention is not the
+    explanation for the lag reports, whatever else is. Non-zero means
+    it does, and `peak_paths` names what was in flight when it did.
+
+    `threads_borrowed` is anyio's own count of checked-out workers,
+    sampled as THIS request entered the middleware rather than read
+    now — the limiter is event-loop state and this handler runs on a
+    worker thread. `in_flight` counts accepted requests including any
+    waiting for a thread, so in_flight above threads_borrowed is the
+    queue.
+
+    Counters are process-lifetime and reset on restart.
+    """
+    _require_local_access()
+    with _conc_lock:
+        in_flight = len(_conc_active)
+        stats = dict(_conc_stats)
+        oldest = min(
+            (started for _, started in _conc_active.values()), default=None
+        )
+    pool = stats["thread_pool_size"]
+    return {
+        "thread_pool_size": pool,
+        "in_flight": in_flight,
+        "threads_borrowed": stats["threads_borrowed"],
+        "longest_in_flight_seconds": (
+            round(time.monotonic() - oldest, 3) if oldest is not None else 0.0
+        ),
+        "requests_total": stats["requests"],
+        "peak_in_flight": stats["peak_in_flight"],
+        "peak_at": stats["peak_at"],
+        "peak_paths": stats["peak_paths"],
+        "started_while_saturated": stats["started_while_saturated"],
+        "peak_threads_borrowed": stats["peak_threads_borrowed"],
+        "saturated": bool(pool and in_flight > pool),
+    }
 
 
 @app.get("/api/realtime/status")

--- a/tests/test_concurrency_diagnostics.py
+++ b/tests/test_concurrency_diagnostics.py
@@ -1,0 +1,110 @@
+"""Threadpool-saturation diagnostics for /api/diagnostics/concurrency.
+
+227 of server.py's 230 endpoints are sync `def`, which Starlette runs
+on anyio's worker threadpool rather than the event loop. Each request
+therefore holds a thread for its whole duration, blocking Tidal I/O
+included, and the pool defaults to 40 with nothing in the app raising
+it. Past 40 concurrent requests, the 41st waits for a thread.
+
+Measured on a synthetic app with the same shape: a fast endpoint
+answers in 1-2 ms with 39 slow requests in flight, 273 ms at 45, and
+1951 ms at 100. A cliff, not a slope.
+
+Whether Tideway reaches 40 in normal use is the open question, and
+it's the leading explanation for four separate reports (UI lag, "Fetch
+is aborted", covers not rendering, pause feeling unresponsive). These
+counters exist so a user who hits the lag can read the answer off the
+endpoint instead of anyone guessing — `started_while_saturated` is the
+figure that settles it.
+"""
+from __future__ import annotations
+
+import copy
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    """Same shape as tests/test_settings_endpoint.py: offline mode on so
+    `_require_local_access` doesn't reject an unauthenticated test, and
+    the settings snapshot restored afterwards."""
+    import app.settings as _settings_mod
+    import server
+
+    monkeypatch.setattr(_settings_mod, "SETTINGS_FILE", tmp_path / "settings.json")
+    original_settings = copy.deepcopy(server.settings)
+    server.settings.offline_mode = True
+    server.downloader.settings = server.settings
+
+    with TestClient(server.app) as c:
+        yield c
+
+    server.settings = original_settings
+    server.downloader.settings = original_settings
+
+
+def test_reports_the_real_thread_ceiling(client):
+    """Read live off anyio rather than hardcoded, so raising the limiter
+    can't silently invalidate the diagnostic. 40 is anyio's default and
+    nothing in the app changes it — if this ever fails, someone raised
+    it and the contention analysis needs redoing."""
+    body = client.get("/api/diagnostics/concurrency").json()
+
+    assert body["thread_pool_size"] == 40
+
+
+def test_counts_requests_and_records_a_peak(client):
+    before = client.get("/api/diagnostics/concurrency").json()
+    client.get("/api/diagnostics/concurrency")
+    after = client.get("/api/diagnostics/concurrency").json()
+
+    assert after["requests_total"] > before["requests_total"]
+    # The request reading the counter is itself in flight.
+    assert after["peak_in_flight"] >= 1
+    assert after["peak_at"] is not None
+
+
+def test_quiet_process_reports_no_saturation(client):
+    """The negative result matters as much as the positive one. A serial
+    test client never fills the pool, so this must read zero — if it
+    didn't, the counter would be measuring something other than what it
+    claims and a real report could not be trusted."""
+    body = client.get("/api/diagnostics/concurrency").json()
+
+    assert body["started_while_saturated"] == 0
+    assert body["saturated"] is False
+
+
+def test_in_flight_unwinds_after_each_request(client):
+    """The finally block has to release the slot on every path, or
+    in_flight ratchets up and the whole diagnostic reads as permanent
+    saturation after a few hundred requests."""
+    for _ in range(5):
+        client.get("/api/diagnostics/concurrency")
+    body = client.get("/api/diagnostics/concurrency").json()
+
+    # Only the reading request itself is outstanding.
+    assert body["in_flight"] == 1
+
+
+def test_a_failing_endpoint_still_releases_its_slot(client):
+    """Same guarantee when the handler raises rather than returns — a
+    404 goes through the same middleware."""
+    before = client.get("/api/diagnostics/concurrency").json()["in_flight"]
+    client.get("/api/definitely-not-a-real-endpoint")
+    after = client.get("/api/diagnostics/concurrency").json()["in_flight"]
+
+    assert after == before
+
+
+def test_reports_the_queue_rather_than_just_the_pool(client):
+    """in_flight counts accepted requests including any waiting for a
+    thread; threads_borrowed is anyio's count of workers checked out.
+    The gap between them is the queue, which is the thing worth seeing."""
+    body = client.get("/api/diagnostics/concurrency").json()
+
+    assert "threads_borrowed" in body
+    assert body["threads_borrowed"] >= 0
+    assert body["longest_in_flight_seconds"] >= 0.0


### PR DESCRIPTION
## Summary

`/api/diagnostics/concurrency` records what real sessions do to the request threadpool, so the download-contention theory can finally be confirmed or killed with evidence instead of reasoning.

### The setup

227 of `server.py`'s 230 endpoints are sync `def`. Starlette runs those on anyio's worker threadpool, so each request holds a thread for its whole duration — blocking Tidal I/O included. The pool defaults to **40** and nothing in the app raises it.

I measured the shape on a synthetic app with the same configuration (sync endpoints, default limiter, no Tidal), watching a latency-sensitive endpoint while N slow requests were in flight:

| in-flight | p50 | max |
|---:|---:|---:|
| 10 | 2 ms | 21 ms |
| 30 | 2 ms | 24 ms |
| 39 | 1 ms | 25 ms |
| 45 | **273 ms** | 887 ms |
| 60 | **951 ms** | 952 ms |
| 100 | **1951 ms** | 1952 ms |

A cliff, not a slope. Nothing at all until the pool is full, then queue depth times however long the blocking calls take.

### The open question

Whether Tideway *reaches* 40 in normal use was never established. It's the leading explanation for four separate reports — UI lag, "Fetch is aborted", covers not rendering, and pause feeling unresponsive — and it's been carried as a theory without anyone confirming it.

The obvious way to find out is to generate download load and watch. I don't think that's the right move: it means pointing synthetic traffic at a live Tidal account, which is precisely what the rate limiters and impersonation layer in `downloader.py` exist to avoid. So this measures real sessions instead.

**`started_while_saturated` is the figure that settles it.** Zero after a session where the UI dragged means the pool never filled and threadpool contention is not the explanation, whatever else is. Non-zero means it is, and `peak_paths` names what was in flight at the high-water mark.

### Two constraints that shaped the implementation

Both are non-obvious and both are commented in place:

1. **anyio's limiter is event-loop state** and raises when read from a worker thread — so the middleware samples it and the endpoint reads the sample. My first attempt read it in the endpoint and silently reported `thread_pool_size: 0`; the test for the real ceiling is what caught it.
2. **The endpoint has to stay sync.** The auth guard in front of it blocks — `_is_logged_in()` waits on session-ready for up to 15s and can fall through to a network `check_login()`. Making the handler `async` to reach the limiter would put that on the event loop and stall every other request. That would be a fine way to *cause* the bug this is meant to diagnose.

### Cost

Two integer updates under a lock held for microseconds, on a path already doing network I/O, plus one dict entry per in-flight request removed in a `finally`. Counters are process-lifetime and reset on restart.

## Test plan

`tests/test_concurrency_diagnostics.py`, 6 cases:

- **reports the real thread ceiling** — asserts 40, read live off anyio rather than hardcoded, so raising the limiter can't silently invalidate the diagnostic. This is the test that caught the event-loop mistake above.
- counts requests and records a peak with a timestamp
- **quiet process reports no saturation** — the negative result matters as much as the positive one. If a serial client read non-zero, the counter would be measuring something other than what it claims and a real report couldn't be trusted.
- `in_flight` unwinds after each request — without the `finally` it ratchets up and everything reads as permanent saturation after a few hundred requests
- a **failing** endpoint still releases its slot (404 through the same middleware)
- reports the queue, not just the pool — `in_flight` above `threads_borrowed` is the queue

Full suite: **1290 passed, 9 skipped, 1 failed** — the failure is the pre-existing `uvloop`-has-no-Windows-wheel test.

## How to actually use it

Use the app normally. Next time the UI drags, hit `/api/diagnostics/concurrency` and read `started_while_saturated` and `peak_in_flight`. That's the experiment — no manufactured load, no traffic at Tidal that wouldn't have happened anyway.
