### PR TITLE
UPnP track metadata + cover proxy (rebase of #352)

### DIFF
--- a/app/audio/http_stream.py
+++ b/app/audio/http_stream.py
@@ -35,6 +35,7 @@ from __future__ import annotations
 import http.server
 import logging
 import os
+import re
 import socket
 import socketserver
 import tempfile
@@ -44,6 +45,7 @@ import urllib.parse
 from typing import Optional
 
 import numpy as np
+import requests
 
 log = logging.getLogger(__name__)
 
@@ -66,6 +68,26 @@ DLNA_CONTENT_FEATURES = (
     "DLNA.ORG_OP=01;DLNA.ORG_CI=0;"
     "DLNA.ORG_FLAGS=05700000000000000000000000000000"
 )
+
+# --- Cover-art proxy for DLNA/UPnP renderers -------------------------
+# Renderers (e.g. UAPP) fetch the albumArtURI we hand them over the LAN.
+# Tidal's image CDN (resources.tidal.com / images.tidal.com) is often
+# unreachable or rejected by the renderer (CORS / signed-URL / auth
+# headers), so instead of handing the renderer Tidal's remote URL we
+# proxy the cover through THIS server — the same LAN-only, 0.0.0.0-
+# bound listener that already streams the FLAC. That keeps the blast
+# radius to this one listener; the FastAPI server stays on 127.0.0.1
+# and is never LAN-reachable (see StreamHTTPServer's docstring).
+#
+# SSRF surface is bounded two ways: the only host we ever fetch is a
+# Tidal image CDN from the allowlist below, and the cover id is
+# constrained to hex + dashes (dashes become path slashes, as Tidal
+# expects) so no `..` / `@` / `:` breakout is possible.
+_COVER_SESSION = requests.Session()
+_COVER_SESSION.headers.update({"User-Agent": "Tideway/1.0"})
+_COVER_ALLOWED_HOSTS = frozenset({"resources.tidal.com", "images.tidal.com"})
+_COVER_MAX_BYTES = 5 * 1024 * 1024
+_COVER_ID_RE = re.compile(r"^[0-9a-fA-F-]{32,40}$")
 
 # The stream is open-ended, but a strict renderer's Range probe wants a
 # finite total to seek against before its decoder-init proceeds. We
@@ -1159,6 +1181,10 @@ class StreamHTTPServer(socketserver.ThreadingMixIn, http.server.HTTPServer):
     # the UPnP session on start_passthrough, cleared when passthrough
     # stops (fallback PCM re-encode is served from the RingBuffer).
     track_source: Optional["TrackFileSource"] = None
+    # Cover-art cache (cover_id -> (bytes, content_type)). Populated
+    # lazily on first renderer fetch; covers are tiny and stable for
+    # the life of a session.
+    cover_cache: dict = {}
 
 
 class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
@@ -1367,6 +1393,10 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
         if not isinstance(server, StreamHTTPServer):
             self.send_error(503, "stream session not ready")
             return
+        _path = self._request_path()
+        if _path.startswith("/cover/"):
+            self._serve_cover(_path[len("/cover/"):], head=True)
+            return
         if self._request_path() != server.stream_path:
             self.send_error(404, "not found")
             return
@@ -1379,11 +1409,69 @@ class _StreamRequestHandler(http.server.BaseHTTPRequestHandler):
             return
         self._send_stream_headers(server)
 
+    def _serve_cover(self, cover_id: str, head: bool = False) -> None:
+        """Proxy a Tidal album cover for a LAN renderer.
+
+        `cover_id` is the raw Tidal cover UUID (hex + dashes). We build
+        the Tidal CDN URL and fetch it, caching the bytes on this server
+        so repeat requests (and the renderer's repeated probes) are
+        cheap. Only Tidal image-CDN hosts are ever contacted (see
+        _COVER_ALLOWED_HOSTS) and the id is regex-constrained, so this
+        is not a general outbound proxy.
+        """
+        if not _COVER_ID_RE.match(cover_id):
+            self.send_error(400, "invalid cover id")
+            return
+        cache = self.server.cover_cache
+        cached = cache.get(cover_id)
+        if cached is None:
+            tidal_url = (
+                "https://resources.tidal.com/images/"
+                f"{cover_id.replace('-', '/')}/640x640.jpg"
+            )
+            parsed = urllib.parse.urlparse(tidal_url)
+            if parsed.hostname not in _COVER_ALLOWED_HOSTS:
+                self.send_error(403, "host not allowed")
+                return
+            try:
+                resp = _COVER_SESSION.get(tidal_url, timeout=10)
+                resp.raise_for_status()
+                body = resp.content
+            except Exception as exc:
+                log.warning("cover fetch failed for %s: %s", cover_id, exc)
+                self.send_error(502, "cover fetch failed")
+                return
+            if len(body) > _COVER_MAX_BYTES:
+                self.send_error(413, "cover too large")
+                return
+            ctype = resp.headers.get("Content-Type") or "image/jpeg"
+            if len(cache) > 256:
+                cache.clear()
+            cache[cover_id] = (body, ctype)
+        else:
+            body, ctype = cached
+        self.send_response(200)
+        self.send_header("Content-Type", ctype)
+        self.send_header("Content-Length", str(len(body)))
+        self.send_header("Cache-Control", "public, max-age=3600")
+        self.send_header("Connection", "close")
+        self.end_headers()
+        if head:
+            return
+        try:
+            self.wfile.write(body)
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
     def do_GET(self) -> None:  # noqa: N802 - stdlib API
         self._log_connection("GET")
         server = self.server  # type: ignore[assignment]
         if not isinstance(server, StreamHTTPServer):
             self.send_error(503, "stream session not ready")
+            return
+        _path = self._request_path()
+        if _path.startswith("/cover/"):
+            self._serve_cover(_path[len("/cover/"):])
             return
         if self._request_path() != server.stream_path:
             self.send_error(404, "not found")

--- a/app/audio/manifest_cache.py
+++ b/app/audio/manifest_cache.py
@@ -43,7 +43,12 @@ _ENTRY_SWEEP_THRESHOLD = 128
 #   info:       Any (StreamInfo) — opaque, passed back to caller
 #   cached_at:  float — time.monotonic() at insertion
 #   bytes_map:  dict[int, bytes] — pre-fetched segment bytes by index
-_Entry = tuple[list[str], Optional[float], Any, float, dict[int, bytes]]
+#   track_meta: Optional[dict] — resolved track metadata (title/artist/
+#               album/cover_id). Stored alongside the manifest so a cache
+#               HIT carries the correct metadata too — without it, the
+#               UPnP renderer was told the previous track's metadata on
+#               every hit (the miss path set it, the hit path didn't).
+_Entry = tuple[list[str], Optional[float], Any, float, dict[int, bytes], Optional[dict]]
 
 
 class ManifestCache:
@@ -71,11 +76,15 @@ class ManifestCache:
 
     def lookup(
         self, key: tuple[str, Optional[str]]
-    ) -> Optional[tuple[list[str], Optional[float], Any, dict[int, bytes]]]:
+    ) -> Optional[
+        tuple[list[str], Optional[float], Any, dict[int, bytes], Optional[dict]]
+    ]:
         """Return a fresh copy of the entry, or None on miss / expiry.
 
         Returns copies of `urls` and `bytes_map` so the caller can
-        mutate freely without poisoning the cache.
+        mutate freely without poisoning the cache. The trailing
+        `track_meta` is the cached resolved metadata (may be None for
+        entries written before this field existed).
         """
         now = time.monotonic()
         with self._lock:
@@ -83,14 +92,14 @@ class ManifestCache:
             if entry is None:
                 self._misses += 1
                 return None
-            urls, duration, info, cached_at, bytes_map = entry
+            urls, duration, info, cached_at, bytes_map, track_meta = entry
             if now - cached_at > self._ttl:
                 self._bytes -= sum(len(v) for v in bytes_map.values())
                 self._entries.pop(key, None)
                 self._misses += 1
                 return None
             self._hits += 1
-            return list(urls), duration, info, dict(bytes_map)
+            return list(urls), duration, info, dict(bytes_map), track_meta
 
     def store(
         self,
@@ -98,19 +107,28 @@ class ManifestCache:
         urls: list[str],
         duration: Optional[float],
         info: Any,
+        track_meta: Optional[dict] = None,
     ) -> None:
         """Insert / refresh a manifest entry.
 
         Preserves any pre-fetched bytes from a prior prefetch for the
         same key — re-resolving the manifest doesn't wipe warmed
         segments, so a hover-prefetch followed by a real play stays
-        warm end-to-end.
+        warm end-to-end. `track_meta`, when supplied, replaces the
+        cached metadata; when omitted it is preserved from any existing
+        entry (so a bytes-only refresh keeps the existing metadata).
         """
         with self._lock:
             existing = self._entries.get(key)
             existing_bytes = existing[4] if existing is not None else {}
+            existing_meta = existing[5] if existing is not None else None
             self._entries[key] = (
-                urls, duration, info, time.monotonic(), existing_bytes,
+                urls,
+                duration,
+                info,
+                time.monotonic(),
+                existing_bytes,
+                track_meta if track_meta is not None else existing_meta,
             )
             # Sweep expired siblings opportunistically while we have
             # the lock — keeps memory bounded without a janitor
@@ -145,7 +163,7 @@ class ManifestCache:
             entry = self._entries.get(key)
             if entry is None:
                 return
-            urls, duration, info, cached_at, bytes_map = entry
+            urls, duration, info, cached_at, bytes_map, track_meta = entry
             merged = dict(bytes_map)
             added = 0
             for idx, data in new_bytes.items():
@@ -153,7 +171,7 @@ class ManifestCache:
                     continue
                 merged[idx] = data
                 added += len(data)
-            self._entries[key] = (urls, duration, info, cached_at, merged)
+            self._entries[key] = (urls, duration, info, cached_at, merged, track_meta)
             self._bytes += added
             self._evict_bytes_over_cap_locked()
 
@@ -174,7 +192,7 @@ class ManifestCache:
                     "prefetched_segments": len(bytes_map),
                     "prefetched_bytes": sum(len(v) for v in bytes_map.values()),
                 }
-                for (tid, q), (urls, _dur, _info, cached_at, bytes_map) in list(
+                for (tid, q), (urls, _dur, _info, cached_at, bytes_map, _meta) in list(
                     self._entries.items()
                 )
             ]
@@ -200,11 +218,11 @@ class ManifestCache:
         # Python 3.7+ dict preserves insertion order — pop in
         # insertion order until we're back under the cap.
         for key in list(self._entries.keys()):
-            urls, duration, info, cached_at, bytes_map = self._entries[key]
+            urls, duration, info, cached_at, bytes_map, track_meta = self._entries[key]
             if not bytes_map:
                 continue
             freed = sum(len(v) for v in bytes_map.values())
-            self._entries[key] = (urls, duration, info, cached_at, {})
+            self._entries[key] = (urls, duration, info, cached_at, {}, track_meta)
             self._bytes -= freed
             if self._bytes <= self._bytes_cap:
                 break

--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -199,6 +199,11 @@ class _Preload:
     sample_rate: int
     channels: int
     sd_dtype: str
+    # Metadata for THIS preloaded track. Carried on the preload so the
+    # gapless swap notifies the renderer with the track actually being
+    # adopted, not the shared _current_track_meta slot (which the racing
+    # desktop clock may have clobbered with a later track's metadata).
+    track_meta: Optional[dict] = None
 
 
 @dataclass
@@ -1267,8 +1272,10 @@ class PCMPlayer:
             self._drop_preload()
 
             try:
-                source_spec, duration_s, stream_info, prefetched_bytes, _ = (
-                    self._resolve_source(track_id, quality)
+                source_spec, duration_s, stream_info, prefetched_bytes, track_meta = (
+                    self._resolve_source(
+                        track_id, quality, set_current_meta=False
+                    )
                 )
                 source = _build_source(source_spec, prefetched=prefetched_bytes)
                 decoder = Decoder(source)
@@ -1326,6 +1333,7 @@ class PCMPlayer:
                 sample_rate=decoder.output_sample_rate,
                 channels=decoder.channels,
                 sd_dtype=decoder.sounddevice_dtype,
+                track_meta=track_meta,
             )
             with self._lock:
                 self._preload = pre
@@ -3361,7 +3369,7 @@ class PCMPlayer:
                 _upnp_manager.start_passthrough(
                     pre.source_urls,
                     prefetched=None,
-                    metadata=self._current_track_meta,
+                    metadata=pre.track_meta or self._current_track_meta,
                 )
             except (ValueError, RuntimeError, OSError) as exc:
                 print(
@@ -4093,7 +4101,7 @@ class PCMPlayer:
                         _upnp_manager.start_passthrough(
                             pre.source_urls,
                             prefetched=None,
-                            metadata=self._current_track_meta,
+                            metadata=pre.track_meta or self._current_track_meta,
                         )
                     except (ValueError, RuntimeError, OSError) as exc:
                         print(
@@ -4181,6 +4189,11 @@ class PCMPlayer:
             self._current_track_id = pre.track_id
             self._current_duration_ms = pre.duration_ms
             self._current_stream_info = pre.stream_info
+            # Keep the now-playing metadata in sync with the adopted
+            # track, and carry the preload's own meta so the swap
+            # notification uses the track actually being adopted.
+            if pre.track_meta is not None:
+                self._current_track_meta = pre.track_meta
             self._source_urls = pre.source_urls
             self._source_path = pre.source_path
             self._stream_sample_rate = pre.sample_rate

--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -3369,7 +3369,7 @@ class PCMPlayer:
                 _upnp_manager.start_passthrough(
                     pre.source_urls,
                     prefetched=None,
-                    metadata=pre.track_meta or self._current_track_meta,
+                    metadata=getattr(pre, "track_meta", None) or self._current_track_meta,
                 )
             except (ValueError, RuntimeError, OSError) as exc:
                 print(
@@ -4101,7 +4101,7 @@ class PCMPlayer:
                         _upnp_manager.start_passthrough(
                             pre.source_urls,
                             prefetched=None,
-                            metadata=pre.track_meta or self._current_track_meta,
+                            metadata=getattr(pre, "track_meta", None) or self._current_track_meta,
                         )
                     except (ValueError, RuntimeError, OSError) as exc:
                         print(
@@ -4192,7 +4192,7 @@ class PCMPlayer:
             # Keep the now-playing metadata in sync with the adopted
             # track, and carry the preload's own meta so the swap
             # notification uses the track actually being adopted.
-            if pre.track_meta is not None:
+            if getattr(pre, "track_meta", None) is not None:
                 self._current_track_meta = pre.track_meta
             self._source_urls = pre.source_urls
             self._source_path = pre.source_path

--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -844,8 +844,8 @@ class PCMPlayer:
             self._transition("loading", track_id=track_id)
 
         try:
-            source_spec, duration_s, stream_info, prefetched_bytes = self._resolve_source(
-                track_id, quality
+            source_spec, duration_s, stream_info, prefetched_bytes, track_meta = (
+                self._resolve_source(track_id, quality)
             )
             t_resolved = time.monotonic()
             initial_source = _build_source(source_spec, prefetched=prefetched_bytes)
@@ -858,7 +858,7 @@ class PCMPlayer:
                         _upnp_manager.start_passthrough(
                             source_spec,
                             prefetched=prefetched_bytes,
-                            metadata=self._current_track_meta,
+                            metadata=track_meta,
                         )
                 except (ValueError, RuntimeError, OSError) as exc:
                     print(
@@ -1267,7 +1267,7 @@ class PCMPlayer:
             self._drop_preload()
 
             try:
-                source_spec, duration_s, stream_info, prefetched_bytes = (
+                source_spec, duration_s, stream_info, prefetched_bytes, _ = (
                     self._resolve_source(track_id, quality)
                 )
                 source = _build_source(source_spec, prefetched=prefetched_bytes)
@@ -1377,8 +1377,8 @@ class PCMPlayer:
         responsible for tearing down the returned pipeline if it
         decides not to adopt it.
         """
-        source_spec, duration_s, stream_info, prefetched_bytes = self._resolve_source(
-            track_id, quality
+        source_spec, duration_s, stream_info, prefetched_bytes, track_meta = (
+            self._resolve_source(track_id, quality)
         )
         source = _build_source(source_spec, prefetched=prefetched_bytes)
 
@@ -1395,7 +1395,7 @@ class PCMPlayer:
                     _upnp_manager.start_passthrough(
                         source_spec,
                         prefetched=prefetched_bytes,
-                        metadata=self._current_track_meta,
+                        metadata=track_meta,
                     )
             except (ValueError, RuntimeError, OSError) as exc:
                 print(
@@ -2085,9 +2085,52 @@ class PCMPlayer:
             self._paused = False
             self._seeking = False
 
+    def _build_track_meta(self, track, duration_s) -> dict:
+        """Extract UPnP/DLNA track metadata from a resolved Tidal track.
+
+        Returns the metadata dict the UPnP layer consumes for
+        SetAVTransportURI. `cover_id` is carried separately so the
+        UPnP layer can build a LAN-local cover URL — the renderer can't
+        reach Tidal's image CDN directly, which is why the cover never
+        showed before.
+        """
+        artist_name = (
+            getattr(track.artist, "name", None)
+            if hasattr(track, "artist")
+            else None
+        )
+        if not artist_name and hasattr(track, "artists") and track.artists:
+            artist_name = track.artists[0].name
+        album_name = (
+            track.album.name
+            if hasattr(track, "album") and track.album
+            else None
+        )
+        cover_id = (
+            track.album.cover
+            if hasattr(track, "album") and track.album
+            else None
+        )
+        return {
+            "title": getattr(track, "name", "") or "",
+            "artist": artist_name or "",
+            "album": album_name or "",
+            "duration_s": duration_s or 0,
+            "cover_id": cover_id or "",
+            "cover_url": (
+                f"https://resources.tidal.com/images/{cover_id}/640x640.jpg"
+                if cover_id
+                else ""
+            ),
+        }
+
     def _resolve_source(
-        self, track_id: str, quality: Optional[str]
-    ) -> tuple[Union[str, list[str]], Optional[float], StreamInfo, dict[int, bytes]]:
+        self,
+        track_id: str,
+        quality: Optional[str],
+        *,
+        set_current_meta: bool = True,
+    ) -> tuple[Union[str, list[str]], Optional[float], StreamInfo, dict[int, bytes], Optional[dict]]:
         """Resolve a track id to a source spec.
 
         Returns either a local filesystem path (str) or a DASH URL
@@ -2100,6 +2143,13 @@ class PCMPlayer:
         sources that have not had byte-level prefetch run against
         them. When populated, SegmentReader seeds its buffer with
         those bytes so decoder_init does not touch the network.
+
+        `set_current_meta` is passed False by speculative resolution
+        (cold-start / hover prefetch): those warm the cache but must
+        NOT overwrite `_current_track_meta`. The renderer's first
+        SetAVTransportURI reads that dict, so a prefetch of a track
+        the user never played would otherwise show up as the wrong
+        "current" track at the start of a session.
         """
         if self._local_lookup is not None:
             local_path = self._local_lookup(track_id)
@@ -2110,6 +2160,7 @@ class PCMPlayer:
                     duration_s,
                     info or StreamInfo(source="local"),
                     {},
+                    None,
                 )
 
         session = self._session_getter()
@@ -2133,7 +2184,17 @@ class PCMPlayer:
         t0 = time.monotonic()
         cached_urls_info = self._manifest_cache.lookup(cache_key)
         if cached_urls_info is not None:
-            urls, duration, info, bytes_map = cached_urls_info
+            urls, duration, info, bytes_map, track_meta = cached_urls_info
+            # Cache HIT must refresh the UPnP metadata for playback too
+            # — the miss path does this inside _resolve_uncached, but a
+            # hit used to leave _current_track_meta pointing at the
+            # previous track, so the renderer was told the wrong
+            # artist/song at session start (and on every replay, since
+            # cold-start prefetch makes the first play a hit). Guarded
+            # by set_current_meta so speculative prefetch doesn't clobber
+            # it.
+            if track_meta is not None and set_current_meta:
+                self._current_track_meta = track_meta
             print(
                 f"[perf] resolve track={track_id} quality={quality} "
                 f"cache=HIT elapsed={(time.monotonic() - t0) * 1000.0:.0f}ms "
@@ -2141,11 +2202,12 @@ class PCMPlayer:
                 file=sys.stderr,
                 flush=True,
             )
-            return (list(urls), duration, info, bytes_map)
+            return (list(urls), duration, info, bytes_map, track_meta)
 
         try:
             return self._resolve_uncached(
-                session, track_id, quality, cache_key, t0
+                session, track_id, quality, cache_key, t0,
+                set_current_meta=set_current_meta,
             )
         except Exception as exc:
             # The playback resolve path must recover from an expired
@@ -2170,6 +2232,7 @@ class PCMPlayer:
                         quality,
                         cache_key,
                         t0,
+                        set_current_meta=set_current_meta,
                     )
                 raise RuntimeError(
                     "Tidal session expired. Please log out and log "
@@ -2184,13 +2247,19 @@ class PCMPlayer:
         quality: Optional[str],
         cache_key: tuple,
         t0: float,
+        *,
+        set_current_meta: bool = True,
     ) -> tuple[
         Union[str, list[str]], Optional[float], StreamInfo, dict[int, bytes]
     ]:
         """Cache-miss network resolution: fetch track + playback-info,
         parse the manifest, populate the cache. Split out of
         _resolve_source so the caller can retry it once after a
-        force-refresh when Tidal returns an expired-token 401."""
+        force-refresh when Tidal returns an expired-token 401.
+
+        `set_current_meta` mirrors _resolve_source: speculative
+        resolution (prefetch) passes False so it doesn't overwrite the
+        metadata of the track that is actually playing."""
         override = None
         if quality:
             try:
@@ -2249,35 +2318,14 @@ class PCMPlayer:
             if not urls:
                 raise RuntimeError("manifest has no segment urls")
             duration = getattr(track, "duration", None)
-            # Save track metadata for UPnP/DLNA track-change notification.
-            artist_name = (
-                getattr(track.artist, "name", None)
-                if hasattr(track, "artist")
-                else None
-            )
-            if not artist_name and hasattr(track, "artists") and track.artists:
-                artist_name = track.artists[0].name
-            album_name = (
-                track.album.name
-                if hasattr(track, "album") and track.album
-                else None
-            )
-            cover_id = (
-                track.album.cover
-                if hasattr(track, "album") and track.album
-                else None
-            )
-            self._current_track_meta = {
-                "title": getattr(track, "name", "") or "",
-                "artist": artist_name or "",
-                "album": album_name or "",
-                "duration_s": duration or 0,
-                "cover_url": (
-                    f"https://resources.tidal.com/images/{cover_id}/640x640.jpg"
-                    if cover_id
-                    else ""
-                ),
-            }
+            # Resolve track metadata for UPnP/DLNA track-change
+            # notification. Also stored on the cache entry (below) so a
+            # later cache HIT carries the correct metadata too. Only for
+            # real loads — speculative prefetch passes set_current_meta
+            # False so it can't clobber the playing track's metadata.
+            track_meta = self._build_track_meta(track, duration)
+            if set_current_meta:
+                self._current_track_meta = track_meta
             info = StreamInfo(
                 source="stream",
                 codec=_normalize_codec(
@@ -2308,7 +2356,9 @@ class PCMPlayer:
                 ),
             )
             duration_s = float(duration) if duration else None
-            self._manifest_cache.store(cache_key, list(urls), duration_s, info)
+            self._manifest_cache.store(
+                cache_key, list(urls), duration_s, info, track_meta
+            )
             # After store, any previously-warmed bytes are preserved
             # — pick them back up so a MISS on manifest that still
             # has bytes cached returns the bytes too.
@@ -2323,7 +2373,7 @@ class PCMPlayer:
                 file=sys.stderr,
                 flush=True,
             )
-            return (list(urls), duration_s, info, bytes_map)
+            return (list(urls), duration_s, info, bytes_map, track_meta)
         finally:
             if override is not None:
                 session.config.quality = original
@@ -2374,7 +2424,9 @@ class PCMPlayer:
 
         tidal_jitter_sleep()
         try:
-            source_spec, _dur, _info, _bytes = self._resolve_source(track_id, quality)
+            source_spec, _dur, _info, _bytes, _ = self._resolve_source(
+                track_id, quality, set_current_meta=False
+            )
         except Exception as exc:
             log.debug("prefetch manifest %s@%s failed: %s", track_id, quality, exc)
             return False

--- a/app/audio/upnp.py
+++ b/app/audio/upnp.py
@@ -799,12 +799,21 @@ class UpnpManager:
                 _ts = track_ts
             _sep = "&" if "?" in session.stream_url else "?"
             _uri = f"{session.stream_url}{_sep}ts={_ts}"
+            # Point albumArtURI at the cover we proxy on THIS server
+            # (LAN-reachable 0.0.0.0 stream listener). The renderer
+            # can't reach Tidal's image CDN directly, so a remote
+            # cover_url never resolved to a picture before.
+            cover_url = ""
+            cover_id = metadata.get("cover_id")
+            if cover_id:
+                _base = session.stream_url.rsplit(_STREAM_PATH, 1)[0]
+                cover_url = f"{_base}/cover/{cover_id}"
             track_meta = TrackMetadata(
                 title=metadata.get("title", ""),
                 artist=metadata.get("artist", ""),
                 album=metadata.get("album", ""),
                 duration_s=metadata.get("duration_s", 0),
-                cover_url=metadata.get("cover_url", ""),
+                cover_url=cover_url,
                 track_uri=_uri,
                 mime_type="audio/flac",
             )

--- a/tests/test_http_stream.py
+++ b/tests/test_http_stream.py
@@ -949,3 +949,87 @@ class TestBoundedTrackServe:
             server.server_close()
             buffer.close()
             os.unlink(path)
+
+
+
+
+# ---------------------------------------------------------------------
+# Cover-art proxy (renderer can't reach Tidal's image CDN directly)
+# ---------------------------------------------------------------------
+
+
+class TestCoverProxy:
+    """The LAN stream server also proxies album covers so a DLNA
+    renderer (e.g. UAPP) can show art without reaching Tidal's CDN.
+    The endpoint must validate the cover id (no SSRF) and cache the
+    fetched bytes."""
+
+    COVER_ID = "12345678-1234-1234-1234-1234567890ab"
+
+    def _server(self):
+        buffer = RingBuffer()
+        # Seed so a concurrent stream GET doesn't block; the cover path
+        # doesn't touch the buffer but the server still expects one.
+        buffer.write(b"\x00" * 256)
+        buffer.data_ready.set()
+        server = start_stream_http_server(
+            buffer, stream_path="/stream", content_type="audio/flac"
+        )
+        return server, buffer
+
+    def _get(self, server, path):
+        import socket as _socket
+
+        port = server.server_address[1]
+        sock = _socket.create_connection(("127.0.0.1", port), timeout=3.0)
+        try:
+            sock.sendall(
+                f"GET {path} HTTP/1.1\r\nHost: localhost\r\n\r\n".encode()
+            )
+            chunks = []
+            while True:
+                data = sock.recv(4096)
+                if not data:
+                    break
+                chunks.append(data)
+            return b"".join(chunks)
+        finally:
+            sock.close()
+
+    def _fake_cover_response(self):
+        resp = MagicMock()
+        resp.raise_for_status.return_value = None
+        resp.content = b"\xff\xd8\xff\xe0COVERJPEG"
+        resp.headers.get.return_value = "image/jpeg"
+        return resp
+
+    def test_cover_proxy_serves_cached_image(self):
+        from app.audio.http_stream import _COVER_SESSION
+
+        fake = self._fake_cover_response()
+        server, buffer = self._server()
+        try:
+            with patch.object(_COVER_SESSION, "get", return_value=fake) as get:
+                raw = self._get(server, f"/cover/{self.COVER_ID}")
+                assert raw.startswith(b"HTTP/1.1 200"), raw[:64]
+                assert b"Content-Type: image/jpeg" in raw, raw[:200]
+                assert b"\xff\xd8\xff\xe0COVERJPEG" in raw, raw
+                # Fetched once; the second request is served from cache.
+                get.assert_called_once()
+                raw2 = self._get(server, f"/cover/{self.COVER_ID}")
+                assert b"\xff\xd8\xff\xe0COVERJPEG" in raw2
+                get.assert_called_once()
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()
+
+    def test_cover_proxy_rejects_malformed_id(self):
+        server, buffer = self._server()
+        try:
+            raw = self._get(server, "/cover/..%2f..%2fetc%2fpasswd")
+            assert raw.startswith(b"HTTP/1.1 400"), raw[:64]
+        finally:
+            server.shutdown()
+            server.server_close()
+            buffer.close()

--- a/tests/test_http_stream.py
+++ b/tests/test_http_stream.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 
 import numpy as np
 import pytest
+from unittest.mock import MagicMock, patch
 
 from app.audio.http_stream import (
     FlacPassthroughEncoder,

--- a/tests/test_prefetch_jitter.py
+++ b/tests/test_prefetch_jitter.py
@@ -41,10 +41,11 @@ def test_player_prefetch_jitters_before_first_tidal_call():
     def fake_jitter() -> None:
         call_order.append("jitter")
 
-    def fake_resolve(track_id, quality):
+    def fake_resolve(track_id, quality, *, set_current_meta=True):
         call_order.append("resolve")
-        # Mimic _resolve_source's return shape: (urls, dur, info, bytes_map).
-        return (["http://seg/0", "http://seg/1"], 180.0, None, {})
+        # Mimic _resolve_source's return shape:
+        # (urls, dur, info, bytes_map, track_meta).
+        return (["http://seg/0", "http://seg/1"], 180.0, None, {}, None)
 
     player._resolve_source = fake_resolve  # type: ignore[assignment]
 

--- a/tests/test_resolve_source_parallel.py
+++ b/tests/test_resolve_source_parallel.py
@@ -22,6 +22,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from app.audio.manifest_cache import ManifestCache
+
 
 def test_resolve_source_runs_metadata_and_playbackinfo_in_parallel():
     from app.audio.player import PCMPlayer
@@ -76,7 +78,7 @@ def test_resolve_source_runs_metadata_and_playbackinfo_in_parallel():
     player._session_getter = lambda: session
 
     with patch("app.audio.player.tidalapi.Track", return_value=holder):
-        urls, duration_s, info, bytes_map = player._resolve_source(
+        urls, duration_s, info, bytes_map, track_meta = player._resolve_source(
             "12345", quality=None
         )
 
@@ -90,7 +92,12 @@ def test_resolve_source_runs_metadata_and_playbackinfo_in_parallel():
     assert urls == ["http://seg/0", "http://seg/1"]
     assert duration_s == 180.0
     assert info.audio_quality == "LOSSLESS"
-    # Manifest cache write fires once for the resolved entry.
+    # Metadata is resolved alongside the manifest and returned as the
+    # 5th element (so the UPnP renderer gets correct artist/album/cover).
+    assert isinstance(track_meta, dict)
+    assert "title" in track_meta and "cover_id" in track_meta
+    # Manifest cache write fires once for the resolved entry, carrying
+    # the metadata.
     player._manifest_cache.store.assert_called_once()
 
 
@@ -187,3 +194,73 @@ def test_resolve_source_bounded_when_tidal_stalls():
         assert elapsed < 3.0, f"resolve hung for {elapsed:.1f}s"
     finally:
         release.set()
+
+
+def test_resolve_source_cache_hit_returns_stored_metadata():
+    """A cache HIT must carry the resolved track metadata (title /
+    artist / cover_id), not the previous track's. Previously the hit
+    path left `_current_track_meta` pointing at the prior track, so the
+    UPnP renderer was told the wrong artist/song at session start (and
+    on every replay, since cold-start prefetch makes the first play a
+    hit)."""
+    from app.audio.player import PCMPlayer
+
+    player = PCMPlayer.__new__(PCMPlayer)
+    player._manifest_cache = ManifestCache()
+    player._local_lookup = None
+    player._quality_clamp = None
+    player._current_track_meta = {"title": "STALE", "artist": "OLD"}
+    stored_meta = {
+        "title": "Real Title",
+        "artist": "Real Artist",
+        "album": "Real Album",
+        "duration_s": 200,
+        "cover_id": "abcd1234-1234-1234-1234-1234567890ab",
+        "cover_url": "https://resources.tidal.com/images/x/640x640.jpg",
+    }
+    player._manifest_cache.store(
+        ("555", None), ["http://seg/0"], 200.0, None, stored_meta
+    )
+    player._session_getter = lambda: MagicMock()
+
+    result = player._resolve_source("555", quality=None)
+
+    assert result[4] == stored_meta
+    assert player._current_track_meta == stored_meta
+
+
+def test_prefetch_does_not_pollute_current_track_meta():
+    """Speculative prefetch must NOT overwrite `_current_track_meta`.
+
+    The cold-start prefetch resolves the persisted track purely to warm
+    the manifest cache. It used to reach _resolve_source (cache-hit),
+    which set `_current_track_meta` to the prefetched track — so when
+    the renderer's session started, the first SetAVTransportURI carried
+    a track the user never played. Prefetch is speculative, so it must
+    leave the playing track's metadata alone."""
+    from app.audio.player import PCMPlayer
+
+    player = PCMPlayer.__new__(PCMPlayer)
+    player._manifest_cache = ManifestCache()
+    player._local_lookup = None
+    player._quality_clamp = None
+    player._current_track_meta = {"title": "PLAYING", "artist": "Now"}
+    stored_meta = {
+        "title": "Prefetched",
+        "artist": "Not Playing",
+        "album": "X",
+        "duration_s": 1,
+        "cover_id": "ab",
+        "cover_url": "",
+    }
+    player._manifest_cache.store(
+        ("777", None), ["http://seg/0"], 1.0, None, stored_meta
+    )
+    player._session_getter = lambda: MagicMock()
+
+    with patch("app.tidal_client.tidal_jitter_sleep", return_value=None):
+        ok = player.prefetch("777", quality=None, warm_bytes=False)
+
+    assert ok is True
+    # The playing track's metadata is untouched by a speculative prefetch.
+    assert player._current_track_meta == {"title": "PLAYING", "artist": "Now"}


### PR DESCRIPTION
## Summary

@dante6913's #352, rebased onto `main`. **Their three commits keep their authorship**; the fourth is mine and is a rebase artifact, called out below.

#352 went `CONFLICTING` when the `#341 → #353 → #385` stack merged. That's on us — all of it touches `app/audio/http_stream.py`, and #352 was mergeable before we sequenced the other three first. Opened as a new PR only because #352 is on a fork and I can't push the rebase there; **prefer @dante6913 rebasing it themselves if they'd rather**, and close this if so.

## Conflicts and how they were resolved

Nine across two files. Most were additive; two needed judgement.

**`app/audio/http_stream.py`** — four:

1. **Imports** — `os` (from #353) vs `re` (#352). Kept both.
2. **`StreamHTTPServer` fields** — `track_source` (#353) vs `cover_cache` (#352). Kept both.
3–4. **`do_HEAD` / `do_GET` routing.** #352 adds a `/cover/` route; #353 added the bounded-track routing. Both kept, and **order matters**: the cover route goes before the stream-path check, since a `/cover/...` path isn't the stream path and would otherwise 404. #352's trailing `if server.buffer is None:` guard was dropped from the insertion — #353 moved that check below the bounded routing, so re-adding it there would have shadowed it.

**`tests/test_http_stream.py`** — five, and this is the part to review.

Git interleaved the two new test classes rather than treating them as separate additions: #352's `TestCoverProxy` and main's `TestBoundedTrackServe` land at the same position, and one conflict cut straight through their respective HTTP helper methods (`_get` vs `_get_full`). Splicing that by hand would have been guesswork.

Instead I took **main's version of the file wholesale** and grafted `TestCoverProxy` on as an intact block extracted from #352's branch. Both classes are therefore byte-identical to their originals rather than merged line-by-line. That's the safer construction, but it means the test file's structure is my doing and deserves a look.

## The one commit that is mine

`56d3a636` adds `from unittest.mock import MagicMock, patch`. #352's test file had it; main's didn't, and the graft left `TestCoverProxy` without it. Separate commit rather than amended into @dante6913's, so it's obvious which change is theirs and which is the rebase.

## Test plan

- `pytest tests/test_http_stream.py` — all pass, covering both the grafted cover-proxy tests and the existing bounded-serve and no-Range→200 tests.
- Full suite: **1303 passed, 9 skipped, 1 failed** — the failure is the pre-existing `uvloop`-has-no-Windows-wheel test.

Not verified on hardware. The cover proxy exists so a renderer can show art without reaching Tidal's CDN, and whether it does is not something any test here can answer — that needs a real UAPP renderer.
