### PR TITLE
Source portaudio from a host that still resolves

### DIFF
--- a/flatpak/com.tidaldownloader.Tideway.yaml
+++ b/flatpak/com.tidaldownloader.Tideway.yaml
@@ -57,12 +57,25 @@ cleanup:
 modules:
   # sounddevice needs libportaudio; the GNOME runtime does not ship
   # it. Built here; sha256 computed off the upstream tarball.
+  #
+  # Sourced from the GitHub release tag rather than
+  # files.portaudio.com, which stopped resolving entirely — the v1.32.2
+  # release build failed with "Could not resolve host:
+  # files.portaudio.com", and it does not resolve from a developer
+  # machine either, so this is the host being gone rather than a flaky
+  # runner. The project's own GitHub release for v19.7.0 carries no
+  # assets, so the tag archive is the source that remains.
+  #
+  # Same upstream code, different packaging: the tag archive ships a
+  # generated `configure`, so autotools still applies unchanged (this
+  # was checked rather than assumed — a repo snapshot without it would
+  # have needed an autoreconf step).
   - name: portaudio
     buildsystem: autotools
     sources:
       - type: archive
-        url: https://files.portaudio.com/archives/pa_stable_v190700_20210406.tgz
-        sha256: 47efbf42c77c19a05d22e627d42873e991ec0c1357219c0d74ce6a2948cb2def
+        url: https://github.com/PortAudio/portaudio/archive/refs/tags/v19.7.0.tar.gz
+        sha256: 5af29ba58bbdbb7bbcefaaecc77ec8fc413f0db6f4c4e286c40c3e1b83174fa0
 
   # Offline, hashed PyPI deps generated from requirements.txt with
   # flatpak-pip-generator. Regenerate by running the script in the


### PR DESCRIPTION
## The failure

The `v1.32.2` release build failed on Linux:

```
Failed to download sources: module portaudio: Could not resolve host: files.portaudio.com
```

This is **not** the earlier `ENOTCACHED` problem — that one is fixed, and the node manifest verified clean (all 435 lockfile tarballs present). This is a different, unrelated break that the first failure was masking.

`files.portaudio.com` doesn't resolve from a developer machine either, so the host is gone rather than the runner being flaky. Nothing we ship can be built on Linux until it points elsewhere.

## The fix

PortAudio's own GitHub release for v19.7.0 **carries no assets**, so `pa_stable_v190700_20210406.tgz` isn't recoverable from there. Debian's pool and a Wayback attempt didn't produce it either. The tag archive is what remains.

Checked rather than assumed: the tag archive **ships a generated `configure`**, so `buildsystem: autotools` applies unchanged. A bare repo snapshot without it would have needed an `autoreconf` step and a different manifest — worth verifying before swapping a URL under a build system that expects one.

Same upstream version. New sha256 because the packaging differs: the old file was an autotools dist tarball, this is the tag archive. Downloaded and hashed locally rather than copied from anywhere — `5af29ba5…`.

## Test plan

- `https://github.com/PortAudio/portaudio/archive/refs/tags/v19.7.0.tar.gz` → HTTP 200, 1,462,961 bytes
- sha256 computed from the downloaded bytes
- archive listing confirms `configure` is present and `configure.in` alongside it
- manifest parses; the portaudio module's `buildsystem` is untouched

**Not verified: the actual Flatpak build.** That needs Linux and flatpak-builder. The build check runs on PRs touching `flatpak/**`, so this PR's own CI is the real test — if it goes green, the release can be re-cut.

## Note on durability

GitHub generates tag archives on demand. It has committed to checksum stability, but if that ever bites, a `type: git` source pinned to the tag's commit is immune and is the fallback worth taking. Not doing it pre-emptively, since `type: archive` is what every other source in this manifest uses.
