### PR TITLE
Adopt curl-cffi 0.16 and port the impersonate-profile guards

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,15 +19,19 @@ orjson>=3.12.0
 # THAT fallback is the bug we're fixing here: shipping it as the
 # production transport meant every Tideway install looked like a
 # scraper to Tidal's anti-abuse layer.
-# Upper-bounded: 0.16 dropped `normalize_browser_type` from
-# `curl_cffi.requests.impersonate`, which our impersonate-profile guard
-# tests import. More to the point, the PyInstaller build bundles whatever
-# is installed here, so an unbounded `>=` lets CI test against a curl-cffi
-# newer than the one we actually ship. Pin to the 0.15.x line so the
-# tested and shipped transport are the same version family. Revisit when
-# adopting 0.16+ deliberately (the profile API and the guard tests move
-# together).
-curl-cffi>=0.15.0,<0.16
+# Upper-bounded: the PyInstaller build bundles whatever is installed
+# here, so an unbounded `>=` would let CI test against a curl-cffi newer
+# than the one we actually ship. Pin to a version family so the tested
+# and shipped transport are the same.
+#
+# 0.16 removed `normalize_browser_type` from
+# `curl_cffi.requests.impersonate`, which the profile guards used to
+# validate a profile string in one call. The replacement is two lookups
+# — REAL_TARGET_MAP for aliases, the BrowserType enum for concrete
+# targets — and the guards moved with the pin. Every profile the app
+# ships (chrome131_android for Tidal, chrome/safari/firefox for AOTY)
+# was checked against 0.16 before bumping.
+curl-cffi>=0.16.1,<0.17
 pillow>=12.3.0
 fastapi>=0.141.1
 uvicorn[standard]>=0.52.4

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -32,3 +32,25 @@ def _reset_tidal_backoff_state():
     yield
     tidal_client._tidal_backoff_until = 0.0
     tidal_client._tidal_backoff_reason = ""
+
+
+def known_to_curl_cffi(profile: str) -> bool:
+    """Whether curl_cffi recognises this impersonate profile.
+
+    Shared by the AOTY and Tidal profile guards. 0.15 answered this with
+    `normalize_browser_type`, which 0.16 removed; the replacement is two
+    lookups — REAL_TARGET_MAP for the aliases that resolve to a latest
+    version ("chrome", "safari", "firefox"), and the BrowserType enum
+    for concrete targets ("chrome131_android"). A typo is in neither,
+    which is the case these guards exist to catch: an unknown profile
+    does not raise at request time, it silently 403s.
+    """
+    from curl_cffi.requests.impersonate import BrowserType, REAL_TARGET_MAP
+
+    if profile in REAL_TARGET_MAP:
+        return True
+    try:
+        BrowserType(profile)
+    except ValueError:
+        return False
+    return True

--- a/tests/test_aoty_blocked.py
+++ b/tests/test_aoty_blocked.py
@@ -15,6 +15,8 @@ from unittest.mock import patch
 
 import pytest
 
+from tests.conftest import known_to_curl_cffi
+
 from app import aoty
 
 
@@ -122,10 +124,16 @@ def test_all_profiles_challenged_sets_blocked_flag():
 
 def test_fallback_profiles_are_known_to_curl_cffi():
     # A typo in a fallback profile would silently 403 every retry.
-    from curl_cffi.requests.impersonate import normalize_browser_type
-
     for profile in aoty._FALLBACK_IMPERSONATE:
-        assert normalize_browser_type(profile)
+        assert known_to_curl_cffi(profile), profile
+
+
+def test_an_unknown_profile_is_rejected():
+    """The guards above are only worth anything if the check can fail.
+    A misspelling has to be caught here rather than at request time,
+    where it degrades into a silent 403 on every retry."""
+    assert not known_to_curl_cffi("chorme")
+    assert not known_to_curl_cffi("")
 
 
 def test_impersonate_profile_is_current_and_known_to_curl_cffi():
@@ -137,10 +145,7 @@ def test_impersonate_profile_is_current_and_known_to_curl_cffi():
     the known-bad one and is a profile curl_cffi actually recognises
     (so a typo like "chorme" fails loudly instead of silently 403'ing
     every request)."""
-    from curl_cffi.requests.impersonate import normalize_browser_type
-
     assert aoty._CFFI_IMPERSONATE != "chrome120"
-    # normalize_browser_type resolves the "chrome" alias / a concrete
-    # version to curl_cffi's internal target; an unknown string raises.
-    resolved = normalize_browser_type(aoty._CFFI_IMPERSONATE)
-    assert resolved  # truthy target, not None/empty
+    # Resolves either as an alias or as a concrete target; an unknown
+    # string is neither.
+    assert known_to_curl_cffi(aoty._CFFI_IMPERSONATE)

--- a/tests/test_tls_impersonation.py
+++ b/tests/test_tls_impersonation.py
@@ -145,3 +145,22 @@ def test_swap_replaces_session_when_curl_cffi_available():
     assert type(s.request_session).__module__.startswith("curl_cffi"), (
         f"expected curl_cffi session, got {type(s.request_session)!r}"
     )
+
+
+def test_tidal_impersonate_profile_is_known_to_curl_cffi():
+    """The profile every Tidal call goes out under.
+
+    Only AOTY's profiles were guarded; this one was not, and it is the
+    more consequential of the two. curl_cffi does not raise on an
+    unknown profile at request time — the handshake just goes out
+    un-impersonated, which is precisely the fingerprint the whole
+    transport exists to avoid. A typo here would be invisible until
+    Tidal started refusing logins.
+    """
+    from tests.conftest import known_to_curl_cffi
+
+    from app import http as app_http
+
+    assert known_to_curl_cffi(app_http._IMPERSONATE_PROFILE), (
+        app_http._IMPERSONATE_PROFILE
+    )


### PR DESCRIPTION
## Summary

Supersedes #378, which dependabot couldn't land on its own.

The pin was held at `<0.16` for one reason, stated in `requirements.txt`: 0.16 removed `normalize_browser_type` from `curl_cffi.requests.impersonate`, which the profile guards used to validate a profile string in a single call.

The replacement is two lookups — `REAL_TARGET_MAP` for aliases that resolve to a latest version (`chrome`, `safari`, `firefox`), and the `BrowserType` enum for concrete targets (`chrome131_android`). A typo is in neither. The helper moved to `conftest.py` because the new Tidal guard needs it too.

**Every profile the app ships was checked against 0.16 before bumping** — `chrome131_android` (Tidal), `chrome`/`safari`/`firefox` (AOTY). All four still resolve.

## The gap this found

Only AOTY's profiles were guarded. `app/http.py`'s `_IMPERSONATE_PROFILE` — the one **every Tidal call** goes out under — had no test at all.

That's the more consequential of the two. curl_cffi doesn't raise on an unknown profile at request time; the handshake just goes out un-impersonated, which is exactly the fingerprint `requirements.txt` describes as "the bug we're fixing here". A typo would have stayed invisible until Tidal started refusing logins. Now guarded.

Also added a negative case (`chorme`, `""`). The existing guards only asserted that valid profiles pass, so nothing proved the check could fail — a validator that can't fail isn't a guard.

## Live-verified, not just fixture-verified

Fixture tests confirm a profile *name* is recognised. They say nothing about whether Cloudflare still lets us through, and this repo has been caught by that gap before. Fetched AOTY's this-week page through 0.16 on the `chrome` profile, using the app's own `_fetch`:

- 76,049 bytes returned
- `is_scraper_blocked()` → **False**
- 241 album links parsed out

## Test plan

- `pytest tests/test_aoty_blocked.py tests/test_tls_impersonation.py tests/test_spotify_curl_session.py` — 33 passed against 0.16
- Full suite: **1311 passed, 9 skipped, 1 failed** — the failure is the pre-existing `uvloop`-has-no-Windows-wheel test
- Live AOTY probe above

## Notes

- I upgraded the local `.venv` to 0.16.2 to run this, so your dev environment already matches the new pin.
- The **Tidal** side is verified only as far as profile resolution. A live Tidal request needs the app's session, and standing up a second one risks the stored token — not worth it for a library patch bump. Worth a login sanity-check after the next build, since the packaged app bundles whatever is installed at build time and is still on 0.15 until then.
