### PR TITLE
Source the Add-to-playlist menu from the same playlist union as the sidebar

### DIFF
--- a/server.py
+++ b/server.py
@@ -8198,19 +8198,39 @@ def library_artists() -> list[dict]:
     return [artist_to_dict(a) for a in tidal.get_favorite_artists()]
 
 
-@app.get("/api/library/playlists")
-def library_playlists() -> list[dict]:
-    _require_auth()
+def _owned_and_favorited_playlists() -> list:
+    """Union of the user's own playlists and their favorited playlists,
+    deduped by id (own-playlist entries win on conflict).
+
+    `tidal.get_user_playlists()` wraps tidalapi's legacy, non-paginated
+    `users/{id}/playlists` endpoint — the only playlist call site in the
+    codebase that doesn't go through `_fetch_all_pages`'s ordered /
+    paginated fetch strategies, since that endpoint accepts no query
+    params at all and falls straight to the bare-call fallback. Tidal
+    has been inconsistent about which playlists this legacy endpoint
+    surfaces for a given account. `get_favorite_playlists()` hits the
+    modern, reliably-paginated v2 collection endpoint and lists every
+    playlist (owned or not) the account has favorited, which in
+    practice includes the account's own playlists too — unioning the
+    two here means a gap in the legacy listing doesn't silently drop
+    an owned playlist from view.
+    """
     faves = tidal.get_favorite_playlists()
     mine = tidal.get_user_playlists()
     seen: set[str] = set()
-    out: list[dict] = []
+    out: list = []
     for p in list(mine) + list(faves):
         pid = str(getattr(p, "id", "") or "")
         if pid and pid not in seen:
             seen.add(pid)
-            out.append(playlist_to_dict(p))
+            out.append(p)
     return out
+
+
+@app.get("/api/library/playlists")
+def library_playlists() -> list[dict]:
+    _require_auth()
+    return [playlist_to_dict(p) for p in _owned_and_favorited_playlists()]
 
 
 # ---------------------------------------------------------------------------
@@ -11940,9 +11960,25 @@ class AddTracksRequest(BaseModel):
 
 @app.get("/api/playlists/mine")
 def my_playlists() -> list[dict]:
-    """Just the user's own playlists — used for the Add-to-Playlist menu."""
+    """Just the user's own (mutable) playlists — used for the
+    Add-to-Playlist menu.
+
+    Sources from the same owned+favorited union `/api/library/playlists`
+    uses (see `_owned_and_favorited_playlists`) rather than
+    `tidal.get_user_playlists()` alone — that legacy endpoint has been
+    observed to under-report an account's own playlists, which made
+    this menu come up empty for playlists the sidebar's Playlist tab
+    (backed by the union) showed just fine. Filtering the union to
+    `owned` keeps the menu's contract intact: every entry here is one
+    `POST /api/playlists/{id}/tracks` will actually accept, since that
+    endpoint 403s on anything `owns_playlist` doesn't confirm.
+    """
     _require_auth()
-    return [playlist_to_dict(p) for p in tidal.get_user_playlists()]
+    return [
+        playlist_to_dict(p)
+        for p in _owned_and_favorited_playlists()
+        if tidal.owns_playlist(p)
+    ]
 
 
 @app.post("/api/playlists")

--- a/tests/test_playlist_menu_sources.py
+++ b/tests/test_playlist_menu_sources.py
@@ -1,0 +1,111 @@
+"""The Add-to-playlist menu and the sidebar list the same playlists.
+
+Reported repeatedly, most recently in #397: the menu comes up empty and
+tells the user to create a playlist, while the sidebar's Playlist tab
+shows their playlists fine. The two surfaces disagreed because they
+asked Tidal different questions.
+
+`/api/library/playlists` unions `get_user_playlists()` with
+`get_favorite_playlists()`. `/api/playlists/mine` called
+`get_user_playlists()` alone — tidalapi's legacy, non-paginated
+`users/{id}/playlists` endpoint, the one playlist call that doesn't go
+through `_fetch_all_pages`. Tidal has been inconsistent about what that
+legacy endpoint reports, so an account whose own playlists were missing
+from it got an empty menu and a populated sidebar.
+
+Both now read the same union. The menu additionally filters to owned
+playlists, because POST /api/playlists/{id}/tracks 403s on anything
+else — offering a row that cannot accept the track would trade an empty
+menu for a failing one.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+def _playlist(pid: str, name: str, creator_id: str | None):
+    return SimpleNamespace(
+        id=pid,
+        name=name,
+        creator=SimpleNamespace(id=creator_id) if creator_id else None,
+    )
+
+
+@pytest.fixture
+def srv(monkeypatch):
+    import server
+
+    monkeypatch.setattr(server, "playlist_to_dict", lambda p: {"id": p.id, "name": p.name})
+    return server
+
+
+def test_union_recovers_a_playlist_the_legacy_endpoint_dropped(srv, monkeypatch):
+    """The #397 case: the legacy call under-reports, the favorites call
+    still has it, so it must survive into the union."""
+    monkeypatch.setattr(srv.tidal, "get_user_playlists", lambda: [])
+    monkeypatch.setattr(
+        srv.tidal, "get_favorite_playlists", lambda: [_playlist("p1", "Mine", "u1")]
+    )
+
+    out = srv._owned_and_favorited_playlists()
+
+    assert [p.id for p in out] == ["p1"]
+
+
+def test_union_dedupes_with_own_entries_winning(srv, monkeypatch):
+    """A playlist in both lists appears once. Own entry first so its
+    (usually richer) object is the one callers see."""
+    own = _playlist("p1", "From own listing", "u1")
+    fav = _playlist("p1", "From favorites", "u1")
+    monkeypatch.setattr(srv.tidal, "get_user_playlists", lambda: [own])
+    monkeypatch.setattr(srv.tidal, "get_favorite_playlists", lambda: [fav])
+
+    out = srv._owned_and_favorited_playlists()
+
+    assert len(out) == 1
+    assert out[0].name == "From own listing"
+
+
+def test_menu_lists_owned_playlists_from_the_union(srv, monkeypatch):
+    monkeypatch.setattr(srv, "_require_auth", lambda: None)
+    monkeypatch.setattr(srv.tidal, "get_user_playlists", lambda: [])
+    monkeypatch.setattr(
+        srv.tidal, "get_favorite_playlists", lambda: [_playlist("p1", "Mine", "u1")]
+    )
+    monkeypatch.setattr(srv.tidal, "owns_playlist", lambda p: True)
+
+    assert [p["id"] for p in srv.my_playlists()] == ["p1"]
+
+
+def test_menu_excludes_playlists_the_user_does_not_own(srv, monkeypatch):
+    """Favorited-but-not-owned playlists are in the union for the
+    sidebar. They must not reach the menu: adding to one 403s."""
+    monkeypatch.setattr(srv, "_require_auth", lambda: None)
+    monkeypatch.setattr(srv.tidal, "get_user_playlists", lambda: [])
+    monkeypatch.setattr(
+        srv.tidal,
+        "get_favorite_playlists",
+        lambda: [_playlist("mine", "Mine", "u1"), _playlist("theirs", "Someone else's", "u2")],
+    )
+    monkeypatch.setattr(
+        srv.tidal, "owns_playlist", lambda p: getattr(p.creator, "id", None) == "u1"
+    )
+
+    assert [p["id"] for p in srv.my_playlists()] == ["mine"]
+
+
+def test_sidebar_and_menu_agree_on_owned_playlists(srv, monkeypatch):
+    """The property the bug violated: anything owned that the sidebar
+    shows must also be offered by the menu."""
+    monkeypatch.setattr(srv, "_require_auth", lambda: None)
+    owned = [_playlist("a", "A", "u1"), _playlist("b", "B", "u1")]
+    monkeypatch.setattr(srv.tidal, "get_user_playlists", lambda: [])
+    monkeypatch.setattr(srv.tidal, "get_favorite_playlists", lambda: owned)
+    monkeypatch.setattr(srv.tidal, "owns_playlist", lambda p: True)
+
+    sidebar = {p["id"] for p in srv.library_playlists()}
+    menu = {p["id"] for p in srv.my_playlists()}
+
+    assert sidebar == menu


### PR DESCRIPTION
Fixes #397.

## Summary

The Add-to-playlist menu comes up empty and tells the user to create a playlist, while the sidebar's Playlist tab shows their playlists fine. Reported again on 1.32.1 by @ChriscomIT.

The two surfaces asked Tidal different questions:

- `/api/library/playlists` (sidebar) unions `get_user_playlists()` with `get_favorite_playlists()`
- `/api/playlists/mine` (menu) called `get_user_playlists()` alone

`get_user_playlists()` wraps tidalapi's legacy, non-paginated `users/{id}/playlists` endpoint — the only playlist call in the codebase that doesn't go through `_fetch_all_pages`, because that endpoint takes no query params and falls straight to the bare-call fallback. Tidal has been inconsistent about which playlists it reports for a given account, so an account it under-reports gets an empty menu and a populated sidebar.

Both now read one `_owned_and_favorited_playlists()` helper. The menu additionally filters to `owns_playlist()`, because `POST /api/playlists/{id}/tracks` 403s on anything else — offering a row that can't accept the track would trade an empty menu for a failing one.

## Provenance

**The fix is not new.** It was written on a branch on 2026-07-08 and never opened as a PR, so the bug has been reported again since. I rebased it onto `main` (clean, no conflicts) and added the tests it never had. The implementation and its reasoning are unchanged from the original commit.

## Test plan

`tests/test_playlist_menu_sources.py`, 5 cases:

- the union recovers a playlist the legacy endpoint dropped — the #397 case directly
- dedupes with the own-listing entry winning
- the menu lists owned playlists from the union
- the menu excludes favorited-but-not-owned playlists, which would 403
- **sidebar and menu agree on owned playlists** — the property the bug violated

Full suite: **1317 passed, 9 skipped, 1 failed** — the failure is the pre-existing `uvloop`-has-no-Windows-wheel test.

## Not verified

I can't reproduce the underlying Tidal inconsistency on demand — it depends on which playlists the legacy endpoint decides to report for a given account. The tests pin our handling of it, not Tidal's behaviour. @ChriscomIT is the one who can confirm the menu populates after this ships.
