### PR TITLE
DLNA connect observability (rebase of #344)

### DIFF
--- a/app/audio/http_stream.py
+++ b/app/audio/http_stream.py
@@ -1220,7 +1220,7 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
             flush=True,
         )
 
-    def _send_stream_headers(self, server: "StreamHTTPServer") -> None:
+    def _send_stream_headers(self, server: "StreamHTTPServer", method: str) -> None:
         """Send the response line + headers shared by HEAD and GET.
 
         Takes the isinstance-validated server so it never reaches
@@ -1239,13 +1239,21 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         GET now gets 200 + the same Content-Length instead of 206.
 
         Cast: plain 200 + chunked transfer, unchanged.
+
+        Logs the response shape (status + body framing + whether the
+        request carried a Range) right after the headers go out. Paired
+        with the request line from _log_connection, a connect report
+        then shows both what the renderer asked for and what we
+        answered — e.g. a 206 sent to a request with range=none is the
+        RFC 9110 §15.3.7 violation that strict renderers (Rygel) reject
+        with UPnP 716, visible in the log without a packet capture.
         """
         # Body offset the do_GET loop starts serving from. DLNA
         # parse of Range: bytes=N- updates this to N so the body
         # actually starts at N (not 0). Cast path leaves it at 0.
         self._range_start = 0
+        range_hdr = self.headers.get("Range", "")
         if server.dlna:
-            range_hdr = self.headers.get("Range", "")
             has_range = range_hdr.startswith("bytes=")
             start = 0
             if has_range:
@@ -1256,7 +1264,8 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
             self._range_start = start
             self._chunked = False
             if has_range:
-                self.send_response(206)
+                status = 206
+                self.send_response(status)
                 self.send_header(
                     "Content-Range",
                     f"bytes {start}-{_STREAM_SYNTHETIC_TOTAL - 1}/{_STREAM_SYNTHETIC_TOTAL}",
@@ -1265,15 +1274,19 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
                     "Content-Length", str(_STREAM_SYNTHETIC_TOTAL - start)
                 )
             else:
-                self.send_response(200)
+                status = 200
+                self.send_response(status)
                 self.send_header(
                     "Content-Length", str(_STREAM_SYNTHETIC_TOTAL)
                 )
             self.send_header("Accept-Ranges", "bytes")
+            body_desc = f"content-length:{_STREAM_SYNTHETIC_TOTAL - start}"
         else:
-            self.send_response(200)
+            status = 200
+            self.send_response(status)
             self.send_header("Transfer-Encoding", "chunked")
             self._chunked = True
+            body_desc = "chunked"
         self.send_header("Content-Type", server.content_type)
         if server.dlna:
             self.send_header("transferMode.dlna.org", "Streaming")
@@ -1283,6 +1296,12 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
                 )
         self.send_header("Connection", "close")
         self.end_headers()
+        print(
+            f"[http_stream] ANSWERED {method} {status} "
+            f"type={server.content_type} body={body_desc} "
+            f"range={range_hdr or 'none'} to {self.client_address[0]}",
+            flush=True,
+        )
 
     def _serve_track(self, server: "StreamHTTPServer", head: bool = False) -> None:
         """Serve a fully-buffered track file with the REAL byte length.
@@ -1377,7 +1396,7 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         if server.buffer is None:
             self.send_error(503, "stream session not ready")
             return
-        self._send_stream_headers(server)
+        self._send_stream_headers(server, "HEAD")
 
     def do_GET(self) -> None:  # noqa: N802 - stdlib API
         self._log_connection("GET")
@@ -1422,7 +1441,7 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         if not buf.data_ready.wait(timeout=10.0):
             self.send_error(503, "stream data not ready")
             return
-        self._send_stream_headers(server)
+        self._send_stream_headers(server, "GET")
         # Set a socket write timeout so that _write_chunk doesn't
         # block for minutes when the receiver stops reading the
         # socket (UAPP pauses reading for ~3.5 min after each seek).

--- a/app/audio/openhome.py
+++ b/app/audio/openhome.py
@@ -311,6 +311,14 @@ class OpenHomeSOAPError(RuntimeError):
     Failed, etc.). `description` is the human-readable string the
     device sent. `action` and `service_type` are echoed for log
     clarity when many calls are in flight.
+
+    `request_envelope` and `response_body` carry the raw SOAP request
+    we sent and the raw fault body the device returned. A bare UPnP
+    code rarely explains a device-specific rejection (e.g. a KEF
+    returning 716 on SetAVTransportURI); the request shows the exact
+    CurrentURI + DIDL the device refused, and the response often
+    carries a more specific errorDescription. Kept off `__str__` (which
+    stays a concise one-liner) so callers choose when to dump them.
     """
 
     def __init__(
@@ -320,11 +328,15 @@ class OpenHomeSOAPError(RuntimeError):
         *,
         action: str = "",
         service_type: str = "",
+        request_envelope: str = "",
+        response_body: str = "",
     ) -> None:
         self.code = code
         self.description = description
         self.action = action
         self.service_type = service_type
+        self.request_envelope = request_envelope
+        self.response_body = response_body
         super().__init__(
             f"UPnP {code} {description!r}"
             f"{f' on {service_type}#{action}' if service_type else ''}"
@@ -389,11 +401,18 @@ def invoke(
     fault = _parse_soap_fault(body)
     if fault is not None:
         code, description = fault
+        # Attach the request we sent + the raw fault body to the error.
+        # The numeric UPnP code alone rarely explains a device-specific
+        # rejection; the caller that treats this fault as significant
+        # (e.g. the DLNA connect path) logs the detail. Truncate the
+        # body so an oversized fault page can't bloat the exception.
         raise OpenHomeSOAPError(
             code,
             description,
             action=action_name,
             service_type=service.service_type,
+            request_envelope=envelope,
+            response_body=body[:2000],
         )
     if resp.status_code >= 400:
         raise RuntimeError(

--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -655,7 +655,7 @@ class PCMPlayer:
                                 prefetched=None,
                                 metadata=self._current_track_meta,
                             )
-                        except (ValueError, RuntimeError, OSError) as exc:
+                        except Exception as exc:  # noqa: BLE001 - passthrough is optional
                             print(
                                 f"[player] upnp start_passthrough failed "
                                 f"(Path 0): {exc!r}",
@@ -860,7 +860,7 @@ class PCMPlayer:
                             prefetched=prefetched_bytes,
                             metadata=self._current_track_meta,
                         )
-                except (ValueError, RuntimeError, OSError) as exc:
+                except Exception as exc:  # noqa: BLE001 - passthrough is optional
                     print(
                         f"[player] upnp start_passthrough failed "
                         f"(Path B): {exc!r}",
@@ -1397,7 +1397,7 @@ class PCMPlayer:
                         prefetched=prefetched_bytes,
                         metadata=self._current_track_meta,
                     )
-            except (ValueError, RuntimeError, OSError) as exc:
+            except Exception as exc:  # noqa: BLE001 - passthrough is optional
                 print(
                     f"[player] upnp start_passthrough failed: {exc!r}",
                     flush=True,
@@ -3311,7 +3311,7 @@ class PCMPlayer:
                     prefetched=None,
                     metadata=self._current_track_meta,
                 )
-            except (ValueError, RuntimeError, OSError) as exc:
+            except Exception as exc:  # noqa: BLE001 - passthrough is optional
                 print(
                     f"[player] upnp start_passthrough failed "
                     f"(adopt_preload): {exc!r}",
@@ -4043,7 +4043,7 @@ class PCMPlayer:
                             prefetched=None,
                             metadata=self._current_track_meta,
                         )
-                    except (ValueError, RuntimeError, OSError) as exc:
+                    except Exception as exc:  # noqa: BLE001 - passthrough is optional
                         print(
                             f"[player] upnp start_passthrough failed "
                             f"(bridge): {exc!r}",

--- a/app/audio/upnp.py
+++ b/app/audio/upnp.py
@@ -74,6 +74,7 @@ from app.audio.http_stream import (
 )
 from app.audio.openhome import (
     OpenHomeDevice,
+    OpenHomeSOAPError,
     TrackMetadata,
     build_didl_lite,
     fetch_device,
@@ -544,7 +545,7 @@ class UpnpManager:
     # ---- passthrough -----------------------------------------------
 
     def start_passthrough(
-        self, source, prefetched=None, metadata=None
+        self, source, prefetched=None, metadata=None,
     ) -> None:
         """Start bit-perfect FLAC passthrough for the current track.
 
@@ -693,20 +694,26 @@ class UpnpManager:
             )
             session.passthrough_encoder.start()
 
-        # Notify the renderer of the new track. Falls back to the
-        # metadata provider callback if no metadata dict was passed.
+        # Resolve metadata for the renderer notify below, falling back
+        # to the metadata provider callback if no dict was passed.
         if metadata is None and self._metadata_provider is not None:
             try:
                 metadata = self._metadata_provider()
             except Exception as exc:
                 print(f"[upnp] metadata provider raised: {exc!r}", flush=True)
-        if metadata:
-            self._notify_track_change(metadata, session, track_ts=_track_ts)
-
+        # Passthrough (the encoder -> ring-buffer pipeline) is on as
+        # soon as the encoder starts; the device notify below is a
+        # separate step, so log it here before the notify can raise.
         print(
             "[upnp] passthrough ON -- bitperfect FLAC passthrough enabled",
             flush=True,
         )
+        # Notify the renderer. _notify_track_change raises on failure;
+        # the caller decides how bad that is. connect() (initial notify)
+        # lets it propagate and tears the session down; mid-session
+        # callers in player.py catch and keep the existing stream going.
+        if metadata:
+            self._notify_track_change(metadata, session, track_ts=_track_ts)
 
     def prepare_next_passthrough(
         self, source_urls, prefetched=None
@@ -771,6 +778,15 @@ class UpnpManager:
         its now-playing display and initiates a fresh HTTP GET for the
         new track's FLAC stream.
 
+        Raises on failure (an OpenHomeSOAPError if the device rejected
+        the action, or the underlying transport error otherwise). The
+        caller owns the policy, because whether a failed notify is fatal
+        depends on the context, not the exception: connect() treats a
+        rejected initial notify as fatal and tears the session down (a
+        Rygel renderer returning UPnP 716 must not report a false
+        "connected"); a mid-session track change treats it as
+        best-effort and keeps the existing stream flowing.
+
         Without this, the renderer keeps showing the previous track's
         name and its decoder may not re-parse the new STREAMINFO header
         that the passthrough encoder writes into the ring buffer.
@@ -817,10 +833,20 @@ class UpnpManager:
                 flush=True,
             )
         except Exception as exc:
+            # Surface the SOAP fault detail the device sent (the request
+            # it refused + its raw fault body), which the numeric UPnP
+            # code alone doesn't explain, then let the caller decide.
+            detail = ""
+            if isinstance(exc, OpenHomeSOAPError) and exc.request_envelope:
+                detail = (
+                    f"\n  request: {exc.request_envelope}"
+                    f"\n  response: {exc.response_body}"
+                )
             print(
-                f"[upnp] track change notification failed: {exc!r}",
+                f"[upnp] track change notification failed: {exc!r}{detail}",
                 flush=True,
             )
+            raise
 
     def signal_source_done(self) -> None:
         """Signal that the current track's source has reached EOF.
@@ -971,43 +997,38 @@ class UpnpManager:
         # If a track is already loaded, start passthrough before play()
         # so the FLAC header is in the ring buffer when the renderer's
         # first GET arrives. Reduces the race to zero in the common case.
-        _notified = False
+        # A source-provider failure only costs us the header pre-roll;
+        # fall back to the placeholder SetAVTransportURI below rather
+        # than failing the connect over it.
+        urls = None
         if self._source_provider is not None:
             try:
-                urls = self._source_provider()
-                if urls and isinstance(urls, list):
-                    self.start_passthrough(urls)
-                    _notified = True
+                _u = self._source_provider()
+                if _u and isinstance(_u, list):
+                    urls = _u
             except (ValueError, RuntimeError, OSError) as exc:
                 log.debug("upnp: source provider raised: %r", exc)
 
         try:
-            if not _notified:
+            if urls is not None:
+                # Passthrough path: the initial SetAVTransportURI + Play
+                # happens inside start_passthrough -> _notify_track_change,
+                # which raises on failure. A rejected URI (e.g. a Rygel
+                # renderer returning UPnP 716) therefore propagates here
+                # and tears down, instead of a false "connected" with no
+                # audio.
+                self.start_passthrough(urls)
+            else:
                 av.set_av_transport_uri(session.stream_url, didl)
                 av.play()
                 session.media_loaded = True
         except Exception as exc:
-            # Undo the early session registration
-            with self._session_lock:
-                self._session = None
-            # Tear down the HTTP server we just stood up; otherwise
-            # we leak a port until the manager's process exits.
-            try:
-                if session.http_server is not None:
-                    session.http_server.shutdown()
-                    session.http_server.server_close()
-            except Exception:
-                pass
-            try:
-                ts = getattr(session.http_server, "track_source", None)
-                if ts is not None:
-                    ts.close()
-            except Exception:
-                pass
-            try:
-                session.buffer.close()
-            except Exception:
-                pass
+            # Full teardown: disconnect() stops the passthrough encoder
+            # start_passthrough may have started, closes the buffer and
+            # HTTP server, Stops the device, and un-silences local
+            # audio. Then surface the failure so the UI shows an error
+            # rather than a dead "connected" session.
+            self.disconnect()
             raise RuntimeError(
                 f"AVTransport handshake to {device.name} failed: {exc}"
             ) from exc

--- a/tests/test_openhome_soap.py
+++ b/tests/test_openhome_soap.py
@@ -346,6 +346,19 @@ class TestInvoke:
         assert exc.value.action == "Insert"
         assert "Playlist:1" in exc.value.service_type
 
+    def test_fault_error_carries_request_and_response(self, monkeypatch):
+        """On a fault, the error carries the SOAP request we sent and
+        the raw fault body, so a caller (the DLNA connect path) can log
+        exactly what the device refused instead of a bare UPnP code."""
+        _mock_post(monkeypatch, body=FAULT_RESPONSE_402, status_code=500)
+        svc = _service()
+        with pytest.raises(OpenHomeSOAPError) as exc:
+            invoke(svc, "Insert", {"AfterId": "abc"})
+        # The request envelope we POSTed (contains the action name).
+        assert "Insert" in exc.value.request_envelope
+        # The raw fault body the device returned.
+        assert "402" in exc.value.response_body
+
     def test_fault_response_with_200_status_still_raises(self, monkeypatch):
         """A few OpenHome firmwares answer with HTTP 200 even on
         UPnP faults. The body shape is what matters; status code

--- a/tests/test_upnp_session.py
+++ b/tests/test_upnp_session.py
@@ -24,7 +24,11 @@ import numpy as np
 import pytest
 import requests
 
-from app.audio.openhome import OpenHomeDevice, OpenHomeService
+from app.audio.openhome import (
+    OpenHomeDevice,
+    OpenHomeService,
+    OpenHomeSOAPError,
+)
 from app.audio.upnp import (
     UpnpDevice,
     UpnpManager,
@@ -423,6 +427,91 @@ class TestConnect:
         assert mock_http_server.shutdown.called
         assert mock_http_server.server_close.called
         # No session should be left dangling.
+        assert mgr._session is None
+
+    def test_notify_track_change_raises_on_fault(self):
+        """_notify_track_change has one contract: it raises on failure,
+        and the caller owns the policy (connect() = fatal, mid-session
+        = best-effort). The raised OpenHomeSOAPError carries the SOAP
+        request + raw fault body so the caller can log what the device
+        actually refused."""
+        mgr = UpnpManager()
+        session = MagicMock()
+        session.stream_url = "http://192.168.1.10:54321/dlna/stream"
+        session.av.set_av_transport_uri.side_effect = OpenHomeSOAPError(
+            716,
+            "Resource not found",
+            action="SetAVTransportURI",
+            service_type="urn:schemas-upnp-org:service:AVTransport:2",
+            request_envelope="<s:Envelope>...CurrentURI...</s:Envelope>",
+            response_body="<UPnPError><errorCode>716</errorCode></UPnPError>",
+        )
+        meta = {"title": "T", "artist": "A", "album": "Al", "duration_s": 1}
+
+        with pytest.raises(OpenHomeSOAPError) as excinfo:
+            mgr._notify_track_change(meta, session)
+        # Play is never attempted once SetAVTransportURI failed.
+        session.av.play.assert_not_called()
+        # The fault detail rides along for the caller to log.
+        assert "CurrentURI" in excinfo.value.request_envelope
+        assert "716" in excinfo.value.response_body
+
+    def test_connect_passthrough_reject_tears_down(
+        self, mock_soap, mock_http_server, monkeypatch,
+    ):
+        """When a track is already loaded, connect() goes through the
+        passthrough path and the initial SetAVTransportURI happens
+        inside start_passthrough. If the device rejects it (716), that
+        failure must propagate: connect tears the session down and
+        raises, instead of the old swallowed-fault false 'connected'
+        with no audio."""
+        mgr = UpnpManager()
+        device = _device_record()
+        mgr._devices = {device.id: device}
+        monkeypatch.setattr(
+            "app.audio.upnp.fetch_device",
+            lambda location, **_kw: _openhome_device(),
+        )
+
+        # A loaded track drives the passthrough path. Stub the encoder
+        # + segment reader so no real network/thread work happens; we
+        # only care about the SOAP handshake outcome.
+        class _StubEncoder:
+            def __init__(self, *a, **k):
+                pass
+
+            def start(self):
+                pass
+
+            def close(self):
+                pass
+
+        class _StubReader:
+            def __init__(self, *a, **k):
+                pass
+
+        monkeypatch.setattr(
+            "app.audio.upnp.FlacPassthroughEncoder", _StubEncoder
+        )
+        monkeypatch.setattr(
+            "app.audio.segment_reader.SegmentReader", _StubReader
+        )
+        mgr.set_source_provider(lambda: ["http://192.168.1.9/seg0"])
+        mgr.set_metadata_provider(lambda: {"title": "T", "artist": "A"})
+
+        # Every SOAP call raises -> the passthrough SetAVTransportURI
+        # fails like a 716-rejecting renderer.
+        def _raising_post(*args, **kwargs):
+            raise RuntimeError("simulated 716 rejection")
+
+        monkeypatch.setattr(requests, "post", _raising_post)
+
+        with pytest.raises(RuntimeError):
+            mgr.connect(device.id)
+
+        # Torn down, not left as a phantom 'connected' session.
+        assert mock_http_server.shutdown.called
+        assert mock_http_server.server_close.called
         assert mgr._session is None
 
 


### PR DESCRIPTION
## Summary

@joelgwebber's #344, rebased onto `main` and conflicts resolved. **All three commits keep their original authorship** — this is a carry, not a rewrite, opened only because #344's branch is on a fork and I can't push the rebase there.

#344 went `CONFLICTING` when the `#341 → #353 → #385` stack merged, which is our doing rather than theirs: all four touch `app/audio/http_stream.py`. They asked to keep this one on #332 — *"#344 does still include some useful o11y improvements that have helped in debugging"* — and given how much of this week's DLNA work turned on reading logs, that seems right.

Prefer @joelgwebber rebasing #344 themselves if they'd rather; close this if so.

## Conflicts and how they were resolved

Four, and two of them were semantic rather than textual — worth reviewing rather than trusting.

**1. `range_hdr` hoisting.** #344 lifts `range_hdr` above `if server.dlna:` so the Cast path can log it too; #341 added `has_range` inside the block. Kept the hoist, kept `has_range` reading from it.

**2. Response status.** #344 introduced a `status` variable for its `ANSWERED` log line, assuming an unconditional 206. #341/#385 made the status conditional. Resolved by assigning `status` inside each branch — 206 with a Range, 200 without — so the log reports what was actually sent rather than a hardcoded value. A log line that lies about the status would defeat the purpose of the PR.

**3. `do_HEAD`.** #344 adds a `method` argument for logging; #353 added the bounded-track routing. Both kept.

**4. Connect teardown (the one to look at).** #344 replaces the inline teardown in the connect `except` with `self.disconnect()`. That looked risky, because #353 later added `track_source` cleanup that didn't exist when #344 was written — dropping it would leak a temp file and a demux thread on every failed connect.

Checked `disconnect()` on `main` before taking it: it already does `_session = None`, `buffer.close()`, `http_server.shutdown()` / `server_close()`, **and** closes `track_source` — #353 updated it. So #344's version is a strict superset of the inline block, and additionally stops the passthrough encoder and un-silences local audio. Took theirs.

## Test plan

- `pytest tests/test_http_stream.py tests/test_upnp_session.py tests/test_openhome_soap.py` — **114 passed**. That covers the no-Range→200 behaviour from #385 and the SOAP fault detail this PR adds, so the resolutions in 1–3 are exercised.
- Full suite: **1302 passed, 9 skipped, 1 failed** — the failure is the pre-existing `uvloop`-has-no-Windows-wheel test.

Not verified on hardware. The teardown change in conflict 4 only fires on a failed connect, which no test here reproduces against a real device.
