### PR TITLE
Stop resolving AOTY entries to unrelated Tidal albums

### DIFF
--- a/app/aoty_resolver.py
+++ b/app/aoty_resolver.py
@@ -29,6 +29,74 @@ log = logging.getLogger(__name__)
 # both integrations age uniformly.
 _RESOLVE_TTL_SEC = 86400.0 * 30
 
+# Bumped when the matching rules change, so entries resolved under the
+# old rules are not served from a 30-day cache. v2 stopped falling back
+# to Tidal's top search hit; without a bump, every album already
+# mis-resolved under v1 would stay wrong for a month.
+_RESOLVE_CACHE_VERSION = "v2"
+
+# How close a Tidal album title has to be to AOTY's before we believe
+# it is the same record. Titles differ in punctuation, capitalisation,
+# bracketed edition suffixes ("(Deluxe)"), so an exact compare is too
+# strict — but the failure this replaces was accepting anything at all,
+# so the bar is set high.
+_TITLE_MATCH_MIN = 88.0
+_ARTIST_MATCH_MIN = 80.0
+
+
+def _norm(text: str) -> str:
+    """Lowercase, strip a trailing bracketed edition tag and collapse
+    whitespace. "Big Fish Theory (Deluxe Edition)" and "big fish
+    theory" should compare equal."""
+    import re
+
+    t = (text or "").strip().lower()
+    t = re.sub(r"[\(\[][^)\]]*[)\]]\s*$", "", t).strip()
+    t = re.sub(r"\s+", " ", t)
+    return t
+
+
+def _similar(a: str, b: str) -> float:
+    """0-100 similarity. rapidfuzz is already a dependency (it backs
+    the local-library search), so this costs nothing new."""
+    from rapidfuzz import fuzz
+
+    return float(fuzz.ratio(_norm(a), _norm(b)))
+
+
+def _is_plausible_match(album, want_artist: str, want_title: str) -> bool:
+    """Whether a Tidal search hit is actually the album AOTY listed.
+
+    Tidal's search returns *something* for almost any query. Asking it
+    for "Denzel Curry & Kenneth Blume ii" returned Vince Staples' "Big
+    Fish Theory" — a different artist, a different title, and nine
+    years older — which then sat at the top of the Top Albums of the
+    Year row because the resolver took the first hit unconditionally.
+
+    Require the title to match closely. The artist is checked too, but
+    only as a veto when we can read one: AOTY credits collaborations in
+    ways Tidal does not ("Denzel Curry & Kenneth Blume" vs two artist
+    entries), so a title-only match with an unreadable artist is
+    allowed through, while a confident artist mismatch is not.
+    """
+    name = getattr(album, "name", "") or ""
+    if _similar(name, want_title) < _TITLE_MATCH_MIN:
+        return False
+    names = [
+        getattr(ar, "name", "") or ""
+        for ar in (getattr(album, "artists", None) or [])
+    ]
+    names = [n for n in names if n]
+    if not names:
+        return True
+    want = _norm(want_artist)
+    return any(
+        _similar(n, want_artist) >= _ARTIST_MATCH_MIN
+        or _norm(n) in want
+        or want in _norm(n)
+        for n in names
+    )
+
 
 def resolve_listing(listing: list[dict]) -> list[dict]:
     """Return a new list with each entry decorated with `tidal_album`.
@@ -68,7 +136,7 @@ def resolve_listing(listing: list[dict]) -> list[dict]:
             return {**entry, "tidal_album": None}
 
         cache_key = (
-            f"aoty:resolve-album:{pref}:"
+            f"aoty:resolve-album:{_RESOLVE_CACHE_VERSION}:{pref}:"
             f"{artist.lower()}:{title.lower()}"
         )
         cached = lastfm_disk_cache.get(cache_key, _RESOLVE_TTL_SEC)
@@ -87,7 +155,11 @@ def resolve_listing(listing: list[dict]) -> list[dict]:
         if not albums:
             return {**entry, "tidal_album": None}
 
-        # Exact title + artist first; fall back to Tidal's top hit.
+        # Exact title + artist first, then the best plausible hit.
+        # Never Tidal's top hit unconditionally: search returns
+        # something for almost any query, and taking it put Vince
+        # Staples' "Big Fish Theory" (2017) at the top of Top Albums of
+        # the Year, standing in for an album by Denzel Curry.
         wt = title.lower()
         wa = artist.lower()
         exact = next(
@@ -101,8 +173,24 @@ def resolve_listing(listing: list[dict]) -> list[dict]:
             ),
             None,
         )
+        if exact is None:
+            exact = next(
+                (a for a in albums if _is_plausible_match(a, artist, title)),
+                None,
+            )
+        if exact is None:
+            # Nothing on Tidal we can stand behind. A row one album
+            # shorter is better than a row with the wrong album in it,
+            # and callers already drop entries whose tidal_album is
+            # None. Not cached — see below.
+            log.info(
+                "aoty resolve: no plausible Tidal match for %r / %r",
+                artist,
+                title,
+            )
+            return {**entry, "tidal_album": None}
         try:
-            resolved = album_to_dict(exact or albums[0])
+            resolved = album_to_dict(exact)
         except Exception as exc:
             log.warning("aoty resolve serialize %r/%r failed: %s", artist, title, exc)
             return {**entry, "tidal_album": None}

--- a/tests/test_aoty_resolve_match.py
+++ b/tests/test_aoty_resolve_match.py
@@ -1,0 +1,80 @@
+"""A Tidal search hit has to actually be the album AOTY listed.
+
+Reported from the Top Albums of the Year row on Home: the first card
+was Vince Staples' "Big Fish Theory" — a 2017 album, in a 2026 chart.
+AOTY had listed "ii" by Denzel Curry & Kenneth Blume. Tidal's search
+for that string returned nothing matching, and the resolver ended with
+
+    resolved = album_to_dict(exact or albums[0])
+
+so it took the top hit unconditionally. Tidal returns *something* for
+almost any query, which is how a different artist, a different title
+and a nine-year-old record ended up presented as this year's number
+one.
+
+A row one album shorter is better than a row with the wrong album in
+it, so an implausible hit now resolves to None and callers drop it —
+they already handle unresolved entries.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace as NS
+
+from app.aoty_resolver import _is_plausible_match, _norm, _similar
+
+
+def _album(name: str, *artists: str):
+    return NS(name=name, artists=[NS(name=a) for a in artists])
+
+
+def test_the_reported_mismatch_is_rejected():
+    got = _album("Big Fish Theory", "Vince Staples")
+
+    assert not _is_plausible_match(got, "Denzel Curry & Kenneth Blume", "ii")
+
+
+def test_the_right_album_is_accepted():
+    got = _album("ii", "Denzel Curry")
+
+    assert _is_plausible_match(got, "Denzel Curry & Kenneth Blume", "ii")
+
+
+def test_edition_suffixes_still_match():
+    """Tidal routinely carries "(Deluxe Edition)" where AOTY does not.
+    Rejecting those would empty the row for the opposite reason."""
+    got = _album("Marrow Deep (Deluxe Edition)", "Mastodon")
+
+    assert _is_plausible_match(got, "Mastodon", "Marrow Deep")
+
+
+def test_case_and_punctuation_differences_still_match():
+    got = _album("WOR$T GIRL IN AMERICA", "Slayyyter")
+
+    assert _is_plausible_match(got, "slayyyter", "WOR$T GIRL IN AMERICA")
+
+
+def test_same_title_by_a_different_artist_is_rejected():
+    """The dangerous near-miss: short generic titles collide across
+    artists, which is how "ii" found something at all."""
+    got = _album("Remains", "Some Other Band")
+
+    assert not _is_plausible_match(got, "Tokyo Jihen", "Remains")
+
+
+def test_an_unreadable_artist_falls_back_to_the_title():
+    """Some Tidal hits carry no usable artist list. A close title is
+    then the only signal there is — better than discarding a correct
+    match, and the title bar is high."""
+    got = NS(name="Lost Weekend", artists=[])
+
+    assert _is_plausible_match(got, "Phoebe Bridgers", "Lost Weekend")
+
+
+def test_norm_strips_a_trailing_bracketed_tag():
+    assert _norm("Big Fish Theory (Deluxe Edition)") == "big fish theory"
+    assert _norm("  Inferno  ") == "inferno"
+
+
+def test_similar_is_a_percentage():
+    assert _similar("Inferno", "Inferno") == 100.0
+    assert _similar("Inferno", "Big Fish Theory") < 50.0

--- a/tests/test_aoty_resolver.py
+++ b/tests/test_aoty_resolver.py
@@ -157,9 +157,13 @@ def test_exact_artist_title_match_wins_over_top_hit(stub_server):
     assert out[0]["tidal_album"]["id"] == "EXACT"
 
 
-def test_falls_back_to_top_hit_when_no_exact_match(stub_server):
-    """If no result exact-matches the requested artist+title, the
-    first (top-hit) result is used."""
+def test_unrelated_top_hit_is_not_used(stub_server):
+    """Previously the top hit was taken whenever nothing matched
+    exactly. Tidal returns something for almost any query, so that put
+    Vince Staples' "Big Fish Theory" at the top of Top Albums of the
+    Year in place of an album by Denzel Curry. An entry with no
+    plausible match now resolves to None and callers drop it — a
+    shorter row beats a wrong one."""
     stub_server.search_results = {
         "albums": [
             _FakeAlbum("Something Else", "Different", id_="TOP"),
@@ -169,7 +173,21 @@ def test_falls_back_to_top_hit_when_no_exact_match(stub_server):
     out = aoty_resolver.resolve_listing(
         [{"artist": "Wanted", "title": "Title"}]
     )
-    assert out[0]["tidal_album"]["id"] == "TOP"
+    assert out[0]["tidal_album"] is None
+
+
+def test_a_close_but_inexact_match_is_still_used(stub_server):
+    """Rejecting everything inexact would empty the rows: Tidal carries
+    edition suffixes and different capitalisation constantly."""
+    stub_server.search_results = {
+        "albums": [
+            _FakeAlbum("Wanted Title (Deluxe Edition)", "Wanted", id_="CLOSE"),
+        ]
+    }
+    out = aoty_resolver.resolve_listing(
+        [{"artist": "Wanted", "title": "Wanted Title"}]
+    )
+    assert out[0]["tidal_album"]["id"] == "CLOSE"
 
 
 def test_match_is_case_insensitive(stub_server):
@@ -202,7 +220,12 @@ def test_empty_search_results_yields_none(stub_server):
 
 def test_cache_hit_short_circuits_search(stub_server):
     """A pre-populated cache entry means no Tidal search call and no
-    rate-limit sleep on the second pass."""
+    rate-limit sleep on the second pass.
+
+    Needs a hit the resolver will actually accept: only successful
+    resolves are cached, and the fixture's default result is
+    deliberately an unrelated album, which now resolves to None."""
+    stub_server.search_results = {"albums": [_FakeAlbum("Y", "X", id_="HIT")]}
     listing = [{"artist": "X", "title": "Y"}]
     aoty_resolver.resolve_listing(listing)
     first_search_count = len(stub_server.searches)


### PR DESCRIPTION
## The bug

The **Top Albums of the Year** row on Home leads with **Vince Staples — "Big Fish Theory"**. That's a 2017 album sitting at position 1 of a 2026 chart.

Reproduced against the running app's own `/api/aoty/top-of-year`:

```
displayed                          | aoty actually wanted
Vince Staples - Big Fish Theory    | Denzel Curry & Kenneth Blume - ii   <== MISMATCH
Phoebe Bridgers - Lost Weekend     | Phoebe Bridgers - Lost Weekend
underscores - U                    | underscores - U
...
```

Two more further down the row: `jane_remover_essentials.zip` and `Remains` both resolved to unrelated 2025 albums.

## Why

```python
resolved = album_to_dict(exact or albums[0])
```

When nothing exact-matched the requested artist and title, the resolver took **Tidal's top search hit unconditionally**. Tidal returns *something* for almost any query, so searching `"Denzel Curry & Kenneth Blume ii"` — a short, generic title with a collaboration credit Tidal spells differently — produced a confident-looking answer that was a different artist, a different title, and nine years old. AOTY's rank was preserved, so it landed at the front of the row.

## The fix

Require a plausible match: a close title, and an artist that doesn't contradict.

**Fuzzy, not exact** — Tidal carries `(Deluxe Edition)` suffixes and different capitalisation constantly, and demanding exactness would empty the rows for the opposite reason.

**The artist is a veto, not a requirement.** AOTY credits collaborations in ways Tidal doesn't, and some Tidal hits carry no readable artist list. A strong title match with an unreadable artist is allowed through; a confident artist mismatch is not.

**No match → `None`**, which every caller already drops. A row one album shorter beats a row with the wrong album in it.

**The cache key gains a version marker.** Successful resolves are cached for 30 days, so without it every album already mis-resolved under the old rule would stay wrong for a month.

## Test plan

`tests/test_aoty_resolve_match.py`, 8 cases, including the reported pair as a regression test — "Big Fish Theory"/Vince Staples against a request for "ii"/Denzel Curry is rejected, and the correct album accepted. Plus edition suffixes and case differences still matching, a same-title-different-artist collision rejected (that's how "ii" found anything at all), and the unreadable-artist fallback.

Two existing tests changed with the behaviour:

- `test_falls_back_to_top_hit_when_no_exact_match` pinned the bug. Replaced with `test_unrelated_top_hit_is_not_used`, plus a new case proving a close-but-inexact hit is still accepted, so the fix can't regress into rejecting everything.
- `test_cache_hit_short_circuits_search` needed a hit the resolver will accept — the fixture's default result is deliberately unrelated and now resolves to `None`, which correctly isn't cached.

Full suite: **1341 passed, 9 skipped, 1 failed** — the pre-existing `uvloop` Windows failure.

## Not verified

The thresholds (88 title / 80 artist) are judgement, tuned against the observed failure and the legitimate matches in that row. Too high empties rows, too low reopens this. Worth checking the row after this ships: if entries you'd expect have gone missing, the title bar is the dial.
