### PR TITLE
Turn hi-res downconvert on by default

### DIFF
--- a/app/settings.py
+++ b/app/settings.py
@@ -112,11 +112,20 @@ class Settings:
     # Downconvert hi-res (24-bit and/or >48 kHz) downloads to
     # 16-bit / 44.1 kHz FLAC so they play on hardware that can't
     # decode hi-res in real time (old iPods running Rockbox, most
-    # legacy DAPs). Off by default — downloads stay bit-exact unless
-    # you opt in. CD-quality and lossy sources are never touched;
+    # legacy DAPs). CD-quality and lossy sources are never touched;
     # the resample is high quality and the bit-depth reduction uses
     # TPDF dither.
-    downconvert_hires_downloads: bool = False
+    #
+    # On by default: a file that plays everywhere is the better
+    # starting point than one that is bit-exact and silent on the
+    # device it was downloaded for. Anyone who wants the hi-res
+    # master turns it off, which is the more deliberate choice of the
+    # two.
+    #
+    # Only affects installs with no stored value — save_settings
+    # writes every field, so an existing settings.json already pins
+    # this either way and keeps whatever the user has.
+    downconvert_hires_downloads: bool = True
     # Resolution of the album cover art embedded in downloads and
     # written as cover.jpg. One of "640", "1280", or "origin" (the
     # 3000x3000 master). Default "1280" — a 4x-area upgrade over the

--- a/tests/test_downconvert_default.py
+++ b/tests/test_downconvert_default.py
@@ -1,0 +1,82 @@
+"""Hi-res downconvert is on by default (fresh installs only).
+
+A downloaded file that plays on the device it was downloaded for is a
+better starting point than one that is bit-exact and silent there —
+old iPods running Rockbox and most legacy DAPs cannot decode 24-bit or
+high-sample-rate FLAC in real time. Wanting the hi-res master is the
+more deliberate choice of the two, so it is the one that takes a
+click.
+
+The scope matters and is easy to get wrong: `save_settings` writes
+every field, so any existing settings.json already pins this value.
+Changing the default cannot and must not move it for someone who has
+run the app before — including someone who deliberately turned it off.
+"""
+from __future__ import annotations
+
+import json
+
+from app.settings import Settings, load_settings, save_settings
+
+
+def test_default_is_on():
+    assert Settings().downconvert_hires_downloads is True
+
+
+def test_an_existing_off_choice_survives(tmp_path, monkeypatch):
+    """The important half. Someone who turned this off — or ran any
+    earlier version, which wrote False — keeps their value."""
+    import app.settings as settings_mod
+
+    path = tmp_path / "settings.json"
+    path.write_text(
+        json.dumps({"downconvert_hires_downloads": False}), encoding="utf-8"
+    )
+    monkeypatch.setattr(settings_mod, "SETTINGS_FILE", path)
+
+    assert load_settings().downconvert_hires_downloads is False
+
+
+def test_an_existing_on_choice_survives(tmp_path, monkeypatch):
+    import app.settings as settings_mod
+
+    path = tmp_path / "settings.json"
+    path.write_text(
+        json.dumps({"downconvert_hires_downloads": True}), encoding="utf-8"
+    )
+    monkeypatch.setattr(settings_mod, "SETTINGS_FILE", path)
+
+    assert load_settings().downconvert_hires_downloads is True
+
+
+def test_a_settings_file_predating_the_field_gets_the_new_default(
+    tmp_path, monkeypatch
+):
+    """An install old enough to have no key for this takes the default,
+    which is the only case the change is meant to reach."""
+    import app.settings as settings_mod
+
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps({"download_lyrics": True}), encoding="utf-8")
+    monkeypatch.setattr(settings_mod, "SETTINGS_FILE", path)
+
+    assert load_settings().downconvert_hires_downloads is True
+
+
+def test_the_value_round_trips_through_a_save(tmp_path, monkeypatch):
+    """Guards the CLAUDE.md foot-gun from the other direction: a field
+    that saves but doesn't reload would look like the setting resetting
+    itself."""
+    import app.settings as settings_mod
+
+    path = tmp_path / "settings.json"
+    monkeypatch.setattr(settings_mod, "SETTINGS_FILE", path)
+
+    s = Settings()
+    s.downconvert_hires_downloads = False
+    save_settings(s)
+
+    assert load_settings().downconvert_hires_downloads is False
+    assert "downconvert_hires_downloads" in json.loads(
+        path.read_text(encoding="utf-8")
+    )


### PR DESCRIPTION
## Summary

Flips `downconvert_hires_downloads` to `True`.

A downloaded file that plays on the device it was downloaded for is a better starting point than one that is bit-exact and silent there. Old iPods running Rockbox and most legacy DAPs can't decode 24-bit or high-sample-rate FLAC in real time — which is the whole reason the option exists. Wanting the hi-res master is the more deliberate of the two choices, so it's the one that takes a click.

CD-quality and lossy sources are untouched either way.

## The scope is narrower than it looks

`save_settings` writes **every** field, so any `settings.json` that has ever been written already carries an explicit value for this. **Changing the default only reaches installs with no stored value** — a fresh install, or one old enough to predate the field.

In particular, someone who deliberately turned it off keeps it off. That's the behaviour we want — a default change shouldn't overwrite a choice someone made — but it does mean this won't retroactively enable it for existing users. If you want that, it needs a migration and it's a different decision, since it overrides explicit choices.

## Test plan

`tests/test_downconvert_default.py`, 5 cases:

- the default is on
- **an existing `false` survives** — the important half
- an existing `true` survives
- a settings file predating the field takes the new default (the only case this reaches)
- the value round-trips through a save — guards the `CLAUDE.md` dataclass/payload foot-gun from the other direction, where a field that saves but doesn't reload would look exactly like a setting resetting itself

Full suite: **1337 passed, 9 skipped, 1 failed** — the pre-existing `uvloop` Windows failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
