### PR TITLE
Defer TypeScript 7 until typescript-eslint supports it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -40,6 +40,22 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@types/react-dom"
         update-types: ["version-update:semver-major"]
+      # TypeScript 7 is blocked upstream, not by us. typescript-eslint
+      # refuses to load against it at all — "typescript-eslint does not
+      # support TS 7.0" — so adopting it turns eslint off entirely,
+      # and eslint is one of the four checks a PR has to pass. The
+      # latest release (8.68.0) still declares
+      # peerDependencies.typescript ">=4.8.4 <6.1.0"; support is
+      # tracked in typescript-eslint#10940 for TS >=7.1.
+      #
+      # The upgrade itself is otherwise ready: on TS 7.0.2 the only
+      # code change needed is dropping `baseUrl` (removed in 7) from
+      # tsconfig.json and tsconfig.app.json, since `paths` is already
+      # relative and Vite resolves the alias itself. tsc -b and all
+      # 172 vitest tests passed. Drop this entry once
+      # typescript-eslint ships TS 7 support.
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       # Peer-linked packages, listed before the catch-all because a
       # dependency joins the first group it matches. No `update-types`


### PR DESCRIPTION
## Summary

I attempted #302 rather than assuming, and it's blocked upstream.

Installing `typescript@7.0.2` and running the checks:

- `tsc -b --noEmit` — **one** error: `Option 'baseUrl' has been removed`. Dropping it from `tsconfig.json` and `tsconfig.app.json` fixes it cleanly, because `paths` is already relative (`"@/*": ["./src/*"]`) and Vite resolves the alias itself in `vite.config.ts`. After that, **tsc is clean**.
- `npm test` — **172 passed**, no changes needed.
- `npm run lint` — **fails to start**:

```
typescript-eslint does not support TS 7.0.
See https://github.com/typescript-eslint/typescript-eslint/issues/10940
for tracking typescript-eslint's support for TS >=7.1
```

It throws at import, so eslint doesn't run at all. Adopting TS 7 today means shipping with the linter silently switched off, and eslint is one of the four checks `CLAUDE.md` requires before a PR.

Confirmed it isn't a stale local version: the latest `typescript-eslint` (8.68.0) declares `peerDependencies.typescript: ">=4.8.4 <6.1.0"`. No published release supports TS 7.

## What this PR does

Adds a `dependabot.yml` ignore for TypeScript **majors only**, so 5.x patches keep flowing and #302 stops being reopened weekly.

The commit records the finding that the upgrade is otherwise ready and needs exactly one edit, so whoever picks this up when typescript-eslint lands support doesn't have to rediscover it.

## Test plan

Config only. YAML parses; the ignore list now reads `react`, `react-dom`, `@types/react`, `@types/react-dom`, `typescript`, all scoped to `version-update:semver-major`.

I reverted the TS 7 install afterward and confirmed the toolchain is back to `5.6.3` with `eslint` running clean at 0 errors.

## Related

#302 can be closed. This is the second dependency this month blocked by a peer that hasn't caught up — same shape as #368's React pair, which is why #377 added the grouping.
