### PR TITLE
Persist the AOTY genre taxonomy across restarts

### DIFF
--- a/server.py
+++ b/server.py
@@ -12497,6 +12497,9 @@ def _dedupe_cap_albums(albums: list, limit: int, exclude: Optional[set] = None) 
 
 
 _GENRE_MAP_TTL_SEC = 24 * 3600.0
+# Disk key for the same map. User-independent, so one row serves every
+# account on the machine.
+_GENRE_MAP_DISK_KEY = "aoty|genre-slug-map"
 _genre_map_cache: dict = {"at": 0.0, "map": None}
 _genre_map_lock = threading.Lock()
 
@@ -12513,11 +12516,32 @@ def _aoty_genre_slug_map() -> dict:
     ("26-shoegaze"). Harvesting name->slug from a couple of years of
     top-rated albums builds the complete map, so "Best of Shoegaze"
     becomes a real row. Cached ~a day — the taxonomy barely moves."""
+    from app import lastfm_disk_cache
+
     now = time.monotonic()
     with _genre_map_lock:
         c = _genre_map_cache
         if c["map"] is not None and now - c["at"] < _GENRE_MAP_TTL_SEC:
             return c["map"]
+    # The day-long TTL above only ever applied within one run — the
+    # dict dies with the process, so every launch re-harvested the
+    # taxonomy. Measured at 1297 ms of a 4515 ms cold taste profile,
+    # paid again on every start. Nothing here is per-user and the
+    # taxonomy barely moves, which is what the disk layer is for.
+    # JSON has no tuples, so the (slug, display) pairs come back as
+    # lists and are restored.
+    _cached = lastfm_disk_cache.get(_GENRE_MAP_DISK_KEY, _GENRE_MAP_TTL_SEC)
+    if isinstance(_cached, dict) and _cached:
+        restored = {
+            k: (v[0], v[1])
+            for k, v in _cached.items()
+            if isinstance(v, (list, tuple)) and len(v) == 2
+        }
+        if restored:
+            with _genre_map_lock:
+                _genre_map_cache["map"] = restored
+                _genre_map_cache["at"] = time.monotonic()
+            return restored
     mapping: dict = {}
     # Curated index first so its canonical display names win.
     for g in _rec_safe(lambda: aoty_module.genre_index(), []) or []:
@@ -12536,6 +12560,10 @@ def _aoty_genre_slug_map() -> dict:
     with _genre_map_lock:
         _genre_map_cache["at"] = time.monotonic()
         _genre_map_cache["map"] = mapping
+    # Persist only a map we actually built. Writing an empty one would
+    # cache an AOTY outage for a day.
+    if mapping:
+        lastfm_disk_cache.set(_GENRE_MAP_DISK_KEY, mapping)
     return mapping
 
 

--- a/tests/test_genre_map_persistence.py
+++ b/tests/test_genre_map_persistence.py
@@ -1,0 +1,106 @@
+"""The AOTY genre taxonomy survives a restart.
+
+Measured on a real cold start, the taste profile every For You row
+blocks on took 4515 ms, and 1297 ms of that was `_aoty_genre_slug_map`
+harvesting AOTY's taxonomy. Its docstring says "cached ~a day" and the
+TTL agrees — but the cache was a module-level dict, so the day only
+ever lasted as long as the process. Quitting Tideway threw it away and
+the next launch paid the 1297 ms again.
+
+That is the same argument `app/lastfm_disk_cache.py` was written for:
+"the in-memory dict dies on app restart, so anyone who quits Tideway
+between visits paid the 18 seconds again." Nothing in this map is
+per-user and the taxonomy barely moves, so it belongs on disk too.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+
+@pytest.fixture
+def srv(tmp_path, monkeypatch):
+    import server
+    from app import lastfm_disk_cache
+
+    lastfm_disk_cache._set_db_path_for_testing(tmp_path / "cache.db")
+    # Clear the in-memory layer so the disk path is what gets exercised.
+    with server._genre_map_lock:
+        server._genre_map_cache["map"] = None
+        server._genre_map_cache["at"] = 0.0
+    yield server
+    lastfm_disk_cache._set_db_path_for_testing(None)
+    with server._genre_map_lock:
+        server._genre_map_cache["map"] = None
+        server._genre_map_cache["at"] = 0.0
+
+
+def _stub_aoty(srv, monkeypatch, calls: list):
+    def genre_index():
+        calls.append("index")
+        return [{"name": "Shoegaze", "slug": "26-shoegaze"}]
+
+    monkeypatch.setattr(
+        srv.aoty_module,
+        "genre_index",
+        genre_index,
+    )
+    monkeypatch.setattr(
+        srv.aoty_module, "top_albums_of_year", lambda y, n: []
+    )
+
+
+def test_map_is_harvested_and_persisted(srv, monkeypatch):
+    calls: list = []
+    _stub_aoty(srv, monkeypatch, calls)
+
+    out = srv._aoty_genre_slug_map()
+
+    assert out["shoegaze"] == ("26-shoegaze", "Shoegaze")
+    assert calls == ["index"]
+
+
+def test_a_restart_reads_the_map_off_disk(srv, monkeypatch):
+    """The point of the change: the second process does no AOTY work."""
+    calls: list = []
+    _stub_aoty(srv, monkeypatch, calls)
+    srv._aoty_genre_slug_map()
+    assert calls == ["index"]
+
+    # Simulate a restart: memory gone, disk intact.
+    with srv._genre_map_lock:
+        srv._genre_map_cache["map"] = None
+        srv._genre_map_cache["at"] = 0.0
+
+    out = srv._aoty_genre_slug_map()
+
+    assert out["shoegaze"] == ("26-shoegaze", "Shoegaze"), "tuple not restored"
+    assert calls == ["index"], "harvested again instead of reading disk"
+
+
+def test_an_empty_harvest_is_not_persisted(srv, monkeypatch):
+    """An AOTY outage returns nothing. Caching that would serve an
+    empty taxonomy for a day and quietly drop every genre row."""
+    from app import lastfm_disk_cache
+
+    monkeypatch.setattr(srv.aoty_module, "genre_index", lambda: [])
+    monkeypatch.setattr(srv.aoty_module, "top_albums_of_year", lambda y, n: [])
+
+    assert srv._aoty_genre_slug_map() == {}
+    assert lastfm_disk_cache.get(srv._GENRE_MAP_DISK_KEY, 24 * 3600.0) is None
+
+
+def test_a_corrupt_row_falls_through_to_a_harvest(srv, monkeypatch):
+    """Entries that aren't (slug, display) pairs are ignored rather
+    than returned as a broken map."""
+    from app import lastfm_disk_cache
+
+    lastfm_disk_cache.set(srv._GENRE_MAP_DISK_KEY, {"shoegaze": "not-a-pair"})
+    calls: list = []
+    _stub_aoty(srv, monkeypatch, calls)
+
+    out = srv._aoty_genre_slug_map()
+
+    assert out["shoegaze"] == ("26-shoegaze", "Shoegaze")
+    assert calls == ["index"]


### PR DESCRIPTION
## Summary

The first real cold-start measurement of the For You page put the taste profile — which every row blocks on — at **4515 ms**, and **1297 ms of that** in `_aoty_genre_slug_map`.

That function's own docstring says "Cached ~a day — the taxonomy barely moves", and `_GENRE_MAP_TTL_SEC` is 24 hours. But the cache is a module-level dict, so **the day only ever lasted as long as the process.** Quitting Tideway threw it away, and the next launch re-harvested AOTY's taxonomy from scratch — a second and a half on every single start.

This is precisely the argument `app/lastfm_disk_cache.py` was written for. From its docstring:

> the in-memory dict dies on app restart, so anyone who quits Tideway between visits paid the 18 seconds again.

Nothing in this map is per-user and the taxonomy barely moves, so one row on disk serves every launch and every account on the machine.

## Two guards worth reviewing

**An empty harvest is not persisted.** An AOTY outage returns nothing; caching that would serve a blank taxonomy for a full day and silently drop every genre-backed row. Failing open costs one retry; failing closed costs a day of broken recommendations.

**Entries that aren't `(slug, display)` pairs are ignored.** JSON has no tuples, so the pairs come back as lists and get restored — but a corrupt or schema-changed row falls through to a fresh harvest rather than being returned as a broken map.

## Test plan

`tests/test_genre_map_persistence.py`, 4 cases, using the disk cache's own `_set_db_path_for_testing` so nothing touches the real DB:

- the map is harvested and persisted
- **a restart reads it off disk** — memory cleared, and the second call does no AOTY work at all. This is the change.
- an empty harvest is not persisted
- a corrupt row falls through to a harvest

Full suite: **1336 passed, 9 skipped, 1 failed** — the pre-existing `uvloop`-has-no-Windows-wheel test.

## Scope

This takes ~29% off the measured cold profile. The other phases are all Last.fm calls:

| phase | cost | user-specific? |
|---|---|---|
| `artist_tags` | 1593 ms | per-artist, but tags barely move |
| `genre_slugs` | 1297 ms | **no — this PR** |
| `seed_artists` | 750 ms | yes, changes with listening |
| `chart_artists` | 500 ms | no, global chart |
| `chart_tags` | 375 ms | no, global chart |

The two global charts are the obvious next candidates on the same reasoning, and `artist_tags` is the biggest single item — an artist's community tags are close to static, so a per-artist disk key should be a large win. Left for a follow-up rather than widened here.

Worth stating plainly: this is a measured 1297 ms on a 4515 ms profile, but the profile is only 4.5 s of a ~30 s cold load. #407 instruments the rest.
