### PR TITLE
Make Pause stop an in-progress download, not just the queue

### DIFF
--- a/app/downloader.py
+++ b/app/downloader.py
@@ -225,6 +225,12 @@ class _Cancelled(Exception):
     _download's own handler, which cleans up the partial file and exits."""
 
 
+class _PausedMidTransfer(Exception):
+    """Internal signal: the user pressed Pause while this item was
+    already transferring. Caught by _download, which drops the partial
+    and re-queues the item so it restarts when the queue resumes."""
+
+
 @dataclass
 class DownloadItem:
     item_id: str
@@ -874,6 +880,30 @@ class Downloader:
         if self._is_cancelled(item_id):
             raise _Cancelled()
 
+    def _check_paused(self) -> None:
+        """Abort the current transfer if the queue was paused.
+
+        `_run_event` was only consulted before the gate, so Pause
+        stopped the queue advancing but let an already-running transfer
+        run to completion (#398). The button said paused while the
+        bytes kept coming, which on Linux is worse than a UI mismatch:
+        a Hi-Res transfer competing with PipeWire produced audio
+        callback underflows, and pausing is the obvious thing to reach
+        for.
+
+        Aborts rather than blocking here. Holding the socket open while
+        idle would trip the 30 s inactivity read timeout, so a pause
+        longer than that would fail the item instead of pausing it.
+        Tidal's streams have no Range support, so a stopped transfer
+        cannot resume from its partial file anyway — the caller
+        re-queues the item and it restarts on resume, the same way any
+        interrupted download already behaves.
+
+        One `Event.is_set()` per 64 KB chunk: no lock, no syscall.
+        """
+        if not self._run_event.is_set():
+            raise _PausedMidTransfer()
+
     def _sweep_orphan_parts(self) -> None:
         """Remove stale `.part` files from the output directory.
 
@@ -1477,6 +1507,7 @@ class Downloader:
                             if not chunk:
                                 continue
                             self._check_cancel(item.item_id)
+                            self._check_paused()
                             f.write(chunk)
                             got += len(chunk)
                             bytes_total += len(chunk)
@@ -1517,6 +1548,7 @@ class Downloader:
                                     if not chunk:
                                         continue
                                     self._check_cancel(item.item_id)
+                                    self._check_paused()
                                     f.write(chunk)
                                     seg_got += len(chunk)
                                     bytes_total += len(chunk)
@@ -1694,6 +1726,25 @@ class Downloader:
             if tid is not None:
                 self.on_file_ready(str(tid), out_path)
 
+        except _PausedMidTransfer:
+            # Paused mid-transfer. Drop the partial and put the item back
+            # on the queue as PENDING; the worker loop already waits on
+            # _run_event before taking anything, so it sits there until
+            # the user resumes and then restarts from zero. Not a
+            # failure — the row must not go red for something the user
+            # asked for.
+            if tmp_path is not None:
+                try:
+                    tmp_path.unlink(missing_ok=True)
+                except Exception:
+                    pass
+            print(
+                f"[downloader] paused mid-transfer, re-queued "
+                f"id={item.item_id[:8]}",
+                flush=True,
+            )
+            self.retry(item)
+            return
         except _Cancelled:
             # User cancelled — already removed from the broker's snapshot
             # in cancel(). Just drop the partial and bail silently.

--- a/tests/test_pause_stops_active_download.py
+++ b/tests/test_pause_stops_active_download.py
@@ -1,0 +1,91 @@
+"""Pause stops an in-progress transfer, not just the queue (#398).
+
+`_run_event` was only consulted before the concurrency gate, so Pause
+stopped the queue advancing while whatever was already downloading ran
+to completion. The button showed the paused state throughout, which is
+what made it a bug rather than a documented limitation.
+
+On Linux it cost more than a mismatched label: a Hi-Res transfer
+competing with PipeWire produced `[audio] callback status=output
+underflow`, and pausing downloads is the obvious way to stop that.
+
+The transfer aborts rather than blocking. Holding the socket open while
+idle would trip the 30 s inactivity read timeout, turning a pause
+longer than that into a failure. Tidal serves no Range header, so a
+stopped transfer cannot resume from its partial anyway — the item is
+re-queued and restarts on resume, which is how every other interrupted
+download already behaves.
+"""
+from __future__ import annotations
+
+import pytest
+
+from app.downloader import Downloader, _Cancelled, _PausedMidTransfer
+
+
+class _Probe:
+    """Just the pause/cancel machinery `_check_paused` touches."""
+
+    def __init__(self, paused: bool):
+        import threading
+
+        self._run_event = threading.Event()
+        if not paused:
+            self._run_event.set()
+        self._cancelled_ids: set = set()
+        self._cancelled_lock = threading.Lock()
+
+
+def _probe(paused: bool) -> _Probe:
+    return _Probe(paused)
+
+
+def test_running_queue_does_not_interrupt_a_transfer():
+    """The hot path: one Event.is_set() per chunk, and it must not
+    raise while the queue is running."""
+    Downloader._check_paused(_probe(paused=False))
+
+
+def test_paused_queue_aborts_the_transfer():
+    with pytest.raises(_PausedMidTransfer):
+        Downloader._check_paused(_probe(paused=True))
+
+
+def test_pause_is_checked_in_both_chunk_loops():
+    """A single track uses the first loop; a DASH hi-res track streams
+    per-segment through the second. Missing either would leave Pause
+    working on one quality tier and not the other.
+    """
+    import inspect
+
+    src = inspect.getsource(Downloader._download)
+
+    assert src.count("self._check_paused()") == 2, (
+        "expected the pause check in both the first-URL and per-segment "
+        "chunk loops"
+    )
+
+
+def test_pause_is_not_a_failure():
+    """The item goes back to PENDING via retry(), not to FAILED. A row
+    turning red because the user pressed Pause would be its own bug."""
+    import inspect
+
+    src = inspect.getsource(Downloader._download)
+    # Split on the *next* handler, not on "except " — the block has an
+    # inner try/except around the unlink.
+    handler = src.split("except _PausedMidTransfer:")[1].split("except _Cancelled:")[0]
+
+    assert "self.retry(item)" in handler
+    assert "FAILED" not in handler
+
+
+def test_cancel_still_takes_precedence():
+    """Both checks run per chunk, cancel first. A cancel while paused
+    must remove the item, not re-queue it."""
+    import inspect
+
+    src = inspect.getsource(Downloader._download)
+    first = src.index("self._check_cancel(item.item_id)")
+    assert first < src.index("self._check_paused()")
+    assert _Cancelled is not _PausedMidTransfer


### PR DESCRIPTION
Fixes #398.

## Summary

Pressing Pause while a transfer is already running changes the button to the paused state, and the download keeps going until it finishes. `_run_event` is only consulted at line 1242, *before* the concurrency gate is acquired — so it gates which items **start**, and nothing re-checks it once bytes are moving.

@DmitriyFM033's framing is right: the UI presents "Pause" and users reasonably expect network and disk activity to stop.

On Linux it costs more than a mismatched label. Their Hi-Res transfers competing with PipeWire produced repeated:

```
[audio] callback status=output underflow (count_since_last=3)
```

Pausing downloads is the obvious thing to reach for when playback starts breaking up, and it did nothing.

## Approach

A `_check_paused()` next to the existing `_check_cancel()` in both chunk loops — the first-URL loop and the per-segment DASH loop. Missing either would leave Pause working on one quality tier and not the other, which is exactly the kind of half-fix that generates a follow-up report.

**It aborts rather than blocks**, and that's the part worth reviewing. Blocking in the chunk loop looks like the natural "pause" but would hold the socket open while idle, tripping the 30 s inactivity read timeout — so any pause longer than half a minute would turn into a failed download. Tidal serves no `Range` header, so a stopped transfer can't resume from its partial anyway; the code already says as much where it handles interrupted items.

So the item drops its partial, goes back on the queue as `PENDING`, and restarts when the user resumes. The worker loop already waits on `_run_event` before taking anything, so it simply sits there until then. Deliberately **not** `FAILED` — a row turning red because the user pressed Pause would be its own bug.

Cost on the hot path is one `Event.is_set()` per 64 KB chunk: no lock, no syscall.

## Test plan

`tests/test_pause_stops_active_download.py`, 5 cases:

- a running queue doesn't interrupt a transfer (the hot path must not raise)
- a paused queue aborts it
- **the check is present in both chunk loops** — asserts on the source, since a unit test can't easily drive the DASH path
- pause re-queues via `retry()` and never sets `FAILED`
- cancel is still checked first, so cancelling a paused item removes it rather than re-queueing it

Full suite: **1317 passed, 9 skipped, 1 failed** — the failure is the pre-existing `uvloop`-has-no-Windows-wheel test. Download tests specifically: 65 passed.

## Not verified

I haven't watched this against a live transfer. Doing so means generating real download traffic against Tidal, which the rate limiters and impersonation layer exist to avoid, and the behaviour under a real socket abort mid-stream is the part tests can't reach. @DmitriyFM033 has the reproduction and the Linux audio setup that motivated it.

## Separate from the lag report

The comment thread here also covers playback lag and `Fetch is aborted` under interactive load (#386 was closed as a duplicate of this issue). That is **not** addressed by this PR, and measurements on a 1.31.0 install rule out the leading theory for it: request concurrency peaked at **6 against a pool of 40** with zero saturation, including on a cold load. The `output underflow` lines point at audio-thread starvation, a different mechanism. Worth keeping the two apart.
