### PR TITLE
Stop cancelling the run that verifies main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,9 +15,22 @@ on:
 # Cancel any older in-progress run on the same ref when a new commit
 # lands. Keeps the queue reasonable when someone pushes several quick
 # fixups during a code review.
+#
+# Pull requests only. On main, cancelling loses the one run that says
+# the default branch is good, and it does so in a way that reads as
+# success: runs are queued rather than started immediately, so they
+# do not begin in commit order, and whichever is in progress when a
+# newer one starts is the one that dies. Merging #341, #353 and #385
+# back to back left the runs for efcb2cac and ea813779 cancelled and
+# the run for 7a5d983f — by then two commits stale — green. main had
+# a passing Tests badge for a commit that was no longer main.
+#
+# A deploy branch merging several approved PRs in one sitting is the
+# normal case for this repo, not an edge case, so the queue saving is
+# not worth buying with an unverified default branch.
 concurrency:
   group: tests-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 # Single source of truth for runtime versions. Bumping either here
 # also has to be matched in .github/workflows/release.yml so the


### PR DESCRIPTION
## Summary

Merging #341, #353 and #385 back to back left `main` with a **passing Tests badge for a commit that was no longer `main`**:

```
16:34  push  efcb2cac  cancelled     ← #353
16:34  push  ea813779  cancelled     ← #385, main's actual head
16:36  push  7a5d983f  success       ← #341, by then two commits stale
```

That isn't the failure mode `cancel-in-progress: true` looks like it has. The obvious reading is "older runs get cancelled, the newest survives." What actually happens is that runs are **queued rather than started immediately** — an automatic `pull_request` run took 8 minutes to appear today — so they don't begin in commit order, and `cancel-in-progress` kills whichever is *running* when a newer one starts. That can be the newer commit's run, which is exactly what happened here.

The result reads as success while the real head is untested. That's worse than a missing run, because a missing run eventually prompts someone to look and a green tick never does.

## The change

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Keeps the cancelling where it earns its place — a PR under review, where several fixup pushes in a row make older runs genuinely uninteresting — and stops it on `main`.

Worth being explicit about why this repo in particular: the documented release process is to merge a batch of approved PRs into a deploy branch in one sitting, then fast-forward `main`. Several merges landing within a minute or two of each other is **the normal case here, not an edge case**. So on `main` the queue saving is bought with an unverified default branch, on precisely the commits that are about to be tagged and shipped.

## Test plan

- `yaml.safe_load` parses the workflow; `concurrency.cancel-in-progress` renders as the expression, `group` unchanged, triggers unchanged (`pull_request`, `push`, `workflow_dispatch`).
- This PR's own `pull_request` run exercises the PR side of the expression — it should still cancel on a re-push.
- The `main` side can't be proven until the next batch of merges lands. The check is that two rapid merges to `main` both keep their runs instead of one being cancelled.

## Not changed

The queue lag itself. I briefly thought `pull_request` runs weren't firing at all on this repo — they were, just several minutes later than I'd looked. That's GitHub's scheduling and there's nothing here to fix; it's only relevant as the reason the cancellation picks the wrong run.
