### PR TITLE
Time the rest of the For You cold load

### DIFF
--- a/server.py
+++ b/server.py
@@ -12921,7 +12921,21 @@ def _aoty_section(key, title, subtitle, listing, profile, taste_rank, deep=False
     # underlying chart barely moves week to week, so without this the row
     # shows the same albums until the year turns over.
     items = _rotate(items, _SECTION_RESOLVE_POOL) if rotate else items[:_SECTION_RESOLVE_POOL]
+    # Resolution is one Tidal search per album on a cold cache, and it
+    # is the last unmeasured stretch of the For You cold load. The taste
+    # profile accounts for 4.5 s of roughly thirty; the AOTY listing
+    # above is cached for a day. If the rest is here, this line says so.
+    _t_resolve = time.monotonic()
     resolved = _rec_safe(lambda: aoty_resolver.resolve_listing(items), []) or []
+    _resolve_ms = (time.monotonic() - _t_resolve) * 1000.0
+    if _resolve_ms >= 250.0:
+        _perf = (
+            f"[perf] rec_resolve key={key} "
+            f"resolve={_resolve_ms:.0f}ms "
+            f"listing_items={len(items)} resolved={len(resolved)}"
+        )
+        print(_perf, flush=True)
+        perf_log.info(_perf)
     albums = [
         it["tidal_album"]
         for it in resolved
@@ -13374,9 +13388,30 @@ def recommendations_section(key: str, limit: int = _SECTION_SIZE) -> dict:
     size = max(1, min(int(limit), _SECTION_RESOLVE_POOL))
 
     def _build() -> dict:
+        # Timed because the For You page's cold load is the app's worst
+        # latency and nobody could say where it went. The taste profile
+        # turned out to be 4.5 s of it (measured, see _taste_profile),
+        # which leaves most of the wait somewhere in here — resolving
+        # each album against Tidal and fetching AOTY pages. Same
+        # one-line-per-build shape, so a cold start reports every row.
+        _t0 = time.monotonic()
         profile = _taste_profile_cached()
+        _t_profile = time.monotonic()
         owned = _owned_album_ids()
+        _t_owned = time.monotonic()
         section = _build_one_rec_section(key, profile, owned, size=size)
+        _t_section = time.monotonic()
+        _ms = lambda a, b: (b - a) * 1000.0
+        _perf = (
+            f"[perf] rec_section key={key} size={size} "
+            f"total={_ms(_t0, _t_section):.0f}ms "
+            f"taste_profile={_ms(_t0, _t_profile):.0f}ms "
+            f"owned_albums={_ms(_t_profile, _t_owned):.0f}ms "
+            f"build_section={_ms(_t_owned, _t_section):.0f}ms "
+            f"albums={len((section or {}).get('albums') or [])}"
+        )
+        print(_perf, flush=True)
+        perf_log.info(_perf)
         if section and section.get("albums"):
             _rec_safe(
                 lambda: rec_analytics.record_impressions([section]), None

--- a/tests/test_rec_section_perf.py
+++ b/tests/test_rec_section_perf.py
@@ -1,0 +1,63 @@
+"""Where the For You cold load actually goes (#401 follow-on).
+
+The page takes roughly thirty seconds cold. Instrumenting
+`_taste_profile` accounted for 4.5 s of that — measured on a real
+cold start, not a stub:
+
+    total=4515ms artist_tags=1593ms genre_slugs=1297ms
+    seed_artists=750ms chart_artists=500ms chart_tags=375ms
+
+which leaves most of the wait unexplained. The two candidates left are
+`_owned_album_ids()` and `_build_one_rec_section()`, and inside the
+latter, resolving each AOTY album to a Tidal search on a cold cache.
+
+These pin that both lines are emitted with the phases that can tell
+those apart. Getting this wrong is expensive in a way tests usually
+aren't: a missing phase means another cold start, and a cold start is
+not something you can ask a user for repeatedly.
+"""
+from __future__ import annotations
+
+import inspect
+
+import server
+
+
+def test_section_build_reports_its_three_phases():
+    src = inspect.getsource(server.recommendations_section)
+
+    assert "[perf] rec_section" in src
+    for phase in ("taste_profile=", "owned_albums=", "build_section="):
+        assert phase in src, f"{phase} missing — cannot attribute the time"
+
+
+def test_section_line_records_what_it_produced():
+    """A row that resolved nothing is fast for an uninteresting reason.
+    Without the album count, a 0 ms build looks like good news."""
+    src = inspect.getsource(server.recommendations_section)
+
+    assert "albums=" in src
+
+
+def test_resolve_step_is_timed():
+    src = inspect.getsource(server._aoty_section)
+
+    assert "[perf] rec_resolve" in src
+    assert "listing_items=" in src
+    assert "resolved=" in src
+
+
+def test_resolve_line_is_thresholded():
+    """Every row resolves on every build, warm or cold. Logging each
+    one would bury the cold start that matters in hundreds of 0 ms
+    lines — the same noise problem that made perf.log useless once."""
+    src = inspect.getsource(server._aoty_section)
+
+    assert "_resolve_ms >= 250.0" in src
+
+
+def test_perf_lines_go_to_the_durable_log():
+    """A packaged launch discards stdout, which is where these reports
+    come from."""
+    for fn in (server.recommendations_section, server._aoty_section):
+        assert "perf_log.info" in inspect.getsource(fn)


### PR DESCRIPTION
## The first real measurement came in

From a genuine cold start on 1.32.1 — `artists=28 genres=20`, so app data, not the stubs that polluted this file before:

```
[perf] taste_profile total=4515ms
  artist_tags    1593ms
  genre_slugs    1297ms
  seed_artists    750ms
  chart_artists   500ms
  chart_tags      375ms
```

**4.5 seconds of roughly thirty.** No single phase dominates, so there's no quick win in there — and it means ~25 s is somewhere nothing has ever timed.

## What's left to measure

`_recs_serve_swr`'s build does three things and only the first is instrumented:

```python
profile = _taste_profile_cached()      # ← 4.5 s, measured
owned   = _owned_album_ids()           # ← untimed
section = _build_one_rec_section(...)  # ← untimed
```

And inside the third, `_aoty_section` resolves each AOTY album to a Tidal album — **one search per album on a cold cache**, by the code's own comment. That's the standing suspicion and the one place a per-album cost would hide.

Two lines added:

- **`rec_section`** — splits a row's build into `taste_profile` / `owned_albums` / `build_section`, plus the album count. A row that resolved nothing is fast for an uninteresting reason; without the count a 0 ms build reads as good news.
- **`rec_resolve`** — times the Tidal resolution, with the listing size and how many resolved.

## Why the resolve line is thresholded

Every row resolves on every build, warm or cold. Logging all of them would bury the one cold start that matters under hundreds of 0 ms lines — the same failure that made `perf.log` unreadable when test runs were writing into it. It logs at ≥250 ms only.

## Test plan

`tests/test_rec_section_perf.py`, 5 cases: both lines exist, all three `rec_section` phases are present, the album count is recorded, the resolve line is thresholded, and both go to `perf_log` (a packaged launch discards stdout, which is where these reports come from).

Full suite: **1332 passed, 9 skipped, 1 failed** — the pre-existing `uvloop` Windows failure.

## Why more instrumentation instead of a fix

Three hypotheses about this page have now been wrong: threadpool saturation (measured 6 of 40, zero saturation), the browser connection limit (only four rows exist), and a serial artist-tag loop (actually a six-worker pool). Each was plausible and each cost a round of work.

This is the second-to-last unmeasured stretch. After a cold start with this in, the 25 seconds has a name.
