### PR TITLE
Report where the cold taste-profile build spends its time

### DIFF
--- a/server.py
+++ b/server.py
@@ -12658,6 +12658,32 @@ def _rank_by_taste(rows: list, orbit: dict, played: set) -> list:
     return sorted(rows, key=_score, reverse=True)
 
 
+# Cold-path timings worth keeping after the fact. A bare print goes to
+# stdout, which a packaged launch discards — the same reason the player
+# mirrors its `[perf] load` line into audio.log. NullHandler if the data
+# dir isn't writable so logging never raises on a request thread.
+perf_log = logging.getLogger("tideway.perf")
+perf_log.setLevel(logging.INFO)
+perf_log.propagate = False
+if not perf_log.handlers:
+    try:
+        from logging.handlers import RotatingFileHandler
+
+        from app.paths import user_data_dir
+
+        _ph = RotatingFileHandler(
+            str(user_data_dir() / "perf.log"),
+            maxBytes=1_000_000,
+            backupCount=3,
+        )
+        _ph.setFormatter(
+            logging.Formatter("%(asctime)s %(message)s", "%Y-%m-%d %H:%M:%S")
+        )
+        perf_log.addHandler(_ph)
+    except Exception:
+        perf_log.addHandler(logging.NullHandler())
+
+
 def _taste_profile() -> dict:
     """Infer taste from Last.fm: recency-blended top artists, and their
     community tags aggregated into genres mapped to AOTY slugs (the full
@@ -12665,16 +12691,20 @@ def _taste_profile() -> dict:
     fine — sections that depend on it just don't render. This is the
     "listening history" half of the popularity-x-history ranking (#307).
     """
+    _t0 = time.monotonic()
     connected = bool(_rec_safe(lambda: lastfm.status().get("connected"), False))
+    _t_status = time.monotonic()
     if not connected:
         return {"connected": False, "artist_names": set(), "genres": []}
     top = _seed_artists()
+    _t_seed = time.monotonic()
     artist_names = {e["name"].strip().lower() for e in top if e.get("name")}
 
     # How widely each tag is applied across all of Last.fm. Broad tags
     # ("rock", "electronic") are enormous and say almost nothing about an
     # individual; the sub-genres worth acting on are far rarer.
     chart_tags = _rec_safe(lambda: lastfm.get_chart_top_tags(limit=250), [])
+    _t_chart_tags = time.monotonic()
     tag_reach = {
         (t.get("name") or "").strip().lower(): float(t.get("reach") or 0)
         for t in chart_tags
@@ -12728,7 +12758,9 @@ def _taste_profile() -> dict:
     # Anything AOTY doesn't recognise falls out here, which also discards
     # Last.fm descriptors that aren't genres at all ("japanese", "seen
     # live") without needing a blocklist.
+    _t_artist_tags = time.monotonic()
     name_to_slug = _aoty_genre_slug_map()
+    _t_slugs = time.monotonic()
     genres: list = []
     seen_slugs: set = set()
     for gname, _w in sorted(weights.items(), key=lambda kv: kv[1], reverse=True):
@@ -12748,12 +12780,32 @@ def _taste_profile() -> dict:
     # count for less and genre fit for more, or "Popular in Your Orbit"
     # just becomes the global chart. 0 = fully niche, 1 = fully mainstream.
     chart = _rec_safe(lambda: lastfm.get_chart_top_artists(limit=500), [])
+    _t_chart_artists = time.monotonic()
     chart_names = {
         (a.get("name") or "").strip().lower() for a in chart if a.get("name")
     }
     mainstream_ratio = (
         len(artist_names & chart_names) / len(artist_names) if artist_names else 0.5
     )
+    # Every For You row blocks on this build behind _taste_cache_lock, so
+    # a cold profile is the whole page's time-to-first-row. Measured at
+    # roughly 30 s on a real cold start without anything saying which of
+    # these six phases owned it — five are Last.fm round trips and one
+    # (_aoty_genre_slug_map) harvests a couple of years of AOTY pages.
+    # Same one-line-at-the-bottom shape as the player's `[perf] load`.
+    _ms = lambda a, b: (b - a) * 1000.0
+    _perf = (
+        f"[perf] taste_profile total={_ms(_t0, _t_chart_artists):.0f}ms "
+        f"status={_ms(_t0, _t_status):.0f}ms "
+        f"seed_artists={_ms(_t_status, _t_seed):.0f}ms "
+        f"chart_tags={_ms(_t_seed, _t_chart_tags):.0f}ms "
+        f"artist_tags={_ms(_t_chart_tags, _t_artist_tags):.0f}ms "
+        f"genre_slugs={_ms(_t_artist_tags, _t_slugs):.0f}ms "
+        f"chart_artists={_ms(_t_slugs, _t_chart_artists):.0f}ms "
+        f"artists={len(top)} genres={len(genres)}"
+    )
+    print(_perf, flush=True)
+    perf_log.info(_perf)
     return {
         "connected": True,
         "artist_names": artist_names,

--- a/tests/test_taste_profile_perf.py
+++ b/tests/test_taste_profile_perf.py
@@ -1,0 +1,86 @@
+"""The cold taste-profile build reports where its time went.
+
+Every For You row blocks on `_taste_profile()` behind `_taste_cache_lock`,
+so a cold profile *is* the page's time-to-first-row. A real cold start was
+measured at roughly 30 seconds with nothing in the app saying which part
+owned it — five of the six phases are Last.fm round trips and the sixth
+harvests a couple of years of AOTY pages to build the genre slug map.
+
+Measurement had to be done by hand, from outside, against a running app:
+restart it, open the page, poll a diagnostic endpoint and hope to catch
+the window. These tests pin that the build says so itself instead — on
+any machine, including a reporter's.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def profile_env(monkeypatch):
+    """Stub every network edge of `_taste_profile` so it runs offline."""
+    import server
+
+    monkeypatch.setattr(
+        server,
+        "lastfm",
+        SimpleNamespace(
+            status=lambda: {"connected": True},
+            get_chart_top_tags=lambda limit=250: [
+                {"name": "shoegaze", "reach": 5000}
+            ],
+            get_artist_top_tags=lambda name, limit=None: [
+                {"name": "shoegaze", "count": 100}
+            ],
+            get_chart_top_artists=lambda limit=500: [{"name": "slowdive"}],
+        ),
+    )
+    monkeypatch.setattr(
+        server, "_seed_artists", lambda: [{"name": "Slowdive", "score": 1.0}]
+    )
+    monkeypatch.setattr(
+        server, "_aoty_genre_slug_map", lambda: {"shoegaze": ("26-shoegaze", "Shoegaze")}
+    )
+    return server
+
+
+def test_reports_every_phase(profile_env, capsys):
+    profile_env._taste_profile()
+    line = capsys.readouterr().out
+
+    assert "[perf] taste_profile" in line
+    # All six phases, or the line can't tell us which one is slow — which
+    # is the entire reason it exists.
+    for phase in (
+        "status=",
+        "seed_artists=",
+        "chart_tags=",
+        "artist_tags=",
+        "genre_slugs=",
+        "chart_artists=",
+    ):
+        assert phase in line, f"{phase} missing from: {line!r}"
+    assert "total=" in line
+
+
+def test_disconnected_profile_reports_nothing(profile_env, capsys):
+    """No Last.fm, no work worth timing — and no misleading 0ms line."""
+    profile_env.lastfm.status = lambda: {"connected": False}
+
+    out = profile_env._taste_profile()
+
+    assert out["connected"] is False
+    assert "[perf] taste_profile" not in capsys.readouterr().out
+
+
+def test_perf_line_also_reaches_the_durable_log(profile_env, caplog):
+    """A packaged launch discards stdout, so the print alone would be
+    invisible exactly where the 30-second cold start was reported."""
+    import logging
+
+    with caplog.at_level(logging.INFO, logger="tideway.perf"):
+        profile_env._taste_profile()
+
+    assert any("[perf] taste_profile" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

The For You page takes ~30 seconds cold. Today's measurements narrowed that to one place and then ran out of road.

**What was ruled out, by measurement:**

- **Threadpool contention.** Three page loads including a genuine cold one, read off `/api/diagnostics/concurrency`: `peak_in_flight` **6 of 40**, `started_while_saturated` **0**, and the busiest moment was the browser fetching six static `.js`/`.css` bundles. The theory carried for months as the explanation for the lag reports — and for #386 — is wrong.
- **The section builds.** Forced cold with a novel `limit` (the cache key includes it): `new` 0.3s, `genres` 0.4s, `popular` 0.1s, `fans` 1.9s. Under 3s for all four.

That leaves `_taste_profile()`. Every row blocks on it behind `_taste_cache_lock`, so a cold profile *is* the page's time-to-first-row, and it's the one thing that can't be forced cold from outside without restarting the app.

**Six candidate phases, no way to choose between them.** Five are Last.fm round trips (`status`, `_seed_artists`, a 250-tag chart call, 15 artist-tag calls at 6-way parallelism, a 500-artist chart call). The sixth, `_aoty_genre_slug_map`, harvests "a couple of years of top-rated albums" from AOTY to build the full ~360-genre taxonomy. Any of them could own the 30 seconds.

So: time each, and print one line, the same shape as the player's `[perf] load`.

## Why it also writes to a file

A bare `print` goes to stdout, which a packaged launch discards — the reason the player already mirrors its `[perf]` line into `audio.log`. Without that, this instrumentation would be blind in exactly the situation it was written for: a user reporting a slow cold start from an installed build. Goes to `perf.log` in the user data dir, rotating, with a `NullHandler` fallback so logging can never raise on a request thread.

## Test plan

`tests/test_taste_profile_perf.py`, 3 cases, all network edges stubbed:

- **every phase is reported** — asserts all six names plus `total=`. A line missing a phase can't identify the slow one, which is the whole point.
- **a disconnected profile reports nothing** — no Last.fm means no work worth timing, and no misleading `0ms` line.
- **the line reaches the durable log** — pins the `perf.log` half, which is the part that matters on an installed build.

Full suite: **1309 passed, 9 skipped, 1 failed** — the failure is the pre-existing `uvloop`-has-no-Windows-wheel test.

## What this does not do

It doesn't make anything faster. It answers which phase to fix, and it answers it from a reporter's machine instead of requiring someone to restart an app and poll an endpoint at the right moment. My prior two guesses at the cause — a browser six-connection limit, and a serial artist-tag loop — were both wrong on inspection, which is the argument for measuring rather than guessing again.
