### PR TITLE
Stop test runs writing to the user's perf.log

### DIFF
--- a/server.py
+++ b/server.py
@@ -12665,7 +12665,13 @@ def _rank_by_taste(rows: list, orbit: dict, played: set) -> list:
 perf_log = logging.getLogger("tideway.perf")
 perf_log.setLevel(logging.INFO)
 perf_log.propagate = False
-if not perf_log.handlers:
+# TIDEWAY_NO_PERF_LOG is set by tests/conftest.py before this module is
+# imported. Without it a test run appends to the user's real perf.log:
+# the recs tests call _taste_profile() directly, so a suite run wrote
+# stub timings (artists=1, everything 0ms) into the same file a cold
+# start writes to, and reading it back you cannot tell which lines came
+# from the app. Diagnostics you cannot trust are worse than none.
+if not perf_log.handlers and not os.environ.get("TIDEWAY_NO_PERF_LOG"):
     try:
         from logging.handlers import RotatingFileHandler
 
@@ -12682,6 +12688,8 @@ if not perf_log.handlers:
         perf_log.addHandler(_ph)
     except Exception:
         perf_log.addHandler(logging.NullHandler())
+elif not perf_log.handlers:
+    perf_log.addHandler(logging.NullHandler())
 
 
 def _taste_profile() -> dict:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@
 Imports anything non-trivial lazily inside fixtures so collection
 doesn't fail for tests that don't need a fully-configured environment.
 """
+import os
 import sys
 from pathlib import Path
 
@@ -11,6 +12,14 @@ import pytest
 # Make the repo root importable as `app.*` etc. without requiring a
 # `pip install -e .` — the project is run directly via `./run.sh`, not
 # installed.
+# Keep test runs out of the user's real data dir. server.py's perf
+# logger writes to perf.log there, and the recs tests call
+# _taste_profile() directly — so without this a suite run interleaves
+# stub timings with whatever a real cold start recorded, and the file
+# stops being usable as evidence. Set before server is ever imported,
+# which is why it is module level rather than a fixture.
+os.environ["TIDEWAY_NO_PERF_LOG"] = "1"
+
 _REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))

--- a/tests/test_taste_profile_perf.py
+++ b/tests/test_taste_profile_perf.py
@@ -84,3 +84,30 @@ def test_perf_line_also_reaches_the_durable_log(profile_env, caplog):
         profile_env._taste_profile()
 
     assert any("[perf] taste_profile" in r.message for r in caplog.records)
+
+
+def test_test_runs_do_not_write_to_the_users_perf_log():
+    """The file handler must be off under pytest.
+
+    The recs tests call `_taste_profile()` directly, so without this a
+    suite run appends stub timings — artists=1, every phase 0ms — to the
+    same perf.log a real cold start writes to. Reading it back, there is
+    no way to tell which lines came from the app. That happened: 40
+    lines of test output were mistaken for real measurements and nearly
+    reported as a recommendations bug.
+    """
+    import logging
+
+    import server
+
+    # pytest's caplog attaches its own handlers to whichever logger a
+    # test captures, so the assertion is about file handlers only.
+    # pytest attaches its own handlers to a captured logger, including a
+    # FileHandler aimed at the null device, so the assertion has to be
+    # about the destination rather than the handler type.
+    writers = [
+        h
+        for h in server.perf_log.handlers
+        if str(getattr(h, "baseFilename", "")).endswith("perf.log")
+    ]
+    assert not writers, f"perf.log would be written during tests: {writers!r}"


### PR DESCRIPTION
## Summary

The perf logger added in #390 writes to `perf.log` in the user data dir, and `tests/test_album_recommendations.py` calls `_taste_profile()` directly. A suite run therefore appends stub timings into the same file a real cold start writes to.

This isn't cosmetic. I read that file today expecting the answer to the For You slowness. **All 40 lines were test output; none were from the app** — and nothing in the file distinguishes them.

The stub values looked exactly like a serious finding:

```
artists=1 genres=1   total=0ms
```

Read as real, that says the taste profile — which every For You row is built from — is derived from a single artist. I checked, and Last.fm returns **15 artists per window**; the value came from my own fixture (`[{"name": "Slowdive"}]`). I was one step from reporting a recommendations bug that doesn't exist.

Ten more lines showed `chart_tags≈350ms`, which looked like real network timing. Those are `test_album_recommendations.py` making live Last.fm calls with `_seed_artists` stubbed — real latency, still not the app.

## The fix

`tests/conftest.py` sets `TIDEWAY_NO_PERF_LOG` before `server` is imported — module level rather than a fixture, because the handler is attached at import time. `server.py` skips the file handler when it's set and falls back to a `NullHandler`.

## Test plan

- Ran `test_taste_profile_perf.py` + `test_album_recommendations.py` and confirmed `perf.log` stayed at 40 lines, where the same run previously added entries.
- New test asserts no handler targets `perf.log`. It checks the **destination**, not the handler type: pytest attaches its own `FileHandler` aimed at the null device (`\.\nul`) to any logger a test captures, so an `isinstance(h, FileHandler)` assertion fails for the wrong reason. I wrote it that way first and it caught me.
- Full suite: **1308 passed, 9 skipped, 3 failed**. One is the pre-existing `uvloop` Windows failure. The other two are `test_aoty_blocked`'s profile guards, failing only because my local venv is on curl-cffi 0.16 for #392 while this branch is off `main`, which still has the 0.15 API. They pass on #392's branch.

## Related

`app/audio/player.py`'s `audio_log` has the same shape — the artist-page `[perf]` line goes to `audio.log` from test runs too. Left alone deliberately: it predates this and deserves its own change rather than being folded into a fix for the problem I introduced.

## Note

Your existing `perf.log` is 40 lines of test output and no real data. Worth clearing so the first genuine cold start after the next release is unambiguous.
