### PR TITLE
Keep connections free so navigation doesn't wait on the API

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -67,120 +67,143 @@ import type { OnDownload } from "@/api/download";
 // are named exports, so we wrap each import to rename the chosen
 // export into `default` for the lazy loader.
 import { lazy, Suspense } from "react";
+import type { ComponentType, LazyExoticComponent } from "react";
 import { HeroSkeleton } from "@/components/Skeletons";
+import {
+  registerRouteChunk,
+  startRoutePrefetch,
+} from "@/lib/routePrefetch";
+
+/**
+ * `lazy`, plus the import registered for prefetching.
+ *
+ * The generic is what keeps prop types intact — `T` flows straight
+ * through to `LazyExoticComponent<T>`, so `<Home onDownload={...} />`
+ * still typechecks. (Widening to `ComponentType<any>` is what breaks
+ * it; this does not.)
+ */
+// Constraint mirrors React's own `lazy`; narrowing it rejects valid
+// routes (a class component with never props fails to satisfy it).
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function lazyRoute<T extends ComponentType<any>>(
+  factory: () => Promise<{ default: T }>,
+): LazyExoticComponent<T> {
+  registerRouteChunk(factory);
+  return lazy(factory);
+}
 
 // Inline `lazy(() => import(...).then(m => ({ default: m.Name })))`
 // calls preserve each component's prop types through TypeScript's
 // inference. A generic wrapper around lazy would strip them to
 // ComponentType<any>, which breaks <Home onDownload={...} />.
-const Login = lazy(() =>
+const Login = lazyRoute(() =>
   import("@/pages/Login").then((m) => ({ default: m.Login })),
 );
-const Home = lazy(() =>
+const Home = lazyRoute(() =>
   import("@/pages/Home").then((m) => ({ default: m.Home })),
 );
-const Search = lazy(() =>
+const Search = lazyRoute(() =>
   import("@/pages/Search").then((m) => ({ default: m.Search })),
 );
-const Library = lazy(() =>
+const Library = lazyRoute(() =>
   import("@/pages/Library").then((m) => ({ default: m.Library })),
 );
-const LocalLibrary = lazy(() =>
+const LocalLibrary = lazyRoute(() =>
   import("@/pages/LocalLibrary").then((m) => ({ default: m.LocalLibrary })),
 );
-const FolderDetail = lazy(() =>
+const FolderDetail = lazyRoute(() =>
   import("@/pages/FolderDetail").then((m) => ({ default: m.FolderDetail })),
 );
-const Collections = lazy(() =>
+const Collections = lazyRoute(() =>
   import("@/pages/Collections").then((m) => ({ default: m.Collections })),
 );
-const CollectionDetail = lazy(() =>
+const CollectionDetail = lazyRoute(() =>
   import("@/pages/CollectionDetail").then((m) => ({
     default: m.CollectionDetail,
   })),
 );
-const FollowListPage = lazy(() =>
+const FollowListPage = lazyRoute(() =>
   import("@/pages/FollowListPage").then((m) => ({ default: m.FollowListPage })),
 );
-const GenresPage = lazy(() =>
+const GenresPage = lazyRoute(() =>
   import("@/pages/GenresPage").then((m) => ({ default: m.GenresPage })),
 );
-const MixesPage = lazy(() =>
+const MixesPage = lazyRoute(() =>
   import("@/pages/MixesPage").then((m) => ({ default: m.MixesPage })),
 );
-const MoodsPage = lazy(() =>
+const MoodsPage = lazyRoute(() =>
   import("@/pages/MoodsPage").then((m) => ({ default: m.MoodsPage })),
 );
-const ProfilePage = lazy(() =>
+const ProfilePage = lazyRoute(() =>
   import("@/pages/ProfilePage").then((m) => ({ default: m.ProfilePage })),
 );
-const BrowsePage = lazy(() =>
+const BrowsePage = lazyRoute(() =>
   import("@/pages/BrowsePage").then((m) => ({ default: m.BrowsePage })),
 );
-const ChartsPage = lazy(() =>
+const ChartsPage = lazyRoute(() =>
   import("@/pages/ChartsPage").then((m) => ({ default: m.ChartsPage })),
 );
-const AotyDrilldownPage = lazy(() =>
+const AotyDrilldownPage = lazyRoute(() =>
   import("@/pages/AotyDrilldownPage").then((m) => ({
     default: m.AotyDrilldownPage,
   })),
 );
-const FeedPage = lazy(() =>
+const FeedPage = lazyRoute(() =>
   import("@/pages/FeedPage").then((m) => ({ default: m.FeedPage })),
 );
-const ForYouPage = lazy(() =>
+const ForYouPage = lazyRoute(() =>
   import("@/pages/ForYouPage").then((m) => ({ default: m.ForYouPage })),
 );
-const ForYouGenresPage = lazy(() =>
+const ForYouGenresPage = lazyRoute(() =>
   import("@/pages/ForYouHubPage").then((m) => ({
     default: m.ForYouGenresPage,
   })),
 );
-const ForYouSectionPage = lazy(() =>
+const ForYouSectionPage = lazyRoute(() =>
   import("@/pages/ForYouSectionPage").then((m) => ({
     default: m.ForYouSectionPage,
   })),
 );
-const HistoryPage = lazy(() =>
+const HistoryPage = lazyRoute(() =>
   import("@/pages/HistoryPage").then((m) => ({ default: m.HistoryPage })),
 );
-const PopularPage = lazy(() =>
+const PopularPage = lazyRoute(() =>
   import("@/pages/PopularPage").then((m) => ({ default: m.PopularPage })),
 );
-const StatsPage = lazy(() =>
+const StatsPage = lazyRoute(() =>
   import("@/pages/StatsPage").then((m) => ({ default: m.StatsPage })),
 );
-const StatsDetail = lazy(() =>
+const StatsDetail = lazyRoute(() =>
   import("@/pages/StatsDetail").then((m) => ({ default: m.StatsDetail })),
 );
-const AlbumDetail = lazy(() =>
+const AlbumDetail = lazyRoute(() =>
   import("@/pages/AlbumDetail").then((m) => ({ default: m.AlbumDetail })),
 );
-const ArtistDetail = lazy(() =>
+const ArtistDetail = lazyRoute(() =>
   import("@/pages/ArtistDetail").then((m) => ({ default: m.ArtistDetail })),
 );
-const ArtistSection = lazy(() =>
+const ArtistSection = lazyRoute(() =>
   import("@/pages/ArtistSection").then((m) => ({ default: m.ArtistSection })),
 );
-const MixDetail = lazy(() =>
+const MixDetail = lazyRoute(() =>
   import("@/pages/MixDetail").then((m) => ({ default: m.MixDetail })),
 );
-const RadioPage = lazy(() =>
+const RadioPage = lazyRoute(() =>
   import("@/pages/RadioPage").then((m) => ({ default: m.RadioPage })),
 );
-const ImportPage = lazy(() =>
+const ImportPage = lazyRoute(() =>
   import("@/pages/ImportPage").then((m) => ({ default: m.ImportPage })),
 );
-const PlaylistDetail = lazy(() =>
+const PlaylistDetail = lazyRoute(() =>
   import("@/pages/PlaylistDetail").then((m) => ({ default: m.PlaylistDetail })),
 );
-const Downloads = lazy(() =>
+const Downloads = lazyRoute(() =>
   import("@/pages/Downloads").then((m) => ({ default: m.Downloads })),
 );
-const MiniPlayerPage = lazy(() =>
+const MiniPlayerPage = lazyRoute(() =>
   import("@/pages/MiniPlayerPage").then((m) => ({ default: m.MiniPlayerPage })),
 );
-const SettingsPage = lazy(() =>
+const SettingsPage = lazyRoute(() =>
   import("@/pages/SettingsPage").then((m) => ({ default: m.SettingsPage })),
 );
 
@@ -256,6 +279,14 @@ function AppInner() {
       refreshMyPlaylists().catch(() => {});
     }
   }, [auth.logged_in, offline, refreshMyPlaylists]);
+
+  // Warm the route chunks too. `prefetch.pageHome` above fills the data
+  // cache; this fills the code cache, which is the half that makes a
+  // click feel dead — the route changes and Suspense holds a skeleton
+  // while the chunk waits its turn for one of the browser's six
+  // connections. The prefetcher only runs while the pool is idle, so
+  // starting it here cannot slow the first screen down.
+  useEffect(() => startRoutePrefetch(), []);
 
   // Hold the spinner until both probes resolve — rendering Login
   // prematurely would flash the sign-in screen for users who'd land

--- a/web/src/api/client.concurrency.test.ts
+++ b/web/src/api/client.concurrency.test.ts
@@ -1,0 +1,98 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The desktop shell is a Chromium webview talking to 127.0.0.1, and
+ * Chromium allows a host six concurrent HTTP/1.1 connections. Route
+ * chunks, cover images and API calls share that pool. Measured: the app
+ * never exceeded 6 in flight while the same server driven from outside
+ * reached 7 — the ceiling is the client.
+ *
+ * So the API client keeps itself below the limit, leaving connections
+ * for the chunk of the page the user just clicked.
+ */
+
+function deferred() {
+  let resolve!: (v: Response) => void;
+  const promise = new Promise<Response>((r) => (resolve = r));
+  return { promise, resolve };
+}
+
+const ok = () =>
+  ({ ok: true, status: 200, text: async () => "{}" }) as unknown as Response;
+
+describe("API request concurrency", () => {
+  let fetchMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.resetModules();
+    fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("issues at most four requests at once", async () => {
+    const { api } = await import("./client");
+    const pending = Array.from({ length: 8 }, () => deferred());
+    let i = 0;
+    fetchMock.mockImplementation(() => pending[i++].promise);
+
+    const calls = Array.from({ length: 8 }, () => api.version().catch(() => {}));
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+
+    pending.forEach((p) => p.resolve(ok()));
+    await Promise.all(calls);
+  });
+
+  it("starts a queued request as soon as one finishes", async () => {
+    const { api } = await import("./client");
+    const pending = Array.from({ length: 5 }, () => deferred());
+    let i = 0;
+    fetchMock.mockImplementation(() => pending[i++].promise);
+
+    const calls = Array.from({ length: 5 }, () => api.version().catch(() => {}));
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+
+    pending[0].resolve(ok());
+    await vi.waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(5));
+
+    pending.slice(1).forEach((p) => p.resolve(ok()));
+    await Promise.all(calls);
+  });
+
+  it("releases the slot when a request fails", async () => {
+    // Without the finally, one network error would permanently shrink
+    // the pool and eventually deadlock every request.
+    const { api } = await import("./client");
+    fetchMock.mockRejectedValue(new Error("boom"));
+
+    await Promise.all(
+      Array.from({ length: 6 }, () => api.version().catch(() => {})),
+    );
+
+    fetchMock.mockResolvedValue(ok());
+    await expect(api.version()).resolves.toBeDefined();
+  });
+
+  it("reports how many requests hold a slot", async () => {
+    const { api, apiRequestsInFlight } = await import("./client");
+    expect(apiRequestsInFlight()).toBe(0);
+
+    const d = deferred();
+    fetchMock.mockReturnValue(d.promise);
+    const call = api.version().catch(() => {});
+    await Promise.resolve();
+
+    expect(apiRequestsInFlight()).toBe(1);
+    d.resolve(ok());
+    await call;
+    expect(apiRequestsInFlight()).toBe(0);
+  });
+});

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -66,7 +66,68 @@ interface ReqOptions {
   timeoutMs?: number;
 }
 
+// Chromium allows a host at most 6 concurrent HTTP/1.1 connections,
+// and the desktop shell is a Chromium webview talking to 127.0.0.1.
+// Route chunks, cover images and API calls all share that one pool.
+//
+// Measured: the app never exceeded 6 requests in flight, while driving
+// the same server from outside reached 7 — so the ceiling is the
+// client, not the backend. When several slow API calls hold those
+// connections, the lazily-loaded JS chunk for the page the user just
+// clicked has nowhere to go. The click registers and the route
+// changes, but Suspense sits on a skeleton until a connection frees
+// up, which reads as "the click did nothing".
+//
+// Capping ourselves below the browser's limit keeps headroom for
+// navigation and images. Four is chosen to leave two: enough for a
+// chunk plus the covers on the page being navigated to.
+const MAX_CONCURRENT_REQUESTS = 4;
+
+let inFlight = 0;
+const waiting: Array<() => void> = [];
+
+function acquireSlot(): Promise<void> {
+  if (inFlight < MAX_CONCURRENT_REQUESTS) {
+    inFlight++;
+    return Promise.resolve();
+  }
+  return new Promise<void>((resolve) => {
+    waiting.push(() => {
+      inFlight++;
+      resolve();
+    });
+  });
+}
+
+function releaseSlot(): void {
+  inFlight--;
+  waiting.shift()?.();
+}
+
+/** Requests currently occupying a connection slot, queued ones
+ *  excluded. The route prefetcher reads this so it only warms chunks
+ *  while the pool is quiet. */
+export function apiRequestsInFlight(): number {
+  return inFlight;
+}
+
 async function req<T>(
+  path: string,
+  init?: RequestInit,
+  opts?: ReqOptions,
+): Promise<T> {
+  // Wait for a connection slot before arming the timeout. Starting the
+  // clock while queued would make a request time out for waiting its
+  // turn rather than for anything the server did.
+  await acquireSlot();
+  try {
+    return await sendRequest<T>(path, init, opts);
+  } finally {
+    releaseSlot();
+  }
+}
+
+async function sendRequest<T>(
   path: string,
   init?: RequestInit,
   opts?: ReqOptions,

--- a/web/src/lib/routePrefetch.test.ts
+++ b/web/src/lib/routePrefetch.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The prefetcher reads live in-flight state from the API client, so
+// stub the client rather than the network.
+let inFlight = 0;
+vi.mock("@/api/client", () => ({
+  apiRequestsInFlight: () => inFlight,
+}));
+
+async function freshModule() {
+  vi.resetModules();
+  return await import("./routePrefetch");
+}
+
+describe("route chunk prefetch", () => {
+  beforeEach(() => {
+    inFlight = 0;
+    vi.useFakeTimers();
+    // Force the setTimeout path so the idle scheduling is deterministic.
+    vi.stubGlobal("requestIdleCallback", undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it("warms registered chunks once the pool is idle", async () => {
+    const mod = await freshModule();
+    const a = vi.fn().mockResolvedValue({});
+    const b = vi.fn().mockResolvedValue({});
+    mod.registerRouteChunk(a);
+    mod.registerRouteChunk(b);
+
+    mod.startRoutePrefetch();
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(a).toHaveBeenCalledTimes(1);
+    expect(b).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not warm anything while requests are in flight", async () => {
+    // The whole point of the delay. Thirty chunk requests during
+    // startup would take the connections the first screen needs.
+    const mod = await freshModule();
+    const chunk = vi.fn().mockResolvedValue({});
+    mod.registerRouteChunk(chunk);
+    inFlight = 3;
+
+    mod.startRoutePrefetch();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(chunk).not.toHaveBeenCalled();
+  });
+
+  it("resumes once the pool goes quiet again", async () => {
+    const mod = await freshModule();
+    const chunk = vi.fn().mockResolvedValue({});
+    mod.registerRouteChunk(chunk);
+    inFlight = 2;
+
+    mod.startRoutePrefetch();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(chunk).not.toHaveBeenCalled();
+
+    inFlight = 0;
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(chunk).toHaveBeenCalledTimes(1);
+  });
+
+  it("warms each chunk at most once", async () => {
+    const mod = await freshModule();
+    const chunk = vi.fn().mockResolvedValue({});
+    mod.registerRouteChunk(chunk);
+
+    mod.startRoutePrefetch();
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(chunk).toHaveBeenCalledTimes(1);
+  });
+
+  it("a failed prefetch is retryable, not sticky", async () => {
+    // A chunk that failed to warm must still be importable on
+    // navigation — swallowing the error and marking it done would turn
+    // a transient blip into a permanently broken route.
+    const mod = await freshModule();
+    const chunk = vi.fn().mockRejectedValue(new Error("offline"));
+
+    mod.prefetchRouteChunk(chunk);
+    await vi.advanceTimersByTimeAsync(100);
+    mod.prefetchRouteChunk(chunk);
+    await vi.advanceTimersByTimeAsync(100);
+
+    expect(chunk).toHaveBeenCalledTimes(2);
+  });
+
+  it("hover prefetch does not wait for idle", async () => {
+    const mod = await freshModule();
+    const chunk = vi.fn().mockResolvedValue({});
+    inFlight = 5;
+
+    mod.prefetchRouteChunk(chunk);
+
+    expect(chunk).toHaveBeenCalledTimes(1);
+  });
+});

--- a/web/src/lib/routePrefetch.ts
+++ b/web/src/lib/routePrefetch.ts
@@ -1,0 +1,92 @@
+import { apiRequestsInFlight } from "@/api/client";
+
+/**
+ * Warms lazily-loaded route chunks while the connection pool is idle.
+ *
+ * Route components are separate chunks, so navigating to a page the
+ * user hasn't visited needs a network round trip at click time. That
+ * round trip competes with API calls for the browser's six connections
+ * to 127.0.0.1, and during startup the API calls win — the click
+ * registers, the route changes, and Suspense shows a skeleton until a
+ * connection frees up.
+ *
+ * Warming the chunks ahead of time removes the round trip entirely, so
+ * navigation stops depending on how busy the API is.
+ *
+ * The timing is the whole point. Prefetching eagerly would make the
+ * problem worse: thirty-odd chunk requests during startup would take
+ * the very connections the first page's data needs. So we only warm
+ * while the pool is quiet, one chunk at a time, and back off the moment
+ * real requests appear.
+ */
+
+const factories: Array<() => Promise<unknown>> = [];
+const warmed = new Set<() => Promise<unknown>>();
+
+/** Register a route's import so it can be prefetched later. Called by
+ *  `lazyRoute` in App.tsx; order is the order routes are declared. */
+export function registerRouteChunk(factory: () => Promise<unknown>): void {
+  factories.push(factory);
+}
+
+/** Warm one chunk immediately — for hover, where the user has told us
+ *  where they are going and waiting for idle would be too late. */
+export function prefetchRouteChunk(factory: () => Promise<unknown>): void {
+  if (warmed.has(factory)) return;
+  warmed.add(factory);
+  void factory().catch(() => {
+    // A failed prefetch is not a failure: the route will import again
+    // on navigation and surface any real error there.
+    warmed.delete(factory);
+  });
+}
+
+const onIdle = (fn: () => void, timeout: number): void => {
+  const ric = (
+    globalThis as { requestIdleCallback?: (cb: () => void, o?: object) => void }
+  ).requestIdleCallback;
+  if (typeof ric === "function") ric(fn, { timeout });
+  else setTimeout(fn, timeout);
+};
+
+/**
+ * Start warming route chunks once the app settles.
+ *
+ * Returns a stop function. Safe to call more than once; a second call
+ * is a no-op while the first is still running.
+ */
+let running = false;
+export function startRoutePrefetch(): () => void {
+  if (running) return () => {};
+  running = true;
+  let stopped = false;
+
+  const step = () => {
+    if (stopped) return;
+    // Only while nothing else needs the pool. Re-checking every tick
+    // rather than once up front matters: the user can navigate at any
+    // point, and their page's data must not queue behind a prefetch.
+    if (apiRequestsInFlight() > 0) {
+      onIdle(step, 2000);
+      return;
+    }
+    const next = factories.find((f) => !warmed.has(f));
+    if (!next) {
+      running = false;
+      return;
+    }
+    warmed.add(next);
+    void next()
+      .catch(() => warmed.delete(next))
+      .finally(() => onIdle(step, 500));
+  };
+
+  // Deliberately late. The first screen's data matters more than any
+  // chunk, and it is exactly the window where connections are scarce.
+  onIdle(step, 4000);
+
+  return () => {
+    stopped = true;
+    running = false;
+  };
+}


### PR DESCRIPTION
## The bug

Clicking an album during startup does nothing. The click registers and the route changes — but the page sits on a skeleton.

## Why

**Chromium allows a host six concurrent HTTP/1.1 connections**, and the desktop shell is a Chromium webview talking to `127.0.0.1`. Route chunks, cover images and API calls all share that one pool.

Measured rather than assumed: every reading of the running app peaked at exactly **6** requests in flight, never 7. Driving the same server from outside reached **7**. So the ceiling is the client, not the backend — and the backend was never near saturation (`started_while_saturated: 0`, 6 of 40 threads).

Route components are lazy chunks. When slow API calls hold the connections — the For You rows sat blocked 11+ seconds in one trace — the chunk for the page you just clicked has nowhere to go. Suspense holds a skeleton until a connection frees up, which reads as "the click did nothing".

## Two changes

**Cap ourselves at four in-flight requests**, leaving two connections for a chunk plus the covers on the page being navigated to. Two details that matter:

- The slot is acquired **before the timeout is armed** — starting the clock while queued would make a request time out for waiting its turn rather than for anything the server did.
- Released in a `finally`, so a failed request can't permanently shrink the pool. Without that, six network errors would deadlock every subsequent request.

**Warm route chunks in the background**, removing the round trip from navigation entirely. The timing is the whole point: warming eagerly would make this *worse*, since thirty-odd chunk requests during startup would take the exact connections the first screen needs. So the prefetcher waits for idle, re-checks `apiRequestsInFlight() === 0` before **each** chunk rather than once up front, and backs off the moment real requests appear. A user navigating mid-prefetch never queues behind it.

## Test plan

`routePrefetch.test.ts` (6) and `client.concurrency.test.ts` (4):

- at most four requests issue at once; a queued one starts as soon as a slot frees
- **a failed request releases its slot** — the deadlock case
- `apiRequestsInFlight()` tracks correctly
- chunks warm once the pool is idle, and **not at all** while requests are in flight
- warming resumes when the pool goes quiet
- a **failed** prefetch is retryable, not sticky — swallowing the error and marking it done would turn a transient blip into a permanently broken route
- hover prefetch bypasses the idle wait

Frontend: **182 tests across 21 files**, `tsc` clean, eslint **0 errors and 127 warnings — identical to `main`**. (I checked: `main` is already at 127 after the last dependency bump; an earlier version of this branch added 2, both now fixed.)

## What this does *not* fix

The API calls are still slow. That's the actual disease and it remains unmeasured — `perf.log` on 1.32.1 will finally say where the cold For You time goes.

This stops the slowness from *spreading to navigation*, which is what makes the app feel broken rather than merely slow. The other half — pages rendering full-page skeletons so there's nothing clickable until all data lands — is a separate change and the next one I'd do.
