### PR TITLE
Clear both deprecation warnings from the September audit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -73,9 +73,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          # pytest + httpx are dev-time only; not in requirements.txt
+          # pytest + httpx2 are dev-time only; not in requirements.txt.
+          # httpx2 rather than httpx: starlette.testclient deprecated the
+          # httpx 0.x backend and warns on every TestClient construction.
           # because the packaged app doesn't need them at runtime.
-          pip install pytest httpx
+          pip install pytest httpx2
 
       - name: Run pytest
         run: pytest tests/ --tb=short -v

--- a/server.py
+++ b/server.py
@@ -1252,8 +1252,31 @@ async def lifespan(_: FastAPI) -> AsyncIterator[None]:
 # under 1ms and stops blocking the audio callback during that window.
 # Routes that already return a `Response` subclass (StreamingResponse,
 # HTMLResponse for the Spotify callback, etc.) are unaffected — only
-# the dict-returning routes route through ORJSONResponse.
-from fastapi.responses import ORJSONResponse as _ORJSONResponse  # noqa: E402
+# the dict-returning routes route through it.
+#
+# Defined here rather than imported from fastapi.responses, which
+# deprecated its ORJSONResponse on the grounds that FastAPI's own
+# Pydantic-based serialization "is faster and doesn't need a custom
+# response class". Measured on a 161 KB artist-shaped payload, it is
+# not: orjson 0.09 ms, pydantic-core 0.58 ms, stdlib json 0.87 ms.
+# Taking the deprecation's advice would make the encode roughly six
+# times longer, which is the GIL hold this class exists to keep off the
+# audio callback.
+#
+# Only the import was deprecated, not orjson. The body below is what
+# FastAPI's class does, options included; keeping our own drops the
+# warning without giving up the measurement.
+import orjson  # noqa: E402
+from starlette.responses import JSONResponse as _JSONResponse  # noqa: E402
+
+
+class _ORJSONResponse(_JSONResponse):
+    def render(self, content: Any) -> bytes:
+        return orjson.dumps(
+            content,
+            option=orjson.OPT_NON_STR_KEYS | orjson.OPT_SERIALIZE_NUMPY,
+        )
+
 
 app = FastAPI(
     title="Tideway",

--- a/tests/test_orjson_response.py
+++ b/tests/test_orjson_response.py
@@ -1,0 +1,71 @@
+"""The JSON responses still go out through orjson (#401).
+
+FastAPI deprecated its `ORJSONResponse` on the grounds that its own
+Pydantic-based serialization "is faster and doesn't need a custom
+response class". Measured on a 161 KB artist-shaped payload it is not:
+
+    orjson         0.09 ms
+    pydantic-core  0.58 ms
+    stdlib json    0.87 ms
+
+That encode happens under the GIL, and the artist endpoint's ~270 KB
+response is built while audio is playing — minimising the hold is why
+the app opted into orjson in the first place. Taking the deprecation's
+advice would make it roughly six times longer.
+
+Only the import was deprecated, not orjson, so the class is defined
+locally. These tests pin that it is still doing the job, since
+"serialization silently got slower" is not something the rest of the
+suite would notice.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+def test_app_serializes_through_orjson():
+    import server
+
+    assert server.app.router.default_response_class is server._ORJSONResponse
+
+
+def test_render_matches_json_semantics():
+    import server
+
+    payload = {"name": "Boards of Canada", "year": 1998, "ok": True, "none": None}
+    rendered = server._ORJSONResponse(content=payload).body
+
+    assert json.loads(rendered) == payload
+
+
+def test_non_string_keys_are_handled():
+    """OPT_NON_STR_KEYS — FastAPI's class set it, so dropping it would
+    turn a working response into a 500 on any int-keyed dict."""
+    import server
+
+    rendered = server._ORJSONResponse(content={1: "a", 2: "b"}).body
+
+    assert json.loads(rendered) == {"1": "a", "2": "b"}
+
+
+def test_numpy_scalars_are_serializable():
+    """OPT_SERIALIZE_NUMPY. The audio paths deal in numpy types, and
+    plain json raises on them."""
+    np = pytest.importorskip("numpy")
+    import server
+
+    rendered = server._ORJSONResponse(content={"peak": np.float32(0.5)}).body
+
+    assert json.loads(rendered)["peak"] == pytest.approx(0.5)
+
+
+def test_no_deprecated_fastapi_response_import():
+    """The point of defining it locally. Re-importing FastAPI's version
+    would bring the warning back without changing behaviour."""
+    import pathlib
+
+    src = pathlib.Path("server.py").read_text(encoding="utf-8")
+
+    assert "from fastapi.responses import ORJSONResponse" not in src


### PR DESCRIPTION
Addresses #401.

## `ORJSONResponse` — the deprecation's premise doesn't hold here

FastAPI deprecated its `ORJSONResponse` saying Pydantic-based serialization "is faster and doesn't need a custom response class". I measured it before following that advice, on a 161 KB artist-shaped payload:

| serializer | time |
|---|---|
| **orjson** | **0.09 ms** |
| pydantic-core | 0.58 ms |
| stdlib json | 0.87 ms |

Roughly **6× slower**, not faster. That matters more here than in a typical app: the encode holds the GIL, the artist endpoint's response is ~270 KB, and it's built while audio is playing. The existing comment records the original measurement — 3–5 ms of GIL hold dropping to under 1 ms — as the reason orjson was adopted at all. Following the deprecation would undo that.

**Only the import is deprecated, not orjson.** So the class is defined locally, with the same body FastAPI's had (`OPT_NON_STR_KEYS | OPT_SERIALIZE_NUMPY` included). Warning gone, measurement kept, no behaviour change.

If FastAPI eventually removes the machinery a custom response class depends on, this is the place to revisit — but that's a different event from the current deprecation.

## `starlette.testclient` + `httpx`

Exactly what the warning asks for: install `httpx2`. CI installed `httpx` explicitly, so it now installs `httpx2`. Confirmed locally that the warning disappears.

## Test plan

`tests/test_orjson_response.py`, 5 cases:

- the app's `default_response_class` is still ours
- rendering round-trips through `json.loads`
- **non-string keys work** — `OPT_NON_STR_KEYS` was on FastAPI's class; dropping it silently would turn any int-keyed dict into a 500
- **numpy scalars serialize** — `OPT_SERIALIZE_NUMPY`; the audio paths deal in numpy types and plain json raises on them
- `server.py` no longer imports FastAPI's deprecated class

Full suite: **1317 passed, 9 skipped, 1 failed** — the pre-existing `uvloop`-has-no-Windows-wheel test. Deprecation warnings across the suite: **49 → 0**.

## Note

The audit says these two don't fail CI because they're `UserWarning` subclasses outside the `DeprecationWarning` hierarchy. With both cleared, the suite now runs warning-free, so tightening the filter to catch these classes is a real option rather than a noisy one.
