### PR TITLE
Format the two files #406 left unformatted

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -69,10 +69,7 @@ import type { OnDownload } from "@/api/download";
 import { lazy, Suspense } from "react";
 import type { ComponentType, LazyExoticComponent } from "react";
 import { HeroSkeleton } from "@/components/Skeletons";
-import {
-  registerRouteChunk,
-  startRoutePrefetch,
-} from "@/lib/routePrefetch";
+import { registerRouteChunk, startRoutePrefetch } from "@/lib/routePrefetch";
 
 /**
  * `lazy`, plus the import registered for prefetching.

--- a/web/src/api/client.concurrency.test.ts
+++ b/web/src/api/client.concurrency.test.ts
@@ -39,7 +39,9 @@ describe("API request concurrency", () => {
     let i = 0;
     fetchMock.mockImplementation(() => pending[i++].promise);
 
-    const calls = Array.from({ length: 8 }, () => api.version().catch(() => {}));
+    const calls = Array.from({ length: 8 }, () =>
+      api.version().catch(() => {}),
+    );
     await Promise.resolve();
     await Promise.resolve();
 
@@ -55,7 +57,9 @@ describe("API request concurrency", () => {
     let i = 0;
     fetchMock.mockImplementation(() => pending[i++].promise);
 
-    const calls = Array.from({ length: 5 }, () => api.version().catch(() => {}));
+    const calls = Array.from({ length: 5 }, () =>
+      api.version().catch(() => {}),
+    );
     await Promise.resolve();
     await Promise.resolve();
     expect(fetchMock).toHaveBeenCalledTimes(4);


### PR DESCRIPTION
## Summary

CI's Prettier step is failing on `main`:

```
[warn] src/api/client.concurrency.test.ts
[warn] src/App.tsx
Code style issues found in 2 files.
```

Both are from #406. Line-wrapping only — no behaviour change, and `tsc` and all 182 tests still pass.

## Why it got through

`format:check` can't be run usefully on this Windows checkout: the working tree is CRLF and `.prettierrc.json` pins `endOfLine: lf`, so it reports **all 200 files** and says nothing about the two that actually differ.

I knew that and treated Prettier as noise-only locally, which is what let a real failure through. CI on a LF checkout named exactly these two files, and running `prettier --write` on just those two produced a 2-file diff rather than a 200-file one — which is the check I should have done in the first place.

## Test plan

- `prettier --write` on the two files CI named; diff is line-wrapping only
- `tsc -b --noEmit` clean, `npm test` 182 passed
- Local `format:check` still reports 200 files (the CRLF artifact); CI is the authority here and this PR's own run is the verification

## Why this is its own PR

`main` is red, so every open PR inherits the failure — including #409, which is workflow-only and otherwise green. Unblocking `main` first keeps that fix reviewable on its own merits.
