### PR TITLE
Answer a bare DLNA GET with 200 on the bounded track path

### DIFF
--- a/app/audio/http_stream.py
+++ b/app/audio/http_stream.py
@@ -1294,8 +1294,15 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         it. Here the Content-Length is the actual file size, so the
         renderer knows the exact end and stops cleanly.
 
-        Always answers 206 (DLNA convention) with a Content-Range over
-        the real total, and honours a byte Range for seek.
+        Status follows what the request actually asked for: a byte
+        Range gets 206 + Content-Range, a bare GET gets 200. RFC 7233
+        forbids answering 206 to a request that carried no Range, and
+        Rygel's GStreamer souphttpsrc (KEF LS50 II and other Rygel
+        renderers) enforces it — an unsolicited 206 made it reject the
+        resource with UPnP 716 "Resource not found", so DLNA connected
+        but never played (#332). Strict renderers that need a length
+        for SEEK_END during decoder-init still get one either way,
+        because this path always knows the real total.
         """
         src = server.track_source
         if src is None:
@@ -1322,10 +1329,13 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
                 start = 0
         if start > total:
             start = total
-        self.send_response(206)
-        self.send_header(
-            "Content-Range", f"bytes {start}-{max(total - 1, 0)}/{total}"
-        )
+        if range_hdr.startswith("bytes="):
+            self.send_response(206)
+            self.send_header(
+                "Content-Range", f"bytes {start}-{max(total - 1, 0)}/{total}"
+            )
+        else:
+            self.send_response(200)
         self.send_header("Content-Length", str(total - start))
         self.send_header("Accept-Ranges", "bytes")
         self.send_header("Content-Type", server.content_type)

--- a/tests/test_http_stream.py
+++ b/tests/test_http_stream.py
@@ -859,6 +859,17 @@ class TestBoundedTrackServe:
             sock.close()
 
     def test_serves_real_content_length_without_range(self):
+        """A bare GET gets 200 with the real Content-Length - no
+        Content-Range, because the request never asked for one.
+
+        The Content-Length assertion is the point of the bounded path
+        (UAPP uses it as the track length, so a synthetic ~1TB made it
+        seek past the real end). The status is 200 rather than 206
+        because RFC 7233 forbids answering 206 to a request that
+        carried no Range, and Rygel's GStreamer souphttpsrc rejects
+        the unsolicited 206 with UPnP 716 (#332). Strict renderers
+        still get the length they need for SEEK_END either way.
+        """
         import os
 
         server, buffer, path, total = self._server(12345)
@@ -867,10 +878,36 @@ class TestBoundedTrackServe:
                 server,
                 b"GET /dlna/stream?ts=12345 HTTP/1.1\r\nHost: localhost\r\n\r\n",
             )
-            assert raw.startswith(b"HTTP/1.1 206"), raw[:60]
+            assert raw.startswith(b"HTTP/1.1 200"), raw[:60]
             assert f"Content-Length: {total}".encode() in raw, raw[:200]
-            assert b"Content-Range: bytes 0-" in raw
+            assert b"Content-Range:" not in raw, (
+                f"no Range was requested, so no Content-Range: {raw[:200]!r}"
+            )
             assert b"\xff\xf8FLAC" in raw
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()
+            os.unlink(path)
+
+    def test_head_probe_without_range_is_200(self):
+        """Receivers and middleboxes probe with HEAD before GET, and
+        HEAD goes through the same handler. An unsolicited 206 on the
+        probe is enough for Rygel to give up before it ever issues the
+        GET, so the probe has to be compliant too (#332)."""
+        import os
+
+        server, buffer, path, total = self._server(12345)
+        try:
+            raw = self._get_full(
+                server,
+                b"HEAD /dlna/stream?ts=12345 HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            )
+            assert raw.startswith(b"HTTP/1.1 200"), raw[:60]
+            assert f"Content-Length: {total}".encode() in raw, raw[:200]
+            assert b"Content-Range:" not in raw, raw[:200]
+            # HEAD carries no body.
+            assert raw.split(b"\r\n\r\n", 1)[1] == b"", raw[:200]
         finally:
             server.shutdown()
             server.server_close()


### PR DESCRIPTION
## Summary

Hardware-verified by @joelgwebber on a KEF LS50 II (Rygel): the `#341 → #353 → #385` stack "works a charm."

#353's bounded per-track path routes every DLNA GET **and HEAD** to `_serve_track`:

```python
if server.dlna and server.track_source is not None:
    self._serve_track(server)
    return
```

`_send_stream_headers` — the only function #341 changes — is never reached for DLNA once a track source exists. And `_serve_track` answered **206 unconditionally**, which is the RFC 7233 violation Rygel's GStreamer souphttpsrc rejects with UPnP 716 (#332). So without this, landing #353 after #341 would have silently reverted the Rygel fix: no conflict, no failing test, just a bypassed code path.

Status now follows the request: a byte Range gets `206 + Content-Range`, a bare GET gets `200`. `Content-Length` is sent either way — UAPP needs it for SEEK_END during decoder-init — and on this path it's the real track length rather than the synthetic `1 << 40`.

`HEAD` matters as much as `GET`: it routes through the same handler, and a renderer can abandon at the header probe without ever issuing the GET.

## This resolved the #341-vs-#345 question

The open question was whether Rygel refuses `200 + Content-Length` outright. It doesn't — the only such response ever tested was #341's, which advertised `_STREAM_SYNTHETIC_TOTAL` = 1,099,511,627,776 bytes. Refusing a 1TB length on a FLAC is reasonable behaviour, and a different finding from refusing a real one.

@joelgwebber confirmed after testing:

> "I'm now fairly certain that I got confused about the precise Rygel behavior, based on an unrelated pathology causing tracks to wedge."

#345 has been closed in favour of this stack, dropping the UA gating.

## Test plan

- Updated `test_serves_real_content_length_without_range`, which asserted the 206 this changes. The Content-Length assertion is kept — that's #353's actual point — with the status corrected and `Content-Range` now asserted **absent**, since none was requested.
- New `test_head_probe_without_range_is_200`.
- `test_serves_byte_range` unchanged and passing: a real Range still gets 206 + Content-Range, so seek is unaffected.
- Full suite: **1299 passed, 9 skipped, 1 failed** — the failure is the pre-existing `uvloop`-has-no-Windows-wheel test.
- **On hardware:** verified on a Rygel renderer by the reporter.

## Note

Rebased onto `main` now that #341 and #353 have merged; this is a single commit and no longer carries anyone else's work.
