### PR TITLE
Stop a seek crashing the audio callback mid-buffer

### DIFF
--- a/app/audio/player.py
+++ b/app/audio/player.py
@@ -3108,6 +3108,16 @@ class PCMPlayer:
             written = frames
 
         while written < frames:
+            # Re-check per iteration, not just at the top of the
+            # callback. `seek()` sets `_seeking` and then clears
+            # `_callback_carry` from the HTTP thread; a callback that
+            # already passed the guard above is inside this loop by
+            # then and would keep feeding the pre-seek buffer. Yielding
+            # here is what the guard intends — the next callback starts
+            # clean on the new decoder.
+            if self._seeking or self._swapping:
+                outdata[written:] = 0
+                return
             if self._callback_carry is None:
                 try:
                     chunk = self._pcm_queue.get_nowait()
@@ -3141,8 +3151,22 @@ class PCMPlayer:
                     return
                 self._callback_carry = chunk
 
-            take = min(frames - written, self._callback_carry.shape[0])
-            src = self._callback_carry[:take]
+            # Read once into a local and use it for the whole iteration.
+            # This callback is lock-free, so `seek()` clearing
+            # `_callback_carry` between the assignment above and the
+            # reads below turned it into None mid-expression and raised
+            # "'NoneType' object has no attribute 'shape'", killing the
+            # callback and stalling audio until the stream was torn
+            # down (#405). A local can't be nulled underneath us.
+            carry = self._callback_carry
+            if carry is None:
+                # Cleared between the check and here — treat it as a
+                # seek in flight rather than reaching for .shape.
+                outdata[written:] = 0
+                return
+
+            take = min(frames - written, carry.shape[0])
+            src = carry[:take]
             if src.shape[1] == channels:
                 outdata[written : written + take] = src
             elif src.shape[1] == 2 and channels == 1:
@@ -3150,10 +3174,10 @@ class PCMPlayer:
             else:
                 outdata[written : written + take] = 0
             written += take
-            if take >= self._callback_carry.shape[0]:
+            if take >= carry.shape[0]:
                 self._callback_carry = None
             else:
-                self._callback_carry = self._callback_carry[take:]
+                self._callback_carry = carry[take:]
 
         # Cast tap. Runs before EQ / volume / mute so the device
         # gets the raw decoded PCM; the Cast device has its own

--- a/tests/test_callback_carry_race.py
+++ b/tests/test_callback_carry_race.py
@@ -1,0 +1,123 @@
+"""The audio callback survives a seek clearing its buffer (#405).
+
+Reported on Linux: repeated seeking through the progress bar during
+DASH playback raised
+
+    app/audio/player.py: 'NoneType' object has no attribute 'shape'
+
+followed by "AUDIO STALL: callback silent for 10.7s while state=playing"
+and, sometimes, the app closing.
+
+`seek()` runs on the request thread and clears `_callback_carry` under
+`_lock`. The audio callback is deliberately lock-free, so `_lock` does
+not keep it out — it only stops a callback that has not started yet,
+via the `_seeking` guard at the top. A callback already inside the fill
+loop is past that guard, and the buffer it is mid-way through reading
+goes None underneath it.
+
+Two changes, both exercised here: the loop reads the buffer into a
+local so nothing can null it mid-expression, and it re-checks
+`_seeking` each iteration so an in-flight callback yields to a seek
+instead of feeding pre-seek audio.
+"""
+from __future__ import annotations
+
+import queue
+import threading
+
+import numpy as np
+
+from app.audio.player import PCMPlayer
+
+
+def _player() -> PCMPlayer:
+    p = PCMPlayer(lambda: None)
+    p._stream_sample_rate = 44100
+    return p
+
+
+def _chunk(frames: int = 512) -> np.ndarray:
+    return np.zeros((frames, 2), dtype=np.int16)
+
+
+def test_the_carry_is_read_once_into_a_local():
+    """The crash fix, asserted structurally.
+
+    The race cannot be reproduced in-process: the window between the
+    None-check and the `.shape` read is a few bytecodes, and CPython
+    only switches threads every 5 ms, so a Python writer thread never
+    lands in it. A concurrent stress test passes with or without the
+    fix, which makes it worse than no test — it looks like coverage.
+    In production the callback runs on PortAudio's thread, which is
+    what made it reachable.
+
+    So assert the property that makes the crash impossible: the fill
+    loop reads `_callback_carry` into a local and never dereferences
+    the attribute afterwards.
+    """
+    import inspect
+
+    src = inspect.getsource(PCMPlayer._audio_callback)
+    body = src[src.index("while written < frames:") :]
+    fill = body[: body.index("# Cast tap")] if "# Cast tap" in body else body
+
+    assert "carry = self._callback_carry" in fill, (
+        "the fill loop should take a local reference"
+    )
+    assert "self._callback_carry.shape" not in fill, (
+        "dereferencing the attribute is the crash: a concurrent seek() "
+        "nulls it between the check and the read"
+    )
+
+
+def test_seek_in_flight_yields_silence():
+    """A callback that started before the seek must stop feeding the
+    old track rather than finishing its buffer."""
+    p = _player()
+    p._callback_carry = _chunk(256)
+    p._seeking = True
+    out = np.full((256, 2), 999, dtype=np.int16)
+
+    p._audio_callback(out, 256, None, None)
+
+    assert not out.any(), "pre-seek audio was written after _seeking was set"
+
+
+def test_swap_in_flight_yields_silence():
+    """Same for a pipeline swap, which the callback already treats the
+    same way at the top."""
+    p = _player()
+    p._callback_carry = _chunk(256)
+    p._swapping = True
+    out = np.full((256, 2), 999, dtype=np.int16)
+
+    p._audio_callback(out, 256, None, None)
+
+    assert not out.any()
+
+
+def test_normal_playback_still_writes_audio():
+    """The guards must not silence ordinary playback — a fix that
+    always emits zeros would pass the tests above."""
+    p = _player()
+    p._callback_carry = np.full((256, 2), 7, dtype=np.int16)
+    p._pcm_queue = queue.Queue()
+    p._decoder_done = threading.Event()
+    out = np.zeros((256, 2), dtype=np.int16)
+
+    p._audio_callback(out, 256, None, None)
+
+    assert out.any(), "no audio written during normal playback"
+
+
+def test_carry_is_consumed_across_callbacks():
+    """A carry larger than one callback is sliced, not dropped."""
+    p = _player()
+    p._callback_carry = np.full((512, 2), 5, dtype=np.int16)
+    p._pcm_queue = queue.Queue()
+    p._decoder_done = threading.Event()
+
+    p._audio_callback(np.zeros((256, 2), dtype=np.int16), 256, None, None)
+
+    assert p._callback_carry is not None
+    assert p._callback_carry.shape[0] == 256


### PR DESCRIPTION
Fixes the crash in #405.

## The bug

Repeated seeking during DASH playback kills the audio thread:

```
app/audio/player.py: 'NoneType' object has no attribute 'shape'
AUDIO STALL: callback silent for 10.7s while state=playing
```

and sometimes closes the app. Reported by @DmitriyFM033 on 1.32.1.

## Why

`seek()` runs on the request thread and clears `_callback_carry` under `_lock`. **The audio callback is deliberately lock-free**, so `_lock` doesn't keep it out.

There *is* a guard — `if self._seeking: outdata.fill(0); return` at the top of the callback — but it only stops a callback that hasn't started. One already inside the fill loop has passed it, and the buffer it's part-way through reading goes `None` underneath it. The loop then dereferenced the attribute *again*:

```python
take = min(frames - written, self._callback_carry.shape[0])
```

## The fix

Read the buffer into a local once per iteration and use that throughout. A local can't be nulled by another thread.

Also re-check `_seeking` / `_swapping` **inside** the loop rather than only at entry, so an in-flight callback yields to a seek instead of finishing with pre-seek audio. That's what the existing guard intends — it just couldn't act on a callback already past it.

## On the test, honestly

**The race isn't reproducible in-process.** The window between the None-check and the read is a few bytecodes, and CPython only switches threads every 5 ms, so a Python writer thread never lands in it. I wrote a concurrent stress test first and it passed **with and without the fix** — worse than no test, because it looks like coverage. It reaches production because the callback runs on PortAudio's own thread.

So the test asserts the property that makes the crash impossible: the fill loop takes a local reference and never dereferences the attribute afterwards. Verified it **fails on the previous code** and passes on this one.

The other four cases are behavioural and reproducible: a seek in flight yields silence, a swap in flight yields silence, normal playback still writes audio (a fix that always emitted zeros would pass the first two), and a carry larger than one callback is sliced rather than dropped.

Full suite: **1337 passed, 9 skipped, 1 failed** — the pre-existing `uvloop` Windows failure.

## Not addressed

The same report notes seeks snapping to a segment boundary — `target_s=27.52` landing at `effective_s=0.00`. That's a separate DASH seek-accuracy question and wants its own investigation; this PR is the crash and the stall.
