### PR TITLE
Keep compilations off the artist Albums shelf

### DIFF
--- a/web/src/pages/ArtistDetail.tsx
+++ b/web/src/pages/ArtistDetail.tsx
@@ -10,6 +10,7 @@ import { useColumnCount } from "@/hooks/useColumnCount";
 import { useLikedByArtist } from "@/hooks/useLikedByArtist";
 import { useSpotifyTrackPlaycountBatch } from "@/hooks/useSpotifyEnrichment";
 import { useVideoPlayer } from "@/hooks/useVideoPlayer";
+import { excludeCompilations } from "./ArtistSection";
 import { ArtistHero } from "@/components/ArtistHero";
 import { ArtistTopCities } from "@/components/ArtistTopCities";
 import { Grid, SectionHeader, ViewMoreLink } from "@/components/Grid";
@@ -88,7 +89,12 @@ export function ArtistDetail({ onDownload }: { onDownload: OnDownload }) {
   // records). Compilations are kept here even though they get their own
   // shelf — they're still the artist's releases, so dropping them would
   // silently shrink the discography download.
-  const fullCatalog = [...artist.albums, ...artist.ep_singles, ...compilations];
+  // Drop anything the Compilations shelf claimed, or the same records
+  // render on both shelves — and fullCatalog below counts them twice,
+  // queueing every retrospective twice on "download full discography".
+  const albums = excludeCompilations(artist.albums, compilations);
+
+  const fullCatalog = [...albums, ...artist.ep_singles, ...compilations];
 
   return (
     <div>
@@ -150,7 +156,7 @@ export function ArtistDetail({ onDownload }: { onDownload: OnDownload }) {
       />
       <MediaRow
         title="Albums"
-        items={artist.albums}
+        items={albums}
         viewMoreTo={`/artist/${id}/all/albums`}
         onDownload={onDownload}
       />

--- a/web/src/pages/ArtistSection.test.ts
+++ b/web/src/pages/ArtistSection.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import type { Album } from "@/api/types";
-import { sortAlbums } from "./ArtistSection";
+import { excludeCompilations, sortAlbums } from "./ArtistSection";
 
 function album(partial: Partial<Album>): Album {
   return {
@@ -98,5 +98,41 @@ describe("sortAlbums", () => {
     expect(sortAlbums([], "newest")).toEqual([]);
     expect(sortAlbums([], "oldest")).toEqual([]);
     expect(sortAlbums([], "alpha")).toEqual([]);
+  });
+});
+
+describe("excludeCompilations", () => {
+  it("drops albums the Compilations shelf already claimed", () => {
+    // Tidal reports a greatest-hits set as album_type "album", so these
+    // arrive in get_albums() alongside the studio records. Michael
+    // Jackson had 21 of them showing on both shelves at once.
+    const albums = [
+      album({ id: "1", name: "Thriller" }),
+      album({ id: "2", name: "Number Ones" }),
+      album({ id: "3", name: "Bad" }),
+    ];
+    const compilations = [album({ id: "2", name: "Number Ones" })];
+
+    const out = excludeCompilations(albums, compilations);
+
+    expect(out.map((a) => a.name)).toEqual(["Thriller", "Bad"]);
+  });
+
+  it("leaves albums alone before /extras lands", () => {
+    // The compilations list is empty until the deferred call returns;
+    // until then the shelf shows everything, as it does today.
+    const albums = [album({ id: "1", name: "Thriller" })];
+
+    expect(excludeCompilations(albums, [])).toBe(albums);
+  });
+
+  it("keeps an album whose id does not match", () => {
+    // Matching is by id. A compilation listed under a different edition
+    // id is not removed — the same outcome as before this existed, so a
+    // miss degrades instead of dropping a record the artist released.
+    const albums = [album({ id: "1", name: "Thriller" })];
+    const compilations = [album({ id: "99", name: "Thriller" })];
+
+    expect(excludeCompilations(albums, compilations)).toHaveLength(1);
   });
 });

--- a/web/src/pages/ArtistSection.tsx
+++ b/web/src/pages/ArtistSection.tsx
@@ -71,6 +71,34 @@ function loadAlbumSort(): AlbumSort {
  * release_date / name. Pure so it can be unit-tested without
  * standing up the page.
  */
+/** Albums with anything the Compilations shelf has claimed removed.
+ *
+ * Tidal never flags a compilation: `album.type` is ALBUM/EP/SINGLE even
+ * for a greatest-hits set, so `get_albums()` hands back retrospectives
+ * mixed in with studio albums. The only place Tidal separates them is a
+ * "Compilations" module on its curated artist page, and fetching that
+ * costs 1.5-3s, so it was deferred to /api/artist/{id}/extras to keep
+ * first paint fast. The server-side precedence that drops a compilation
+ * from Albums runs on the primary payload, where that module is not yet
+ * available — so it never fires, and the records show up on both
+ * shelves. Michael Jackson had 21 of them in Albums and in Compilations
+ * at once.
+ *
+ * Matching on id: verified against the live API, all 21 compilations
+ * carried the same album id as their entry in Albums. An id that does
+ * not match simply is not removed, which is exactly the behaviour
+ * before this function existed — so a miss degrades rather than losing
+ * a record.
+ */
+export function excludeCompilations(
+  albums: Album[],
+  compilations: Album[],
+): Album[] {
+  if (!compilations.length) return albums;
+  const claimed = new Set(compilations.map((c) => c.id));
+  return albums.filter((a) => !claimed.has(a.id));
+}
+
 export function sortAlbums(albums: Album[], sort: AlbumSort): Album[] {
   // Build sortable keys once so the comparator doesn't repeatedly
   // parse the same release_date string. .slice() so we don't


### PR DESCRIPTION
## Summary

Michael Jackson's **Albums** shelf lists *Scream*, *Immortal*, *Gold*, *Number Ones*, *The Essential*, *The Definitive Collection*, *Love Songs*, *Pure Michael*, *The Stripped Mixes*, *20th Century Masters* and more, alongside *Thriller* and *Bad*.

All 21 of them **also** render on the Compilations shelf below — so the page shows each one twice.

## Why the existing mechanism doesn't catch them

Tidal never flags a compilation. `album.type` is `ALBUM`/`EP`/`SINGLE` even for a greatest-hits set, so `get_albums()` can't tell them apart — `server.py` says so in a comment. The only place Tidal separates them is a "Compilations" module on its curated artist page, and the dedup already has the right precedence: a record claimed by Compilations is dropped from Albums.

**That precedence never runs.** `artist.page()` costs 1.5–3s, so it was deferred out of `/api/artist/{id}` into `/api/artist/{id}/extras` to protect first paint. The primary payload therefore builds its Albums list with `artist_page` hardcoded to `None`:

```python
artist_page = None
artist_mix_id = None
```

Its own comment even says "compilations is empty … until /extras lands". By the time `/extras` supplies them, Albums is already built, and the frontend overlays the new shelf without touching the old list:

```tsx
const compilations = extras?.compilations ?? artist.compilations;
```

Measured against the live API: `/api/artist/606` returns `albums=36, compilations=0`; `/api/artist/606/extras` returns `compilations=21`, and those 21 titles are all present in the 36.

## The fix

Filter Albums by what Compilations claimed, once `/extras` arrives.

Matching on **id**, which I verified rather than assumed: all 21 compilations carry the same album id as their Albums entry (checked by intersecting both lists from the running app — 21 matches, 0 misses). An id that doesn't match is simply not removed, which is exactly today's behaviour — so a miss degrades instead of dropping a record the artist actually released.

## Second bug, same cause

```tsx
const fullCatalog = [...artist.albums, ...artist.ep_singles, ...compilations];
```

With compilations present in *both* halves, "download full discography" queued every retrospective **twice**. Now built from the filtered list.

## Test plan

Three cases added to `ArtistSection.test.ts`, using the existing `sortAlbums` seam:

- drops albums the Compilations shelf claimed
- leaves Albums untouched before `/extras` lands (the shelf still shows everything until then, as it does now)
- keeps an album whose id doesn't match — pins the degrade-don't-lose behaviour

`npm test` **172 passed** (19 files), `tsc -b --noEmit` clean, `eslint` 0 errors, `stylelint` clean, backend suite **1306 passed** with only the pre-existing `uvloop` failure.

## Not addressed

The deferral itself. Building Albums without the compilation data and reconciling afterwards is the underlying awkwardness; the alternative is paying `artist.page()`'s 1.5–3s on first paint, which is what the deferral was introduced to avoid. This fixes the symptom on the client where the data finally exists. Moving the reconciliation server-side — `/extras` returning a corrected Albums list — would be the tidier shape if the double-render turns up on other artists in a form id matching misses.
